### PR TITLE
Do not request 0-length skips; sanity-check return.

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -195,10 +195,12 @@ client_skip_proxy(struct archive_read_filter *self, int64_t request)
 				ask = skip_limit;
 			get = (self->archive->client.skipper)
 				(&self->archive->archive, self->data, ask);
-			if (get == 0)
-				return (total);
-			request -= get;
 			total += get;
+			if (get == 0 || get == request)
+				return (total);
+			if (get > request)
+				return ARCHIVE_FATAL;
+			request -= get;
 		}
 	} else if (self->archive->client.seeker != NULL
 		&& request > 64 * 1024) {


### PR DESCRIPTION
I noticed that my skip callback was always being invoked with a request of
0.  This is a bit wasteful since skip callbacks commonly involve a syscall
like lseek().

Also, it seems good to error out when the skip callback is buggy, and claims
to skip more than requested.

#### Test Plan ####

```
autoreconf -ivf && ./configure && make && make check
```

The same tests fail as before, with the same error messages. If interested,
both failure logs are here: https://github.com/snarkmaster/libarchive/commit/00c9751cde6cc888fb844b7a1fcc0f82dbaaedb1

These are on Ubuntu 14.04.