### PR TITLE
Fix an error test on the result from fread

### DIFF
--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -108,11 +108,11 @@ static ssize_t
 file_read(struct archive *a, void *client_data, const void **buff)
 {
 	struct read_FILE_data *mine = (struct read_FILE_data *)client_data;
-	ssize_t bytes_read;
+	size_t bytes_read;
 
 	*buff = mine->buffer;
 	bytes_read = fread(mine->buffer, 1, mine->block_size, mine->f);
-	if (bytes_read < 0) {
+	if (bytes_read < mine->block_size && ferror(mine->f)) {
 		archive_set_error(a, errno, "Error reading file");
 	}
 	return (bytes_read);


### PR DESCRIPTION
fread returns a short byte count on error (and ferror has to be used
to determine if it really was an error).  There was a check for < 0,
which fread cannot return.
