### PR TITLE
fixed 'current scope has no parent' warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1495,7 +1495,7 @@ ADD_DEFINITIONS(-DHAVE_CONFIG_H)
 # Expose ADDITIONAL_LIBS for projects using libarchive as a subdirectory
 # and linking against archive_static.
 #
-set(LIBARCHIVE_ADDITIONAL_LIBS ${ADDITIONAL_LIBS} PARENT_SCOPE)
+set(LIBARCHIVE_ADDITIONAL_LIBS ${ADDITIONAL_LIBS} CACHE INTERNAL "libarchive dependencies")
 
 #
 # Register installation of PDF documents.


### PR DESCRIPTION
This fixes the warning introduced by #75 by using a CACHE INTERNAL (global) variable instead of PARENT_SCOPE which is typically null.
