### PR TITLE
fixed hang in UUEncode filter

### DIFF
--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -509,7 +509,7 @@ read_more:
 			return (ARCHIVE_FATAL);
 		}
 		llen = len;
-		if (nl == 0) {
+		if ((nl == 0) && (uudecode->state != ST_UUEND)) {
 			/*
 			 * Save remaining data which does not contain
 			 * NL('\n','\r').


### PR DESCRIPTION
Addresses hang when running the following file through bsdcat:

```
begin 644 uue.txt
85&AI<R!F:6QE(&ES('5U+65N8V]D960N
`
end
```
