### PR TITLE
Report cpio version string with one dash only

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -498,7 +498,7 @@ long_help(void)
 static void
 version(void)
 {
-	fprintf(stdout,"bsdcpio %s -- %s\n",
+	fprintf(stdout,"bsdcpio %s - %s\n",
 	    BSDCPIO_VERSION_STRING,
 	    archive_version_details());
 	exit(0);


### PR DESCRIPTION
Both bsdtar and bsdcat report their version string with one dash between tool version and libarchive version. Cpio should do the same.