### PR TITLE
Fixing path to UC Regents-copyrighted file.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -17,7 +17,7 @@ the actual statements in the files are controlling.
   files for details:
    libarchive/archive_entry.c
    libarchive/archive_read_support_filter_compress.c
-   libarchive/archive_write_set_filter_compress.c
+   libarchive/archive_write_add_filter_compress.c
    libarchive/mtree.5
    tar/matching.c
 


### PR DESCRIPTION
The path pointed to a file whose name has changed.