### PR TITLE
Use correct variable types for ASCII Windows functions.

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -1152,7 +1152,7 @@ set_timefilter_pathname_mbs(struct archive_match *a, int timetype,
 {
 	/* NOTE: stat() on Windows cannot handle nano seconds. */
 	HANDLE h;
-	WIN32_FIND_DATA d;
+	WIN32_FIND_DATAA d;
 
 	if (path == NULL || *path == '\0') {
 		archive_set_error(&(a->archive), EINVAL, "pathname is empty");

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -525,7 +525,7 @@ la_GetFunctionKernel32(const char *name)
 	static int set;
 	if (!set) {
 		set = 1;
-		lib = LoadLibrary("kernel32.dll");
+		lib = LoadLibrary(TEXT("kernel32.dll"));
 	}
 	if (lib == NULL) {
 		fprintf(stderr, "Can't load kernel32.dll?!\n");

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -36,7 +36,7 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout)
 {
 	HANDLE childStdout[2], childStdin[2],childStderr;
 	SECURITY_ATTRIBUTES secAtts;
-	STARTUPINFO staInfo;
+	STARTUPINFOA staInfo;
 	PROCESS_INFORMATION childInfo;
 	struct archive_string cmdline;
 	struct archive_string fullpath;


### PR DESCRIPTION
There are both an ASCII and an Unicode variant for most of the Win32 API.
Fix some inconsistent uses.
