### PR TITLE
Fix trailing whitespace in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -353,7 +353,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_write_add_filter_by_name.c \
 	libarchive/test/test_archive_write_set_filter_option.c \
 	libarchive/test/test_archive_write_set_format_by_name.c \
-	libarchive/test/test_archive_write_set_format_filter_by_ext.c \	
+	libarchive/test/test_archive_write_set_format_filter_by_ext.c \
 	libarchive/test/test_archive_write_set_format_option.c \
 	libarchive/test/test_archive_write_set_option.c \
 	libarchive/test/test_archive_write_set_options.c \


### PR DESCRIPTION
Previously, running the build process gave a warning:

$ sh build/autogen.sh
...
Makefile.am:356: warning: whitespace following trailing backslash
...

This removes that warning by fixing the whitespace.

(I know that the contributor guidelines calls for "no unnecessary whitespace changes", and this isn't strictly *necessary*, but I hope it can be merged because the warning is annoying)