### PR TITLE
Incorrectly decremented the count in the loop

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -2416,26 +2416,29 @@ tar_atol8(const char *p, unsigned char_cnt)
 	limit = INT64_MAX / base;
 	last_digit_limit = INT64_MAX % base;
 
-	while (char_cnt-- > 0 && (*p == ' ' || *p == '\t'))
+	while ((*p == ' ' || *p == '\t') && char_cnt != 0) {
 		p++;
+		char_cnt--;
+	}
 
 	sign = 1;
-	if (char_cnt > 0 && *p == '-') {
+	if (char_cnt != 0 && *p == '-') {
 		sign = -1;
 		p++;
 		char_cnt--;
 	}
 
 	l = 0;
-	if (char_cnt > 0) {
+	if (char_cnt != 0) {
 		digit = *p - '0';
-		while (digit >= 0 && digit < base  && char_cnt-- > 0) {
+		while (digit >= 0 && digit < base  && char_cnt != 0) {
 			if (l>limit || (l == limit && digit > last_digit_limit)) {
 				l = INT64_MAX; /* Truncate on overflow. */
 				break;
 			}
 			l = (l * base) + digit;
 			digit = *++p - '0';
+			char_cnt--;
 		}
 	}
 	return (sign < 0) ? -l : l;
@@ -2456,26 +2459,29 @@ tar_atol10(const char *p, unsigned char_cnt)
 	limit = INT64_MAX / base;
 	last_digit_limit = INT64_MAX % base;
 
-	while (char_cnt-- > 0 && (*p == ' ' || *p == '\t'))
+	while ((*p == ' ' || *p == '\t') && char_cnt != 0) {
 		p++;
+		char_cnt--;
+	}
 
 	sign = 1;
-	if (char_cnt > 0 && *p == '-') {
+	if (char_cnt != 0 && *p == '-') {
 		sign = -1;
 		p++;
 		char_cnt--;
 	}
 
 	l = 0;
-	if (char_cnt > 0) {
+	if (char_cnt != 0) {
 		digit = *p - '0';
-		while (digit >= 0 && digit < base  && char_cnt-- > 0) {
+		while (digit >= 0 && digit < base  && char_cnt != 0) {
 			if (l > limit || (l == limit && digit > last_digit_limit)) {
 				l = INT64_MAX; /* Truncate on overflow. */
 				break;
 			}
 			l = (l * base) + digit;
 			digit = *++p - '0';
+			char_cnt--;
 		}
 	}
 	return (sign < 0) ? -l : l;


### PR DESCRIPTION
I do apologize for not running 'make check-TESTS' first...... 

Logically the count should have been decrement _after_ the
character checks for space and tab. I incorrectly put the length
check before the character checks causing a cascading failure in the
rest of the string to integer conversion.

successfully passes 'make check-TESTS' on my system.... with the caveat that I'm seeing the following error

`57: test_fuzz                                         unxz: (stdin): Compressed data is corrupt`
