### PR TITLE
Expose postdescend/postascend visit types for archive_read_disk()

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -995,6 +995,8 @@ __LA_DECL int  archive_read_disk_set_atime_restored(struct archive *);
 #define	ARCHIVE_READDISK_NO_TRAVERSE_MOUNTS	(0x0008)
 /* Default: Xattrs are read from disk. */
 #define	ARCHIVE_READDISK_NO_XATTR		(0x0010)
+/* Default: Report only "regular" visits for directories. */
+#define	ARCHIVE_READDISK_ALL_VISIT_TYPES	(0x0020)
 
 __LA_DECL int  archive_read_disk_set_behavior(struct archive *,
 		    int flags);

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -211,6 +211,9 @@ archive_entry_clone(struct archive_entry *entry)
 	p = archive_entry_mac_metadata(entry, &s);
 	archive_entry_copy_mac_metadata(entry2, p, s);
 
+	/* Copy visit type flag over.  */
+	entry2->visit_type = entry->visit_type;
+
 	/* Copy xattr data over. */
 	xp = entry->xattr_head;
 	while (xp != NULL) {
@@ -591,6 +594,12 @@ _archive_entry_pathname_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_get_mbs_l(&entry->ae_pathname, p, len, sc));
+}
+
+enum visit_type
+archive_entry_visit_type(struct archive_entry *entry)
+{
+	return (entry->visit_type);
 }
 
 mode_t
@@ -1166,6 +1175,12 @@ archive_entry_update_pathname_utf8(struct archive_entry *entry, const char *name
 	if (errno == ENOMEM)
 		__archive_errx(1, "No memory");
 	return (0);
+}
+
+void
+archive_entry_set_visit_type(struct archive_entry *entry, enum visit_type type)
+{
+	entry->visit_type = type;
 }
 
 int

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -539,6 +539,28 @@ __LA_DECL void	 archive_entry_sparse_add_entry(struct archive_entry *,
 	    la_int64_t /* offset */, la_int64_t /* length */);
 
 /*
+ * To report the entry visit type. When entries are part of a tree, they
+ * can be visited at different times during the traversal: "regular" (first
+ * time they are retrieved), "before contents" (just before their content gets
+ * enumerated), and "after contents" (after all their content has been visited).
+ *
+ * This can be the case when visiting directories, where:
+ * - "regular" is the first time the directory is visited while enumerating
+ *   its parent;
+ * - "before contents" is "postdescent", when we are visiting the directory to
+ *   enumerate its children;
+ * - "after contents" is "postascent", when we are visiting it back after all its
+ *   children have been visited.
+ */
+enum visit_type {
+	VISIT_TYPE_REGULAR=1,
+	VISIT_TYPE_BEFORE_CONTENTS,
+	VISIT_TYPE_AFTER_CONTENTS
+};
+__LA_DECL enum visit_type archive_entry_visit_type(struct archive_entry *);
+__LA_DECL void archive_entry_set_visit_type(struct archive_entry *, enum visit_type);
+
+/*
  * To retrieve the xattr list, first "reset", then repeatedly ask for the
  * "next" entry.
  */

--- a/libarchive/archive_entry_private.h
+++ b/libarchive/archive_entry_private.h
@@ -174,6 +174,9 @@ struct archive_entry {
 	struct ae_sparse *sparse_tail;
 	struct ae_sparse *sparse_p;
 
+	/* visit type flag. */
+	int visit_type;
+
 	/* Miscellaneous. */
 	char		 strmode[12];
 };

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -2142,7 +2142,7 @@ tree_reopen(struct tree *t, const char *path, int restore_time)
 }
 
 static int
-tree_descent(struct tree *t)
+tree_descend(struct tree *t)
 {
 	int flag, new_fd, r = 0;
 
@@ -2310,7 +2310,7 @@ tree_next(struct tree *t)
 			tree_append(t, t->stack->name.s,
 			    archive_strlen(&(t->stack->name)));
 			t->stack->flags &= ~needsDescent;
-			r = tree_descent(t);
+			r = tree_descend(t);
 			if (r != 0) {
 				tree_pop(t);
 				t->visit_type = r;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -2169,6 +2169,9 @@ tree_descend(struct tree *t)
 		/* Renew the current working directory. */
 		t->working_dir_fd = new_fd;
 		t->flags &= ~onWorkingDir;
+		/* clear flags to force stat/lstat refresh of the new entries */
+		t->flags &= ~hasLstat;
+		t->flags &= ~hasStat;
 	}
 	return (r);
 }
