### PR TITLE
Remove unnecessary windows.h include

### DIFF
--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -43,10 +43,6 @@
 #include <stddef.h>  /* for wchar_t */
 #include <time.h>
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#include <windows.h>
-#endif
-
 /* Get a suitable 64-bit integer type. */
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # define	__LA_INT64_T	__int64


### PR DESCRIPTION
Including windows.h brings a lot of useless identifiers to the includer's namespace, making autocomplete less useful, and potentially increases compile times. libarchive builds without any warnings or errors without this include.
