### PR TITLE
Minor libarchive fixes from tarsnap

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -962,7 +962,7 @@ _archive_read_data_block(struct archive *_a,
 	if (a->format->read_data == NULL) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 		    "Internal error: "
-		    "No format_read_data_block function registered");
+		    "No format->read_data function registered");
 		return (ARCHIVE_FATAL);
 	}
 

--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -83,7 +83,7 @@ static const char *	lookup_uname_helper(struct name_cache *, id_t uid);
  * a simple cache to accelerate such lookups---into the archive_read_disk
  * object.  This is in a separate file because getpwuid()/getgrgid()
  * can pull in a LOT of library code (including NIS/LDAP functions, which
- * pull in DNS resolveers, etc).  This can easily top 500kB, which makes
+ * pull in DNS resolvers, etc).  This can easily top 500kB, which makes
  * it inappropriate for some space-constrained applications.
  *
  * Applications that are size-sensitive may want to just use the

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -86,6 +86,11 @@ archive_write_disk_set_standard_lookup(struct archive *a)
 {
 	struct bucket *ucache = malloc(cache_size * sizeof(struct bucket));
 	struct bucket *gcache = malloc(cache_size * sizeof(struct bucket));
+	if (ucache == NULL || gcache == NULL) {
+		free(ucache);
+		free(gcache);
+		return (ARCHIVE_FATAL);
+	}
 	memset(ucache, 0, cache_size * sizeof(struct bucket));
 	memset(gcache, 0, cache_size * sizeof(struct bucket));
 	archive_write_disk_set_group_lookup(a, gcache, lookup_gid, cleanup);

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -67,7 +67,7 @@ static void	cleanup(void *);
  * a simple cache to accelerate such lookups---into the archive_write_disk
  * object.  This is in a separate file because getpwnam()/getgrnam()
  * can pull in a LOT of library code (including NIS/LDAP functions, which
- * pull in DNS resolveers, etc).  This can easily top 500kB, which makes
+ * pull in DNS resolvers, etc).  This can easily top 500kB, which makes
  * it inappropriate for some space-constrained applications.
  *
  * Applications that are size-sensitive may want to just use the


### PR DESCRIPTION
At some point I made these fixes but forgot to send them upstream.  Two typos; one function name which changed but didn't get updated in an error message; and error-handling for a malloc failure.

I can split these up if it would help but I'm guessing these are all pretty straightforward to accept...