### PR TITLE
Add large file support for android

### DIFF
--- a/contrib/android/Android.mk
+++ b/contrib/android/Android.mk
@@ -179,9 +179,7 @@ LOCAL_MODULE := libarchive
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(libarchive_src_files) $(libarchive_host_src_files)
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_host_config)\"
-ifneq ($(strip $(USE_MINGW)),)
-	LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
-endif
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive
 include $(BUILD_HOST_STATIC_LIBRARY)
 
@@ -191,9 +189,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_host_config)\"
 LOCAL_SHARED_LIBRARIES := libz-host
 LOCAL_WHOLE_STATIC_LIBRARIES := libarchive
-ifneq ($(strip $(USE_MINGW)),)
-	LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
-endif
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive
 include $(BUILD_HOST_SHARED_LIBRARY)
 
@@ -202,9 +198,7 @@ LOCAL_MODULE := libarchive_fe
 LOCAL_MODULE_TAGS := optional
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_host_config)\"
 LOCAL_SRC_FILES := $(libarchive_fe_src_files)
-ifneq ($(strip $(USE_MINGW)),)
-	LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
-endif
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive_fe
 include $(BUILD_HOST_STATIC_LIBRARY)
 
@@ -222,6 +216,7 @@ LOCAL_CFLAGS :=  -DBSDTAR_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM_
 LOCAL_SHARED_LIBRARIES := libz-host
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdtar_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_HOST_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -231,6 +226,7 @@ LOCAL_CFLAGS :=  -DBSDCPIO_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM
 LOCAL_SHARED_LIBRARIES := libz-host
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdcpio_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_HOST_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -240,6 +236,7 @@ LOCAL_CFLAGS := -DBSDCAT_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM_C
 LOCAL_SHARED_LIBRARIES := libz-host
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdcat_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_HOST_EXECUTABLE)
 
 
@@ -248,8 +245,9 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libarchive
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := $(libarchive_src_files)
-LOCAL_STATIC_LIBRARIES := libz
+LOCAL_STATIC_LIBRARIES := libz liblz4
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_target_config)\"
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive
 include $(BUILD_STATIC_LIBRARY)
 
@@ -261,6 +259,7 @@ LOCAL_C_INCLUDES :=
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_target_config)\"
 LOCAL_SHARED_LIBRARIES := libz
 LOCAL_WHOLE_STATIC_LIBRARIES := libarchive
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive
 include $(BUILD_SHARED_LIBRARY)
 
