### PR TITLE
Replace usage of _NSIG with SIGRTMAX

### DIFF
--- a/libarchive_fe/passphrase.c
+++ b/libarchive_fe/passphrase.c
@@ -142,7 +142,7 @@ readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
 #  define _POSIX_VDISABLE       VDISABLE
 #endif
 
-static volatile sig_atomic_t signo[_NSIG];
+static volatile sig_atomic_t signo[SIGRTMAX];
 
 static void
 handler(int s)
@@ -168,7 +168,7 @@ readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
 	}
 
 restart:
-	for (i = 0; i < _NSIG; i++)
+	for (i = 0; i < SIGRTMAX; i++)
 		signo[i] = 0;
 	nr = -1;
 	save_errno = 0;
@@ -273,7 +273,7 @@ restart:
 	 * If we were interrupted by a signal, resend it to ourselves
 	 * now that we have restored the signal handlers.
 	 */
-	for (i = 0; i < _NSIG; i++) {
+	for (i = 0; i < SIGRTMAX; i++) {
 		if (signo[i]) {
 			kill(getpid(), i);
 			switch (i) {


### PR DESCRIPTION
POSIX specification defines SIGRTMAX.  _NSIG is not defined on all
platforms (e.g, AIX).