### PR TITLE
include linux/types.h on CentOS 5 in test/test_sparse_basic.c

### DIFF
--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -40,6 +40,9 @@ __FBSDID("$FreeBSD$");
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_LINUX_TYPES_H
+#include <linux/types.h>
+#endif
 #ifdef HAVE_LINUX_FIEMAP_H
 #include <linux/fiemap.h>
 #endif


### PR DESCRIPTION
Was getting this compilation error on CentOS 5.8:

In file included from ....../libarchive-3.1.2/libarchive/test/test_sparse_basic.c:44:
/usr/include/linux/fiemap.h:15: error: expected specifier-qualifier-list before ‘__u64’
/usr/include/linux/fiemap.h:26: error: expected specifier-qualifier-list before ‘__u64’

From https://groups.google.com/forum/#!msg/libarchive-discuss/691PHz5ENOc/4OzXBevG75AJ I see that the <linux/types.h> file was not included.

This fixed the problem for me on CentOS 5.8.
It was not visible as an issue on CentOS 6.3 or Ubuntu 10.04 or 12.04.

This change did not appear to break those already functioning platforms.
