### PR TITLE
Set xattrs after setting times

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1620,16 +1620,6 @@ _archive_write_disk_finish_entry(struct archive *_a)
 	}
 
 	/*
-	 * Security-related extended attributes (such as
-	 * security.capability on Linux) have to be restored last,
-	 * since they're implicitly removed by other file changes.
-	 */
-	if (a->todo & TODO_XATTR) {
-		int r2 = set_xattrs(a);
-		if (r2 < ret) ret = r2;
-	}
-
-	/*
 	 * Some flags prevent file modification; they must be restored after
 	 * file contents are written.
 	 */
@@ -1644,6 +1634,17 @@ _archive_write_disk_finish_entry(struct archive *_a)
 	 */
 	if (a->todo & TODO_TIMES) {
 		int r2 = set_times_from_entry(a);
+		if (r2 < ret) ret = r2;
+	}
+
+	/*
+	 * Security-related extended attributes (such as
+	 * security.capability or security.ima on Linux) have to be restored last,
+	 * since they're implicitly removed by other file changes like setting
+	 * times.
+	 */
+	if (a->todo & TODO_XATTR) {
+		int r2 = set_xattrs(a);
 		if (r2 < ret) ret = r2;
 	}
 


### PR DESCRIPTION
With Integrity Measurement Architecture (IMA) enabled in Linux
kernel the security.ima extended attribute gets overwritten
when setting times on a file with a futimens() call. So it's safer
to set xattrs after times.

In order to test the fix compile the program below, run it on a host with IMA enabled as root. It will create a new file (`test`) with a fake signature set to its security.ima.

```
$ getfattr -d -m . test
# file: test
security.ima=0sA2JyYWNhZGFicmFhYnJhY2FkYWJyYWFicmFjYWRhYnJhYWJyYWNhZGFicmFhYnJhY2FkYWJyYWFicmFjYWRhYnJhYWJyYWNhZGFicmFhYnJhY2FkYWJyYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
```

Make sure that IMA policy includes the file for measurement and appraisal. Then put the file into an archive and extract from it into a separate directory.

```
# bsdtar --preserve-permissions -cf test.tar test
# mkdir foodir
# bsdtar -C foodir --preserve-permissions -xf test.tar
```

Check that the security.ima attribute hasn't been actually preserved:

```
$ getfattr -d -m . foodir/test
# file: test
security.ima=0sAar0xh3cxeii2r7eDztILNmuqUNN
```

```
#include <sys/types.h>
#include <fcntl.h>
#include <sys/stat.h>
#include <unistd.h>
#include <sys/xattr.h>
#include <string.h>
#include <errno.h>
#include <stdio.h>

enum evm_ima_xattr_type {
        IMA_XATTR_DIGEST = 0x01,
        EVM_XATTR_HMAC,
        EVM_IMA_XATTR_DIGSIG,
        IMA_XATTR_DIGEST_NG,
        IMA_XATTR_LAST
};

int main()
{
        char fakesig[256] = "abracadabraabracadabraabracadabraabracadabraabracadabraabracadabraabracadabraabracadabra";
        fakesig[0] = EVM_IMA_XATTR_DIGSIG;
        int fd = open("test", O_WRONLY | O_CREAT);
        write(fd, "hello", 5);
        fchown(fd, 0, 0);
        int ret = fsetxattr(fd, "security.ima", fakesig, sizeof(fakesig), 0);
        close(fd);
        if (ret) {
            printf("Oops: %s\n", strerror(errno));
        }
        return ret;
}

```