@@ -2205,6 +2208,9 @@ tree_ascend(struct tree *t)
 			te->symlink_parent_fd = -1;
 		}
 		t->depth--;
+		/* clear flags to force stat/lstat refresh of the new entries */
+		t->flags &= ~hasLstat;
+		t->flags &= ~hasStat;
 	}
 	return (r);
 }

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -308,6 +308,7 @@ static int tree_current_dir_fd(struct tree *);
 #define	TREE_ERROR_FATAL	-2
 
 static int tree_next(struct tree *);
+static void entry_set_visit_type(struct archive_entry *, int);
 
 /*
  * Return information about the current entry.
@@ -618,6 +619,10 @@ archive_read_disk_set_behavior(struct archive *_a, int flags)
 		a->suppress_xattr = 1;
 	else
 		a->suppress_xattr = 0;
+	if (flags & ARCHIVE_READDISK_ALL_VISIT_TYPES)
+		a->report_all_visit_types = 1;
+	else
+		a->report_all_visit_types = 0;
 	return (r);
 }
 
@@ -863,6 +868,24 @@ abort_read_data:
 	return (r);
 }
 
+static void
+entry_set_visit_type(struct archive_entry *entry, int type)
+{
+
+	/* map the tree visit type to the correct archive_entry type */
+	switch (type) {
+	case TREE_REGULAR:
+		archive_entry_set_visit_type(entry, VISIT_TYPE_REGULAR);
+		break;
+	case TREE_POSTDESCENT:
+		archive_entry_set_visit_type(entry, VISIT_TYPE_BEFORE_CONTENTS);
+		break;
+	case TREE_POSTASCENT:
+		archive_entry_set_visit_type(entry, VISIT_TYPE_AFTER_CONTENTS);
+		break;
+	}
+}
+
 static int
 next_entry(struct archive_read_disk *a, struct tree *t,
     struct archive_entry *entry)
