### PR TITLE
fix capitalized windows includes

### DIFF
--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -36,7 +36,7 @@
 typedef	CCHmacContext archive_hmac_sha1_ctx;
 
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-#include <Bcrypt.h>
+#include <bcrypt.h>
 
 typedef struct {
 	BCRYPT_ALG_HANDLE	hAlg;

--- a/libarchive_fe/passphrase.c
+++ b/libarchive_fe/passphrase.c
@@ -76,7 +76,7 @@ __FBSDID("$FreeBSD$");
 
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-#include <Windows.h>
+#include <windows.h>
 
 static char *
 readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)


### PR DESCRIPTION
In order to use mingw on Linux to cross-compile libarchive, these two includes must be fixed. 
The misleading Microsoft docs are listing them capitalized.