### PR TITLE
Issue 578: Close temp_fd in 7zip and xar writers

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1450,6 +1450,10 @@ _7z_free(struct archive_write *a)
 {
 	struct _7zip *zip = (struct _7zip *)a->format_data;
 
+	/* Close the temporary file. */
+	if (zip->temp_fd >= 0)
+		close(zip->temp_fd);
+
 	file_free_register(zip);
 	compression_end(&(a->archive), &(zip->stream));
 	free(zip->coder.props);

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1877,6 +1877,11 @@ xar_free(struct archive_write *a)
 	struct xar *xar;
 
 	xar = (struct xar *)a->format_data;
+
+	/* Close the temporary file. */
+	if (xar->temp_fd >= 0)
+		close(xar->temp_fd);
+
 	archive_string_free(&(xar->cur_dirstr));
 	archive_string_free(&(xar->tstr));
 	archive_string_free(&(xar->vstr));


### PR DESCRIPTION
The ISO9660 writer uses a temp_fd and closes it in the archive_free handler. The same logic is added to the archive_free handlers for the 7zip and xar writers.

Tested with a standard 'make' and 'make check', no failures seen except for UTF8 paths in the zip file reader which is already reported as #600. I've also tested that the new code path is taken in both functions by adding a dummy printf and re-running the tests - the branch is taken as expected.