### PR TITLE
Avoid infinite loop when there's unsupported acl type

### DIFF
--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -584,6 +584,7 @@ translate_acl(struct archive_read_disk *a,
 			break;
 		default:
 			/* Skip types that libarchive can't support. */
+			s = acl_get_entry(acl, ACL_NEXT_ENTRY, &acl_entry);
 			continue;
 		}
 


### PR DESCRIPTION
translate_acl() dose not update "s" when it find unsupported acl types, so that it go into infinite loop.
This error cause test_read_disk_directory_traversals to hung.
