### PR TITLE
Fix autotools build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -440,6 +440,8 @@ libarchive_test_SOURCES=					\
 	libarchive/test/test_read_format_zip_encryption_header.c	\
 	libarchive/test/test_read_format_zip_filename.c		\
 	libarchive/test/test_read_format_zip_mac_metadata.c	\
+	libarchive/test/test_read_format_zip_nofiletype.c	\
+	libarchive/test/test_read_format_zip_padded.c		\
 	libarchive/test/test_read_format_zip_sfx.c		\
 	libarchive/test/test_read_large.c			\
 	libarchive/test/test_read_pax_truncated.c		\


### PR DESCRIPTION
Follows commits 4e002d9a92ecd7cec0fb98b0bedbace8aad81f6e &
7a90710e0d3c786cf4f3af2457a815db6c9b5a5a that only handled CMake.
