### PR TITLE
Do not redefine _WIN32_WINNT and WINVER

### DIFF
--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -1106,8 +1106,13 @@ typedef uint64_t uintmax_t;
 #cmakedefine _LARGE_FILES ${_LARGE_FILES}
 
 /* Define for Windows to use Windows 2000+ APIs. */
+#ifndef _WIN32_WINNT
 #cmakedefine _WIN32_WINNT ${_WIN32_WINNT}
+#endif // _WIN32_WINNT
+
+#ifndef WINVER
 #cmakedefine WINVER ${WINVER}
+#endif // WINVER
 
 /* Define to empty if `const' does not conform to ANSI C. */
 #cmakedefine const ${const}


### PR DESCRIPTION
This is especially useful in case libarchive is part of a superproject that already provides both defines.