@@ -894,9 +917,13 @@ next_entry(struct archive_read_disk *a, struct tree *t,
 			tree_enter_initial_dir(t);
 			return (ARCHIVE_EOF);
 		case TREE_POSTDESCENT:
+			/* FALLTHROUGH */
 		case TREE_POSTASCENT:
-			break;
+			if (!a->report_all_visit_types)
+				break;
+			/* FALLTHROUGH */
 		case TREE_REGULAR:
+			entry_set_visit_type(entry, t->visit_type);
 			lst = tree_current_lstat(t);
 			if (lst == NULL) {
 				archive_set_error(&a->archive, errno,
@@ -2557,6 +2584,12 @@ tree_current_is_symblic_link_target(struct tree *t)
 static const char *
 tree_current_access_path(struct tree *t)
 {
+	/*
+	 * The current access path for a POSTDESCENT entry is '.' as we already
+	 * descended into the directory. Else we return current basename.
+	 */
+	if (t->visit_type == TREE_POSTDESCENT)
+		return ".";
 	return (t->basename);
 }
 

--- a/libarchive/archive_read_disk_private.h
+++ b/libarchive/archive_read_disk_private.h
@@ -73,6 +73,8 @@ struct archive_read_disk {
 	int		 traverse_mount_points;
 	/* Set 1 if users want to suppress xattr information. */
 	int		 suppress_xattr;
+	/* Set 1 if users want to have all the visit_type flags reported. */
+	int		 report_all_visit_types;
 
 	const char * (*lookup_gname)(void *private, int64_t gid);
 	void	(*cleanup_gname)(void *private);

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -242,6 +242,7 @@ static void tree_push(struct tree *, const wchar_t *, const wchar_t *,
 #define	TREE_ERROR_FATAL	-2
 
 static int tree_next(struct tree *);
+static void entry_set_visit_type(struct archive_entry *, int);
 
 /*
  * Return information about the current entry.
@@ -530,6 +531,10 @@ archive_read_disk_set_behavior(struct archive *_a, int flags)
 		a->traverse_mount_points = 0;
 	else
 		a->traverse_mount_points = 1;
+	if (flags & ARCHIVE_READDISK_ALL_VISIT_TYPES)
+		a->report_all_visit_types = 1;
+	else
+		a->report_all_visit_types = 0;
 	return (r);
 }
 
@@ -752,6 +757,24 @@ abort_read_data:
 	return (r);
 }
 
+static void
+entry_set_visit_type(struct archive_entry *entry, int type)
+{
+
+       /* map the tree visit type to the correct archive_entry type */
+       switch (type) {
+       case TREE_REGULAR:
+	       archive_entry_set_visit_type(entry, VISIT_TYPE_REGULAR);
+	       break;
+       case TREE_POSTDESCENT:
+	       archive_entry_set_visit_type(entry, VISIT_TYPE_BEFORE_CONTENTS);
+	       break;
+       case TREE_POSTASCENT:
+	       archive_entry_set_visit_type(entry, VISIT_TYPE_AFTER_CONTENTS);
+	       break;
+       }
+}
+
 static int
 next_entry(struct archive_read_disk *a, struct tree *t,
     struct archive_entry *entry)
@@ -780,9 +803,13 @@ next_entry(struct archive_read_disk *a, struct tree *t,
 		case 0:
 			return (ARCHIVE_EOF);
 		case TREE_POSTDESCENT:
+			/* FALLTHROUGH */
 		case TREE_POSTASCENT:
-			break;
+			if (!a->report_all_visit_types)
+				break;
+			/* FALLTHROUGH */
 		case TREE_REGULAR:
+			entry_set_visit_type(entry, t->visit_type);
 			lst = tree_current_lstat(t);
 			if (lst == NULL) {
 				archive_set_error(&a->archive, t->tree_errno,

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1650,6 +1650,8 @@ tree_descend(struct tree *t)
 	t->dirname_length = archive_strlen(&t->path);
 	t->full_path_dir_length = archive_strlen(&t->full_path);
 	t->depth++;
+	t->flags &= ~hasLstat;
+	t->flags &= ~hasStat;
 	return (0);
 }
 
@@ -1664,6 +1666,8 @@ tree_ascend(struct tree *t)
 	te = t->stack;
 	t->depth--;
 	close_and_restore_time(INVALID_HANDLE_VALUE, t, &te->restore_time);
+	t->flags &= ~hasLstat;
+	t->flags &= ~hasStat;
 	return (0);
 }
 

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1645,7 +1645,7 @@ failed:
 }
 
 static int
-tree_descent(struct tree *t)
+tree_descend(struct tree *t)
 {
 	t->dirname_length = archive_strlen(&t->path);
 	t->full_path_dir_length = archive_strlen(&t->full_path);
@@ -1745,7 +1745,7 @@ tree_next(struct tree *t)
 			tree_append(t, t->stack->name.s,
 			    archive_strlen(&(t->stack->name)));
 			t->stack->flags &= ~needsDescent;
-			r = tree_descent(t);
+			r = tree_descend(t);
 			if (r != 0) {
 				tree_pop(t);
 				t->visit_type = r;


### PR DESCRIPTION
Allows exposing all visit types during file-system tree traversal for POSIX and win32 hierarchies.

Previous code only returns "regular" visits during tree traversal, but mtree requires postdescend/postascend visit types to properly detect and verify mismatches between the specification and the file-system. As such, when program asks for it explicitly through ARCHIVE_READDISK_ALL_VISIT_TYPES flag (through archive_read_disk_set_behavior()), the archive_read_disk() code will also return POSTDESCEND/ASCEND visits. Caller obtains visit_type through the archive_entry_visit_type getter.

Short explanation:
When entries are part of a tree, they can be visited at different times during the tree traversal:
* VISIT_TYPE_REGULAR: first time they are retrieved. Typically, the first time we enter the node;
* VISIT_TYPE_BEFORE_CONTENTS: just before their content gets enumerated. Generally we are visiting the node and enumerating its children. Called POSTDESCENT visit in libarchive (also named pre-order);
* VISIT_TYPE_AFTER_CONTENTS: after all their content has been visited. Called POSTASCENT visit (also named post-order).

Default behavior is to report only regular visits for retro-compatibility reasons. Note however that archive_entry's visit_type will still be set to "VISIT_TYPE_REGULAR" regardless (for POLA reasons).

POSIX and win32 implementations differ a bit. While win32 API uses full paths for entries, POSIX next entries are usually looked through their basename + working directory. This has a side effect when descending into a directory for POSIX (POSTDESCENT), as the code will descend into the directory and look it up through its basename, which is obviously wrong. Return "." for this special case.

We also force clear hasLstat/hasStat flags upon descending/ascending. This can be overkill in the normal case (1 extra *statat call in specific circumstances), but this is required to avoid the previously cached "regular" visited entry to be reused as-is by the postascended/postdescended entry. Another possibility would be to cache stat structs for each directory tree_entry, but this consumes quite a bit more memory.