### PR TITLE
Warn if target of hard-link is not present

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -496,6 +496,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_tar_large.c \
 	libarchive/test/test_ustar_filenames.c \
 	libarchive/test/test_ustar_filename_encoding.c \
+	libarchive/test/test_warn_missing_hardlink_target.c \
 	libarchive/test/test_write_disk.c \
 	libarchive/test/test_write_disk_appledouble.c \
 	libarchive/test/test_write_disk_failures.c \

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1876,6 +1876,13 @@ restore_entry(struct archive_write_disk *a)
 		en = create_filesystem_object(a);
 	}
 
+	if ((en == ENOENT) && (archive_entry_hardlink(a->entry) != NULL)) {
+		archive_set_error(&a->archive, en,
+		    "Hard-link target '%s' does not exist.",
+		    archive_entry_hardlink(a->entry));
+		return (ARCHIVE_FAILED);
+	}
+
 	if ((en == EISDIR || en == EEXIST)
 	    && (a->flags & ARCHIVE_EXTRACT_NO_OVERWRITE)) {
 		/* If we're not overwriting, we're done. */

--- a/libarchive/test/test_warn_missing_hardlink_target.c
+++ b/libarchive/test/test_warn_missing_hardlink_target.c
@@ -1,0 +1,45 @@
+/*-
+ * Copyright (c) 2015 Graham Percival
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+DEFINE_TEST(test_warn_missing_hardlink_target)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+
+	assert(NULL != (a = archive_write_disk_new()));
+	assert(NULL != (ae = archive_entry_new()));
+
+	archive_entry_set_pathname(ae, "hardlink-name");
+	archive_entry_set_hardlink(ae, "hardlink-target");
+
+	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
+	assertEqualInt(ENOENT, archive_errno(a));
+	assertEqualString("Hard-link target 'hardlink-target' does not exist.",
+	    archive_error_string(a));
+
+	archive_entry_free(ae);
+	archive_free(a);
+}


### PR DESCRIPTION
To reproduce,

        touch a
        ln a b
        ./bsdtar -c -f warn-hard-links.tar a b
        rm a b
        ./bsdtar -x -f warn-hard-links.tar b

should produce a warning message about failing to create 'b' because the
hard-link target 'a' does not exist.  Previously, it did not give any hints
about why 'b' could not be created.