### PR TITLE
Integrate portability changes made in CMake to upstream libarchive

### DIFF
--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(libarchive_SOURCES
   archive_entry_strmode.c
   archive_entry_xattr.c
   archive_getdate.c
+  archive_getdate.h
   archive_hmac.c
   archive_hmac_private.h
   archive_match.c

--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -31,7 +31,7 @@
 #include "archive.h"
 #include "archive_cryptor_private.h"
 
-#ifdef __APPLE__
+#ifdef ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
 
 static int
 pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
@@ -114,7 +114,10 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 
 #endif
 
-#ifdef __APPLE__
+#ifdef ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
+# if MAC_OS_X_VERSION_MAX_ALLOWED < 1090
+#  define kCCAlgorithmAES kCCAlgorithmAES128
+# endif
 
 static int
 aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -31,6 +31,13 @@
 #define ARCHIVE_CRYPTOR_PRIVATE_H_INCLUDED
 
 #ifdef __APPLE__
+# include <AvailabilityMacros.h>
+# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+#  define ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
+# endif
+#endif
+
+#ifdef ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
 #include <CommonCrypto/CommonCryptor.h>
 #include <CommonCrypto/CommonKeyDerivation.h>
 #define AES_BLOCK_SIZE	16

--- a/libarchive/archive_getdate.c
+++ b/libarchive/archive_getdate.c
@@ -38,8 +38,8 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <time.h>
 
-/* This file defines a single public function. */
-time_t __archive_get_date(time_t now, char *);
+#define __LIBARCHIVE_BUILD 1
+#include "archive_getdate.h"
 
 /* Basic time units. */
 #define	EPOCH		1970
@@ -782,7 +782,7 @@ RelativeMonth(time_t Start, time_t Timezone, time_t RelMonth)
  * Tokenizer.
  */
 static int
-nexttoken(char **in, time_t *value)
+nexttoken(const char **in, time_t *value)
 {
 	char	c;
 	char	buff[64];
@@ -809,7 +809,7 @@ nexttoken(char **in, time_t *value)
 		/* Try the next token in the word table first. */
 		/* This allows us to match "2nd", for example. */
 		{
-			char *src = *in;
+			const char *src = *in;
 			const struct LEXICON *tp;
 			unsigned i = 0;
 
@@ -894,7 +894,7 @@ difftm (struct tm *a, struct tm *b)
  * TODO: tokens[] array should be dynamically sized.
  */
 time_t
-__archive_get_date(time_t now, char *p)
+__archive_get_date(time_t now, const char *p)
 {
 	struct token	tokens[256];
 	struct gdstate	_gds;

--- a/libarchive/archive_getdate.h
+++ b/libarchive/archive_getdate.h
@@ -1,0 +1,39 @@
+/*-
+ * Copyright (c) 2003-2015 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef __LIBARCHIVE_BUILD
+#error This header is only to be used internally to libarchive.
+#endif
+
+#ifndef ARCHIVE_GETDATE_H_INCLUDED
+#define	ARCHIVE_GETDATE_H_INCLUDED
+
+#include <time.h>
+
+time_t __archive_get_date(time_t now, const char *);
+
+#endif

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -31,7 +31,7 @@
 #include "archive.h"
 #include "archive_hmac_private.h"
 
-#ifdef __APPLE__
+#ifdef ARCHIVE_HMAC_USE_Apple_CommonCrypto
 
 static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -31,6 +31,13 @@
 #define ARCHIVE_HMAC_PRIVATE_H_INCLUDED
 
 #ifdef __APPLE__
+# include <AvailabilityMacros.h>
+# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#  define ARCHIVE_HMAC_USE_Apple_CommonCrypto
+# endif
+#endif
+
+#ifdef ARCHIVE_HMAC_USE_Apple_CommonCrypto
 #include <CommonCrypto/CommonHMAC.h>
 
 typedef	CCHmacContext archive_hmac_sha1_ctx;

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -35,7 +35,7 @@
 
 typedef	CCHmacContext archive_hmac_sha1_ctx;
 
-#elif defined(_WIN32) && !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 
 typedef struct {

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -40,6 +40,7 @@ __FBSDID("$FreeBSD$");
 #include "archive.h"
 #include "archive_private.h"
 #include "archive_entry.h"
+#include "archive_getdate.h"
 #include "archive_pathmatch.h"
 #include "archive_rb.h"
 #include "archive_string.h"
@@ -184,7 +185,6 @@ static int	time_excluded(struct archive_match *,
 		    struct archive_entry *);
 static int	validate_time_flag(struct archive *, int, const char *);
 
-time_t __archive_get_date(time_t now, const char *);
 #define get_date __archive_get_date
 
 static const struct archive_rb_tree_ops rb_ops_mbs = {

--- a/libarchive/archive_options.c
+++ b/libarchive/archive_options.c
@@ -42,9 +42,9 @@ _archive_set_option(struct archive *a,
 
 	archive_check_magic(a, magic, ARCHIVE_STATE_NEW, fn);
 
-	mp = m != NULL && m[0] == '\0' ? NULL : m;
-	op = o != NULL && o[0] == '\0' ? NULL : o;
-	vp = v != NULL && v[0] == '\0' ? NULL : v;
+	mp = (m != NULL && m[0] != '\0') ? m : NULL;
+	op = (o != NULL && o[0] != '\0') ? o : NULL;
+	vp = (v != NULL && v[0] != '\0') ? v : NULL;
 
 	if (op == NULL && vp == NULL)
 		return (ARCHIVE_OK);

--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -62,6 +62,10 @@ static void arc4random_buf(void *, size_t);
 #include <wincrypt.h>
 #endif
 
+#ifndef O_CLOEXEC
+#define O_CLOEXEC	0
+#endif
+
 /*
  * Random number generator function.
  * This simply calls arc4random_buf function if the platform provides it.

--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -142,11 +142,10 @@ struct arc4_stream {
 	uint8_t s[256];
 };
 
-static pthread_mutex_t	arc4random_mtx = PTHREAD_MUTEX_INITIALIZER;
-
 #define	RANDOMDEV	"/dev/urandom"
 #define	KEYSIZE		128
 #ifdef HAVE_PTHREAD_H
+static pthread_mutex_t	arc4random_mtx = PTHREAD_MUTEX_INITIALIZER;
 #define	_ARC4_LOCK()	pthread_mutex_lock(&arc4random_mtx);
 #define	_ARC4_UNLOCK()  pthread_mutex_unlock(&arc4random_mtx);
 #else

--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -133,9 +133,9 @@ archive_random(void *buf, size_t nbytes)
 #endif				/* !__GNUC__ */
 
 struct arc4_stream {
-	u_int8_t i;
-	u_int8_t j;
-	u_int8_t s[256];
+	uint8_t i;
+	uint8_t j;
+	uint8_t s[256];
 };
 
 static pthread_mutex_t	arc4random_mtx = PTHREAD_MUTEX_INITIALIZER;
@@ -155,7 +155,7 @@ static struct arc4_stream rs;
 static pid_t arc4_stir_pid;
 static int arc4_count;
 
-static inline u_int8_t arc4_getbyte(void);
+static inline uint8_t arc4_getbyte(void);
 static void arc4_stir(void);
 
 static inline void
@@ -173,7 +173,7 @@ static inline void
 arc4_addrandom(u_char *dat, int datlen)
 {
 	int     n;
-	u_int8_t si;
+	uint8_t si;
 
 	rs.i--;
 	for (n = 0; n < 256; n++) {
@@ -235,10 +235,10 @@ arc4_stir_if_needed(void)
 	}
 }
 
-static inline u_int8_t
+static inline uint8_t
 arc4_getbyte(void)
 {
-	u_int8_t si, sj;
+	uint8_t si, sj;
 
 	rs.i = (rs.i + 1);
 	si = rs.s[rs.i];

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1157,7 +1157,7 @@ static const char *
 _archive_filter_name(struct archive *_a, int n)
 {
 	struct archive_read_filter *f = get_filter(_a, n);
-	return f == NULL ? NULL : f->name;
+	return f != NULL ? f->name : NULL;
 }
 
 static int64_t

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1201,7 +1201,7 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 			}
 			archive_set_error(&a->archive, err,
 			    "Internal error initializing decompressor: %s",
-			    detail == NULL ? "??" : detail);
+			    detail != NULL ? detail : "??");
 			zip->bzstream_valid = 0;
 			return (ARCHIVE_FAILED);
 		}

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -418,10 +418,11 @@ deconst(const void *c)
 }
 
 static char*
-xmemmem(const char *hay, const size_t hz, const char *ndl, const size_t nz)
+xmemmem(const char *hay, const size_t haysize,
+	const char *needle, const size_t needlesize)
 {
-	const char *const eoh = hay + hz;
-	const char *const eon = ndl + nz;
+	const char *const eoh = hay + haysize;
+	const char *const eon = needle + needlesize;
 	const char *hp;
 	const char *np;
 	const char *cand;
@@ -433,9 +434,9 @@ xmemmem(const char *hay, const size_t hz, const char *ndl, const size_t nz)
          * a 0-sized needle is defined to be found anywhere in haystack
          * then run strchr() to find a candidate in HAYSTACK (i.e. a portion
          * that happens to begin with *NEEDLE) */
-	if (nz == 0UL) {
+	if (needlesize == 0UL) {
 		return deconst(hay);
-	} else if ((hay = memchr(hay, *ndl, hz)) == NULL) {
+	} else if ((hay = memchr(hay, *needle, haysize)) == NULL) {
 		/* trivial */
 		return NULL;
 	}
@@ -444,11 +445,11 @@ xmemmem(const char *hay, const size_t hz, const char *ndl, const size_t nz)
 	 * guaranteed to be at least one character long.  Now computes the sum
 	 * of characters values of needle together with the sum of the first
 	 * needle_len characters of haystack. */
-	for (hp = hay + 1U, np = ndl + 1U, hsum = *hay, nsum = *hay, eqp = 1U;
+	for (hp = hay + 1U, np = needle + 1U, hsum = *hay, nsum = *hay, eqp = 1U;
 	     hp < eoh && np < eon;
 	     hsum ^= *hp, nsum ^= *np, eqp &= *hp == *np, hp++, np++);
 
-	/* HP now references the (NZ + 1)-th character. */
+	/* HP now references the (NEEDLESIZE + 1)-th character. */
 	if (np < eon) {
 		/* haystack is smaller than needle, :O */
 		return NULL;
@@ -464,10 +465,10 @@ xmemmem(const char *hay, const size_t hz, const char *ndl, const size_t nz)
 		hsum ^= *hp;
 
 		/* Since the sum of the characters is already known to be
-		 * equal at that point, it is enough to check just NZ - 1
+		 * equal at that point, it is enough to check just NEEDLESIZE - 1
 		 * characters for equality,
 		 * also CAND is by design < HP, so no need for range checks */
-		if (hsum == nsum && memcmp(cand, ndl, nz - 1U) == 0) {
+		if (hsum == nsum && memcmp(cand, needle, needlesize - 1U) == 0) {
 			return deconst(cand);
 		}
 	}

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -725,7 +725,7 @@ static const char *
 _archive_filter_name(struct archive *_a, int n)
 {
 	struct archive_write_filter *f = filter_lookup(_a, n);
-	return f == NULL ? NULL : f->name;
+	return f != NULL ? f->name : NULL;
 }
 
 static int64_t

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -197,7 +197,7 @@ struct isofile {
 	enum {
 		NO = 0,
 		BOOT_CATALOG,
-		BOOT_IMAGE,
+		BOOT_IMAGE
 	} boot;
 
 	/*
@@ -850,7 +850,7 @@ enum dir_rec_type {
 	DIR_REC_VD,		/* Stored in Volume Descriptor.	*/
 	DIR_REC_SELF,		/* Stored as Current Directory.	*/
 	DIR_REC_PARENT,		/* Stored as Parent Directory.	*/
-	DIR_REC_NORMAL,		/* Stored as Child.		*/
+	DIR_REC_NORMAL 		/* Stored as Child.		*/
 };
 
 /*
@@ -860,7 +860,7 @@ enum vdc {
 	VDC_STD,
 	VDC_LOWERCASE,
 	VDC_UCS2,
-	VDC_UCS2_DIRECT,
+	VDC_UCS2_DIRECT
 };
 
 /*
@@ -897,7 +897,7 @@ struct idr {
 
 enum char_type {
 	A_CHAR,
-	D_CHAR,
+	D_CHAR
 };
 
 
@@ -4004,7 +4004,7 @@ enum keytype {
 	KEY_FLG,
 	KEY_STR,
 	KEY_INT,
-	KEY_HEX,
+	KEY_HEX
 };
 static void
 set_option_info(struct archive_string *info, int *opt, const char *key,

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -66,6 +66,9 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_format_zip.c 201168 20
 #define ZIP_ENTRY_FLAG_LENGTH_AT_END	(1<<3)
 #define ZIP_ENTRY_FLAG_UTF8_NAME	(1 << 11)
 
+#define ZIP_4GB_MAX ARCHIVE_LITERAL_LL(0xffffffff)
+#define ZIP_4GB_MAX_UNCOMPRESSED ARCHIVE_LITERAL_LL(0xff000000)
+
 enum compression {
 	COMPRESSION_UNSPECIFIED = -1,
 	COMPRESSION_STORE = 0,
@@ -532,13 +535,13 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	if (zip->flags & ZIP_FLAG_AVOID_ZIP64) {
 		/* Reject entries over 4GB. */
 		if (archive_entry_size_is_set(entry)
-		    && (archive_entry_size(entry) > 0xffffffff)) {
+		    && (archive_entry_size(entry) > ZIP_4GB_MAX)) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Files > 4GB require Zip64 extensions");
 			return ARCHIVE_FAILED;
 		}
 		/* Reject entries if archive is > 4GB. */
-		if (zip->written_bytes > 0xffffffff) {
+		if (zip->written_bytes > ZIP_4GB_MAX) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Archives > 4GB require Zip64 extensions");
 			return ARCHIVE_FAILED;
@@ -726,8 +729,8 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 		 *    (compression might make file larger)
 		 */
 		if ((zip->flags & ZIP_FLAG_FORCE_ZIP64)
-		    || (zip->entry_uncompressed_size + additional_size > 0xffffffffLL)
-		    || (zip->entry_uncompressed_size > 0xff000000LL
+		    || (zip->entry_uncompressed_size + additional_size > ZIP_4GB_MAX)
+		    || (zip->entry_uncompressed_size > ZIP_4GB_MAX_UNCOMPRESSED
 			&& zip->entry_compression != COMPRESSION_STORE)) {
 			zip->entry_uses_zip64 = 1;
 			version_needed = 45;
@@ -785,8 +788,8 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 		 * are included only if these are 0xffffffff;
 		 * THEREFORE these must be set this way, even if we
 		 * know one of them is smaller. */
-		archive_le32enc(local_header + 18, 0xffffffffLL);
-		archive_le32enc(local_header + 22, 0xffffffffLL);
+		archive_le32enc(local_header + 18, ZIP_4GB_MAX);
+		archive_le32enc(local_header + 22, ZIP_4GB_MAX);
 	} else {
 		archive_le32enc(local_header + 18, (uint32_t)zip->entry_compressed_size);
 		archive_le32enc(local_header + 22, (uint32_t)zip->entry_uncompressed_size);
@@ -1214,22 +1217,22 @@ archive_write_zip_finish_entry(struct archive_write *a)
 	}
 
 	/* Append Zip64 extra data to central directory information. */
-	if (zip->entry_compressed_written > 0xffffffffLL
-	    || zip->entry_uncompressed_written > 0xffffffffLL
-	    || zip->entry_offset > 0xffffffffLL) {
+	if (zip->entry_compressed_written > ZIP_4GB_MAX
+	    || zip->entry_uncompressed_written > ZIP_4GB_MAX
+	    || zip->entry_offset > ZIP_4GB_MAX) {
 		unsigned char zip64[32];
 		unsigned char *z = zip64, *zd;
 		memcpy(z, "\001\000\000\000", 4);
 		z += 4;
-		if (zip->entry_uncompressed_written >= 0xffffffffLL) {
+		if (zip->entry_uncompressed_written >= ZIP_4GB_MAX) {
 			archive_le64enc(z, zip->entry_uncompressed_written);
 			z += 8;
 		}
-		if (zip->entry_compressed_written >= 0xffffffffLL) {
+		if (zip->entry_compressed_written >= ZIP_4GB_MAX) {
 			archive_le64enc(z, zip->entry_compressed_written);
 			z += 8;
 		}
-		if (zip->entry_offset >= 0xffffffffLL) {
+		if (zip->entry_offset >= ZIP_4GB_MAX) {
 			archive_le64enc(z, zip->entry_offset);
 			z += 8;
 		}
@@ -1253,15 +1256,15 @@ archive_write_zip_finish_entry(struct archive_write *a)
 		archive_le32enc(zip->file_header + 16, zip->entry_crc32);
 	archive_le32enc(zip->file_header + 20,
 		(uint32_t)zipmin(zip->entry_compressed_written,
-				 ARCHIVE_LITERAL_LL(0xffffffff)));
+				 ZIP_4GB_MAX));
 	archive_le32enc(zip->file_header + 24,
 		(uint32_t)zipmin(zip->entry_uncompressed_written,
-				 ARCHIVE_LITERAL_LL(0xffffffff)));
+				 ZIP_4GB_MAX));
 	archive_le16enc(zip->file_header + 30,
 	    (uint16_t)(zip->central_directory_bytes - zip->file_header_extra_offset));
 	archive_le32enc(zip->file_header + 42,
 		(uint32_t)zipmin(zip->entry_offset,
-				 ARCHIVE_LITERAL_LL(0xffffffff)));
+				 ZIP_4GB_MAX));
 
 	return (ARCHIVE_OK);
 }
@@ -1288,8 +1291,8 @@ archive_write_zip_close(struct archive_write *a)
 	offset_end = zip->written_bytes;
 
 	/* If central dir info is too large, write Zip64 end-of-cd */
-	if (offset_end - offset_start > ARCHIVE_LITERAL_LL(0xffffffff)
-	    || offset_start > ARCHIVE_LITERAL_LL(0xffffffff)
+	if (offset_end - offset_start > ZIP_4GB_MAX
+	    || offset_start > ZIP_4GB_MAX
 	    || zip->central_directory_entries > 0xffffUL
 	    || (zip->flags & ZIP_FLAG_FORCE_ZIP64)) {
 	  /* Zip64 end-of-cd record */
@@ -1329,9 +1332,9 @@ archive_write_zip_close(struct archive_write *a)
 	archive_le16enc(buff + 10, (uint16_t)zipmin(0xffffU,
 		zip->central_directory_entries));
 	archive_le32enc(buff + 12,
-		(uint32_t)zipmin(0xffffffffLL, (offset_end - offset_start)));
+		(uint32_t)zipmin(ZIP_4GB_MAX, (offset_end - offset_start)));
 	archive_le32enc(buff + 16,
-		(uint32_t)zipmin(0xffffffffLL, offset_start));
+		(uint32_t)zipmin(ZIP_4GB_MAX, offset_start));
 	ret = __archive_write_output(a, buff, 22);
 	if (ret != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);

--- a/libarchive/test/test_archive_getdate.c
+++ b/libarchive/test/test_archive_getdate.c
@@ -27,11 +27,13 @@ __FBSDID("$FreeBSD$");
 
 #include <time.h>
 
+#define __LIBARCHIVE_BUILD 1
+#include "archive_getdate.h"
+
 /*
  * Verify that the getdate() function works.
  */
 
-time_t __archive_get_date(time_t, const char *);
 #define get_date __archive_get_date
 
 DEFINE_TEST(test_archive_getdate)

--- a/libarchive/test/test_archive_match_time.c
+++ b/libarchive/test/test_archive_match_time.c
@@ -26,7 +26,8 @@
 #include "test.h"
 __FBSDID("$FreeBSD$");
 
-time_t __archive_get_date(time_t, const char *);
+#define __LIBARCHIVE_BUILD 1
+#include "archive_getdate.h"
 
 static void
 test_newer_time(void)


### PR DESCRIPTION
CMake has a copy of libarchive in which we've made several portability changes and other minor tweaks.  I've extracted them into this branch for integration upstream.
