### PR TITLE
Add tighter checks to avoid reading past end of buffer

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -2407,16 +2407,18 @@ tar_atol(const char *p, unsigned char_cnt)
  * it does obey locale.
  */
 static int64_t
-tar_atol8(const char *p, unsigned char_cnt)
+tar_atol_base_n(const char *p, unsigned char_cnt, int base)
 {
 	int64_t	l, limit, last_digit_limit;
-	int digit, sign, base;
+	int digit, sign;
 
-	base = 8;
 	limit = INT64_MAX / base;
 	last_digit_limit = INT64_MAX % base;
 
-	while ((*p == ' ' || *p == '\t') && char_cnt != 0) {
+	/* the pointer will not be dereferenced if char_cnt is zero
+	 * due to the way the && operator is evaulated.
+	 */
+	while (char_cnt != 0 && (*p == ' ' || *p == '\t')) {
 		p++;
 		char_cnt--;
 	}
@@ -2444,47 +2446,16 @@ tar_atol8(const char *p, unsigned char_cnt)
 	return (sign < 0) ? -l : l;
 }
 
-/*
- * Note that this implementation does not (and should not!) obey
- * locale settings; you cannot simply substitute strtol here, since
- * it does obey locale.
- */
+static int64_t
+tar_atol8(const char *p, unsigned char_cnt)
+{
+	return tar_atol_base_n(p, char_cnt, 8);
+}
+
 static int64_t
 tar_atol10(const char *p, unsigned char_cnt)
 {
-	int64_t l, limit, last_digit_limit;
-	int base, digit, sign;
-
-	base = 10;
-	limit = INT64_MAX / base;
-	last_digit_limit = INT64_MAX % base;
-
-	while ((*p == ' ' || *p == '\t') && char_cnt != 0) {
-		p++;
-		char_cnt--;
-	}
-
-	sign = 1;
-	if (char_cnt != 0 && *p == '-') {
-		sign = -1;
-		p++;
-		char_cnt--;
-	}
-
-	l = 0;
-	if (char_cnt != 0) {
-		digit = *p - '0';
-		while (digit >= 0 && digit < base  && char_cnt != 0) {
-			if (l > limit || (l == limit && digit > last_digit_limit)) {
-				l = INT64_MAX; /* Truncate on overflow. */
-				break;
-			}
-			l = (l * base) + digit;
-			digit = *++p - '0';
-			char_cnt--;
-		}
-	}
-	return (sign < 0) ? -l : l;
+	return tar_atol_base_n(p, char_cnt, 10);
 }
 
 /*


### PR DESCRIPTION
This is a second attempt at the patch. I successfully ran the test suite against 
the changes with only one error regarding a corrupt compressed stream:

`57: test_fuzz  unxz: (stdin): Compressed data is corrupt`

In the previous attempt the first character decrement was done even if the
required character match didn't occur. This resulted in processing to _little_
of the buffer. I tried to avoid any character decrements in the loop checks
to avoid a repeat of the previous logic flaw.

The string to base 8/10 conversion routines could read past the
counted end of the buffer if the string is correctly formated.
The number of characters is now checked and decremented for every
character that is consumed for processing.

successfully passes 'make check-TESTS'
