### PR TITLE
Fix archive_write_set_format_warc.c compilation

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -235,7 +235,6 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			/*cty*/NULL,
 			/*len*/0,
 		};
-		ssize_t r;
 		rh.tgturi = archive_entry_pathname(entry);
 		rh.rtime = w->now;
 		rh.mtime = archive_entry_mtime(entry);


### PR DESCRIPTION
libarchive/archive_write_set_format_warc.c: In function '_warc_header':
libarchive/archive_write_set_format_warc.c:238:11: error: declaration of
'r' shadows a previous local [-Werror=shadow]
   ssize_t r;
           ^
libarchive/archive_write_set_format_warc.c:185:10: note: shadowed
declaration is here
ssize_t r;
          ^