### PR TITLE
Fix libarchive/archive_read_support_format_mtree.c:1388:11: error: ar…

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1385,12 +1385,12 @@ parse_device(dev_t *pdev, struct archive *a, char *val)
 				    "Missing number");
 				return ARCHIVE_WARN;
 			}
-			numbers[argc++] = (unsigned long)mtree_atol(&p);
-			if (argc > MAX_PACK_ARGS) {
+			if (argc >= MAX_PACK_ARGS) {
 				archive_set_error(a, ARCHIVE_ERRNO_FILE_FORMAT,
 				    "Too many arguments");
 				return ARCHIVE_WARN;
 			}
+			numbers[argc++] = (unsigned long)mtree_atol(&p);
 		}
 		if (argc < 2) {
 			archive_set_error(a, ARCHIVE_ERRNO_FILE_FORMAT,


### PR DESCRIPTION
 Version of libarchive: libarchive-3.2.0
 How you obtained it:  Source from git release  libarchive-3.2.0.tar.gz
 Operating system and version: Ubuntu 14.04
 What compiler and/or IDE you are using (include version): arm-none-linux-gnueabi


This patch fix a bug (see below) that we found while crosscompiling libarchive-3.2.0 to build opkg for arm platform. 

~~~
make  all-am
make[1]: Entering directory `/mnt/host/libarchive-3.2.0'
  CC       libarchive/archive_read_support_format_mtree.lo
cc1: warnings being treated as errors
libarchive/archive_read_support_format_mtree.c: In function 'parse_device':
libarchive/archive_read_support_format_mtree.c:1388:11: error: array subscript is above array bounds
make[1]: *** [libarchive/archive_read_support_format_mtree.lo] Error 1
make[1]: Leaving directory `/mnt/host/libarchive-3.2.0'
make: *** [all] Error 
~~~

