### PR TITLE
Fix build on linux and under autotools setup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,6 +161,7 @@ libarchive_la_SOURCES=						\
 	libarchive/archive_util.c				\
 	libarchive/archive_virtual.c				\
 	libarchive/archive_write.c				\
+	libarchive/archive_write_disk_acl.c			\
 	libarchive/archive_write_disk_posix.c			\
 	libarchive/archive_write_disk_private.h			\
 	libarchive/archive_write_disk_set_standard_lookup.c	\
@@ -255,7 +256,8 @@ libarchive_test_SOURCES=					\
 	libarchive/test/main.c					\
 	libarchive/test/read_open_memory.c			\
 	libarchive/test/test.h					\
-	libarchive/test/test_acl_freebsd.c			\
+	libarchive/test/test_acl_freebsd_posix1e.c		\
+	libarchive/test/test_acl_freebsd_nfs4.c			\
 	libarchive/test/test_acl_nfs4.c				\
 	libarchive/test/test_acl_pax.c				\
 	libarchive/test/test_acl_posix1e.c			\

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -388,7 +388,7 @@ setup_mac_metadata(struct archive_read_disk *a,
 #endif
 
 
-#ifdef HAVE_POSIX_ACL
+#if defined(HAVE_POSIX_ACL) && defined(ACL_TYPE_NFS4)
 static int translate_acl(struct archive_read_disk *a,
     struct archive_entry *entry, acl_t acl, int archive_entry_acl_type);
 

--- a/libarchive/archive_write_disk_acl.c
+++ b/libarchive/archive_write_disk_acl.c
@@ -43,7 +43,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_disk.c 201159 2009-12-29 0
 #include "archive_acl_private.h"
 #include "archive_write_disk_private.h"
 
-#ifndef HAVE_POSIX_ACL
+#if !defined(HAVE_POSIX_ACL) || !defined(ACL_TYPE_NFS4)
 /* Default empty function body to satisfy mainline code. */
 int
 archive_write_disk_set_acls(struct archive *a, int fd, const char *name,


### PR DESCRIPTION
New and changed files were missing in Makefile.am, breaking the build.

The ACL support added in commit f67370d5c33b requires NFSv4 style ACLs,
so make all of the code dependent on ACL_TYPE_NFS4 being defined.
