### PR TITLE
Fix CMake build - add HAVE_WMEMMOVE to config.h.in

### DIFF
--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -1051,6 +1051,9 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `wmemcpy' function. */
 #cmakedefine HAVE_WMEMCPY 1
 
+/* Define to 1 if you have the `wmemmove' function. */
+#cmakedefine HAVE_WMEMMOVE 1
+
 /* Define to 1 if you have a working EXT2_IOC_GETFLAGS */
 #cmakedefine HAVE_WORKING_EXT2_IOC_GETFLAGS 1
 


### PR DESCRIPTION
HAVE_WMEMMOVE was added to CMakeLists.txt in b6ba5603,
but not added to config.h.in