### PR TITLE
Allow library installation to be disabled in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ OPTION(ENABLE_OPENSSL "Enable use of OpenSSL" ON)
 OPTION(ENABLE_LZMA "Enable the use of the system found LZMA library if found" ON)
 OPTION(ENABLE_ZLIB "Enable the use of the system found ZLIB library if found" ON)
 OPTION(ENABLE_BZip2 "Enable the use of the system found BZip2 library if found" ON)
+OPTION(ENABLE_LIBXML2 "Enable the use of the system found libxml2 library if found" ON)
 OPTION(ENABLE_EXPAT "Enable the use of the system found EXPAT library if found" ON)
 OPTION(ENABLE_PCREPOSIX "Enable the use of the system found PCREPOSIX library if found" ON)
 OPTION(ENABLE_LibGCC "Enable the use of the system found LibGCC library if found" ON)
@@ -965,8 +966,12 @@ ENDIF(ENABLE_ICONV)
 
 #
 # Find Libxml2
-FIND_PACKAGE(LibXml2)
 #
+IF(ENABLE_LIBXML2)
+  FIND_PACKAGE(LibXml2)
+ELSE()
+  SET(LIBXML2_FOUND FALSE)
+ENDIF()
 IF(LIBXML2_FOUND)
   CMAKE_PUSH_CHECK_STATE()	# Save the state of the variables
   INCLUDE_DIRECTORIES(${LIBXML2_INCLUDE_DIR})
@@ -991,7 +996,11 @@ ELSE(LIBXML2_FOUND)
   #
   # Find Expat
   #
-  FIND_PACKAGE(EXPAT)
+  IF(ENABLE_EXPAT)
+    FIND_PACKAGE(EXPAT)
+  ELSE()
+    SET(EXPAT_FOUND FALSE)
+  ENDIF()
   IF(EXPAT_FOUND)
     CMAKE_PUSH_CHECK_STATE()	# Save the state of the variables
     INCLUDE_DIRECTORIES(${EXPAT_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ OPTION(ENABLE_ACL "Enable ACL support" ON)
 OPTION(ENABLE_ICONV "Enable iconv support" ON)
 OPTION(ENABLE_TEST "Enable unit and regression tests" ON)
 OPTION(ENABLE_COVERAGE "Enable code coverage (GCC only, automatically sets ENABLE_TEST to ON)" FALSE)
+OPTION(ENABLE_INSTALL "Enable installing of libraries" ON)
 
 SET(POSIX_REGEX_LIB "AUTO" CACHE STRING "Choose what library should provide POSIX regular expression support")
 SET(ENABLE_SAFESEH "AUTO" CACHE STRING "Enable use of /SAFESEH linker flag (MSVC only)")

--- a/build/cmake/CreatePkgConfigFile.cmake
+++ b/build/cmake/CreatePkgConfigFile.cmake
@@ -27,5 +27,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc.in
 		${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc
 		@ONLY)
 # And install it, of course ;).
-INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc
-	DESTINATION "lib/pkgconfig")
+IF(ENABLE_INSTALL)
+  INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc
+          DESTINATION "lib/pkgconfig")
+ENDIF()

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -203,12 +203,14 @@ IF(NOT WIN32 OR CYGWIN)
   SET_TARGET_PROPERTIES(archive_static PROPERTIES OUTPUT_NAME archive)
 ENDIF(NOT WIN32 OR CYGWIN)
 
-# How to install the libraries
-INSTALL(TARGETS archive archive_static
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
-INSTALL_MAN(${libarchive_MANS})
-INSTALL(FILES ${include_HEADERS} DESTINATION include)
+IF(ENABLE_INSTALL)
+  # How to install the libraries
+  INSTALL(TARGETS archive archive_static
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib)
+  INSTALL_MAN(${libarchive_MANS})
+  INSTALL(FILES ${include_HEADERS} DESTINATION include)
+ENDIF()
 
 add_subdirectory(test)


### PR DESCRIPTION
libarchive's CMake build system already allows it to be included in other projects using `add_subdirectory()`, but this causes the libarchive library to be installed when `make install` is run for the parent project.

This commit allows the parent project to specify something like:

```
set(ENABLE_TAR OFF CACHE INTERNAL "Enable tar building")
set(ENABLE_CPIO OFF CACHE INTERNAL "Enable cpio building")
set(ENABLE_CAT OFF CACHE INTERNAL "Enable cat building")
set(ENABLE_INSTALL OFF CACHE INTERNAL "Enable installation of libraries")
add_subdirectory(external/libarchive)
```

and have the libarchive static library used for building only.