### PR TITLE
Make sure has_encrypted_entries is a signed int

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -328,7 +328,7 @@ struct _7zip {
 	char			 format_name[64];
 
 	/* Custom value that is non-zero if this archive contains encrypted entries. */
-	char			 has_encrypted_entries;
+	int			 has_encrypted_entries;
 };
 
 static int	archive_read_format_7zip_has_encrypted_entries(struct archive_read *);
@@ -515,7 +515,7 @@ check_7zip_header_in_sfx(const char *p)
 	switch ((unsigned char)p[5]) {
 	case 0x1C:
 		if (memcmp(p, _7ZIP_SIGNATURE, 6) != 0)
-			return (6); 
+			return (6);
 		/*
 		 * Test the CRC because its extraction code has 7-Zip
 		 * Magic Code, so we should do this in order not to
@@ -523,15 +523,15 @@ check_7zip_header_in_sfx(const char *p)
 		 */
 		if (crc32(0, (const unsigned char *)p + 12, 20)
 			!= archive_le32dec(p + 8))
-			return (6); 
+			return (6);
 		/* Hit the header! */
 		return (0);
-	case 0x37: return (5); 
-	case 0x7A: return (4); 
-	case 0xBC: return (3); 
-	case 0xAF: return (2); 
-	case 0x27: return (1); 
-	default: return (6); 
+	case 0x37: return (5);
+	case 0x7A: return (4);
+	case 0xBC: return (3);
+	case 0xAF: return (2);
+	case 0x27: return (1);
+	default: return (6);
 	}
 }
 
@@ -655,7 +655,7 @@ archive_read_format_7zip_read_header(struct archive_read *a,
 		if (zip->sconv == NULL)
 			return (ARCHIVE_FATAL);
 	}
