### PR TITLE
Fix time_t related warning from clang 3.5 in cpio/cpio.c

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -1162,7 +1162,8 @@ list_item_verbose(struct cpio *cpio, struct archive_entry *entry)
 	else
 		fmt = cpio->day_first ? "%d %b %H:%M" : "%b %d %H:%M";
 #else
-	if (abs(mtime - now) > (365/2)*86400)
+	if (mtime - now > 365*86400/2
+		|| mtime - now < -365*86400/2)
 		fmt = cpio->day_first ? "%e %b  %Y" : "%b %e  %Y";
 	else
 		fmt = cpio->day_first ? "%e %b %H:%M" : "%b %e %H:%M";


### PR DESCRIPTION
Fix the following -Werror warning from clang 3.5.0, while building cpio/cpio.c on amd64 (or any arch with 64-bit time_t):

```
libarchive/cpio/cpio.c:1143:6: error: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Werror,-Wabsolute-value]
        if (abs(mtime - now) > (365/2)*86400)
            ^
libarchive/cpio/cpio.c:1143:6: note: use function 'labs' instead
        if (abs(mtime - now) > (365/2)*86400)
            ^~~
            labs
1 error generated.
```

This is because time_t is a long on amd64. To avoid the warning, just copy the equivalent test from a few lines before, which is used in the Windows case, and which is type safe.

Obtained from:  https://reviews.freebsd.org/D1198
