### PR TITLE
Close leaked temporary file descriptors (fix for bug #578)

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1452,6 +1452,11 @@ _7z_free(struct archive_write *a)
 
 	file_free_register(zip);
 	compression_end(&(a->archive), &(zip->stream));
+	if(zip->temp_fd >= 0)
+	{
+		close(zip->temp_fd);
+		zip->temp_fd = -1;
+	}
 	free(zip->coder.props);
 	free(zip);
 

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1883,6 +1883,11 @@ xar_free(struct archive_write *a)
 	file_free_hardlinks(xar);
 	file_free_register(xar);
 	compression_end(&(a->archive), &(xar->stream));
+	if(xar->temp_fd >= 0)
+	{
+		close(xar->temp_fd);
+		xar->temp_fd = -1;
+	}
 	free(xar);
 
 	return (ARCHIVE_OK);


### PR DESCRIPTION
The 7zip change has been tested.  The xar change is assumed to work.