### PR TITLE
Updating references to tar/matching.c and get_date.c

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -19,10 +19,9 @@ the actual statements in the files are controlling.
    libarchive/archive_read_support_filter_compress.c
    libarchive/archive_write_set_filter_compress.c
    libarchive/mtree.5
-   tar/matching.c
 
 * The following source files are in the public domain:
-   tar/getdate.c
+   libarchive/archive_getdate.c
 
 * The build files---including Makefiles, configure scripts,
   and auxiliary scripts used as part of the compile process---have


### PR DESCRIPTION
tar/matching.c is no a longer a file in the codebase. It has been replaced by libarchive/archive_match.c which is different code.

tar/get_date.c is now libarchive archive_getdate.c