### PR TITLE
Show third party library versions in version string

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -500,7 +500,7 @@ version(void)
 {
 	fprintf(stdout,"bsdcpio %s -- %s\n",
 	    BSDCPIO_VERSION_STRING,
-	    archive_version_string());
+	    archive_version_details());
 	exit(0);
 }
 

--- a/cpio/test/test.h
+++ b/cpio/test/test.h
@@ -66,6 +66,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <time.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/cpio/test/test_option_version.c
+++ b/cpio/test/test_option_version.c
@@ -74,6 +74,11 @@ verify(const char *p, size_t s)
 	/* Skip a single trailing a,b,c, or d. */
 	if (*q == 'a' || *q == 'b' || *q == 'c' || *q == 'd')
 		++q;
+	/* Skip arbitrary third-party version numbers. */
+	while (s > 0 && (*q == ' ' || *q == '/' || *q == '.' || isalnum(*q))) {
+		++q;
+		--s;
+	}
 	/* All terminated by end-of-line: \r, \r\n, or \n */
 	assert(s >= 1);
 	failure("Version: %s", p);

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -133,6 +133,11 @@ __LA_DECL int		archive_version_number(void);
 #define	ARCHIVE_VERSION_STRING "libarchive 3.1.2"
 __LA_DECL const char *	archive_version_string(void);
 
+/*
+ * Detailed textual name/version of the library and its dependencies.
+ */
+__LA_DECL const char *	archive_version_details(void);
+
 /* Declare our basic types. */
 struct archive;
 struct archive_entry;

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -45,6 +45,15 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_util.c 201098 2009-12-28 02:58:1
 #if defined(HAVE_WINCRYPT_H) && !defined(__CYGWIN__)
 #include <wincrypt.h>
 #endif
+#ifdef HAVE_ZLIB_H
+#include <zlib.h>
+#endif
+#ifdef HAVE_LZMA_H
+#include <lzma.h>
+#endif
+#ifdef HAVE_BZLIB_H
+#include <bzlib.h>
+#endif
 
 #include "archive.h"
 #include "archive_private.h"
@@ -74,6 +83,33 @@ const char *
 archive_version_string(void)
 {
 	return (ARCHIVE_VERSION_STRING);
+}
+
+const char *
+archive_version_details(void)
+{
+	static char version[80];
+#ifdef HAVE_BZLIB_H
+	char *bzlib_version = strdup(BZ2_bzlibVersion());
+	char *ptr = strchr(bzlib_version, ',');
+	if (ptr)
+		*ptr = '\0';
+#endif
+	snprintf(version, sizeof(version), ARCHIVE_VERSION_STRING
+#ifdef HAVE_ZLIB_H
+		" zlib/" ZLIB_VERSION
+#endif
+#ifdef HAVE_LZMA_H
+		" liblzma/" LZMA_VERSION_STRING
+#endif
+#ifdef HAVE_BZLIB_H
+		" bz2lib/%s", bzlib_version
+#endif
+		);
+#ifdef HAVE_BZLIB_H
+	free(bzlib_version);
+#endif
+	return (version);
 }
 
 int

--- a/libarchive/test/main.c
+++ b/libarchive/test/main.c
@@ -67,7 +67,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/test/main.c 201247 2009-12-30 05:59:21Z 
 #define	LIBRARY	"libarchive"
 #define	EXTRA_DUMP(x)	archive_error_string((struct archive *)(x))
 #define	EXTRA_ERRNO(x)	archive_errno((struct archive *)(x))
-#define	EXTRA_VERSION	archive_version_string()
+#define	EXTRA_VERSION	archive_version_details()
 
 /*
  *

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -859,7 +859,7 @@ version(void)
 {
 	printf("bsdtar %s - %s\n",
 	    BSDTAR_VERSION_STRING,
-	    archive_version_string());
+	    archive_version_details());
 	exit(0);
 }
 

--- a/tar/test/test.h
+++ b/tar/test/test.h
@@ -66,6 +66,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <time.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/tar/test/test_version.c
+++ b/tar/test/test_version.c
@@ -87,6 +87,11 @@ DEFINE_TEST(test_version)
 	/* Skip a single trailing a,b,c, or d. */
 	if (*q == 'a' || *q == 'b' || *q == 'c' || *q == 'd')
 		++q;
+	/* Skip arbitrary third-party version numbers. */
+	while (s > 0 && (*q == ' ' || *q == '/' || *q == '.' || isalnum(*q))) {
+		++q;
+		--s;
+	}
 	/* All terminated by end-of-line. */
 	assert(s >= 1);
 	/* Skip an optional CR character (e.g., Windows) */


### PR DESCRIPTION
Add a utility function, archive_version_details, to return a string
containing the libarchive version as well as the versions of third party
libraries such as zlib, bz2lib and liblzma.  Use this function for
bsdtar --version and bsdcpio --version.

http://code.google.com/p/libarchive/issues/detail?id=118
