### PR TITLE
Remove dead code in archive_entry_xattr_add_entry()

### DIFF
--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -91,9 +91,6 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 {
 	struct ae_xattr	*xp;
 
-	for (xp = entry->xattr_head; xp != NULL; xp = xp->next)
-		;
-
 	if ((xp = (struct ae_xattr *)malloc(sizeof(struct ae_xattr))) == NULL)
 		__archive_errx(1, "Out of memory");
 


### PR DESCRIPTION
The code seems to be walking through the linked list beginning at
`entry->xattr_head`, but then it immediately sets `xp` to be something different.

This is 10-year old code; it was added in the first "POSIX.1e-style Extended
Attribute support" commit, on March 21 2006:
https://svnweb.freebsd.org/base/head/lib/libarchive/archive_entry.c?annotate=156961&pathrev=156961#l1387