### PR TITLE
Force UTF-8 as the default charset on Android

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -450,6 +450,8 @@ default_iconv_charset(const char *charset) {
 	return locale_charset();
 #elif HAVE_NL_LANGINFO
 	return nl_langinfo(CODESET);
+#elif defined(__BIONIC__)
+	return "UTF-8";
 #else
 	return "";
 #endif


### PR DESCRIPTION
This forces `default_iconv_charset()` to return "UTF-8" on Android. Since the NDK has no support for any locale functions, when archiving a path with UTF-8 encoded characters (to a pax restricted archive), the process fails with:

```
Can't translate pathname '/data/media/0/Piano/童年的回憶.pdf' to UTF-8
```
