### PR TITLE
Fix overflow checking in archive_entry_sparse_add_entry()

### DIFF
--- a/libarchive/archive_entry_sparse.c
+++ b/libarchive/archive_entry_sparse.c
@@ -58,7 +58,7 @@ archive_entry_sparse_add_entry(struct archive_entry *entry,
 	if (offset < 0 || length < 0)
 		/* Invalid value */
 		return;
-	if (offset + length < 0 ||
+	if (offset > INT64_MAX - length ||
 	    offset + length > archive_entry_size(entry))
 		/* A value of "length" parameter is too large. */
 		return;


### PR DESCRIPTION
gcc optimizes the overflow check `x + y < 0` (assuming x, y >= 0) into false, since signed integer overflow is undefined behavior in C.

Below is the simplified code.

``` c
#include <stdint.h>

void bar(void);

void foo(int64_t offset, int64_t length)
{
    if (offset < 0 || length < 0)
        return;
    if (offset + length < 0)
        bar();
}
```

Run gcc with `-O2`.

```
$ gcc -S -o - -O2 t.c
...
foo:
.LFB0:
    .cfi_startproc
    rep ret
```

We can see that gcc optimizes away the check.

This patch uses a safe precondition check instead.
