### PR TITLE
Fix mtree generation

### DIFF
--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -887,6 +887,9 @@ write_entry(struct archive_write *a, struct mtree_entry *me)
 
 	archive_string_empty(&mtree->ebuf);
 	str = (mtree->indent)? &mtree->ebuf : &mtree->buf;
+	if (strchr(me->pathname, '/') == NULL ) {
+		archive_strcat(str, "./");
+	}
 	mtree_quote(str, me->pathname);
 	keys = get_keys(mtree, me);
 	if ((keys & F_NLINK) != 0 &&


### PR DESCRIPTION
When generating an mtree file, libarchive writes a "Relative" type (entries
that have no /) for files in the base directory. For directories, this causes
the mtree reader to change the parent directory and give subsequent files in
the root directory the wrong path.

Fix this by prefixing entries in the root directory with "./".
