### PR TITLE
Prevent unnecessary linking against deflate code

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2215,7 +2215,8 @@ _archive_write_disk_free(struct archive *_a)
 	free(a->resource_fork);
 	free(a->compressed_buffer);
 	free(a->uncompressed_buffer);
-#ifdef HAVE_ZLIB_H
+#if defined(__APPLE__) && defined(UF_COMPRESSED) && defined(HAVE_SYS_XATTR_H)\
+	&& defined(HAVE_ZLIB_H)
 	if (a->stream_valid) {
 		switch (deflateEnd(&a->stream)) {
 		case Z_OK:


### PR DESCRIPTION
In _archive_write_disk_free, the call to deflateEnd was compiled if HAVE_ZLIB_H
was defined. However, all other calls to deflate functions were only compiled
if __APPLE__, UF_COMPRESSED and HAVE_SYS_XATTR_H were also defined. So if one of
these macros was not defined but HAVE_ZLIB_H was defined, the call the
deflateEnd would be unnecessary as deflateInit could never have been called.

In statically linked applications which don't use deflate functions elsewhere
this was causing unnecessary linking of the deflate code from zlib, adding at
least 20k of object code to the final executable size.

This patch fixes the above issue by surrounding the call to deflateEnd with the
same conditional compilation checks as surround the call to deflateInit.

This was reported to the issue tracker as issue #352. 
