### PR TITLE
Check for strdup() allocation failure

### DIFF
--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -98,7 +98,10 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 		/* XXX Error XXX */
 		return;
 
-	xp->name = strdup(name);
+	if ((xp->name = strdup(name)) == NULL)
+		/* XXX Error XXX */
+		return;
+
 	if ((xp->value = malloc(size)) != NULL) {
 		memcpy(xp->value, value, size);
 		xp->size = size;


### PR DESCRIPTION
I used the same "memory allocation error" technique (namely, "`return;`") as the malloc() two lines above, but I'm slightly concerned that this function has no means to report success or failure.

Sponsored by:	Tarsnap Backup Inc.