### PR TITLE
Remove .Pp before .Bl

### DIFF
--- a/libarchive/libarchive-formats.5
+++ b/libarchive/libarchive-formats.5
@@ -65,7 +65,6 @@ Later variants have extended this by either appropriating undefined
 areas of the header record, extending the header to multiple records,
 or by storing special entries that modify the interpretation of
 subsequent entries.
-.Pp
 .Bl -tag -width indent
 .It Cm gnutar
 The


### PR DESCRIPTION
.Pp before .Bl is not required and mandoc -Tlint complains about it. 