### PR TITLE
Bugfix - should be copy+converting from mbs to utf. Not mbs to mbs.

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -3891,7 +3891,7 @@ archive_mstring_get_utf8(struct archive *a, struct archive_mstring *aes,
 		sc = archive_string_conversion_to_charset(a, "UTF-8", 1);
 		if (sc == NULL)
 			return (-1);/* Couldn't allocate memory for sc. */
-		r = archive_strncpy_l(&(aes->aes_mbs), aes->aes_mbs.s,
+		r = archive_strncpy_l(&(aes->aes_utf8), aes->aes_mbs.s,
 		    aes->aes_mbs.length, sc);
 		if (a == NULL)
 			free_sconv_object(sc);


### PR DESCRIPTION
I'm not sure if this is a valid bugfix, although it seems obvious to me.
Unfortunately, this patch does not fix the failing 303 test.

Please examine and let me know :)