### PR TITLE
Expose ADDITIONAL_LIBS 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1492,6 +1492,12 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 ADD_DEFINITIONS(-DHAVE_CONFIG_H)
 
 #
+# Expose ADDITIONAL_LIBS for projects using libarchive as a subdirectory
+# and linking against archive_static.
+#
+set(LIBARCHIVE_ADDITIONAL_LIBS ${ADDITIONAL_LIBS} PARENT_SCOPE)
+
+#
 # Register installation of PDF documents.
 #
 IF(WIN32 AND NOT CYGWIN)


### PR DESCRIPTION
for projects using libarchive as a subdirectory and linking against archive_static.
