### PR TITLE
cat: declare static variables and fix compiler warnings

### DIFF
--- a/cat/bsdcat.c
+++ b/cat/bsdcat.c
@@ -42,10 +42,10 @@ __FBSDID("$FreeBSD$");
 
 #define	BYTES_PER_BLOCK	(20*512)
 
-struct archive *a;
-struct archive_entry *ae;
-char *bsdcat_current_path;
-int exit_status = 0;
+static struct archive *a;
+static struct archive_entry *ae;
+static const char *bsdcat_current_path;
+static int exit_status = 0;
 
 
 void
@@ -68,7 +68,7 @@ version(void)
 }
 
 void
-bsdcat_next()
+bsdcat_next(void)
 {
 	a = archive_read_new();
 	archive_read_support_filter_all(a);
@@ -85,7 +85,7 @@ bsdcat_print_error(void)
 }
 
 void
-bsdcat_read_to_stdout(char* filename)
+bsdcat_read_to_stdout(const char* filename)
 {
 	int r;
 

--- a/cat/bsdcat.h
+++ b/cat/bsdcat.h
@@ -53,4 +53,4 @@ int bsdcat_getopt(struct bsdcat *);
 void usage(FILE *stream, int eval);
 void bsdcat_next(void);
 void bsdcat_print_error(void);
-void bsdcat_read_to_stdout(char* filename);
+void bsdcat_read_to_stdout(const char* filename);


### PR DESCRIPTION
Declare initial variables as static and fix a const char cast