### PR TITLE
Make calls to the finish_entry callback optional

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -503,8 +503,9 @@ _archive_write_close(struct archive *_a)
 
 	archive_clear_error(&a->archive);
 
-	/* Finish the last entry. */
-	if (a->archive.state == ARCHIVE_STATE_DATA)
+	/* Finish the last entry if a finish callback is specified */
+	if (a->archive.state == ARCHIVE_STATE_DATA
+		&& a->format_finish_entry != NULL)
 		r = ((a->format_finish_entry)(a));
 
 	/* Finish off the archive. */
@@ -658,7 +659,8 @@ _archive_write_finish_entry(struct archive *_a)
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_HEADER | ARCHIVE_STATE_DATA,
 	    "archive_write_finish_entry");
-	if (a->archive.state & ARCHIVE_STATE_DATA)
+	if (a->archive.state & ARCHIVE_STATE_DATA
+		&& a->format_finish_entry != NULL)
 		ret = (a->format_finish_entry)(a);
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	return (ret);


### PR DESCRIPTION
As discussed in PR #37, I made `finish_entry` optional, so it can be set to `NULL` if a format does not need this callback.

I tested it by merging #37 into this, getting rid of the dummy function and running the new tests. It worked for me.
