### PR TITLE
Fix `time` shadowing in archive_write_set_format_warc.c

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -331,16 +331,16 @@ xstrftime(struct archive_string *as, const char *fmt, time_t t)
 /** like strftime(3) but for time_t objects */
 	struct tm *rt;
 #if defined(HAVE_GMTIME_R) || defined(HAVE__GMTIME64_S)
-	struct tm time;
+	struct tm timeHere;
 #endif
 	char strtime[100];
 	size_t len;
 
 #ifdef HAVE_GMTIME_R
-	if ((rt = gmtime_r(&t, &time)) == NULL)
+	if ((rt = gmtime_r(&t, &timeHere)) == NULL)
 		return;
 #elif defined(HAVE__GMTIME64_S)
-	_gmtime64_s(&time, &t);
+	_gmtime64_s(&timeHere, &t);
 #else
 	if ((rt = gmtime(&t)) == NULL)
 		return;


### PR DESCRIPTION
Fixes #640 by renaming the shadowed variable. libarchive now compiles.

