### PR TITLE
fix missing archive_write_close for write object

### DIFF
--- a/examples/untar.c
+++ b/examples/untar.c
@@ -190,6 +190,9 @@ extract(const char *filename, int do_extract, int flags)
 	}
 	archive_read_close(a);
 	archive_read_free(a);
+	
+	archive_write_close(ext);
+  	archive_write_free(ext);
 	exit(0);
 }
 


### PR DESCRIPTION
 missing archive_write_close and archive_write_free, thus causing memory release