### PR TITLE
Disable ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS in bsdcpio p mode

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -295,6 +295,7 @@ main(int argc, char *argv[])
 				    "Cannot use both -p and -%c", cpio->mode);
 			cpio->mode = opt;
 			cpio->extract_flags &= ~ARCHIVE_EXTRACT_SECURE_NODOTDOT;
+			cpio->extract_flags &= ~ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
 			break;
 		case OPTION_PASSPHRASE:
 			cpio->passphrase = cpio->argument;


### PR DESCRIPTION
The discussion around CVE-2015-2304 does not mention the pass-through mode anywhere.

This patch unbreaks the following command syntax:
cd /bin && find -d . | bsdcpio -dumpl /tmp/bin

This would fix the problems we have with latest cpio on FreeBSD.