### PR TITLE
Fix static linking: use -all-static

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -857,7 +857,7 @@ endif
 bsdtar_DEPENDENCIES= libarchive.la libarchive_fe.la
 
 if STATIC_BSDTAR
-bsdtar_ldstatic= -static
+bsdtar_ldstatic= -all-static
 bsdtar_ccstatic= -DLIBARCHIVE_STATIC
 else
 bsdtar_ldstatic=
@@ -1012,7 +1012,7 @@ bsdcpio_DEPENDENCIES = libarchive.la libarchive_fe.la
 
 
 if STATIC_BSDCPIO
-bsdcpio_ldstatic= -static
+bsdcpio_ldstatic= -all-static
 bsdcpio_ccstatic= -DLIBARCHIVE_STATIC
 else
 bsdcpio_ldstatic=


### PR DESCRIPTION
Hi there,

It seems there is some problem with statically linking the executables of libarchive (like `bsdtar`).
Without the patch from this pull request, I have the following:
```shell
# ./configure CC='musl-clang -Qunused-arguments' --enable-bsdtar=static
# make -j8
# file bsdtar
bsdtar: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, BuildID[sha1]=bdd52430098ac4b1f83038ca62624f12af2ace5c, not stripped
```

If I run again the same commands but this time with the patch, I'll get the following:
```shell
# ./configure CC='musl-clang -Qunused-arguments' --enable-bsdtar=static
# make -j8
# file bsdtar
bsdtar: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=ec551d063984e61af5b4f9c0c8029b943b0864cd, not stripped
```

This is what I was expecting at first.
However, I'm not that much experienced with autoconf/libtool/... and I'm not sure this is the correct way to fix this behavior.

For the record (as this is asked on the contributing guidelines) I'm on Debian Jessie.
I compiled with clang-3.8 and the master branch of the musl libc (`musl-clang` from the `CC` variable being a simple wrapper script installed by musl to ease the compilation) the libarchive sources by cloning the master branch of this repository.

Original patch from David Lee via
https://groups.google.com/forum/#!msg/libarchive-discuss/PJl1UWf5IPU/G5ZdDIiTGwAJ

Regards.
