### PR TITLE
Test 330 - Add assert to catch a segfault.

### DIFF
--- a/libarchive/test/test_read_format_zip_utf8_paths.c
+++ b/libarchive/test/test_read_format_zip_utf8_paths.c
@@ -44,19 +44,21 @@ verify(struct archive *a) {
 
 	for (file = 0; file < 20; ++file) {
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-		wp = archive_entry_pathname_w(ae);
-		for (i = 0; wp[i] != 0; ++i) {
-			if (wp[i] == '2') {
-				failure("Unicode 'o with umlaut' expected");
-				assertEqualInt(wp[i + 4], 0xF6);
-			} else if (wp[i] == '3') {
-				failure("Unicode 'a with umlaut' expected");
-				assertEqualInt(wp[i + 4], 0xE4);
-			} else if (wp[i] == '4') {
-				failure("Unicode 'a with ring' expected");
-				assertEqualInt(wp[i + 4], 0xE5);
-			}
-		}
+		assert((wp = archive_entry_pathname_w(ae)) != NULL);
+      if (wp) {
+         for (i = 0; wp[i] != 0; ++i) {
+            if (wp[i] == '2') {
+               failure("Unicode 'o with umlaut' expected");
+               assertEqualInt(wp[i + 4], 0xF6);
+            } else if (wp[i] == '3') {
+               failure("Unicode 'a with umlaut' expected");
+               assertEqualInt(wp[i + 4], 0xE4);
+            } else if (wp[i] == '4') {
+               failure("Unicode 'a with ring' expected");
+               assertEqualInt(wp[i + 4], 0xE5);
+            }
+         }
+      }
 	}
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 }


### PR DESCRIPTION
The assert shouldn't fail, but it currently does.

This doesn't fix the underlying reason that the test is failing,
but at least now it is failing more clearly.

(note I had originally written test 303, which was wrong. its 330).