### PR TITLE
Visual Studio 2015 Changes

### DIFF
--- a/cat/test/test.h
+++ b/cat/test/test.h
@@ -92,7 +92,7 @@
 #endif
 
 /* Visual Studio */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf	sprintf_s
 #endif
 

--- a/cpio/cpio_windows.h
+++ b/cpio/cpio_windows.h
@@ -36,8 +36,10 @@
 #define getpwnam(name)	NULL
 #define getpwuid(id)	NULL
 
-#ifdef _MSC_VER
-#define snprintf	sprintf_s
+#if defined(_MSC_VER)
+ #if _MSC_VER < 1900
+ #define snprintf	sprintf_s
+ #endif // _MSC_VER < 1900
 #define strdup		_strdup
 #define open	_open
 #define read	_read

--- a/cpio/test/test.h
+++ b/cpio/test/test.h
@@ -90,7 +90,7 @@
 #endif
 
 /* Visual Studio */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf	sprintf_s
 #endif
 

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -402,7 +402,7 @@ _popul_ehdr(struct archive_string *tgt, size_t tsz, warc_essential_hdr_t hdr)
 		 * handle the minimum number following '%'.
 		 * So we have to use snprintf function here instead
 		 * of archive_string_snprintf function. */
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !( defined(_MSC_VER) && _MSC_VER >= 1900)
 #define snprintf _snprintf
 #endif
 		snprintf(

--- a/libarchive/test/test.h
+++ b/libarchive/test/test.h
@@ -89,7 +89,7 @@
 #endif
 
 /* Visual Studio */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf	sprintf_s
 #endif
 

--- a/tar/test/test.h
+++ b/tar/test/test.h
@@ -92,7 +92,7 @@
 #endif
 
 /* Visual Studio */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf	sprintf_s
 #endif
 


### PR DESCRIPTION
snprintf shouldn't be defined in a macro in VS2015 and above due to its C99 changes