### PR TITLE
Fix an out of bound read (issue #648)

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1531,7 +1531,7 @@ read_header(struct archive_read *a, struct archive_entry *entry,
   /* Split file in multivolume RAR. No more need to process header. */
   if (rar->filename_save &&
     filename_size == rar->filename_save_size &&
-    !memcmp(rar->filename, rar->filename_save, filename_size + 1))
+    !strncmp(rar->filename, rar->filename_save, filename_size + 1))
   {
     __archive_read_consume(a, header_size - 7);
     rar->cursor++;


### PR DESCRIPTION
If the current filename is significantly longer than the previous filename, memcmp can read after the end of the buffer because of an optimization.
strncmp offer the guaranty that it won't occur, and is aware that a NULL byte signal the end of the memory buffer it should consider.
This change should be propagated to the whole codebase but because most of the compare are performed with format's signature, and because memcmp is more liberal when it comes to optimization, I can understand why keeping memcmp is those case make sense.