### PR TITLE
add GNU and CPIO compat aliases

### DIFF
--- a/cpio/cmdline.c
+++ b/cpio/cmdline.c
@@ -70,6 +70,7 @@ static const struct option {
 	{ "grzip",			0, OPTION_GRZIP },
 	{ "help",			0, 'h' },
 	{ "insecure",			0, OPTION_INSECURE },
+	{ "dereference",		0, 'L' },
 	{ "link",			0, 'l' },
 	{ "list",			0, 't' },
 	{ "lrzip",			0, OPTION_LRZIP },

--- a/cpio/cmdline.c
+++ b/cpio/cmdline.c
@@ -63,6 +63,7 @@ static const struct option {
 } cpio_longopts[] = {
 	{ "b64encode",			0, OPTION_B64ENCODE },
 	{ "create",			0, 'o' },
+	{ "dereference",		0, 'L' },
 	{ "dot",			0, 'V' },
 	{ "extract",			0, 'i' },
 	{ "file",			1, 'F' },
@@ -70,7 +71,6 @@ static const struct option {
 	{ "grzip",			0, OPTION_GRZIP },
 	{ "help",			0, 'h' },
 	{ "insecure",			0, OPTION_INSECURE },
-	{ "dereference",		0, 'L' },
 	{ "link",			0, 'l' },
 	{ "list",			0, 't' },
 	{ "lrzip",			0, OPTION_LRZIP },

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -68,6 +68,7 @@ static const struct bsdtar_option {
 	{ "auto-compress",        0, 'a' },
 	{ "b64encode",            0, OPTION_B64ENCODE },
 	{ "block-size",           1, 'b' },
+	{ "blocking-factor",	  1, 'b' },
 	{ "bunzip2",              0, 'j' },
 	{ "bzip",                 0, 'j' },
 	{ "bzip2",                0, 'j' },


### PR DESCRIPTION
Hi @kientzle 

please merge this pull request as it adds aliasaes for
tar:
--blocking-factor

cpio:
--dereference --L

