### PR TITLE
Revert ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS from cpio

### DIFF
--- a/cpio/bsdcpio.1
+++ b/cpio/bsdcpio.1
@@ -156,8 +156,7 @@ See above for description.
 .It Fl Fl insecure
 (i and p mode only)
 Disable security checks during extraction or copying.
-This allows extraction via symbolic links, absolute paths,
-and path names containing
+This allows extraction via symbolic links and path names containing
 .Sq ..
 in the name.
 .It Fl J , Fl Fl xz

--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -171,7 +171,6 @@ main(int argc, char *argv[])
 	cpio->extract_flags |= ARCHIVE_EXTRACT_NO_OVERWRITE_NEWER;
 	cpio->extract_flags |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
 	cpio->extract_flags |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
-	cpio->extract_flags |= ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
 	cpio->extract_flags |= ARCHIVE_EXTRACT_PERM;
 	cpio->extract_flags |= ARCHIVE_EXTRACT_FFLAGS;
 	cpio->extract_flags |= ARCHIVE_EXTRACT_ACL;
@@ -257,7 +256,6 @@ main(int argc, char *argv[])
 		case OPTION_INSECURE:
 			cpio->extract_flags &= ~ARCHIVE_EXTRACT_SECURE_SYMLINKS;
 			cpio->extract_flags &= ~ARCHIVE_EXTRACT_SECURE_NODOTDOT;
-			cpio->extract_flags &= ~ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
 			break;
 		case 'L': /* GNU cpio */
 			cpio->option_follow_links = 1;


### PR DESCRIPTION
Change in 59357157706d47c365b2227739e17daba3607526 breaks cpio behavior.
Noticed in FreeBSD when compiling and installing git from ports or using ezjail.

I would like to know what was the author's intention, maybe we could find another way to solve this.

A revert like this will require a 3.2.1 bugfix release.