### PR TITLE
Add --ignore-zeros option to bsdtar

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -256,6 +256,10 @@ Show usage.
 .It Fl Fl hfsCompression
 (x mode only)
 Mac OS X specific(v10.6 or later). Compress extracted regular files with HFS+ compression.
+.It Fl Fl ignore-zeros
+An alias of
+.Fl Fl options Cm read_concatenated_archives
+for compatibility with GNU tar.
 .It Fl Fl include Ar pattern
 Process only files or directories that match the specified pattern.
 Note that exclusions specified with

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -339,6 +339,9 @@ main(int argc, char **argv)
 			bsdtar->extract_flags |=
 			    ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED;
 			break;
+		case OPTION_IGNORE_ZEROS:
+			bsdtar->option_ignore_zeros = 1;
+			break;
 		case 'I': /* GNU tar */
 			/*
 			 * TODO: Allow 'names' to come from an archive,

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -63,6 +63,7 @@ struct bsdtar {
 	char		  option_chroot; /* --chroot */
 	char		  option_fast_read; /* --fast-read */
 	const char	 *option_options; /* --options */
+	char		  option_ignore_zeros; /* --ignore-zeros */
 	char		  option_interactive; /* -w */
 	char		  option_no_owner; /* -o */
 	char		  option_no_subdirs; /* -n */
@@ -124,6 +125,7 @@ enum {
 	OPTION_GRZIP,
 	OPTION_HELP,
 	OPTION_HFS_COMPRESSION,
+	OPTION_IGNORE_ZEROS,
 	OPTION_INCLUDE,
 	OPTION_KEEP_NEWER_FILES,
 	OPTION_LRZIP,

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -94,6 +94,7 @@ static const struct bsdtar_option {
 	{ "gzip",                 0, 'z' },
 	{ "help",                 0, OPTION_HELP },
 	{ "hfsCompression",       0, OPTION_HFS_COMPRESSION },
+	{ "ignore-zeros",         0, OPTION_IGNORE_ZEROS },
 	{ "include",              1, OPTION_INCLUDE },
 	{ "insecure",             0, 'P' },
 	{ "interactive",          0, 'w' },

--- a/tar/read.c
+++ b/tar/read.c
@@ -201,6 +201,10 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 	}
 	if (ARCHIVE_OK != archive_read_set_options(a, bsdtar->option_options))
 		lafe_errc(1, 0, "%s", archive_error_string(a));
+	if (bsdtar->option_ignore_zeros)
+		if (archive_read_set_options(a,
+		    "read_concatenated_archives") != ARCHIVE_OK)
+			lafe_errc(1, 0, "%s", archive_error_string(a));
 	if (archive_read_open_filename(a, bsdtar->filename,
 					bsdtar->bytes_per_block))
 		lafe_errc(1, 0, "Error opening archive: %s",


### PR DESCRIPTION
As suggested in #60, this pull request adds support for `--ignore-zeros` as an alias of `--options read_concatenated_archive` for compatibility with GNU tar.

The implementation adds an `option_ignore_zeros` member to `struct bsdtar` which isn't strictly necessary, since `"read_concatenated_archive"` could either overwrite or be appended to `option_options`.  However, (perhaps this is due to my rustiness with C) this would seem to require `option_options` to either be dynamically allocated (in at least some cases - requiring cleanup) or have a static buffer set aside or for `--ignore-zeros` to be incompatible with `--options`, all of which seemed less preferable to me than the additional field in `stuct bsdtar`.  But, if I'm overlooking something or you'd prefer it implemented another way, I'd be happy to rewrite it.

Thanks,
Kevin