@@ -269,6 +268,7 @@ LOCAL_MODULE := libarchive_fe
 LOCAL_MODULE_TAGS := optional
 LOCAL_CFLAGS := -DPLATFORM_CONFIG_H=\"$(libarchive_target_config)\"
 LOCAL_SRC_FILES := $(libarchive_fe_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/contrib/android/include
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/libarchive_fe
 include $(BUILD_STATIC_LIBRARY)
 
@@ -280,6 +280,7 @@ LOCAL_CFLAGS :=  -DBSDTAR_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM_
 LOCAL_SHARED_LIBRARIES := libz
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdtar_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/libarchive $(LOCAL_PATH)/libarchive_fe $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -289,6 +290,7 @@ LOCAL_CFLAGS :=  -DBSDCPIO_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM
 LOCAL_SHARED_LIBRARIES := libz
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdcpio_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/libarchive $(LOCAL_PATH)/libarchive_fe $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -298,6 +300,7 @@ LOCAL_CFLAGS := -DBSDCAT_VERSION_STRING=ARCHIVE_VERSION_ONLY_STRING -DPLATFORM_C
 LOCAL_SHARED_LIBRARIES := libz
 LOCAL_STATIC_LIBRARIES := libarchive libarchive_fe
 LOCAL_SRC_FILES := $(bsdcat_src_files)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/libarchive $(LOCAL_PATH)/libarchive_fe $(LOCAL_PATH)/contrib/android/include
 include $(BUILD_EXECUTABLE)
 
 endif

--- a/contrib/android/include/android_lf.h
+++ b/contrib/android/include/android_lf.h
@@ -1,0 +1,47 @@
+/* 
+ * Macros for file64 functions
+ *
+ * Android does not support the macro _FILE_OFFSET_BITS=64
+ * As of android-21 it does however support many file64 functions
+*/
+
+#ifndef ARCHIVE_ANDROID_LF_H_INCLUDED
+#define ARCHIVE_ANDROID_LF_H_INCLUDED
+
+#if __ANDROID_API__ > 20
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <sys/vfs.h>
+
+//dirent.h
+#define readdir_r readdir64_r
+#define readdir readdir64
+#define dirent dirent64
+//fcntl.h
+#define openat openat64
+#define open open64
+#define mkstemp mkstemp64
+//unistd.h
+#define lseek lseek64
+#define ftruncate ftruncate64
+//sys/stat.h
+#define fstatat fstatat64
+#define fstat fstat64
+#define lstat lstat64
+#define stat stat64
+//sys/statvfs.h
+#define fstatvfs fstatvfs64
+#define statvfs statvfs64
+//sys/types.h
+#define off_t off64_t
+//sys/vfs.h
+#define fstatfs fstatfs64
+#define statfs statfs64
+#endif
+
+#endif /* ARCHIVE_ANDROID_LF_H_INCLUDED */

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -95,6 +95,11 @@ typedef ssize_t la_ssize_t;
 # endif
 #endif
 
+/* Large file support for Android */
+#ifdef __ANDROID__
+#include "android_lf.h"
+#endif
+
 /*
  * On Windows, define LIBARCHIVE_STATIC if you're building or using a
  * .lib.  The default here assumes you're building a DLL.  Only

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -75,6 +75,11 @@ typedef int64_t la_int64_t;
 # define	__LA_MODE_T	mode_t
 #endif
 
+/* Large file support for Android */
+#ifdef __ANDROID__
+#include "android_lf.h"
+#endif
+
 /*
  * On Windows, define LIBARCHIVE_STATIC if you're building or using a
  * .lib.  The default here assumes you're building a DLL.  Only

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -150,7 +150,9 @@ file_skip(struct archive *a, void *client_data, int64_t request)
 			skip = max_skip;
 	}
 
-#if HAVE_FSEEKO
+#ifdef __ANDROID__
+	if (lseek(fileno(mine->f), skip, SEEK_CUR) < 0)
+#elif HAVE_FSEEKO
 	if (fseeko(mine->f, skip, SEEK_CUR) != 0)
 #elif HAVE__FSEEKI64
 	if (_fseeki64(mine->f, skip, SEEK_CUR) != 0)


### PR DESCRIPTION
Android doesn't support the macro _FILE_OFFSET_BITS=64 however it does
support a few file64 functions

Output of bsdtar without patch and 2.4GB testfile
```
shell@D5803:/data/local/tmp $ ./bsdtar -t -f /sdcard1/test_z5p_dual.zip -v
./bsdtar -t -f /sdcard1/test_z5p_dual.zip -v
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/
-rw-rw-r--  0 0      0        1714 Dec 24 19:46 META-INF/CERT.RSA
-rw-rw-r--  0 0      0         865 Dec 24 19:46 META-INF/CERT.SF
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/android/
-rw-rw-r--  0 0      0        1675 Dec 24 19:46 META-INF/com/android/otacert
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/google/
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/google/android/
-rw-rw-r--  0 0      0         400 Dec 24 19:46 META-INF/com/google/android/update-binary
-rw-rw-r--  0 0      0      221824 Dec 24 19:46 META-INF/com/google/android/update-binary2
bsdtar: Truncated input file (needed 138961 bytes, only 0 available)
bsdtar: Error exit delayed from previous errors.
```

Output with bsdtar and patch
```
shell@D5803:/data/local/tmp $ ./bsdtar -t -f /sdcard1/test_z5p_dual.zip -v
./bsdtar -t -f /sdcard1/test_z5p_dual.zip -v
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/
-rw-rw-r--  0 0      0        1714 Dec 24 19:46 META-INF/CERT.RSA
-rw-rw-r--  0 0      0         865 Dec 24 19:46 META-INF/CERT.SF
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/android/
-rw-rw-r--  0 0      0        1675 Dec 24 19:46 META-INF/com/android/otacert
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/google/
drwxrwxr-x  0 0      0           0 Dec 24 19:46 META-INF/com/google/android/
-rw-rw-r--  0 0      0         400 Dec 24 19:46 META-INF/com/google/android/update-binary
-rw-rw-r--  0 0      0      221824 Dec 24 19:46 META-INF/com/google/android/update-binary2
-rw-rw-r--  0 0      0        6496 Dec 24 19:46 META-INF/com/google/android/updater-script-names
-rw-rw-r--  0 0      0        5765 Mar  8 21:38 META-INF/com/google/android/updater-script
-rw-rw-r--  0 0      0        6862 Dec 24 19:46 META-INF/com/google/android/updater-script-uuid
-rw-rw-r--  0 0      0         740 Dec 24 19:46 META-INF/MANIFEST.MF
-rw-rw-r--  0 0      0          49 Dec 24 19:46 prfconfig
drwxrwxr-x  0 0      0           0 Dec 24 19:46 utils/
-rw-rw-r--  0 0      0      730912 Dec 24 19:46 utils/busybox
-rw-rw-r--  0 0      0        1218 Dec 24 19:46 utils/create-uuidlinks.sh
-rw-rw-r--  0 0      0        1077 Dec 24 19:46 utils/flash_apps.sh
-rw-rw-r--  0 0      0     1678733 Dec 24 19:46 utils/sgdisk
-rw-rw-r--  0 0      0      522716 Jan 25 15:39 utils/sinflash
-rw-rw-r--  0 0      0     4311027 Mar  4 18:07 SuperSU.zip
-rw-rw-r--  0 0      0  2682532659 Mar  1 10:47 system.sin
shell@D5803:/data/local/tmp $
```

This is a fix for https://github.com/libarchive/libarchive/issues/665