### PR TITLE
Fix intermittent segfault when reading zip files

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -744,7 +744,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 		zip->end_of_entry = 1;
 
 	/* Set up a more descriptive format name. */
-	sprintf(zip->format_name, "ZIP %d.%d (%s)",
+	snprintf(zip->format_name, sizeof(zip->format_name), "ZIP %d.%d (%s)",
 	    version / 10, version % 10,
 	    compression_name(zip->entry->compression));
 	a->archive.archive_format_name = zip->format_name;


### PR DESCRIPTION
When looking up the compression name for a zip file the index variable was being
incremented too soon. Thus element zero ("uncompressed") was never checked and
reads could be made past the end of the array. This was causing intermittent
segfaults in the call to sprintf in zip_read_local_file_header.
