### PR TITLE
libarchive: use lzma_stream_encoder_mt() if it's available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,13 +12,13 @@ m4_define([BSDTAR_VERSION_S],LIBARCHIVE_VERSION_S())
 m4_define([BSDCPIO_VERSION_S],LIBARCHIVE_VERSION_S())
 m4_define([BSDCAT_VERSION_S],LIBARCHIVE_VERSION_S())
 
-AC_PREREQ(2.65)
+AC_PREREQ([2.69])
 
 #
 # Now starts the "real" configure script.
 #
 
-AC_INIT([libarchive],LIBARCHIVE_VERSION_S(),[libarchive-discuss@googlegroups.com])
+AC_INIT([libarchive],[LIBARCHIVE_VERSION_S()],[libarchive-discuss@googlegroups.com])
 # Make sure the srcdir contains "libarchive" directory
 AC_CONFIG_SRCDIR([libarchive])
 # Use auxiliary subscripts from this subdirectory (cleans up root)
@@ -364,6 +364,7 @@ AC_ARG_WITH([lzma],
 if test "x$with_lzma" != "xno"; then
   AC_CHECK_HEADERS([lzma.h])
   AC_CHECK_LIB(lzma,lzma_stream_decoder)
+  AC_CHECK_FUNCS([lzma_stream_encoder_mt])
 fi
 
 AC_ARG_WITH([lzo2],
@@ -472,7 +473,7 @@ fi
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-# AC_TYPE_UID_T defaults to "int", which is incorrect for MinGW
+# la_TYPE_UID_T defaults to "int", which is incorrect for MinGW
 # and MSVC. Use a customized version.
 la_TYPE_UID_T
 AC_TYPE_MODE_T

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -221,16 +221,30 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 {
 	static const lzma_stream lzma_stream_init_data = LZMA_STREAM_INIT;
 	int ret;
+#ifdef HAVE_LZMA_STREAM_ENCODER_MT
+	lzma_mt mt_options;
+#endif
 
 	data->stream = lzma_stream_init_data;
 	data->stream.next_out = data->compressed;
 	data->stream.avail_out = data->compressed_buffer_size;
-	if (f->code == ARCHIVE_FILTER_XZ)
-		ret = lzma_stream_encoder(&(data->stream),
-		    data->lzmafilters, LZMA_CHECK_CRC64);
-	else if (f->code == ARCHIVE_FILTER_LZMA)
+	if (f->code == ARCHIVE_FILTER_XZ) {
+#ifdef HAVE_LZMA_STREAM_ENCODER_MT
+		if (lzma_cputhreads() > 1) {
+			bzero(&mt_options, sizeof(mt_options));
+			mt_options.threads = lzma_cputhreads();
+			mt_options.timeout = 300;
+			mt_options.filters = data->lzmafilters;
+			mt_options.check = LZMA_CHECK_CRC64;
+			ret = lzma_stream_encoder_mt(&(data->stream),
+			    &mt_options);
+		} else
+#endif
+			ret = lzma_stream_encoder(&(data->stream),
+			    data->lzmafilters, LZMA_CHECK_CRC64);
+	} else if (f->code == ARCHIVE_FILTER_LZMA) {
 		ret = lzma_alone_encoder(&(data->stream), &data->lzma_opt);
-	else {	/* ARCHIVE_FILTER_LZIP */
+	} else {	/* ARCHIVE_FILTER_LZIP */
 		int dict_size = data->lzma_opt.dict_size;
 		int ds, log2dic, wedges;
 

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -100,6 +100,7 @@ archive_write_add_filter_lzip(struct archive *a)
 
 struct private_data {
 	int		 compression_level;
+	uint32_t	 threads;
 	lzma_stream	 stream;
 	lzma_filter	 lzmafilters[2];
 	lzma_options_lzma lzma_opt;
@@ -151,6 +152,7 @@ common_setup(struct archive_write_filter *f)
 	}
 	f->data = data;
 	data->compression_level = LZMA_PRESET_DEFAULT;
+	data->threads = 1;
 	f->open = &archive_compressor_xz_open;
 	f->close = archive_compressor_xz_close;
 	f->free = archive_compressor_xz_free;
@@ -230,9 +232,9 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 	data->stream.avail_out = data->compressed_buffer_size;
 	if (f->code == ARCHIVE_FILTER_XZ) {
 #ifdef HAVE_LZMA_STREAM_ENCODER_MT
-		if (lzma_cputhreads() > 1) {
+		if (data->threads != 1) {
 			bzero(&mt_options, sizeof(mt_options));
-			mt_options.threads = lzma_cputhreads();
+			mt_options.threads = data->threads;
 			mt_options.timeout = 300;
 			mt_options.filters = data->lzmafilters;
 			mt_options.check = LZMA_CHECK_CRC64;
@@ -386,6 +388,17 @@ archive_compressor_xz_options(struct archive_write_filter *f,
 		data->compression_level = value[0] - '0';
 		if (data->compression_level > 6)
 			data->compression_level = 6;
+		return (ARCHIVE_OK);
+	} else if (strcmp(key, "threads") == 0) {
+		if (value == NULL)
+			return (ARCHIVE_WARN);
+		data->threads = (int)strtoul(value, NULL, 10);
+		if (data->threads == 0 && errno != 0) {
+			data->threads = 1;
+			return (ARCHIVE_WARN);
+		}
+		if (data->threads == 0)
+			data->threads = lzma_cputhreads();
 		return (ARCHIVE_OK);
 	}
 


### PR DESCRIPTION
This is the multi-threaded stream encoder version of lzma that brings
significant speed improvements.  libarchive is using all the available
threads when lzma_stream_encoder_mt() is present.