### PR TITLE
Remove xxhash.h from CMakeLists.txt (fixes CMake build issue after 20d5451)

### DIFF
--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -143,7 +143,6 @@ SET(libarchive_SOURCES
   filter_fork_posix.c
   filter_fork.h
   xxhash.c
-  xxhash.h
 )
 
 # Man pages


### PR DESCRIPTION
This commit removes xxhash.h from CMakeLists.txt to fix the build failure with CMake :)

The same change was made to Makefile.am in 20d545194b222ea6d1a0e497f16f889e1588d394
