### PR TITLE
Add support for archive_read_data() for read_disk archives.

### DIFF
--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -119,6 +119,23 @@ struct archive {
 	unsigned current_codepage; /* Current ACP(ANSI CodePage). */
 	unsigned current_oemcp; /* Current OEMCP(OEM CodePage). */
 	struct archive_string_conv *sconv;
+
+	/*
+	 * Used by archive_read_data() to track blocks and copy
+	 * data to client buffers, filling gaps with zero bytes.
+	 */
+	const char	 *read_data_block;
+	int64_t		  read_data_offset;
+	int64_t		  read_data_output_offset;
+	size_t		  read_data_remaining;
+
+	/*
+	 * Used by formats/filters to determine the amount of data
+	 * requested from a call to archive_read_data(). This is only
+	 * useful when the format/filter has seek support.
+	 */
+	char		  read_data_is_posix_read;
+	size_t		  read_data_requested;
 };
 
 /* Check magic value and state; return(ARCHIVE_FATAL) if it isn't valid. */
@@ -138,6 +155,8 @@ void	__archive_ensure_cloexec_flag(int fd);
 int	__archive_mktemp(const char *tmpdir);
 
 int	__archive_clean(struct archive *);
+
+void __archive_reset_read_data(struct archive *);
 
 #define	err_combine(a,b)	((a) < (b) ? (a) : (b))
 

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1152,6 +1152,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
 		break;
 	}
 
+   __archive_reset_read_data(&a->archive);
+
 	return (r);
 }
 

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1000,6 +1000,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
 		break;
 	}
 
+   __archive_reset_read_data(&a->archive);
+
 	return (r);
 }
 

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -166,23 +166,6 @@ struct archive_read {
 	int64_t		  skip_file_dev;
 	int64_t		  skip_file_ino;
 
-	/*
-	 * Used by archive_read_data() to track blocks and copy
-	 * data to client buffers, filling gaps with zero bytes.
-	 */
-	const char	 *read_data_block;
-	int64_t		  read_data_offset;
-	int64_t		  read_data_output_offset;
-	size_t		  read_data_remaining;
-
-	/*
-	 * Used by formats/filters to determine the amount of data
-	 * requested from a call to archive_read_data(). This is only
-	 * useful when the format/filter has seek support.
-	 */
-	char		  read_data_is_posix_read;
-	size_t		  read_data_requested;
-
 	/* Callbacks to open/read/write/close client archive streams. */
 	struct archive_read_client client;
 

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1203,10 +1203,8 @@ archive_read_format_rar_seek_data(struct archive_read *a, int64_t offset,
     ret -= rar->dbo[0].start_offset;
 
     /* Always restart reading the file after a seek */
-    a->read_data_block = NULL;
-    a->read_data_offset = 0;
-    a->read_data_output_offset = 0;
-    a->read_data_remaining = 0;
+    __archive_reset_read_data(&a->archive);
+
     rar->bytes_unconsumed = 0;
     rar->offset = 0;
 
@@ -2907,8 +2905,8 @@ rar_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
   int ret;
   if (avail)
   {
-    if (a->read_data_is_posix_read && *avail > (ssize_t)a->read_data_requested)
-      *avail = a->read_data_requested;
+    if (a->archive.read_data_is_posix_read && *avail > (ssize_t)a->archive.read_data_requested)
+      *avail = a->archive.read_data_requested;
     if (*avail > rar->bytes_remaining)
       *avail = (ssize_t)rar->bytes_remaining;
     if (*avail < 0)


### PR DESCRIPTION
Hoisted the relevant archive_read variables into the
common archive struct.

This vastly simplifies the code for reading data from a disk (no need to pad your own zeros!).
eg for the case where reading the data to push through some other computation, before passing into archive_write or wherever.