### PR TITLE
LZ4 code update

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -580,10 +580,19 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 				    prefix64k);
 			}
 		}
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+		uncompressed_size = LZ4_decompress_safe_usingDict(
+		    read_buf + 4,
+		    state->out_block + prefix64k, (int)compressed_size,
+		    state->flags.block_maximum_size,
+		    state->out_block,
+		    prefix64k);
+#else
 		uncompressed_size = LZ4_decompress_safe_withPrefix64k(
 		    read_buf + 4,
 		    state->out_block + prefix64k, (int)compressed_size,
 		    state->flags.block_maximum_size);
+#endif
 	}
 
 	/* Check if an error happend in decompression process. */

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -565,6 +565,8 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 				return (ARCHIVE_FATAL);
 			}
 		}
+		else
+			LZ4_loadDictHC(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
 
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		outsize = LZ4_compress_HC_continue(
@@ -587,6 +589,8 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 				return (ARCHIVE_FATAL);
 			}
 		}
+		else
+			LZ4_loadDict(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
 
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		outsize = LZ4_compress_fast_continue(

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -379,7 +379,11 @@ archive_filter_lz4_free(struct archive_write_filter *f)
 	if (data->lz4_stream != NULL) {
 #ifdef HAVE_LZ4HC_H
 		if (data->compression_level >= 3)
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+			LZ4_freeStreamHC(data->lz4_stream);
+#else
 			LZ4_freeHC(data->lz4_stream);
+#endif
 		else
 #endif
 #if LZ4_VERSION_MINOR >= 3
@@ -495,13 +499,24 @@ drive_compressor_independence(struct archive_write_filter *f, const char *p,
 
 #ifdef HAVE_LZ4HC_H
 	if (data->compression_level >= 4)
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+		outsize = LZ4_compress_HC(p, data->out + 4,
+		     (int)length, (int)data->block_size,
+		    data->compression_level);
+#else
 		outsize = LZ4_compressHC2_limitedOutput(p, data->out + 4,
 		    (int)length, (int)data->block_size,
 		    data->compression_level);
+#endif
 	else
 #endif
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+		outsize = LZ4_compress_default(p, data->out + 4,
+		    (int)length, (int)data->block_size);
+#else
 		outsize = LZ4_compress_limitedOutput(p, data->out + 4,
 		    (int)length, (int)data->block_size);
+#endif
 
 	if (outsize) {
 		/* The buffer is compressed. */
@@ -532,11 +547,17 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 	struct private_data *data = (struct private_data *)f->data;
 	int outsize;
 
+#define DICT_SIZE	(64 * 1024)
 #ifdef HAVE_LZ4HC_H
 	if (data->compression_level >= 3) {
 		if (data->lz4_stream == NULL) {
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+			data->lz4_stream = LZ4_createStreamHC();
+			LZ4_resetStreamHC(data->lz4_stream, data->compression_level);
+#else
 			data->lz4_stream =
 			    LZ4_createHC(data->in_buffer_allocated);
+#endif
 			if (data->lz4_stream == NULL) {
 				archive_set_error(f->archive, ENOMEM,
 				    "Can't allocate data for compression"
@@ -544,9 +565,16 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 				return (ARCHIVE_FATAL);
 			}
 		}
+
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+		outsize = LZ4_compress_HC_continue(
+		    data->lz4_stream, p, data->out + 4, (int)length,
+		    (int)data->block_size);
+#else
 		outsize = LZ4_compressHC2_limitedOutput_continue(
 		    data->lz4_stream, p, data->out + 4, (int)length,
 		    (int)data->block_size, data->compression_level);
+#endif
 	} else
 #endif
 	{
@@ -559,9 +587,16 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 				return (ARCHIVE_FATAL);
 			}
 		}
+
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+		outsize = LZ4_compress_fast_continue(
+		    data->lz4_stream, p, data->out + 4, (int)length,
+		    (int)data->block_size, 1);
+#else
 		outsize = LZ4_compress_limitedOutput_continue(
 		    data->lz4_stream, p, data->out + 4, (int)length,
 		    (int)data->block_size);
+#endif
 	}
 
 	if (outsize) {
@@ -585,10 +620,13 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 	}
 
 	if (length == data->block_size) {
-#define DICT_SIZE	(64 * 1024)
 #ifdef HAVE_LZ4HC_H
 		if (data->compression_level >= 3) {
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+			LZ4_saveDictHC(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
+#else
 			LZ4_slideInputBufferHC(data->lz4_stream);
+#endif
 			data->in_buffer = data->in_buffer_allocated + DICT_SIZE;
 		}
 		else

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -498,7 +498,7 @@ drive_compressor_independence(struct archive_write_filter *f, const char *p,
 	unsigned int outsize;
 
 #ifdef HAVE_LZ4HC_H
-	if (data->compression_level >= 4)
+	if (data->compression_level >= 3)
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		outsize = LZ4_compress_HC(p, data->out + 4,
 		     (int)length, (int)data->block_size,


### PR DESCRIPTION
* Update functions in read / write for new lz4 api
* Make hc code optional
* Use loadDict for writing
* Fix a typo in a compression_level check

Fixes https://github.com/libarchive/libarchive/issues/639

I think you have to decide how far you want to support the old lz4 api. Because it's starting to get a bit messy. Maybe add a warning if lz4 version is less than 1.7 and remove that code in a few months?