-	
+
 	/* Figure out if the entry is encrypted by looking at the folder
 	   that is associated to the current 7zip entry. If the folder
 	   has a coder with a _7Z_CRYPTO codec then the folder is encrypted.
@@ -1076,7 +1076,7 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 		 * for BCJ+LZMA. If we were able to tell the uncompressed
 		 * size to liblzma when using lzma_raw_decoder() liblzma
 		 * could correctly deal with BCJ+LZMA. But unfortunately
-		 * there is no way to do that. 
+		 * there is no way to do that.
 		 * Discussion about this can be found at XZ Utils forum.
 		 */
 		if (coder2 != NULL) {
@@ -1519,7 +1519,7 @@ decompress(struct archive_read *a, struct _7zip *zip,
 
 		do {
 			int sym;
-			
+
 			sym = __archive_ppmd7_functions.Ppmd7_DecodeSymbol(
 				&(zip->ppmd7_context), &(zip->range_dec.p));
 			if (sym < 0) {
@@ -3264,7 +3264,7 @@ read_stream(struct archive_read *a, const void **buff, size_t size,
 		return (r);
 
 	/*
-	 * Skip the bytes we alrady has skipped in skip_stream(). 
+	 * Skip the bytes we alrady has skipped in skip_stream().
 	 */
 	while (skip_bytes) {
 		ssize_t skipped;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -304,11 +304,11 @@ struct rar
     ssize_t		 avail_in;
     const unsigned char *next_in;
   } br;
-  
+
   /*
    * Custom field to denote that this archive contains encrypted entries
    */
-  char has_encrypted_entries;
+  int has_encrypted_entries;
 };
 
 static int archive_read_support_format_rar_capabilities(struct archive_read *);
@@ -791,7 +791,7 @@ archive_read_format_rar_options(struct archive_read *a,
 {
   struct rar *rar;
   int ret = ARCHIVE_FAILED;
-        
+
   rar = (struct rar *)(a->format->data);
   if (strcmp(key, "hdrcharset")  == 0) {
     if (val == NULL || val[0] == 0)
@@ -1013,7 +1013,7 @@ archive_read_format_rar_read_data(struct archive_read *a, const void **buff,
   {
   case COMPRESS_METHOD_STORE:
     ret = read_data_stored(a, buff, size, offset);
-    break; 
+    break;
 
   case COMPRESS_METHOD_FASTEST:
   case COMPRESS_METHOD_FAST:
@@ -1023,13 +1023,13 @@ archive_read_format_rar_read_data(struct archive_read *a, const void **buff,
     ret = read_data_compressed(a, buff, size, offset);
     if (ret != ARCHIVE_OK && ret != ARCHIVE_WARN)
       __archive_ppmd7_functions.Ppmd7_Free(&rar->ppmd7_context, &g_szalloc);
-    break; 
+    break;
 
   default:
     archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
                       "Unsupported compression method for RAR file.");
     ret = ARCHIVE_FATAL;
-    break; 
+    break;
   }
   return (ret);
 }
@@ -1438,7 +1438,7 @@ read_header(struct archive_read *a, struct archive_entry *entry,
           flagbyte = *(p + offset++);
           flagbits = 8;
         }
-	
+
         flagbits -= 2;
         switch((flagbyte >> flagbits) & 3)
         {
@@ -2672,7 +2672,7 @@ expand(struct archive_read *a, int64_t end)
     if ((symbol = read_next_symbol(a, &rar->maincode)) < 0)
       return (ARCHIVE_FATAL);
     rar->output_last_match = 0;
-    
+
     if (symbol < 256)
     {
       lzss_emit_literal(rar, symbol);

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -78,7 +78,7 @@ struct zip {
 	size_t			central_directory_entries_on_this_disk;
 	char			have_central_directory;
 	int64_t			offset;
-	char			has_encrypted_entries;
+	int			has_encrypted_entries;
 
 	/* List of entries (seekable Zip only) */
 	size_t			entries_remaining;
@@ -126,8 +126,8 @@ struct zip {
 #define ZIP_STRONG_ENCRYPTED	(1<<6)
 /* See "7.2 Single Password Symmetric Encryption Method"
    in http://www.pkware.com/documents/casestudies/APPNOTE.TXT */
-#define ZIP_CENTRAL_DIRECTORY_ENCRYPTED	(1<<13)	
-#define ZIP_UTF8_NAME	(1<<11)	
+#define ZIP_CENTRAL_DIRECTORY_ENCRYPTED	(1<<13)
+#define ZIP_UTF8_NAME	(1<<11)
 
 static int	archive_read_format_zip_has_encrypted_entries(struct archive_read *);
 static int	archive_read_support_format_zip_capabilities_seekable(struct archive_read *a);
@@ -229,7 +229,7 @@ archive_read_support_format_zip_seekable(struct archive *_a)
 	 */
 	zip->has_encrypted_entries = ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW;
 
-	
+
 	r = __archive_read_register_format(a,
 	    zip,
 	    "zip",
@@ -359,7 +359,7 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 		if (!found)
 			return 0;
 	}
-    
+
 	/* Since we've already done the hard work of finding the
 	   end of central directory record, let's save the important
 	   information. */
@@ -525,7 +525,7 @@ slurp_central_directory(struct archive_read *a, struct zip *zip)
 		external_attributes = archive_le32dec(p + 38);
 		zip_entry->local_header_offset =
 		    archive_le32dec(p + 42) + correction;
-		
+
 		/* If we can't guess the mode, leave it zero here;
 		   when we read the local file header we might get
 		   more information. */
@@ -783,7 +783,7 @@ archive_read_format_zip_seekable_read_header(struct archive_read *a,
 	if (zip->entries_remaining <= 0 || zip->entry == NULL)
 		return ARCHIVE_EOF;
 	--zip->entries_remaining;
-	
+
 	if (zip->entry->rsrcname.s)
 		rsrc = (struct zip_entry *)__archive_rb_tree_find_node(
 		    &zip->tree_rsrc, zip->entry->rsrcname.s);
@@ -1076,7 +1076,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 			archive_entry_set_is_metadata_encrypted(entry, 1);
 			return ARCHIVE_FATAL;
         }
-	}	
+	}
 	zip_entry->compression = (char)archive_le16dec(p + 8);
 	zip_entry->mtime = zip_time(p + 10);
 	local_crc32 = archive_le32dec(p + 14);
@@ -1430,7 +1430,7 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 		}
 		/* Check for a complete PK\007\010 signature. */
 		p = buff;
-		if (p[0] == 'P' && p[1] == 'K' 
+		if (p[0] == 'P' && p[1] == 'K'
 		    && p[2] == '\007' && p[3] == '\010'
 		    && archive_le32dec(p + 4) == zip->entry_crc32
 		    && archive_le32dec(p + 8) ==


### PR DESCRIPTION
Related to cd1740912b18f748a4f9b491a32b44c1712a7478

Trying to assign -1 (ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW)
to a data type we're not sure will always be signed is a bad idea
(blew up on ARM, for instance).

Sorry for the whitespace noise :/.
