### PR TITLE
Fix a typographical error in a struct member: candiate -> candidate

### DIFF
--- a/libarchive/archive_read_add_passphrase.c
+++ b/libarchive/archive_read_add_passphrase.c
@@ -125,7 +125,7 @@ void
 __archive_read_reset_passphrase(struct archive_read *a)
 {
 
-	a->passphrases.candiate = -1;
+	a->passphrases.candidate = -1;
 }
 
 /*
@@ -137,31 +137,31 @@ __archive_read_next_passphrase(struct archive_read *a)
 	struct archive_read_passphrase *p;
 	const char *passphrase;
 
-	if (a->passphrases.candiate < 0) {
+	if (a->passphrases.candidate < 0) {
 		/* Count out how many passphrases we have. */
 		int cnt = 0;
 
 		for (p = a->passphrases.first; p != NULL; p = p->next)
 			cnt++;
-		a->passphrases.candiate = cnt;
+		a->passphrases.candidate = cnt;
 		p = a->passphrases.first;
-	} else if (a->passphrases.candiate > 1) {
+	} else if (a->passphrases.candidate > 1) {
 		/* Rotate a passphrase list. */
-		a->passphrases.candiate--;
+		a->passphrases.candidate--;
 		p = remove_passphrases_from_head(a);
 		add_passphrase_to_tail(a, p);
-		/* Pick a new passphrase candiate up. */
+		/* Pick a new passphrase candidate up. */
 		p = a->passphrases.first;
-	} else if (a->passphrases.candiate == 1) {
-		/* This case is that all cadiates failed to decryption. */
-		a->passphrases.candiate = 0;
+	} else if (a->passphrases.candidate == 1) {
+		/* This case is that all candidates failed to decrypt. */
+		a->passphrases.candidate = 0;
 		if (a->passphrases.first->next != NULL) {
 			/* Rotate a passphrase list. */
 			p = remove_passphrases_from_head(a);
 			add_passphrase_to_tail(a, p);
 		}
 		p = NULL;
-	} else  /* There is no passphrase candaite. */
+	} else  /* There is no passphrase candidate. */
 		p = NULL;
 
 	if (p != NULL)
@@ -177,7 +177,7 @@ __archive_read_next_passphrase(struct archive_read *a)
 			if (p == NULL)
 				return (NULL);
 			insert_passphrase_to_head(a, p);
-			a->passphrases.candiate = 1;
+			a->passphrases.candidate = 1;
 		}
 	} else
 		passphrase = NULL;

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -221,7 +221,7 @@ struct archive_read {
 	struct {
 		struct archive_read_passphrase *first;
 		struct archive_read_passphrase **last;
-		int candiate;
+		int candidate;
 		archive_passphrase_callback *callback;
 		void *client_data;
 	}		passphrases;


### PR DESCRIPTION
Hi,

This is another almost-trivial fix: rename a struct member to get rid of a typo, as well as fixing some more candidate-related typos in the comments around the code.

G'luck,
Peter
