### PR TITLE
7z inflation fails. #556

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -108,6 +108,7 @@ __FBSDID("$FreeBSD$");
 #define kMTime			0x14
 #define kAttributes		0x15
 #define kEncodedHeader		0x17
+#define kDummy			0x19
 
 struct _7z_digests {
 	unsigned char	*defineds;
@@ -2559,6 +2560,9 @@ read_Header(struct archive_read *a, struct _7z_header_info *h,
 			}
 			break;
 		}
+		case kDummy:
+			if (ll == 0)
+				break;
 		default:
 			if (header_bytes(a, ll) == NULL)
 				return (-1);


### PR DESCRIPTION
Hi,

I'm using the latest libarchive release (not master).

I've created a file with 7zip (lzma - default settings).
I then tried to inflate it VIA libarchive.

I was unable to get it to work. It would fail without an error reason.

So I started debugging the code and discovered that I'm missing the "seek_callback" (Too bad there is no error code for that).

After implementing the "seek_callback" I tried again. It had failed again but this time it told me the 7zip header is corrupted.

So I started debugging a second time and discovered there is a bug in the libarchive 7zip code. It would seem that libarchive 7zip has issues with handling the "Dummy" header (kDummy). The "Dummy" header is for padding and is often of length 0. The current code has issues with handling headers of length 0.

After fixing the bug - inflation was successful.

To reproduce:
1. Create a 7z archive VIA 7zip.
2. Try inflating it with libarchive (don't forget to add a seek_callback).

10x,
Tomer.