### PR TITLE
Include windows.h in archive_entry.h

### DIFF
--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -43,7 +43,7 @@
 #include <stddef.h>  /* for wchar_t */
 #include <time.h>
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
This commit fixes an issue where the windows build would fail with the following error message:

```
In file included from /stuff/chenxiaolong/Android/DualBootPatcher/temp/libarchive/cat/bsdcat.h:35:0,
                 from /stuff/chenxiaolong/Android/DualBootPatcher/temp/libarchive/cat/bsdcat.c:31:
/stuff/chenxiaolong/Android/DualBootPatcher/temp/libarchive/libarchive/archive_entry.h:250:64: error: unknown type name 'BY_HANDLE_FILE_INFORMATION'
 __LA_DECL void archive_entry_copy_bhfi(struct archive_entry *, BY_HANDLE_FILE_INFORMATION *);
```

The MSDN website suggests adding windows.h instead of the FileAPI.h that contains the `BY_HANDLE_FILE_INFORMATION` struct. http://msdn.microsoft.com/en-us/library/windows/desktop/aa363788%28v=vs.85%29.aspx
