### PR TITLE
Hide internal symbols in the shared library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -583,6 +583,27 @@ AC_HEADER_TIME
 
 # Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
+
+AC_MSG_CHECKING([for the symbol visibility flags and attributes])
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -fvisibility=hidden"
+AC_COMPILE_IFELSE(
+ [AC_LANG_PROGRAM([[#include <stdlib.h>
+int __attribute__((visibility("default"))) foo(void);
+int foo(void) {
+	 return 0;
+}
+]],
+                  [[return foo();]])],
+ [
+  AC_MSG_RESULT([-fvisibility])
+  AC_DEFINE(HAVE_GCC_VISIBILITY,1,[Define to 1 if GCC supports the -fvisibility flag.])
+  save_CFLAGS="$CFLAGS"
+ ],
+ [AC_MSG_RESULT([none])]
+)
+CFLAGS="$save_CFLAGS"
+
 AC_HEADER_MAJOR
 AC_FUNC_FSEEKO
 AC_FUNC_MEMCMP

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -115,14 +115,22 @@ typedef ssize_t la_ssize_t;
 #  endif
 # else
 #  ifdef __GNUC__
-#   define __LA_DECL
+#   ifdef HAVE_GCC_VISIBILITY
+#    define __LA_DECL	__attribute__((visibility("default")))
+#   else
+#    define __LA_DECL
+#   endif
 #  else
 #   define __LA_DECL	__declspec(dllimport)
 #  endif
 # endif
 #else
 /* Static libraries or non-Windows needs no special declaration. */
-# define __LA_DECL
+# if defined(__GNUC__) && defined(HAVE_GCC_VISIBILITY)
+#  define __LA_DECL	__attribute__((visibility("default")))
+# else
+#  define __LA_DECL
+# endif
 #endif
 
 #if defined(__GNUC__) && __GNUC__ >= 3 && !defined(__MINGW32__)
@@ -1176,8 +1184,5 @@ __LA_DECL int archive_utility_string_sort(char **);
 #ifdef __cplusplus
 }
 #endif
-
-/* These are meaningless outside of this header. */
-#undef __LA_DECL
 
 #endif /* !ARCHIVE_H_INCLUDED */

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -150,7 +150,7 @@ static size_t wcslen(const wchar_t *s)
  *
  ****************************************************************************/
 
-struct archive_entry *
+__LA_DECL struct archive_entry *
 archive_entry_clear(struct archive_entry *entry)
 {
 	if (entry == NULL)
@@ -171,7 +171,7 @@ archive_entry_clear(struct archive_entry *entry)
 	return entry;
 }
 
-struct archive_entry *
+__LA_DECL struct archive_entry *
 archive_entry_clone(struct archive_entry *entry)
 {
 	struct archive_entry *entry2;
@@ -230,20 +230,20 @@ archive_entry_clone(struct archive_entry *entry)
 	return (entry2);
 }
 
-void
+__LA_DECL void
 archive_entry_free(struct archive_entry *entry)
 {
 	archive_entry_clear(entry);
 	free(entry);
 }
 
-struct archive_entry *
+__LA_DECL struct archive_entry *
 archive_entry_new(void)
 {
 	return archive_entry_new2(NULL);
 }
 
-struct archive_entry *
+__LA_DECL struct archive_entry *
 archive_entry_new2(struct archive *a)
 {
 	struct archive_entry *entry;
@@ -260,61 +260,61 @@ archive_entry_new2(struct archive *a)
  * Functions for reading fields from an archive_entry.
  */
 
-time_t
+__LA_DECL time_t
 archive_entry_atime(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_atime);
 }
 
-long
+__LA_DECL long
 archive_entry_atime_nsec(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_atime_nsec);
 }
 
-int
+__LA_DECL int
 archive_entry_atime_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_ATIME);
 }
 
-time_t
+__LA_DECL time_t
 archive_entry_birthtime(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_birthtime);
 }
 
-long
+__LA_DECL long
 archive_entry_birthtime_nsec(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_birthtime_nsec);
 }
 
-int
+__LA_DECL int
 archive_entry_birthtime_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_BIRTHTIME);
 }
 
-time_t
+__LA_DECL time_t
 archive_entry_ctime(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_ctime);
 }
 
-int
+__LA_DECL int
 archive_entry_ctime_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_CTIME);
 }
 
-long
+__LA_DECL long
 archive_entry_ctime_nsec(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_ctime_nsec);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_dev(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_dev_is_broken_down)
@@ -324,13 +324,13 @@ archive_entry_dev(struct archive_entry *entry)
 		return (entry->ae_stat.aest_dev);
 }
 
-int
+__LA_DECL int
 archive_entry_dev_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_DEV);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_devmajor(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_dev_is_broken_down)
@@ -339,7 +339,7 @@ archive_entry_devmajor(struct archive_entry *entry)
 		return major(entry->ae_stat.aest_dev);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_devminor(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_dev_is_broken_down)
@@ -348,13 +348,13 @@ archive_entry_devminor(struct archive_entry *entry)
 		return minor(entry->ae_stat.aest_dev);
 }
 
-mode_t
+__LA_DECL mode_t
 archive_entry_filetype(struct archive_entry *entry)
 {
 	return (AE_IFMT & entry->acl.mode);
 }
 
-void
+__LA_DECL void
 archive_entry_fflags(struct archive_entry *entry,
     unsigned long *set, unsigned long *clear)
 {
@@ -371,7 +371,7 @@ archive_entry_fflags(struct archive_entry *entry,
  * they aren't supported on the current system.  The bitmap<->text
  * conversions are platform-specific (see below).
  */
-const char *
+__LA_DECL const char *
 archive_entry_fflags_text(struct archive_entry *entry)
 {
 	const char *f;
@@ -401,13 +401,13 @@ archive_entry_fflags_text(struct archive_entry *entry)
 	return (NULL);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_entry_gid(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_gid);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_gname(struct archive_entry *entry)
 {
 	const char *p;
@@ -418,7 +418,7 @@ archive_entry_gname(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_gname_utf8(struct archive_entry *entry)
 {
 	const char *p;
@@ -430,7 +430,7 @@ archive_entry_gname_utf8(struct archive_entry *entry)
 }
 
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_gname_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -448,7 +448,7 @@ _archive_entry_gname_l(struct archive_entry *entry,
 	return (archive_mstring_get_mbs_l(&entry->ae_gname, p, len, sc));
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_hardlink(struct archive_entry *entry)
 {
 	const char *p;
@@ -462,7 +462,7 @@ archive_entry_hardlink(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_hardlink_utf8(struct archive_entry *entry)
 {
 	const char *p;
@@ -476,7 +476,7 @@ archive_entry_hardlink_utf8(struct archive_entry *entry)
 	return (NULL);
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_hardlink_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -502,55 +502,55 @@ _archive_entry_hardlink_l(struct archive_entry *entry,
 	return (archive_mstring_get_mbs_l(&entry->ae_hardlink, p, len, sc));
 }
 
-int64_t
+__LA_DECL int64_t
 archive_entry_ino(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_ino);
 }
 
-int
+__LA_DECL int
 archive_entry_ino_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_INO);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_entry_ino64(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_ino);
 }
 
-mode_t
+__LA_DECL mode_t
 archive_entry_mode(struct archive_entry *entry)
 {
 	return (entry->acl.mode);
 }
 
-time_t
+__LA_DECL time_t
 archive_entry_mtime(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_mtime);
 }
 
-long
+__LA_DECL long
 archive_entry_mtime_nsec(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_mtime_nsec);
 }
 
-int
+__LA_DECL int
 archive_entry_mtime_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_MTIME);
 }
 
-unsigned int
+__LA_DECL unsigned int
 archive_entry_nlink(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_nlink);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_pathname(struct archive_entry *entry)
 {
 	const char *p;
@@ -562,7 +562,7 @@ archive_entry_pathname(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_pathname_utf8(struct archive_entry *entry)
 {
 	const char *p;
@@ -574,7 +574,7 @@ archive_entry_pathname_utf8(struct archive_entry *entry)
 	return (NULL);
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_pathname_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -593,13 +593,13 @@ _archive_entry_pathname_l(struct archive_entry *entry,
 	return (archive_mstring_get_mbs_l(&entry->ae_pathname, p, len, sc));
 }
 
-mode_t
+__LA_DECL mode_t
 archive_entry_perm(struct archive_entry *entry)
 {
 	return (~AE_IFMT & entry->acl.mode);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_rdev(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_rdev_is_broken_down)
@@ -609,7 +609,7 @@ archive_entry_rdev(struct archive_entry *entry)
 		return (entry->ae_stat.aest_rdev);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_rdevmajor(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_rdev_is_broken_down)
@@ -618,7 +618,7 @@ archive_entry_rdevmajor(struct archive_entry *entry)
 		return major(entry->ae_stat.aest_rdev);
 }
 
-dev_t
+__LA_DECL dev_t
 archive_entry_rdevminor(struct archive_entry *entry)
 {
 	if (entry->ae_stat.aest_rdev_is_broken_down)
@@ -627,19 +627,19 @@ archive_entry_rdevminor(struct archive_entry *entry)
 		return minor(entry->ae_stat.aest_rdev);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_entry_size(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_size);
 }
 
-int
+__LA_DECL int
 archive_entry_size_is_set(struct archive_entry *entry)
 {
 	return (entry->ae_set & AE_SET_SIZE);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_sourcepath(struct archive_entry *entry)
 {
 	const char *p;
@@ -651,7 +651,7 @@ archive_entry_sourcepath(struct archive_entry *entry)
 	return (NULL);
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_sourcepath_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -661,7 +661,7 @@ archive_entry_sourcepath_w(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_symlink(struct archive_entry *entry)
 {
 	const char *p;
@@ -675,7 +675,7 @@ archive_entry_symlink(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_symlink_utf8(struct archive_entry *entry)
 {
 	const char *p;
@@ -689,7 +689,7 @@ archive_entry_symlink_utf8(struct archive_entry *entry)
 	return (NULL);
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_symlink_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -715,13 +715,13 @@ _archive_entry_symlink_l(struct archive_entry *entry,
 	return (archive_mstring_get_mbs_l( &entry->ae_symlink, p, len, sc));
 }
 
-int64_t
+__LA_DECL int64_t
 archive_entry_uid(struct archive_entry *entry)
 {
 	return (entry->ae_stat.aest_uid);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_uname(struct archive_entry *entry)
 {
 	const char *p;
@@ -732,7 +732,7 @@ archive_entry_uname(struct archive_entry *entry)
 	return (NULL);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_uname_utf8(struct archive_entry *entry)
 {
 	const char *p;
@@ -743,7 +743,7 @@ archive_entry_uname_utf8(struct archive_entry *entry)
 	return (NULL);
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_uname_w(struct archive_entry *entry)
 {
 	const wchar_t *p;
@@ -761,19 +761,19 @@ _archive_entry_uname_l(struct archive_entry *entry,
 	return (archive_mstring_get_mbs_l(&entry->ae_uname, p, len, sc));
 }
 
-int
+__LA_DECL int
 archive_entry_is_data_encrypted(struct archive_entry *entry)
 {
 	return ((entry->encryption & AE_ENCRYPTION_DATA) == AE_ENCRYPTION_DATA);
 }
 
-int
+__LA_DECL int
 archive_entry_is_metadata_encrypted(struct archive_entry *entry)
 {
 	return ((entry->encryption & AE_ENCRYPTION_METADATA) == AE_ENCRYPTION_METADATA);
 }
 
-int
+__LA_DECL int
 archive_entry_is_encrypted(struct archive_entry *entry)
 {
 	return (entry->encryption & (AE_ENCRYPTION_DATA|AE_ENCRYPTION_METADATA));
@@ -783,7 +783,7 @@ archive_entry_is_encrypted(struct archive_entry *entry)
  * Functions to set archive_entry properties.
  */
 
-void
+__LA_DECL void
 archive_entry_set_filetype(struct archive_entry *entry, unsigned int type)
 {
 	entry->stat_valid = 0;
@@ -791,7 +791,7 @@ archive_entry_set_filetype(struct archive_entry *entry, unsigned int type)
 	entry->acl.mode |= AE_IFMT & type;
 }
 
-void
+__LA_DECL void
 archive_entry_set_fflags(struct archive_entry *entry,
     unsigned long set, unsigned long clear)
 {
@@ -800,7 +800,7 @@ archive_entry_set_fflags(struct archive_entry *entry,
 	entry->ae_fflags_clear = clear;
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_copy_fflags_text(struct archive_entry *entry,
     const char *flags)
 {
@@ -809,7 +809,7 @@ archive_entry_copy_fflags_text(struct archive_entry *entry,
 		    &entry->ae_fflags_set, &entry->ae_fflags_clear));
 }
 
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_copy_fflags_text_w(struct archive_entry *entry,
     const wchar_t *flags)
 {
@@ -818,38 +818,38 @@ archive_entry_copy_fflags_text_w(struct archive_entry *entry,
 		    &entry->ae_fflags_set, &entry->ae_fflags_clear));
 }
 
-void
+__LA_DECL void
 archive_entry_set_gid(struct archive_entry *entry, int64_t g)
 {
 	entry->stat_valid = 0;
 	entry->ae_stat.aest_gid = g;
 }
 
-void
+__LA_DECL void
 archive_entry_set_gname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_gname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_set_gname_utf8(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_utf8(&entry->ae_gname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_gname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_gname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_gname_w(struct archive_entry *entry, const wchar_t *name)
 {
 	archive_mstring_copy_wcs(&entry->ae_gname, name);
 }
 
-int
+__LA_DECL int
 archive_entry_update_gname_utf8(struct archive_entry *entry, const char *name)
 {
 	if (archive_mstring_update_utf8(entry->archive,
@@ -867,7 +867,7 @@ _archive_entry_copy_gname_l(struct archive_entry *entry,
 	return (archive_mstring_copy_mbs_len_l(&entry->ae_gname, name, len, sc));
 }
 
-void
+__LA_DECL void
 archive_entry_set_ino(struct archive_entry *entry, int64_t ino)
 {
 	entry->stat_valid = 0;
@@ -875,7 +875,7 @@ archive_entry_set_ino(struct archive_entry *entry, int64_t ino)
 	entry->ae_stat.aest_ino = ino;
 }
 
-void
+__LA_DECL void
 archive_entry_set_ino64(struct archive_entry *entry, int64_t ino)
 {
 	entry->stat_valid = 0;
@@ -883,7 +883,7 @@ archive_entry_set_ino64(struct archive_entry *entry, int64_t ino)
 	entry->ae_stat.aest_ino = ino;
 }
 
-void
+__LA_DECL void
 archive_entry_set_hardlink(struct archive_entry *entry, const char *target)
 {
 	archive_mstring_copy_mbs(&entry->ae_hardlink, target);
@@ -893,7 +893,7 @@ archive_entry_set_hardlink(struct archive_entry *entry, const char *target)
 		entry->ae_set &= ~AE_SET_HARDLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_set_hardlink_utf8(struct archive_entry *entry, const char *target)
 {
 	archive_mstring_copy_utf8(&entry->ae_hardlink, target);
@@ -903,7 +903,7 @@ archive_entry_set_hardlink_utf8(struct archive_entry *entry, const char *target)
 		entry->ae_set &= ~AE_SET_HARDLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_hardlink(struct archive_entry *entry, const char *target)
 {
 	archive_mstring_copy_mbs(&entry->ae_hardlink, target);
@@ -913,7 +913,7 @@ archive_entry_copy_hardlink(struct archive_entry *entry, const char *target)
 		entry->ae_set &= ~AE_SET_HARDLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_hardlink_w(struct archive_entry *entry, const wchar_t *target)
 {
 	archive_mstring_copy_wcs(&entry->ae_hardlink, target);
@@ -923,7 +923,7 @@ archive_entry_copy_hardlink_w(struct archive_entry *entry, const wchar_t *target
 		entry->ae_set &= ~AE_SET_HARDLINK;
 }
 
-int
+__LA_DECL int
 archive_entry_update_hardlink_utf8(struct archive_entry *entry, const char *target)
 {
 	if (target != NULL)
@@ -953,7 +953,7 @@ _archive_entry_copy_hardlink_l(struct archive_entry *entry,
 	return (r);
 }
 
-void
+__LA_DECL void
 archive_entry_set_atime(struct archive_entry *entry, time_t t, long ns)
 {
 	FIX_NS(t, ns);
@@ -963,14 +963,14 @@ archive_entry_set_atime(struct archive_entry *entry, time_t t, long ns)
 	entry->ae_stat.aest_atime_nsec = ns;
 }
 
-void
+__LA_DECL void
 archive_entry_unset_atime(struct archive_entry *entry)
 {
 	archive_entry_set_atime(entry, 0, 0);
 	entry->ae_set &= ~AE_SET_ATIME;
 }
 
-void
+__LA_DECL void
 archive_entry_set_birthtime(struct archive_entry *entry, time_t t, long ns)
 {
 	FIX_NS(t, ns);
@@ -980,14 +980,14 @@ archive_entry_set_birthtime(struct archive_entry *entry, time_t t, long ns)
 	entry->ae_stat.aest_birthtime_nsec = ns;
 }
 
-void
+__LA_DECL void
 archive_entry_unset_birthtime(struct archive_entry *entry)
 {
 	archive_entry_set_birthtime(entry, 0, 0);
 	entry->ae_set &= ~AE_SET_BIRTHTIME;
 }
 
-void
+__LA_DECL void
 archive_entry_set_ctime(struct archive_entry *entry, time_t t, long ns)
 {
 	FIX_NS(t, ns);
@@ -997,14 +997,14 @@ archive_entry_set_ctime(struct archive_entry *entry, time_t t, long ns)
 	entry->ae_stat.aest_ctime_nsec = ns;
 }
 
-void
+__LA_DECL void
 archive_entry_unset_ctime(struct archive_entry *entry)
 {
 	archive_entry_set_ctime(entry, 0, 0);
 	entry->ae_set &= ~AE_SET_CTIME;
 }
 
-void
+__LA_DECL void
 archive_entry_set_dev(struct archive_entry *entry, dev_t d)
 {
 	entry->stat_valid = 0;
@@ -1013,7 +1013,7 @@ archive_entry_set_dev(struct archive_entry *entry, dev_t d)
 	entry->ae_stat.aest_dev = d;
 }
 
-void
+__LA_DECL void
 archive_entry_set_devmajor(struct archive_entry *entry, dev_t m)
 {
 	entry->stat_valid = 0;
@@ -1022,7 +1022,7 @@ archive_entry_set_devmajor(struct archive_entry *entry, dev_t m)
 	entry->ae_stat.aest_devmajor = m;
 }
 
-void
+__LA_DECL void
 archive_entry_set_devminor(struct archive_entry *entry, dev_t m)
 {
 	entry->stat_valid = 0;
@@ -1032,7 +1032,7 @@ archive_entry_set_devminor(struct archive_entry *entry, dev_t m)
 }
 
 /* Set symlink if symlink is already set, else set hardlink. */
-void
+__LA_DECL void
 archive_entry_set_link(struct archive_entry *entry, const char *target)
 {
 	if (entry->ae_set & AE_SET_SYMLINK)
@@ -1041,7 +1041,7 @@ archive_entry_set_link(struct archive_entry *entry, const char *target)
 		archive_mstring_copy_mbs(&entry->ae_hardlink, target);
 }
 
-void
+__LA_DECL void
 archive_entry_set_link_utf8(struct archive_entry *entry, const char *target)
 {
 	if (entry->ae_set & AE_SET_SYMLINK)
@@ -1051,7 +1051,7 @@ archive_entry_set_link_utf8(struct archive_entry *entry, const char *target)
 }
 
 /* Set symlink if symlink is already set, else set hardlink. */
-void
+__LA_DECL void
 archive_entry_copy_link(struct archive_entry *entry, const char *target)
 {
 	if (entry->ae_set & AE_SET_SYMLINK)
@@ -1061,7 +1061,7 @@ archive_entry_copy_link(struct archive_entry *entry, const char *target)
 }
 
 /* Set symlink if symlink is already set, else set hardlink. */
-void
+__LA_DECL void
 archive_entry_copy_link_w(struct archive_entry *entry, const wchar_t *target)
 {
 	if (entry->ae_set & AE_SET_SYMLINK)
@@ -1070,7 +1070,7 @@ archive_entry_copy_link_w(struct archive_entry *entry, const wchar_t *target)
 		archive_mstring_copy_wcs(&entry->ae_hardlink, target);
 }
 
-int
+__LA_DECL int
 archive_entry_update_link_utf8(struct archive_entry *entry, const char *target)
 {
 	int r;
@@ -1102,14 +1102,14 @@ _archive_entry_copy_link_l(struct archive_entry *entry,
 	return (r);
 }
 
-void
+__LA_DECL void
 archive_entry_set_mode(struct archive_entry *entry, mode_t m)
 {
 	entry->stat_valid = 0;
 	entry->acl.mode = m;
 }
 
-void
+__LA_DECL void
 archive_entry_set_mtime(struct archive_entry *entry, time_t t, long ns)
 {
 	FIX_NS(t, ns);
@@ -1119,45 +1119,45 @@ archive_entry_set_mtime(struct archive_entry *entry, time_t t, long ns)
 	entry->ae_stat.aest_mtime_nsec = ns;
 }
 
-void
+__LA_DECL void
 archive_entry_unset_mtime(struct archive_entry *entry)
 {
 	archive_entry_set_mtime(entry, 0, 0);
 	entry->ae_set &= ~AE_SET_MTIME;
 }
 
-void
+__LA_DECL void
 archive_entry_set_nlink(struct archive_entry *entry, unsigned int nlink)
 {
 	entry->stat_valid = 0;
 	entry->ae_stat.aest_nlink = nlink;
 }
 
-void
+__LA_DECL void
 archive_entry_set_pathname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_pathname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_set_pathname_utf8(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_utf8(&entry->ae_pathname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_pathname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_pathname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_pathname_w(struct archive_entry *entry, const wchar_t *name)
 {
 	archive_mstring_copy_wcs(&entry->ae_pathname, name);
 }
 
-int
+__LA_DECL int
 archive_entry_update_pathname_utf8(struct archive_entry *entry, const char *name)
 {
 	if (archive_mstring_update_utf8(entry->archive,
@@ -1176,7 +1176,7 @@ _archive_entry_copy_pathname_l(struct archive_entry *entry,
 	    name, len, sc));
 }
 
-void
+__LA_DECL void
 archive_entry_set_perm(struct archive_entry *entry, mode_t p)
 {
 	entry->stat_valid = 0;
@@ -1184,7 +1184,7 @@ archive_entry_set_perm(struct archive_entry *entry, mode_t p)
 	entry->acl.mode |= ~AE_IFMT & p;
 }
 
-void
+__LA_DECL void
 archive_entry_set_rdev(struct archive_entry *entry, dev_t m)
 {
 	entry->stat_valid = 0;
@@ -1192,7 +1192,7 @@ archive_entry_set_rdev(struct archive_entry *entry, dev_t m)
 	entry->ae_stat.aest_rdev_is_broken_down = 0;
 }
 
-void
+__LA_DECL void
 archive_entry_set_rdevmajor(struct archive_entry *entry, dev_t m)
 {
 	entry->stat_valid = 0;
@@ -1200,7 +1200,7 @@ archive_entry_set_rdevmajor(struct archive_entry *entry, dev_t m)
 	entry->ae_stat.aest_rdevmajor = m;
 }
 
-void
+__LA_DECL void
 archive_entry_set_rdevminor(struct archive_entry *entry, dev_t m)
 {
 	entry->stat_valid = 0;
@@ -1208,7 +1208,7 @@ archive_entry_set_rdevminor(struct archive_entry *entry, dev_t m)
 	entry->ae_stat.aest_rdevminor = m;
 }
 
-void
+__LA_DECL void
 archive_entry_set_size(struct archive_entry *entry, int64_t s)
 {
 	entry->stat_valid = 0;
@@ -1216,26 +1216,26 @@ archive_entry_set_size(struct archive_entry *entry, int64_t s)
 	entry->ae_set |= AE_SET_SIZE;
 }
 
-void
+__LA_DECL void
 archive_entry_unset_size(struct archive_entry *entry)
 {
 	archive_entry_set_size(entry, 0);
 	entry->ae_set &= ~AE_SET_SIZE;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_sourcepath(struct archive_entry *entry, const char *path)
 {
 	archive_mstring_copy_mbs(&entry->ae_sourcepath, path);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_sourcepath_w(struct archive_entry *entry, const wchar_t *path)
 {
 	archive_mstring_copy_wcs(&entry->ae_sourcepath, path);
 }
 
-void
+__LA_DECL void
 archive_entry_set_symlink(struct archive_entry *entry, const char *linkname)
 {
 	archive_mstring_copy_mbs(&entry->ae_symlink, linkname);
@@ -1245,7 +1245,7 @@ archive_entry_set_symlink(struct archive_entry *entry, const char *linkname)
 		entry->ae_set &= ~AE_SET_SYMLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_set_symlink_utf8(struct archive_entry *entry, const char *linkname)
 {
 	archive_mstring_copy_utf8(&entry->ae_symlink, linkname);
@@ -1255,7 +1255,7 @@ archive_entry_set_symlink_utf8(struct archive_entry *entry, const char *linkname
 		entry->ae_set &= ~AE_SET_SYMLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_symlink(struct archive_entry *entry, const char *linkname)
 {
 	archive_mstring_copy_mbs(&entry->ae_symlink, linkname);
@@ -1265,7 +1265,7 @@ archive_entry_copy_symlink(struct archive_entry *entry, const char *linkname)
 		entry->ae_set &= ~AE_SET_SYMLINK;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_symlink_w(struct archive_entry *entry, const wchar_t *linkname)
 {
 	archive_mstring_copy_wcs(&entry->ae_symlink, linkname);
@@ -1275,7 +1275,7 @@ archive_entry_copy_symlink_w(struct archive_entry *entry, const wchar_t *linknam
 		entry->ae_set &= ~AE_SET_SYMLINK;
 }
 
-int
+__LA_DECL int
 archive_entry_update_symlink_utf8(struct archive_entry *entry, const char *linkname)
 {
 	if (linkname != NULL)
@@ -1305,38 +1305,38 @@ _archive_entry_copy_symlink_l(struct archive_entry *entry,
 	return (r);
 }
 
-void
+__LA_DECL void
 archive_entry_set_uid(struct archive_entry *entry, int64_t u)
 {
 	entry->stat_valid = 0;
 	entry->ae_stat.aest_uid = u;
 }
 
-void
+__LA_DECL void
 archive_entry_set_uname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_uname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_set_uname_utf8(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_utf8(&entry->ae_uname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_uname(struct archive_entry *entry, const char *name)
 {
 	archive_mstring_copy_mbs(&entry->ae_uname, name);
 }
 
-void
+__LA_DECL void
 archive_entry_copy_uname_w(struct archive_entry *entry, const wchar_t *name)
 {
 	archive_mstring_copy_wcs(&entry->ae_uname, name);
 }
 
-int
+__LA_DECL int
 archive_entry_update_uname_utf8(struct archive_entry *entry, const char *name)
 {
 	if (archive_mstring_update_utf8(entry->archive,
@@ -1347,7 +1347,7 @@ archive_entry_update_uname_utf8(struct archive_entry *entry, const char *name)
 	return (0);
 }
 
-void
+__LA_DECL void
 archive_entry_set_is_data_encrypted(struct archive_entry *entry, char is_encrypted)
 {
 	if (is_encrypted) {
@@ -1357,7 +1357,7 @@ archive_entry_set_is_data_encrypted(struct archive_entry *entry, char is_encrypt
 	}
 }
 
-void
+__LA_DECL void
 archive_entry_set_is_metadata_encrypted(struct archive_entry *entry, char is_encrypted)
 {
 	if (is_encrypted) {
@@ -1375,14 +1375,14 @@ _archive_entry_copy_uname_l(struct archive_entry *entry,
 	    name, len, sc));
 }
 
-const void *
+__LA_DECL const void *
 archive_entry_mac_metadata(struct archive_entry *entry, size_t *s)
 {
   *s = entry->mac_metadata_size;
   return entry->mac_metadata;
 }
 
-void
+__LA_DECL void
 archive_entry_copy_mac_metadata(struct archive_entry *entry,
     const void *p, size_t s)
 {
@@ -1408,13 +1408,13 @@ archive_entry_copy_mac_metadata(struct archive_entry *entry,
  * uninitiated.
  */
 
-struct archive_acl *
+__LA_DECL struct archive_acl *
 archive_entry_acl(struct archive_entry *entry)
 {
 	return &entry->acl;
 }
 
-void
+__LA_DECL void
 archive_entry_acl_clear(struct archive_entry *entry)
 {
 	archive_acl_clear(&entry->acl);
@@ -1423,7 +1423,7 @@ archive_entry_acl_clear(struct archive_entry *entry)
 /*
  * Add a single ACL entry to the internal list of ACL data.
  */
-int
+__LA_DECL int
 archive_entry_acl_add_entry(struct archive_entry *entry,
     int type, int permset, int tag, int id, const char *name)
 {
@@ -1433,7 +1433,7 @@ archive_entry_acl_add_entry(struct archive_entry *entry,
 /*
  * As above, but with a wide-character name.
  */
-int
+__LA_DECL int
 archive_entry_acl_add_entry_w(struct archive_entry *entry,
     int type, int permset, int tag, int id, const wchar_t *name)
 {
@@ -1444,7 +1444,7 @@ archive_entry_acl_add_entry_w(struct archive_entry *entry,
 /*
  * Return a count of entries matching "want_type".
  */
-int
+__LA_DECL int
 archive_entry_acl_count(struct archive_entry *entry, int want_type)
 {
 	return archive_acl_count(&entry->acl, want_type);
@@ -1455,7 +1455,7 @@ archive_entry_acl_count(struct archive_entry *entry, int want_type)
  * of entries matching "want_type", or zero if there are no
  * non-extended ACL entries of that type.
  */
-int
+__LA_DECL int
 archive_entry_acl_reset(struct archive_entry *entry, int want_type)
 {
 	return archive_acl_reset(&entry->acl, want_type);
@@ -1465,7 +1465,7 @@ archive_entry_acl_reset(struct archive_entry *entry, int want_type)
  * Return the next ACL entry in the list.  Fake entries for the
  * standard permissions and include them in the returned list.
  */
-int
+__LA_DECL int
 archive_entry_acl_next(struct archive_entry *entry, int want_type, int *type,
     int *permset, int *tag, int *id, const char **name)
 {
@@ -1481,7 +1481,7 @@ archive_entry_acl_next(struct archive_entry *entry, int want_type, int *type,
  * Generate a text version of the ACL.  The flags parameter controls
  * the style of the generated ACL.
  */
-const wchar_t *
+__LA_DECL const wchar_t *
 archive_entry_acl_text_w(struct archive_entry *entry, int flags)
 {
 	const wchar_t *r;
@@ -1491,7 +1491,7 @@ archive_entry_acl_text_w(struct archive_entry *entry, int flags)
 	return (r);
 }
 
-const char *
+__LA_DECL const char *
 archive_entry_acl_text(struct archive_entry *entry, int flags)
 {
 	const char *p;

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -94,14 +94,22 @@ typedef int64_t la_int64_t;
 #  endif
 # else
 #  ifdef __GNUC__
-#   define __LA_DECL
+#   ifdef HAVE_GCC_VISIBILITY
+#    define __LA_DECL	__attribute__((visibility("default")))
+#   else
+#    define __LA_DECL
+#   endif
 #  else
 #   define __LA_DECL	__declspec(dllimport)
 #  endif
 # endif
 #else
 /* Static libraries on all platforms and shared libraries on non-Windows. */
-# define __LA_DECL
+# if defined(__GNUC__) && defined(HAVE_GCC_VISIBILITY)
+#  define __LA_DECL	__attribute__((visibility("default")))
+# else
+#  define __LA_DECL
+# endif
 #endif
 
 #ifdef __cplusplus
@@ -635,8 +643,5 @@ __LA_DECL struct archive_entry *archive_entry_partial_links(
 #ifdef __cplusplus
 }
 #endif
-
-/* This is meaningless outside of this header. */
-#undef __LA_DECL
 
 #endif /* !ARCHIVE_ENTRY_H_INCLUDED */

--- a/libarchive/archive_entry_copy_bhfi.c
+++ b/libarchive/archive_entry_copy_bhfi.c
@@ -50,7 +50,7 @@ fileTimeToUtc(const FILETIME *filetime, time_t *t, long *ns)
 	}
 }
 
-void
+__LA_DECL void
 archive_entry_copy_bhfi(struct archive_entry *entry,
 			BY_HANDLE_FILE_INFORMATION *bhfi)
 {

--- a/libarchive/archive_entry_copy_stat.c
+++ b/libarchive/archive_entry_copy_stat.c
@@ -33,7 +33,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_entry_copy_stat.c 189466 2009-03
 #include "archive.h"
 #include "archive_entry.h"
 
-void
+__LA_DECL void
 archive_entry_copy_stat(struct archive_entry *entry, const struct stat *st)
 {
 #if HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC

--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -96,7 +96,7 @@ static struct links_entry *insert_entry(struct archive_entry_linkresolver *,
 static struct links_entry *next_entry(struct archive_entry_linkresolver *,
     int);
 
-struct archive_entry_linkresolver *
+__LA_DECL struct archive_entry_linkresolver *
 archive_entry_linkresolver_new(void)
 {
 	struct archive_entry_linkresolver *res;
@@ -118,7 +118,7 @@ archive_entry_linkresolver_new(void)
 	return (res);
 }
 
-void
+__LA_DECL void
 archive_entry_linkresolver_set_strategy(struct archive_entry_linkresolver *res,
     int fmt)
 {
@@ -156,7 +156,7 @@ archive_entry_linkresolver_set_strategy(struct archive_entry_linkresolver *res,
 	}
 }
 
-void
+__LA_DECL void
 archive_entry_linkresolver_free(struct archive_entry_linkresolver *res)
 {
 	struct links_entry *le;
@@ -170,7 +170,7 @@ archive_entry_linkresolver_free(struct archive_entry_linkresolver *res)
 	free(res);
 }
 
-void
+__LA_DECL void
 archive_entry_linkify(struct archive_entry_linkresolver *res,
     struct archive_entry **e, struct archive_entry **f)
 {
@@ -417,7 +417,7 @@ grow_hash(struct archive_entry_linkresolver *res)
 	res->number_buckets = new_size;
 }
 
-struct archive_entry *
+__LA_DECL struct archive_entry *
 archive_entry_partial_links(struct archive_entry_linkresolver *res,
     unsigned int *links)
 {

--- a/libarchive/archive_entry_sparse.c
+++ b/libarchive/archive_entry_sparse.c
@@ -36,7 +36,7 @@ __FBSDID("$FreeBSD$");
  * sparse handling
  */
 
-void
+__LA_DECL void
 archive_entry_sparse_clear(struct archive_entry *entry)
 {
 	struct ae_sparse *sp;
@@ -49,7 +49,7 @@ archive_entry_sparse_clear(struct archive_entry *entry)
 	entry->sparse_tail = NULL;
 }
 
-void
+__LA_DECL void
 archive_entry_sparse_add_entry(struct archive_entry *entry,
 	int64_t offset, int64_t length)
 {
@@ -99,7 +99,7 @@ archive_entry_sparse_add_entry(struct archive_entry *entry,
 /*
  * returns number of the sparse entries
  */
-int
+__LA_DECL int
 archive_entry_sparse_count(struct archive_entry *entry)
 {
 	struct ae_sparse *sp;
@@ -125,7 +125,7 @@ archive_entry_sparse_count(struct archive_entry *entry)
 	return (count);
 }
 
-int
+__LA_DECL int
 archive_entry_sparse_reset(struct archive_entry * entry)
 {
 	entry->sparse_p = entry->sparse_head;
@@ -133,7 +133,7 @@ archive_entry_sparse_reset(struct archive_entry * entry)
 	return archive_entry_sparse_count(entry);
 }
 
-int
+__LA_DECL int
 archive_entry_sparse_next(struct archive_entry * entry,
 	int64_t *offset, int64_t *length)
 {

--- a/libarchive/archive_entry_stat.c
+++ b/libarchive/archive_entry_stat.c
@@ -36,7 +36,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_entry_stat.c 201100 2009-12-28 0
 #include "archive_entry.h"
 #include "archive_entry_private.h"
 
-const struct stat *
+__LA_DECL const struct stat *
 archive_entry_stat(struct archive_entry *entry)
 {
 	struct stat *st;

--- a/libarchive/archive_entry_strmode.c
+++ b/libarchive/archive_entry_strmode.c
@@ -36,7 +36,7 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_entry_strmode.c,v 1.4 2008/06/15 
 #include "archive_entry.h"
 #include "archive_entry_private.h"
 
-const char *
+__LA_DECL const char *
 archive_entry_strmode(struct archive_entry *entry)
 {
 	static const mode_t permbits[] =

--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -69,7 +69,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_entry_xattr.c 201096 2009-12-28 
  * extended attribute handling
  */
 
-void
+__LA_DECL void
 archive_entry_xattr_clear(struct archive_entry *entry)
 {
 	struct ae_xattr	*xp;
@@ -85,7 +85,7 @@ archive_entry_xattr_clear(struct archive_entry *entry)
 	entry->xattr_head = NULL;
 }
 
-void
+__LA_DECL void
 archive_entry_xattr_add_entry(struct archive_entry *entry,
 	const char *name, const void *value, size_t size)
 {
@@ -111,7 +111,7 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 /*
  * returns number of the extended attribute entries
  */
-int
+__LA_DECL int
 archive_entry_xattr_count(struct archive_entry *entry)
 {
 	struct ae_xattr *xp;
@@ -123,7 +123,7 @@ archive_entry_xattr_count(struct archive_entry *entry)
 	return count;
 }
 
-int
+__LA_DECL int
 archive_entry_xattr_reset(struct archive_entry * entry)
 {
 	entry->xattr_p = entry->xattr_head;
@@ -131,7 +131,7 @@ archive_entry_xattr_reset(struct archive_entry * entry)
 	return archive_entry_xattr_count(entry);
 }
 
-int
+__LA_DECL int
 archive_entry_xattr_next(struct archive_entry * entry,
 	const char **name, const void **value, size_t *size)
 {

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -213,7 +213,7 @@ error_nomem(struct archive_match *a)
 /*
  * Create an ARCHIVE_MATCH object.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_match_new(void)
 {
 	struct archive_match *a;
@@ -236,7 +236,7 @@ archive_match_new(void)
 /*
  * Free an ARCHIVE_MATCH object.
  */
-int
+__LA_DECL int
 archive_match_free(struct archive *_a)
 {
 	struct archive_match *a;
@@ -264,7 +264,7 @@ archive_match_free(struct archive *_a)
  * Returns 0 if archive entry is not excluded.
  * Returns <0 if something error happened.
  */
-int
+__LA_DECL int
 archive_match_excluded(struct archive *_a, struct archive_entry *entry)
 {
 	struct archive_match *a;
@@ -305,7 +305,7 @@ archive_match_excluded(struct archive *_a, struct archive_entry *entry)
  * Utility functions to manage exclusion/inclusion patterns
  */
 
-int
+__LA_DECL int
 archive_match_exclude_pattern(struct archive *_a, const char *pattern)
 {
 	struct archive_match *a;
@@ -324,7 +324,7 @@ archive_match_exclude_pattern(struct archive *_a, const char *pattern)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_match_exclude_pattern_w(struct archive *_a, const wchar_t *pattern)
 {
 	struct archive_match *a;
@@ -343,7 +343,7 @@ archive_match_exclude_pattern_w(struct archive *_a, const wchar_t *pattern)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_match_exclude_pattern_from_file(struct archive *_a,
     const char *pathname, int nullSeparator)
 {
@@ -357,7 +357,7 @@ archive_match_exclude_pattern_from_file(struct archive *_a,
 		nullSeparator);
 }
 
-int
+__LA_DECL int
 archive_match_exclude_pattern_from_file_w(struct archive *_a,
     const wchar_t *pathname, int nullSeparator)
 {
@@ -371,7 +371,7 @@ archive_match_exclude_pattern_from_file_w(struct archive *_a,
 		nullSeparator);
 }
 
-int
+__LA_DECL int
 archive_match_include_pattern(struct archive *_a, const char *pattern)
 {
 	struct archive_match *a;
@@ -390,7 +390,7 @@ archive_match_include_pattern(struct archive *_a, const char *pattern)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_match_include_pattern_w(struct archive *_a, const wchar_t *pattern)
 {
 	struct archive_match *a;
@@ -409,7 +409,7 @@ archive_match_include_pattern_w(struct archive *_a, const wchar_t *pattern)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_match_include_pattern_from_file(struct archive *_a,
     const char *pathname, int nullSeparator)
 {
@@ -423,7 +423,7 @@ archive_match_include_pattern_from_file(struct archive *_a,
 		nullSeparator);
 }
 
-int
+__LA_DECL int
 archive_match_include_pattern_from_file_w(struct archive *_a,
     const wchar_t *pathname, int nullSeparator)
 {
@@ -444,7 +444,7 @@ archive_match_include_pattern_from_file_w(struct archive *_a,
  * Returns 0 if archive entry is not excluded.
  * Returns <0 if something error happened.
  */
-int
+__LA_DECL int
 archive_match_path_excluded(struct archive *_a,
     struct archive_entry *entry)
 {
@@ -473,7 +473,7 @@ archive_match_path_excluded(struct archive *_a,
 /*
  * Utilty functions to get statistic information for inclusion patterns.
  */
-int
+__LA_DECL int
 archive_match_path_unmatched_inclusions(struct archive *_a)
 {
 	struct archive_match *a;
@@ -485,7 +485,7 @@ archive_match_path_unmatched_inclusions(struct archive *_a)
 	return (a->inclusions.unmatched_count);
 }
 
-int
+__LA_DECL int
 archive_match_path_unmatched_inclusions_next(struct archive *_a,
     const char **_p)
 {
@@ -502,7 +502,7 @@ archive_match_path_unmatched_inclusions_next(struct archive *_a,
 	return (r);
 }
 
-int
+__LA_DECL int
 archive_match_path_unmatched_inclusions_next_w(struct archive *_a,
     const wchar_t **_p)
 {
@@ -885,7 +885,7 @@ match_list_unmatched_inclusions_next(struct archive_match *a,
 /*
  * Utility functions to manage inclusion timestamps.
  */
-int
+__LA_DECL int
 archive_match_include_time(struct archive *_a, int flag, time_t sec,
     long nsec)
 {
@@ -898,7 +898,7 @@ archive_match_include_time(struct archive *_a, int flag, time_t sec,
 			sec, nsec, sec, nsec);
 }
 
-int
+__LA_DECL int
 archive_match_include_date(struct archive *_a, int flag,
     const char *datestr)
 {
@@ -910,7 +910,7 @@ archive_match_include_date(struct archive *_a, int flag,
 	return set_timefilter_date((struct archive_match *)_a, flag, datestr);
 }
 
-int
+__LA_DECL int
 archive_match_include_date_w(struct archive *_a, int flag,
     const wchar_t *datestr)
 {
@@ -923,7 +923,7 @@ archive_match_include_date_w(struct archive *_a, int flag,
 	return set_timefilter_date_w((struct archive_match *)_a, flag, datestr);
 }
 
-int
+__LA_DECL int
 archive_match_include_file_time(struct archive *_a, int flag,
     const char *pathname)
 {
@@ -936,7 +936,7 @@ archive_match_include_file_time(struct archive *_a, int flag,
 			flag, pathname);
 }
 
-int
+__LA_DECL int
 archive_match_include_file_time_w(struct archive *_a, int flag,
     const wchar_t *pathname)
 {
@@ -949,7 +949,7 @@ archive_match_include_file_time_w(struct archive *_a, int flag,
 			flag, pathname);
 }
 
-int
+__LA_DECL int
 archive_match_exclude_entry(struct archive *_a, int flag,
     struct archive_entry *entry)
 {
@@ -977,7 +977,7 @@ archive_match_exclude_entry(struct archive *_a, int flag,
  * Returns 0 if archive entry is not excluded.
  * Returns <0 if something error happened.
  */
-int
+__LA_DECL int
 archive_match_time_excluded(struct archive *_a,
     struct archive_entry *entry)
 {
@@ -1581,7 +1581,7 @@ time_excluded(struct archive_match *a, struct archive_entry *entry)
  * Utility functions to manage inclusion owners
  */
 
-int
+__LA_DECL int
 archive_match_include_uid(struct archive *_a, int64_t uid)
 {
 	struct archive_match *a;
@@ -1592,7 +1592,7 @@ archive_match_include_uid(struct archive *_a, int64_t uid)
 	return (add_owner_id(a, &(a->inclusion_uids), uid));
 }
 
-int
+__LA_DECL int
 archive_match_include_gid(struct archive *_a, int64_t gid)
 {
 	struct archive_match *a;
@@ -1603,7 +1603,7 @@ archive_match_include_gid(struct archive *_a, int64_t gid)
 	return (add_owner_id(a, &(a->inclusion_gids), gid));
 }
 
-int
+__LA_DECL int
 archive_match_include_uname(struct archive *_a, const char *uname)
 {
 	struct archive_match *a;
@@ -1614,7 +1614,7 @@ archive_match_include_uname(struct archive *_a, const char *uname)
 	return (add_owner_name(a, &(a->inclusion_unames), 1, uname));
 }
 
-int
+__LA_DECL int
 archive_match_include_uname_w(struct archive *_a, const wchar_t *uname)
 {
 	struct archive_match *a;
@@ -1625,7 +1625,7 @@ archive_match_include_uname_w(struct archive *_a, const wchar_t *uname)
 	return (add_owner_name(a, &(a->inclusion_unames), 0, uname));
 }
 
-int
+__LA_DECL int
 archive_match_include_gname(struct archive *_a, const char *gname)
 {
 	struct archive_match *a;
@@ -1636,7 +1636,7 @@ archive_match_include_gname(struct archive *_a, const char *gname)
 	return (add_owner_name(a, &(a->inclusion_gnames), 1, gname));
 }
 
-int
+__LA_DECL int
 archive_match_include_gname_w(struct archive *_a, const wchar_t *gname)
 {
 	struct archive_match *a;
@@ -1654,7 +1654,7 @@ archive_match_include_gname_w(struct archive *_a, const wchar_t *gname)
  * Returns 0 if archive entry is not excluded.
  * Returns <0 if something error happened.
  */
-int
+__LA_DECL int
 archive_match_owner_excluded(struct archive *_a,
     struct archive_entry *entry)
 {

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -96,7 +96,7 @@ archive_read_vtable(void)
 /*
  * Allocate, initialize and return a struct archive object.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_read_new(void)
 {
 	struct archive_read *a;
@@ -118,7 +118,7 @@ archive_read_new(void)
 /*
  * Record the do-not-extract-to file. This belongs in archive_read_extract.c.
  */
-void
+__LA_DECL void
 archive_read_extract_set_skip_file(struct archive *_a, int64_t d, int64_t i)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -134,7 +134,7 @@ archive_read_extract_set_skip_file(struct archive *_a, int64_t d, int64_t i)
 /*
  * Open the archive
  */
-int
+__LA_DECL int
 archive_read_open(struct archive *a, void *client_data,
     archive_open_callback *client_opener, archive_read_callback *client_reader,
     archive_close_callback *client_closer)
@@ -149,7 +149,7 @@ archive_read_open(struct archive *a, void *client_data,
 }
 
 
-int
+__LA_DECL int
 archive_read_open2(struct archive *a, void *client_data,
     archive_open_callback *client_opener,
     archive_read_callback *client_reader,
@@ -303,7 +303,7 @@ client_switch_proxy(struct archive_read_filter *self, unsigned int iindex)
 	return (r1 < r2) ? r1 : r2;
 }
 
-int
+__LA_DECL int
 archive_read_set_open_callback(struct archive *_a,
     archive_open_callback *client_opener)
 {
@@ -314,7 +314,7 @@ archive_read_set_open_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_read_callback(struct archive *_a,
     archive_read_callback *client_reader)
 {
@@ -325,7 +325,7 @@ archive_read_set_read_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_skip_callback(struct archive *_a,
     archive_skip_callback *client_skipper)
 {
@@ -336,7 +336,7 @@ archive_read_set_skip_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_seek_callback(struct archive *_a,
     archive_seek_callback *client_seeker)
 {
@@ -347,7 +347,7 @@ archive_read_set_seek_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_close_callback(struct archive *_a,
     archive_close_callback *client_closer)
 {
@@ -358,7 +358,7 @@ archive_read_set_close_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_switch_callback(struct archive *_a,
     archive_switch_callback *client_switcher)
 {
@@ -369,13 +369,13 @@ archive_read_set_switch_callback(struct archive *_a,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_set_callback_data(struct archive *_a, void *client_data)
 {
 	return archive_read_set_callback_data2(_a, client_data, 0);
 }
 
-int
+__LA_DECL int
 archive_read_set_callback_data2(struct archive *_a, void *client_data,
     unsigned int iindex)
 {
@@ -408,7 +408,7 @@ archive_read_set_callback_data2(struct archive *_a, void *client_data,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_add_callback_data(struct archive *_a, void *client_data,
     unsigned int iindex)
 {
@@ -442,20 +442,20 @@ archive_read_add_callback_data(struct archive *_a, void *client_data,
 	return ARCHIVE_OK;
 }
 
-int
+__LA_DECL int
 archive_read_append_callback_data(struct archive *_a, void *client_data)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 	return archive_read_add_callback_data(_a, client_data, a->client.nodes);
 }
 
-int
+__LA_DECL int
 archive_read_prepend_callback_data(struct archive *_a, void *client_data)
 {
 	return archive_read_add_callback_data(_a, client_data, 0);
 }
 
-int
+__LA_DECL int
 archive_read_open1(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -748,7 +748,7 @@ choose_format(struct archive_read *a)
  * Return the file offset (within the uncompressed data stream) where
  * the last header started.
  */
-int64_t
+__LA_DECL int64_t
 archive_read_header_position(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -775,7 +775,7 @@ archive_read_header_position(struct archive *_a)
  * function does not return the number of encrypted entries but#
  * just shows that there are some.
  */
-int
+__LA_DECL int
 archive_read_has_encrypted_entries(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -800,7 +800,7 @@ archive_read_has_encrypted_entries(struct archive *_a)
  * Returns a bitmask of capabilities that are supported by the archive format reader.
  * If the reader has no special capabilities, ARCHIVE_READ_FORMAT_CAPS_NONE is returned.
  */
-int
+__LA_DECL int
 archive_read_format_capabilities(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -915,7 +915,7 @@ void __archive_reset_read_data(struct archive * a)
 /*
  * Skip over all remaining data in this entry.
  */
-int
+__LA_DECL int
 archive_read_data_skip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -943,7 +943,7 @@ archive_read_data_skip(struct archive *_a)
 	return (r);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_seek_data(struct archive *_a, int64_t offset, int whence)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_add_passphrase.c
+++ b/libarchive/archive_read_add_passphrase.c
@@ -80,7 +80,7 @@ new_read_passphrase(struct archive_read *a, const char *passphrase)
 	return (p);
 }
 
-int
+__LA_DECL int
 archive_read_add_passphrase(struct archive *_a, const char *passphrase)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -103,7 +103,7 @@ archive_read_add_passphrase(struct archive *_a, const char *passphrase)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_set_passphrase_callback(struct archive *_a, void *client_data,
     archive_passphrase_callback *cb)
 {

--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -34,7 +34,7 @@ __FBSDID("$FreeBSD$");
 #include "archive_private.h"
 #include "archive_read_private.h"
 
-int
+__LA_DECL int
 archive_read_append_filter(struct archive *_a, int code)
 {
   int r1, r2, number_bidders, i;
@@ -143,13 +143,13 @@ archive_read_append_filter(struct archive *_a, int code)
   return (r1 < r2) ? r1 : r2;
 }
 
-int
+__LA_DECL int
 archive_read_append_filter_program(struct archive *_a, const char *cmd)
 {
   return (archive_read_append_filter_program_signature(_a, cmd, NULL, 0));
 }
 
-int
+__LA_DECL int
 archive_read_append_filter_program_signature(struct archive *_a,
   const char *cmd, const void *signature, size_t signature_len)
 {

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -126,7 +126,7 @@ static int setup_xattrs(struct archive_read_disk *,
 static int setup_sparse(struct archive_read_disk *,
     struct archive_entry *, int *fd);
 
-int
+__LA_DECL int
 archive_read_disk_entry_from_file(struct archive *_a,
     struct archive_entry *entry,
     int fd,

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -386,7 +386,7 @@ archive_read_disk_vtable(void)
 	return (&av);
 }
 
-const char *
+__LA_DECL const char *
 archive_read_disk_gname(struct archive *_a, int64_t gid)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -398,7 +398,7 @@ archive_read_disk_gname(struct archive *_a, int64_t gid)
 	return ((*a->lookup_gname)(a->lookup_gname_data, gid));
 }
 
-const char *
+__LA_DECL const char *
 archive_read_disk_uname(struct archive *_a, int64_t uid)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -410,7 +410,7 @@ archive_read_disk_uname(struct archive *_a, int64_t uid)
 	return ((*a->lookup_uname)(a->lookup_uname_data, uid));
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_gname_lookup(struct archive *_a,
     void *private_data,
     const char * (*lookup_gname)(void *private, int64_t gid),
@@ -429,7 +429,7 @@ archive_read_disk_set_gname_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_uname_lookup(struct archive *_a,
     void *private_data,
     const char * (*lookup_uname)(void *private, int64_t uid),
@@ -451,7 +451,7 @@ archive_read_disk_set_uname_lookup(struct archive *_a,
 /*
  * Create a new archive_read_disk object and initialize it with global state.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_read_disk_new(void)
 {
 	struct archive_read_disk *a;
@@ -530,7 +530,7 @@ setup_symlink_mode(struct archive_read_disk *a, char symlink_mode,
 	}
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_logical(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -540,7 +540,7 @@ archive_read_disk_set_symlink_logical(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_physical(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -550,7 +550,7 @@ archive_read_disk_set_symlink_physical(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_hybrid(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -560,7 +560,7 @@ archive_read_disk_set_symlink_hybrid(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_atime_restored(struct archive *_a)
 {
 #ifndef HAVE_UTIMES
@@ -586,7 +586,7 @@ archive_read_disk_set_atime_restored(struct archive *_a)
 #endif
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_behavior(struct archive *_a, int flags)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1218,7 +1218,7 @@ setup_sparse(struct archive_read_disk *a, struct archive_entry *entry)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_matching(struct archive *_a, struct archive *_ma,
     void (*_excluded_func)(struct archive *, void *, struct archive_entry *),
     void *_client_data)
@@ -1232,7 +1232,7 @@ archive_read_disk_set_matching(struct archive *_a, struct archive *_ma,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_metadata_filter_callback(struct archive *_a,
     int (*_metadata_filter_func)(struct archive *, void *,
     struct archive_entry *), void *_client_data)
@@ -1247,7 +1247,7 @@ archive_read_disk_set_metadata_filter_callback(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_can_descend(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1264,7 +1264,7 @@ archive_read_disk_can_descend(struct archive *_a)
  * Called by the client to mark the directory just returned from
  * tree_next() as needing to be visited.
  */
-int
+__LA_DECL int
 archive_read_disk_descend(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1290,7 +1290,7 @@ archive_read_disk_descend(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_open(struct archive *_a, const char *pathname)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1303,7 +1303,7 @@ archive_read_disk_open(struct archive *_a, const char *pathname)
 	return (_archive_read_disk_open(_a, pathname));
 }
 
-int
+__LA_DECL int
 archive_read_disk_open_w(struct archive *_a, const wchar_t *pathname)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1359,7 +1359,7 @@ _archive_read_disk_open(struct archive *_a, const char *pathname)
  * Return a current filesystem ID which is index of the filesystem entry
  * you've visited through archive_read_disk.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1423,7 +1423,7 @@ update_current_filesystem(struct archive_read_disk *a, int64_t dev)
  * Returns 1 if current filesystem is generated filesystem, 0 if it is not
  * or -1 if it is unknown.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem_is_synthetic(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1438,7 +1438,7 @@ archive_read_disk_current_filesystem_is_synthetic(struct archive *_a)
  * Returns 1 if current filesystem is remote filesystem, 0 if it is not
  * or -1 if it is unknown.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem_is_remote(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;

--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -48,7 +48,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read_disk_set_standard_lookup.c 
 #include "archive.h"
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-int
+__LA_DECL int
 archive_read_disk_set_standard_lookup(struct archive *a)
 {
 	archive_set_error(a, -1, "Standard lookups not available on Windows");
@@ -91,7 +91,7 @@ static const char *	lookup_uname_helper(struct name_cache *, id_t uid);
  * use the uid/gid without the lookup.  Or define your own custom functions
  * if you prefer.
  */
-int
+__LA_DECL int
 archive_read_disk_set_standard_lookup(struct archive *a)
 {
 	struct name_cache *ucache = malloc(sizeof(struct name_cache));

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -319,7 +319,7 @@ archive_read_disk_vtable(void)
 	return (&av);
 }
 
-const char *
+__LA_DECL const char *
 archive_read_disk_gname(struct archive *_a, int64_t gid)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -331,7 +331,7 @@ archive_read_disk_gname(struct archive *_a, int64_t gid)
 	return ((*a->lookup_gname)(a->lookup_gname_data, gid));
 }
 
-const char *
+__LA_DECL const char *
 archive_read_disk_uname(struct archive *_a, int64_t uid)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -343,7 +343,7 @@ archive_read_disk_uname(struct archive *_a, int64_t uid)
 	return ((*a->lookup_uname)(a->lookup_uname_data, uid));
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_gname_lookup(struct archive *_a,
     void *private_data,
     const char * (*lookup_gname)(void *private, int64_t gid),
@@ -362,7 +362,7 @@ archive_read_disk_set_gname_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_uname_lookup(struct archive *_a,
     void *private_data,
     const char * (*lookup_uname)(void *private, int64_t uid),
@@ -384,7 +384,7 @@ archive_read_disk_set_uname_lookup(struct archive *_a,
 /*
  * Create a new archive_read_disk object and initialize it with global state.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_read_disk_new(void)
 {
 	struct archive_read_disk *a;
@@ -460,7 +460,7 @@ setup_symlink_mode(struct archive_read_disk *a, char symlink_mode,
 	}
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_logical(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -470,7 +470,7 @@ archive_read_disk_set_symlink_logical(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_physical(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -480,7 +480,7 @@ archive_read_disk_set_symlink_physical(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_symlink_hybrid(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -490,7 +490,7 @@ archive_read_disk_set_symlink_hybrid(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_atime_restored(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -502,7 +502,7 @@ archive_read_disk_set_atime_restored(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_behavior(struct archive *_a, int flags)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1094,7 +1094,7 @@ setup_sparse(struct archive_read_disk *a, struct archive_entry *entry)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_matching(struct archive *_a, struct archive *_ma,
     void (*_excluded_func)(struct archive *, void *, struct archive_entry *),
     void *_client_data)
@@ -1108,7 +1108,7 @@ archive_read_disk_set_matching(struct archive *_a, struct archive *_ma,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_set_metadata_filter_callback(struct archive *_a,
     int (*_metadata_filter_func)(struct archive *, void *,
     struct archive_entry *), void *_client_data)
@@ -1123,7 +1123,7 @@ archive_read_disk_set_metadata_filter_callback(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_can_descend(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1140,7 +1140,7 @@ archive_read_disk_can_descend(struct archive *_a)
  * Called by the client to mark the directory just returned from
  * tree_next() as needing to be visited.
  */
-int
+__LA_DECL int
 archive_read_disk_descend(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1170,7 +1170,7 @@ archive_read_disk_descend(struct archive *_a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_disk_open(struct archive *_a, const char *pathname)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1201,7 +1201,7 @@ archive_read_disk_open(struct archive *_a, const char *pathname)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_read_disk_open_w(struct archive *_a, const wchar_t *pathname)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1238,7 +1238,7 @@ _archive_read_disk_open_w(struct archive *_a, const wchar_t *pathname)
  * Return a current filesystem ID which is index of the filesystem entry
  * you've visited through archive_read_disk.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1298,7 +1298,7 @@ update_current_filesystem(struct archive_read_disk *a, int64_t dev)
  * Returns 1 if current filesystem is generated filesystem, 0 if it is not
  * or -1 if it is unknown.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem_is_synthetic(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -1313,7 +1313,7 @@ archive_read_disk_current_filesystem_is_synthetic(struct archive *_a)
  * Returns 1 if current filesystem is remote filesystem, 0 if it is not
  * or -1 if it is unknown.
  */
-int
+__LA_DECL int
 archive_read_disk_current_filesystem_is_remote(struct archive *_a)
 {
 	struct archive_read_disk *a = (struct archive_read_disk *)_a;
@@ -2067,7 +2067,7 @@ tree_free(struct tree *t)
 /*
  * Populate the archive_entry with metadata from the disk.
  */
-int
+__LA_DECL int
 archive_read_disk_entry_from_file(struct archive *_a,
     struct archive_entry *entry, int fd, const struct stat *st)
 {

--- a/libarchive/archive_read_extract.c
+++ b/libarchive/archive_read_extract.c
@@ -35,7 +35,7 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include "archive_private.h"
 #include "archive_read_private.h"
 
-int
+__LA_DECL int
 archive_read_extract(struct archive *_a, struct archive_entry *entry, int flags)
 {
 	struct archive_read_extract *extract;

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -79,7 +79,7 @@ archive_read_extract_cleanup(struct archive_read *a)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_read_extract2(struct archive *_a, struct archive_entry *entry,
     struct archive *ad)
 {
@@ -111,7 +111,7 @@ archive_read_extract2(struct archive *_a, struct archive_entry *entry,
 	return (r);
 }
 
-void
+__LA_DECL void
 archive_read_extract_set_progress_callback(struct archive *_a,
     void (*progress_func)(void *), void *user_data)
 {

--- a/libarchive/archive_read_open_fd.c
+++ b/libarchive/archive_read_open_fd.c
@@ -62,7 +62,7 @@ static ssize_t	file_read(struct archive *, void *, const void **buff);
 static int64_t	file_seek(struct archive *, void *, int64_t request, int);
 static int64_t	file_skip(struct archive *, void *, int64_t request);
 
-int
+__LA_DECL int
 archive_read_open_fd(struct archive *a, int fd, size_t block_size)
 {
 	struct stat st;

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -61,7 +61,7 @@ static int	file_close(struct archive *, void *);
 static ssize_t	file_read(struct archive *, void *, const void **buff);
 static int64_t	file_skip(struct archive *, void *, int64_t request);
 
-int
+__LA_DECL int
 archive_read_open_FILE(struct archive *a, FILE *f)
 {
 	struct stat st;

--- a/libarchive/archive_read_open_filename.c
+++ b/libarchive/archive_read_open_filename.c
@@ -92,14 +92,14 @@ static int64_t	file_seek(struct archive *, void *, int64_t request, int);
 static int64_t	file_skip(struct archive *, void *, int64_t request);
 static int64_t	file_skip_lseek(struct archive *, void *, int64_t request);
 
-int
+__LA_DECL int
 archive_read_open_file(struct archive *a, const char *filename,
     size_t block_size)
 {
 	return (archive_read_open_filename(a, filename, block_size));
 }
 
-int
+__LA_DECL int
 archive_read_open_filename(struct archive *a, const char *filename,
     size_t block_size)
 {
@@ -109,7 +109,7 @@ archive_read_open_filename(struct archive *a, const char *filename,
 	return archive_read_open_filenames(a, filenames, block_size);
 }
 
-int
+__LA_DECL int
 archive_read_open_filenames(struct archive *a, const char **filenames,
     size_t block_size)
 {
@@ -155,7 +155,7 @@ no_memory:
 	return (ARCHIVE_FATAL);
 }
 
-int
+__LA_DECL int
 archive_read_open_filename_w(struct archive *a, const wchar_t *wfilename,
     size_t block_size)
 {

--- a/libarchive/archive_read_open_memory.c
+++ b/libarchive/archive_read_open_memory.c
@@ -53,7 +53,7 @@ static int64_t	memory_read_seek(struct archive *, void *, int64_t offset, int wh
 static int64_t	memory_read_skip(struct archive *, void *, int64_t request);
 static ssize_t	memory_read(struct archive *, void *, const void **buff);
 
-int
+__LA_DECL int
 archive_read_open_memory(struct archive *a, const void *buff, size_t size)
 {
 	return archive_read_open_memory2(a, buff, size, size);
@@ -64,7 +64,7 @@ archive_read_open_memory(struct archive *a, const void *buff, size_t size)
  * version is the one you really want.  This is just here so that
  * test harnesses can exercise block operations inside the library.
  */
-int
+__LA_DECL int
 archive_read_open_memory2(struct archive *a, const void *buff,
     size_t size, size_t read_size)
 {

--- a/libarchive/archive_read_set_format.c
+++ b/libarchive/archive_read_set_format.c
@@ -34,7 +34,7 @@ __FBSDID("$FreeBSD$");
 #include "archive_private.h"
 #include "archive_read_private.h"
 
-int
+__LA_DECL int
 archive_read_set_format(struct archive *_a, int code)
 {
   int r1, r2, slots, i;

--- a/libarchive/archive_read_set_options.c
+++ b/libarchive/archive_read_set_options.c
@@ -36,7 +36,7 @@ static int	archive_set_filter_option(struct archive *a,
 static int	archive_set_option(struct archive *a,
 		    const char *m, const char *o, const char *v);
 
-int
+__LA_DECL int
 archive_read_set_format_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -45,7 +45,7 @@ archive_read_set_format_option(struct archive *a, const char *m, const char *o,
 	    archive_set_format_option);
 }
 
-int
+__LA_DECL int
 archive_read_set_filter_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -54,7 +54,7 @@ archive_read_set_filter_option(struct archive *a, const char *m, const char *o,
 	    archive_set_filter_option);
 }
 
-int
+__LA_DECL int
 archive_read_set_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -63,7 +63,7 @@ archive_read_set_option(struct archive *a, const char *m, const char *o,
 	    archive_set_option);
 }
 
-int
+__LA_DECL int
 archive_read_set_options(struct archive *a, const char *options)
 {
 	return _archive_set_options(a, options,

--- a/libarchive/archive_read_support_filter_all.c
+++ b/libarchive/archive_read_support_filter_all.c
@@ -31,14 +31,14 @@ __FBSDID("$FreeBSD$");
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_all(struct archive *a)
 {
 	return archive_read_support_filter_all(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_all(struct archive *a)
 {
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -74,14 +74,14 @@ static int	bzip2_reader_free(struct archive_read_filter_bidder *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_bzip2(struct archive *a)
 {
 	return archive_read_support_filter_bzip2(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_bzip2(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -143,14 +143,14 @@ static int	next_code(struct archive_read_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_compress(struct archive *a)
 {
 	return archive_read_support_filter_compress(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_compress(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -61,7 +61,7 @@ grzip_reader_free(struct archive_read_filter_bidder *self)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_support_filter_grzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -80,14 +80,14 @@ static int	gzip_bidder_init(struct archive_read_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_gzip(struct archive *a)
 {
 	return archive_read_support_filter_gzip(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_gzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -60,7 +60,7 @@ lrzip_reader_free(struct archive_read_filter_bidder *self)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_support_filter_lrzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -107,7 +107,7 @@ static ssize_t  lz4_filter_read_legacy_stream(struct archive_read_filter *,
 		    const void **);
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_lz4(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -101,7 +101,7 @@ static int lzop_bidder_bid(struct archive_read_filter_bidder *,
     struct archive_read_filter *);
 static int lzop_bidder_init(struct archive_read_filter *);
 
-int
+__LA_DECL int
 archive_read_support_filter_lzop(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_none.c
+++ b/libarchive/archive_read_support_filter_none.c
@@ -31,7 +31,7 @@ __FBSDID("$FreeBSD$");
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_none(struct archive *a)
 {
 	return archive_read_support_filter_none(a);
@@ -42,7 +42,7 @@ archive_read_support_compression_none(struct archive *a)
  * Uncompressed streams are handled implicitly by the read core,
  * so this is now a no-op.
  */
-int
+__LA_DECL int
 archive_read_support_filter_none(struct archive *a)
 {
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -61,13 +61,13 @@ __FBSDID("$FreeBSD$");
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_program(struct archive *a, const char *cmd)
 {
 	return archive_read_support_filter_program(a, cmd);
 }
 
-int
+__LA_DECL int
 archive_read_support_compression_program_signature(struct archive *a,
     const char *cmd, const void *signature, size_t signature_len)
 {
@@ -76,7 +76,7 @@ archive_read_support_compression_program_signature(struct archive *a,
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_program(struct archive *a, const char *cmd)
 {
 	return (archive_read_support_filter_program_signature(a, cmd, NULL, 0));
@@ -145,7 +145,7 @@ set_bidder_signature(struct archive_read_filter_bidder *bidder,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_support_filter_program_signature(struct archive *_a,
     const char *cmd, const void *signature, size_t signature_len)
 {

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -65,14 +65,14 @@ static int	rpm_filter_close(struct archive_read_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_rpm(struct archive *a)
 {
 	return archive_read_support_filter_rpm(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_rpm(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -69,14 +69,14 @@ static int	uudecode_filter_close(struct archive_read_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_uu(struct archive *a)
 {
 	return archive_read_support_filter_uu(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_uu(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -116,14 +116,14 @@ static int	lzip_bidder_init(struct archive_read_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
-int
+__LA_DECL int
 archive_read_support_compression_xz(struct archive *a)
 {
 	return archive_read_support_filter_xz(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_xz(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -151,14 +151,14 @@ archive_read_support_filter_xz(struct archive *_a)
 }
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_read_support_compression_lzma(struct archive *a)
 {
 	return archive_read_support_filter_lzma(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_lzma(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -189,14 +189,14 @@ archive_read_support_filter_lzma(struct archive *_a)
 
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_read_support_compression_lzip(struct archive *a)
 {
 	return archive_read_support_filter_lzip(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_support_filter_lzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -399,7 +399,7 @@ static size_t	x86_Convert(struct _7zip *, uint8_t *, size_t);
 static ssize_t		Bcj2_Decode(struct _7zip *, uint8_t *, size_t);
 
 
-int
+__LA_DECL int
 archive_read_support_format_7zip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_all.c
+++ b/libarchive/archive_read_support_format_all.c
@@ -29,7 +29,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read_support_format_all.c 174991
 #include "archive.h"
 #include "archive_private.h"
 
-int
+__LA_DECL int
 archive_read_support_format_all(struct archive *a)
 {
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -94,7 +94,7 @@ static int	ar_parse_gnu_filename_table(struct archive_read *a);
 static int	ar_parse_common_header(struct ar *ar, struct archive_entry *,
 		    const char *h);
 
-int
+__LA_DECL int
 archive_read_support_format_ar(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_by_code.c
+++ b/libarchive/archive_read_support_format_by_code.c
@@ -29,7 +29,7 @@ __FBSDID("$FreeBSD$");
 #include "archive.h"
 #include "archive_private.h"
 
-int
+__LA_DECL int
 archive_read_support_format_by_code(struct archive *a, int format_code)
 {
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -355,7 +355,7 @@ static inline int lzx_decode_huffman(struct huffman *, unsigned);
 static int	lzx_decode_huffman_tree(struct huffman *, unsigned, int);
 
 
-int
+__LA_DECL int
 archive_read_support_format_cab(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -217,7 +217,7 @@ static int64_t	le4(const unsigned char *);
 static int	record_hardlink(struct archive_read *a,
 		    struct cpio *cpio, struct archive_entry *entry);
 
-int
+__LA_DECL int
 archive_read_support_format_cpio(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_empty.c
+++ b/libarchive/archive_read_support_format_empty.c
@@ -36,7 +36,7 @@ static int	archive_read_format_empty_read_data(struct archive_read *,
 		    const void **, size_t *, int64_t *);
 static int	archive_read_format_empty_read_header(struct archive_read *,
 		    struct archive_entry *);
-int
+__LA_DECL int
 archive_read_support_format_empty(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -443,7 +443,7 @@ static struct file_info *heap_get_entry(struct heap_queue *heap);
 #define next_entry(iso9660)		\
 	heap_get_entry(&((iso9660)->pending_files))
 
-int
+__LA_DECL int
 archive_read_support_format_iso9660(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -253,7 +253,7 @@ static inline int lzh_decode_huffman(struct huffman *, unsigned);
 static int	lzh_decode_huffman_tree(struct huffman *, unsigned, int);
 
 
-int
+__LA_DECL int
 archive_read_support_format_lha(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -213,7 +213,7 @@ free_options(struct mtree_option *head)
 	}
 }
 
-int
+__LA_DECL int
 archive_read_support_format_mtree(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -637,7 +637,7 @@ ppmd_read(void *p)
   return b;
 }
 
-int
+__LA_DECL int
 archive_read_support_format_rar(struct archive *_a)
 {
   struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -52,7 +52,7 @@ static int	archive_read_format_raw_read_data_skip(struct archive_read *);
 static int	archive_read_format_raw_read_header(struct archive_read *,
 		    struct archive_entry *);
 
-int
+__LA_DECL int
 archive_read_support_format_raw(struct archive *_a)
 {
 	struct raw_info *info;

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -223,7 +223,7 @@ static char	*url_decode(const char *);
 static void	tar_flush_unconsumed(struct archive_read *, size_t *);
 
 
-int
+__LA_DECL int
 archive_read_support_format_gnutar(struct archive *a)
 {
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,
@@ -232,7 +232,7 @@ archive_read_support_format_gnutar(struct archive *a)
 }
 
 
-int
+__LA_DECL int
 archive_read_support_format_tar(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -136,7 +136,7 @@ static time_t _warc_rdmtm(const char *buf, size_t bsz);
 static const char *_warc_find_eoh(const char *buf, size_t bsz);
 
 
-int
+__LA_DECL int
 archive_read_support_format_warc(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -442,7 +442,7 @@ static void	expat_data_cb(void *, const XML_Char *, int);
 static int	expat_read_toc(struct archive_read *);
 #endif
 
-int
+__LA_DECL int
 archive_read_support_format_xar(struct archive *_a)
 {
 	struct xar *xar;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -2011,7 +2011,7 @@ archive_read_format_zip_options(struct archive_read *a,
 	return (ARCHIVE_WARN);
 }
 
-int
+__LA_DECL int
 archive_read_support_format_zip(struct archive *a)
 {
 	int r;
@@ -2258,7 +2258,7 @@ archive_read_format_zip_read_data_skip_streamable(struct archive_read *a)
 	}
 }
 
-int
+__LA_DECL int
 archive_read_support_format_zip_streamable(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
@@ -3014,7 +3014,7 @@ archive_read_format_zip_read_data_skip_seekable(struct archive_read *a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_read_support_format_zip_seekable(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -77,19 +77,19 @@ __archive_clean(struct archive *a)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_version_number(void)
 {
 	return (ARCHIVE_VERSION_NUMBER);
 }
 
-const char *
+__LA_DECL const char *
 archive_version_string(void)
 {
 	return (ARCHIVE_VERSION_STRING);
 }
 
-const char *
+__LA_DECL const char *
 archive_version_details(void)
 {
 	static struct archive_string str;
@@ -127,7 +127,7 @@ archive_version_details(void)
 	return str.s;
 }
 
-const char *
+__LA_DECL const char *
 archive_zlib_version(void)
 {
 #ifdef HAVE_ZLIB_H
@@ -137,7 +137,7 @@ archive_zlib_version(void)
 #endif
 }
 
-const char *
+__LA_DECL const char *
 archive_liblzma_version(void)
 {
 #ifdef HAVE_LZMA_H
@@ -147,7 +147,7 @@ archive_liblzma_version(void)
 #endif
 }
 
-const char *
+__LA_DECL const char *
 archive_bzlib_version(void)
 {
 #ifdef HAVE_BZLIB_H
@@ -157,7 +157,7 @@ archive_bzlib_version(void)
 #endif
 }
 
-const char *
+__LA_DECL const char *
 archive_liblz4_version(void)
 {
 #if defined(HAVE_LZ4_H) && defined(HAVE_LIBLZ4)
@@ -171,13 +171,13 @@ archive_liblz4_version(void)
 #endif
 }
 
-int
+__LA_DECL int
 archive_errno(struct archive *a)
 {
 	return (a->archive_error_number);
 }
 
-const char *
+__LA_DECL const char *
 archive_error_string(struct archive *a)
 {
 
@@ -187,32 +187,32 @@ archive_error_string(struct archive *a)
 		return (NULL);
 }
 
-int
+__LA_DECL int
 archive_file_count(struct archive *a)
 {
 	return (a->file_count);
 }
 
-int
+__LA_DECL int
 archive_format(struct archive *a)
 {
 	return (a->archive_format);
 }
 
-const char *
+__LA_DECL const char *
 archive_format_name(struct archive *a)
 {
 	return (a->archive_format_name);
 }
 
 
-int
+__LA_DECL int
 archive_compression(struct archive *a)
 {
 	return archive_filter_code(a, 0);
 }
 
-const char *
+__LA_DECL const char *
 archive_compression_name(struct archive *a)
 {
 	return archive_filter_name(a, 0);
@@ -222,7 +222,7 @@ archive_compression_name(struct archive *a)
 /*
  * Return a count of the number of compressed bytes processed.
  */
-int64_t
+__LA_DECL int64_t
 archive_position_compressed(struct archive *a)
 {
 	return archive_filter_bytes(a, -1);
@@ -231,13 +231,13 @@ archive_position_compressed(struct archive *a)
 /*
  * Return a count of the number of uncompressed bytes processed.
  */
-int64_t
+__LA_DECL int64_t
 archive_position_uncompressed(struct archive *a)
 {
 	return archive_filter_bytes(a, 0);
 }
 
-void
+__LA_DECL void
 archive_clear_error(struct archive *a)
 {
 	archive_string_empty(&a->error_string);
@@ -245,7 +245,7 @@ archive_clear_error(struct archive *a)
 	a->archive_error_number = 0;
 }
 
-void
+__LA_DECL void
 archive_set_error(struct archive *a, int error_number, const char *fmt, ...)
 {
 	va_list ap;
@@ -263,7 +263,7 @@ archive_set_error(struct archive *a, int error_number, const char *fmt, ...)
 	a->error = a->error_string.s;
 }
 
-void
+__LA_DECL void
 archive_copy_error(struct archive *dest, struct archive *src)
 {
 	dest->archive_error_number = src->archive_error_number;
@@ -657,7 +657,7 @@ archive_utility_string_sort_helper(char **strings, unsigned int n)
 	return (retval1 < retval2) ? retval1 : retval2;
 }
 
-int
+__LA_DECL int
 archive_utility_string_sort(char **strings)
 {
 	  unsigned int size = 0;

--- a/libarchive/archive_virtual.c
+++ b/libarchive/archive_virtual.c
@@ -30,31 +30,31 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_virtual.c 201098 2009-12-28 02:5
 #include "archive_entry.h"
 #include "archive_private.h"
 
-int
+__LA_DECL int
 archive_filter_code(struct archive *a, int n)
 {
 	return ((a->vtable->archive_filter_code)(a, n));
 }
 
-int
+__LA_DECL int
 archive_filter_count(struct archive *a)
 {
 	return ((a->vtable->archive_filter_count)(a));
 }
 
-const char *
+__LA_DECL const char *
 archive_filter_name(struct archive *a, int n)
 {
 	return ((a->vtable->archive_filter_name)(a, n));
 }
 
-int64_t
+__LA_DECL int64_t
 archive_filter_bytes(struct archive *a, int n)
 {
 	return ((a->vtable->archive_filter_bytes)(a, n));
 }
 
-int
+__LA_DECL int
 archive_free(struct archive *a)
 {
 	if (a == NULL)
@@ -62,26 +62,26 @@ archive_free(struct archive *a)
 	return ((a->vtable->archive_free)(a));
 }
 
-int
+__LA_DECL int
 archive_write_close(struct archive *a)
 {
 	return ((a->vtable->archive_close)(a));
 }
 
-int
+__LA_DECL int
 archive_read_close(struct archive *a)
 {
 	return ((a->vtable->archive_close)(a));
 }
 
-int
+__LA_DECL int
 archive_write_fail(struct archive *a)
 {
 	a->state = ARCHIVE_STATE_FATAL;
 	return a->state;
 }
 
-int
+__LA_DECL int
 archive_write_free(struct archive *a)
 {
 	return archive_free(a);
@@ -89,14 +89,14 @@ archive_write_free(struct archive *a)
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* For backwards compatibility; will be removed with libarchive 4.0. */
-int
+__LA_DECL int
 archive_write_finish(struct archive *a)
 {
 	return archive_write_free(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_read_free(struct archive *a)
 {
 	return archive_free(a);
@@ -104,33 +104,33 @@ archive_read_free(struct archive *a)
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* For backwards compatibility; will be removed with libarchive 4.0. */
-int
+__LA_DECL int
 archive_read_finish(struct archive *a)
 {
 	return archive_read_free(a);
 }
 #endif
 
-int
+__LA_DECL int
 archive_write_header(struct archive *a, struct archive_entry *entry)
 {
 	++a->file_count;
 	return ((a->vtable->archive_write_header)(a, entry));
 }
 
-int
+__LA_DECL int
 archive_write_finish_entry(struct archive *a)
 {
 	return ((a->vtable->archive_write_finish_entry)(a));
 }
 
-ssize_t
+__LA_DECL ssize_t
 archive_write_data(struct archive *a, const void *buff, size_t s)
 {
 	return ((a->vtable->archive_write_data)(a, buff, s));
 }
 
-ssize_t
+__LA_DECL ssize_t
 archive_write_data_block(struct archive *a, const void *buff, size_t s, int64_t o)
 {
 	if (a->vtable->archive_write_data_block == NULL) {
@@ -142,19 +142,19 @@ archive_write_data_block(struct archive *a, const void *buff, size_t s, int64_t 
 	return ((a->vtable->archive_write_data_block)(a, buff, s, o));
 }
 
-int
+__LA_DECL int
 archive_read_next_header(struct archive *a, struct archive_entry **entry)
 {
 	return ((a->vtable->archive_read_next_header)(a, entry));
 }
 
-int
+__LA_DECL int
 archive_read_next_header2(struct archive *a, struct archive_entry *entry)
 {
 	return ((a->vtable->archive_read_next_header2)(a, entry));
 }
 
-int
+__LA_DECL int
 archive_read_data_block(struct archive *a,
     const void **buff, size_t *s, int64_t *o)
 {

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -103,7 +103,7 @@ archive_write_vtable(void)
 /*
  * Allocate, initialize and return an archive object.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_write_new(void)
 {
 	struct archive_write *a;
@@ -139,7 +139,7 @@ archive_write_new(void)
 /*
  * Set the block size.  Returns 0 if successful.
  */
-int
+__LA_DECL int
 archive_write_set_bytes_per_block(struct archive *_a, int bytes_per_block)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -152,7 +152,7 @@ archive_write_set_bytes_per_block(struct archive *_a, int bytes_per_block)
 /*
  * Get the current block size.  -1 if it has never been set.
  */
-int
+__LA_DECL int
 archive_write_get_bytes_per_block(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -165,7 +165,7 @@ archive_write_get_bytes_per_block(struct archive *_a)
  * Set the size for the last block.
  * Returns 0 if successful.
  */
-int
+__LA_DECL int
 archive_write_set_bytes_in_last_block(struct archive *_a, int bytes)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -178,7 +178,7 @@ archive_write_set_bytes_in_last_block(struct archive *_a, int bytes)
 /*
  * Return the value set above.  -1 indicates it has not been set.
  */
-int
+__LA_DECL int
 archive_write_get_bytes_in_last_block(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -191,7 +191,7 @@ archive_write_get_bytes_in_last_block(struct archive *_a)
  * dev/ino of a file to be rejected.  Used to prevent adding
  * an archive to itself recursively.
  */
-int
+__LA_DECL int
 archive_write_set_skip_file(struct archive *_a, int64_t d, int64_t i)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -456,7 +456,7 @@ archive_write_client_close(struct archive_write_filter *f)
 /*
  * Open the archive using the current settings.
  */
-int
+__LA_DECL int
 archive_write_open(struct archive *_a, void *client_data,
     archive_open_callback *opener, archive_write_callback *writer,
     archive_close_callback *closer)

--- a/libarchive/archive_write_add_filter.c
+++ b/libarchive/archive_write_add_filter.c
@@ -56,7 +56,7 @@ struct { int code; int (*setter)(struct archive *); } codes[] =
 	{ -1,			NULL }
 };
 
-int
+__LA_DECL int
 archive_write_add_filter(struct archive *a, int code)
 {
 	int i;

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -77,7 +77,7 @@ static const char base64[] = {
 /*
  * Add a compress filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_b64encode(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_by_name.c
+++ b/libarchive/archive_write_add_filter_by_name.c
@@ -60,7 +60,7 @@ struct { const char *name; int (*setter)(struct archive *); } names[] =
 	{ NULL,			NULL }
 };
 
-int
+__LA_DECL int
 archive_write_add_filter_by_name(struct archive *a, const char *name)
 {
 	int i;

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -47,7 +47,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_compression_bzip2.c 20
 #include "archive_write_private.h"
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_write_set_compression_bzip2(struct archive *a)
 {
 	__archive_write_filters_free(a);
@@ -78,7 +78,7 @@ static int archive_compressor_bzip2_write(struct archive_write_filter *,
 /*
  * Add a bzip2 compression filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_bzip2(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -115,7 +115,7 @@ static int archive_compressor_compress_close(struct archive_write_filter *);
 static int archive_compressor_compress_free(struct archive_write_filter *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_write_set_compression_compress(struct archive *a)
 {
 	__archive_write_filters_free(a);
@@ -126,7 +126,7 @@ archive_write_set_compression_compress(struct archive *a)
 /*
  * Add a compress filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_compress(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -49,7 +49,7 @@ static int archive_write_grzip_write(struct archive_write_filter *,
 static int archive_write_grzip_close(struct archive_write_filter *);
 static int archive_write_grzip_free(struct archive_write_filter *);
 
-int
+__LA_DECL int
 archive_write_add_filter_grzip(struct archive *_a)
 {
 	struct archive_write_filter *f = __archive_write_allocate_filter(_a);

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -47,7 +47,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_compression_gzip.c 201
 #include "archive_write_private.h"
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_write_set_compression_gzip(struct archive *a)
 {
 	__archive_write_filters_free(a);
@@ -94,7 +94,7 @@ static int drive_compressor(struct archive_write_filter *,
 /*
  * Add a gzip compression filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_gzip(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -55,7 +55,7 @@ static int archive_write_lrzip_write(struct archive_write_filter *,
 static int archive_write_lrzip_close(struct archive_write_filter *);
 static int archive_write_lrzip_free(struct archive_write_filter *);
 
-int
+__LA_DECL int
 archive_write_add_filter_lrzip(struct archive *_a)
 {
 	struct archive_write_filter *f = __archive_write_allocate_filter(_a);

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -92,7 +92,7 @@ static int archive_filter_lz4_write(struct archive_write_filter *,
 /*
  * Add a lz4 compression filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_lz4(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -133,7 +133,7 @@ static const unsigned char header[] = {
 };
 #endif
 
-int
+__LA_DECL int
 archive_write_add_filter_lzop(struct archive *_a)
 {
 	struct archive_write_filter *f = __archive_write_allocate_filter(_a);

--- a/libarchive/archive_write_add_filter_none.c
+++ b/libarchive/archive_write_add_filter_none.c
@@ -28,14 +28,14 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_compression_none.c 201
 
 #include "archive.h"
 
-int
+__LA_DECL int
 archive_write_set_compression_none(struct archive *a)
 {
 	(void)a; /* UNUSED */
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_write_add_filter_none(struct archive *a)
 {
 	(void)a; /* UNUSED */

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_compression_program.c 
 #include "filter_fork.h"
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_write_set_compression_program(struct archive *a, const char *cmd)
 {
 	__archive_write_filters_free(a);
@@ -87,7 +87,7 @@ static int archive_compressor_program_free(struct archive_write_filter *);
  * Add a filter to this write handle that passes all data through an
  * external program.
  */
-int
+__LA_DECL int
 archive_write_add_filter_program(struct archive *_a, const char *cmd)
 {
 	struct archive_write_filter *f = __archive_write_allocate_filter(_a);

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -66,7 +66,7 @@ static int64_t atol8(const char *, size_t);
 /*
  * Add a compress filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_uuencode(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -48,21 +48,21 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write_set_compression_xz.c 20110
 #include "archive_write_private.h"
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
-int
+__LA_DECL int
 archive_write_set_compression_lzip(struct archive *a)
 {
 	__archive_write_filters_free(a);
 	return (archive_write_add_filter_lzip(a));
 }
 
-int
+__LA_DECL int
 archive_write_set_compression_lzma(struct archive *a)
 {
 	__archive_write_filters_free(a);
 	return (archive_write_add_filter_lzma(a));
 }
 
-int
+__LA_DECL int
 archive_write_set_compression_xz(struct archive *a)
 {
 	__archive_write_filters_free(a);
@@ -163,7 +163,7 @@ common_setup(struct archive_write_filter *f)
 /*
  * Add an xz compression filter to this write handle.
  */
-int
+__LA_DECL int
 archive_write_add_filter_xz(struct archive *_a)
 {
 	struct archive_write_filter *f;
@@ -183,7 +183,7 @@ archive_write_add_filter_xz(struct archive *_a)
 /* LZMA is handled identically, we just need a different compression
  * code set.  (The liblzma setup looks at the code to determine
  * the one place that XZ and LZMA require different handling.) */
-int
+__LA_DECL int
 archive_write_add_filter_lzma(struct archive *_a)
 {
 	struct archive_write_filter *f;
@@ -200,7 +200,7 @@ archive_write_add_filter_lzma(struct archive *_a)
 	return (r);
 }
 
-int
+__LA_DECL int
 archive_write_add_filter_lzip(struct archive *_a)
 {
 	struct archive_write_filter *f;

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -424,7 +424,7 @@ _archive_write_disk_filter_bytes(struct archive *_a, int n)
 }
 
 
-int
+__LA_DECL int
 archive_write_disk_set_options(struct archive *_a, int flags)
 {
 	struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -741,7 +741,7 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_skip_file(struct archive *_a, int64_t d, int64_t i)
 {
 	struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1687,7 +1687,7 @@ finish_metadata:
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_group_lookup(struct archive *_a,
     void *private_data,
     int64_t (*lookup_gid)(void *private, const char *gname, int64_t gid),
@@ -1706,7 +1706,7 @@ archive_write_disk_set_group_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_user_lookup(struct archive *_a,
     void *private_data,
     int64_t (*lookup_uid)(void *private, const char *uname, int64_t uid),
@@ -1725,7 +1725,7 @@ archive_write_disk_set_user_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_write_disk_gid(struct archive *_a, const char *name, int64_t id)
 {
        struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1736,7 +1736,7 @@ archive_write_disk_gid(struct archive *_a, const char *name, int64_t id)
        return (id);
 }
  
-int64_t
+__LA_DECL int64_t
 archive_write_disk_uid(struct archive *_a, const char *name, int64_t id)
 {
 	struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1750,7 +1750,7 @@ archive_write_disk_uid(struct archive *_a, const char *name, int64_t id)
 /*
  * Create a new archive_write_disk object and initialize it with global state.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_write_disk_new(void)
 {
 	struct archive_write_disk *a;

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -81,7 +81,7 @@ static void	cleanup(void *);
  * walking a list of 128 items is a lot faster than calling
  * getpwnam()!
  */
-int
+__LA_DECL int
 archive_write_disk_set_standard_lookup(struct archive *a)
 {
 	struct bucket *ucache = malloc(cache_size * sizeof(struct bucket));

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -654,7 +654,7 @@ _archive_write_disk_filter_bytes(struct archive *_a, int n)
 }
 
 
-int
+__LA_DECL int
 archive_write_disk_set_options(struct archive *_a, int flags)
 {
 	struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -905,7 +905,7 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_skip_file(struct archive *_a, int64_t d, int64_t i)
 {
 	struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1153,7 +1153,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_group_lookup(struct archive *_a,
     void *private_data,
     int64_t (*lookup_gid)(void *private, const char *gname, int64_t gid),
@@ -1172,7 +1172,7 @@ archive_write_disk_set_group_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_write_disk_set_user_lookup(struct archive *_a,
     void *private_data,
     int64_t (*lookup_uid)(void *private, const char *uname, int64_t uid),
@@ -1191,7 +1191,7 @@ archive_write_disk_set_user_lookup(struct archive *_a,
 	return (ARCHIVE_OK);
 }
 
-int64_t
+__LA_DECL int64_t
 archive_write_disk_gid(struct archive *_a, const char *name, int64_t id)
 {
        struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1202,7 +1202,7 @@ archive_write_disk_gid(struct archive *_a, const char *name, int64_t id)
        return (id);
 }
  
-int64_t
+__LA_DECL int64_t
 archive_write_disk_uid(struct archive *_a, const char *name, int64_t id)
 {
        struct archive_write_disk *a = (struct archive_write_disk *)_a;
@@ -1216,7 +1216,7 @@ archive_write_disk_uid(struct archive *_a, const char *name, int64_t id)
 /*
  * Create a new archive_write_disk object and initialize it with global state.
  */
-struct archive *
+__LA_DECL struct archive *
 archive_write_disk_new(void)
 {
 	struct archive_write_disk *a;

--- a/libarchive/archive_write_open_fd.c
+++ b/libarchive/archive_write_open_fd.c
@@ -58,7 +58,7 @@ static int	file_close(struct archive *, void *);
 static int	file_open(struct archive *, void *);
 static ssize_t	file_write(struct archive *, void *, const void *buff, size_t);
 
-int
+__LA_DECL int
 archive_write_open_fd(struct archive *a, int fd)
 {
 	struct write_fd_data *mine;

--- a/libarchive/archive_write_open_file.c
+++ b/libarchive/archive_write_open_file.c
@@ -55,7 +55,7 @@ static int	file_close(struct archive *, void *);
 static int	file_open(struct archive *, void *);
 static ssize_t	file_write(struct archive *, void *, const void *buff, size_t);
 
-int
+__LA_DECL int
 archive_write_open_FILE(struct archive *a, FILE *f)
 {
 	struct write_FILE_data *mine;

--- a/libarchive/archive_write_open_filename.c
+++ b/libarchive/archive_write_open_filename.c
@@ -66,13 +66,13 @@ static int	file_open(struct archive *, void *);
 static ssize_t	file_write(struct archive *, void *, const void *buff, size_t);
 static int	open_filename(struct archive *, int, const void *);
 
-int
+__LA_DECL int
 archive_write_open_file(struct archive *a, const char *filename)
 {
 	return (archive_write_open_filename(a, filename));
 }
 
-int
+__LA_DECL int
 archive_write_open_filename(struct archive *a, const char *filename)
 {
 
@@ -82,7 +82,7 @@ archive_write_open_filename(struct archive *a, const char *filename)
 	return (open_filename(a, 1, filename));
 }
 
-int
+__LA_DECL int
 archive_write_open_filename_w(struct archive *a, const wchar_t *filename)
 {
 

--- a/libarchive/archive_write_open_memory.c
+++ b/libarchive/archive_write_open_memory.c
@@ -48,7 +48,7 @@ static ssize_t	memory_write(struct archive *, void *, const void *buff, size_t);
  * the data.  The 'size' param both tells us the size of the
  * client buffer and lets us tell the client the final size.
  */
-int
+__LA_DECL int
 archive_write_open_memory(struct archive *a, void *buff, size_t buffSize, size_t *used)
 {
 	struct write_memory_data *mine;

--- a/libarchive/archive_write_set_format.c
+++ b/libarchive/archive_write_set_format.c
@@ -63,7 +63,7 @@ struct { int code; int (*setter)(struct archive *); } codes[] =
 	{ 0,		NULL }
 };
 
-int
+__LA_DECL int
 archive_write_set_format(struct archive *a, int code)
 {
 	int i;

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -281,7 +281,7 @@ static int	make_header(struct archive_write *, uint64_t, uint64_t,
 static int	make_streamsInfo(struct archive_write *, uint64_t, uint64_t,
 		    	uint64_t, int, struct coder *, int, uint32_t);
 
-int
+__LA_DECL int
 archive_write_set_format_7zip(struct archive *_a)
 {
 	static const struct archive_rb_tree_ops rb_ops = {

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -82,7 +82,7 @@ static const char	*ar_basename(const char *path);
 static int		 format_octal(int64_t v, char *p, int s);
 static int		 format_decimal(int64_t v, char *p, int s);
 
-int
+__LA_DECL int
 archive_write_set_format_ar_bsd(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -98,7 +98,7 @@ archive_write_set_format_ar_bsd(struct archive *_a)
 	return (r);
 }
 
-int
+__LA_DECL int
 archive_write_set_format_ar_svr4(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_by_name.c
+++ b/libarchive/archive_write_set_format_by_name.c
@@ -76,7 +76,7 @@ struct { const char *name; int (*setter)(struct archive *); } names[] =
 	{ NULL,		NULL }
 };
 
-int
+__LA_DECL int
 archive_write_set_format_by_name(struct archive *a, const char *name)
 {
 	int i;

--- a/libarchive/archive_write_set_format_cpio.c
+++ b/libarchive/archive_write_set_format_cpio.c
@@ -97,7 +97,7 @@ struct cpio {
 /*
  * Set output format to 'cpio' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_cpio(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -103,7 +103,7 @@ struct cpio {
 /*
  * Set output format to 'cpio' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_cpio_newc(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_filter_by_ext.c
+++ b/libarchive/archive_write_set_format_filter_by_ext.c
@@ -96,7 +96,7 @@ static int get_array_index(const char *name)
   
 }
 
-int
+__LA_DECL int
 archive_write_set_format_filter_by_ext(struct archive *a, const char *filename)
 {
   int names_index = get_array_index(filename);
@@ -115,7 +115,7 @@ archive_write_set_format_filter_by_ext(struct archive *a, const char *filename)
   return (ARCHIVE_FATAL);
 }
 
-int
+__LA_DECL int
 archive_write_set_format_filter_by_ext_def(struct archive *a, const char *filename, const char * def_ext)
 {
   int names_index = get_array_index(filename);

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -169,7 +169,7 @@ static int	format_octal(int64_t, char *, int);
 /*
  * Set output format to 'GNU tar' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_gnutar(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1047,7 +1047,7 @@ static int	zisofs_finish_entry(struct archive_write *);
 static int	zisofs_rewind_boot_file(struct archive_write *);
 static int	zisofs_free(struct archive_write *);
 
-int
+__LA_DECL int
 archive_write_set_format_iso9660(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1428,14 +1428,14 @@ archive_write_set_format_mtree_default(struct archive *_a, const char *fn)
 	return (ARCHIVE_OK);
 }
 
-int
+__LA_DECL int
 archive_write_set_format_mtree(struct archive *_a)
 {
 	return archive_write_set_format_mtree_default(_a,
 		"archive_write_set_format_mtree");
 }
 
-int
+__LA_DECL int
 archive_write_set_format_mtree_classic(struct archive *_a)
 {
 	int r;

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -97,7 +97,7 @@ static char		*url_encode(const char *in);
  * the pax header whenever possible.  This is the default for
  * bsdtar, for instance.
  */
-int
+__LA_DECL int
 archive_write_set_format_pax_restricted(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -115,7 +115,7 @@ archive_write_set_format_pax_restricted(struct archive *_a)
 /*
  * Set output format to 'pax' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_pax(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_raw.c
+++ b/libarchive/archive_write_set_format_raw.c
@@ -45,7 +45,7 @@ struct raw {
 /*
  * Set output format to 'raw' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_raw(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -100,7 +100,7 @@ shar_quote(struct archive_string *buf, const char *str, int in_shell)
 /*
  * Set output format to 'shar' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_shar(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -139,7 +139,7 @@ archive_write_set_format_shar(struct archive *_a)
  * In addition, this variant also attempts to restore ownership, file modes,
  * and other extended file information.
  */
-int
+__LA_DECL int
 archive_write_set_format_shar_dump(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -163,7 +163,7 @@ static int	format_octal(int64_t, char *, int);
 /*
  * Set output format to 'ustar' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_ustar(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -140,7 +140,7 @@ static int	format_header_v7tar(struct archive_write *, char h[512],
 /*
  * Set output format to 'v7tar' format.
  */
-int
+__LA_DECL int
 archive_write_set_format_v7tar(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -114,7 +114,7 @@ static int _gen_uuid(warc_uuid_t *tgt);
 /*
  * Set output format to ISO 28500 (aka WARC) format.
  */
-int
+__LA_DECL int
 archive_write_set_format_warc(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -333,7 +333,7 @@ static int	save_xattrs(struct archive_write *, struct file *);
 static int	getalgsize(enum sumalg);
 static const char *getalgname(enum sumalg);
 
-int
+__LA_DECL int
 archive_write_set_format_xar(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -394,7 +394,7 @@ archive_write_zip_options(struct archive_write *a, const char *key,
 	return (ARCHIVE_WARN);
 }
 
-int
+__LA_DECL int
 archive_write_zip_set_compression_deflate(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -422,7 +422,7 @@ archive_write_zip_set_compression_deflate(struct archive *_a)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_zip_set_compression_store(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -444,7 +444,7 @@ archive_write_zip_set_compression_store(struct archive *_a)
 	return (ret);
 }
 
-int
+__LA_DECL int
 archive_write_set_format_zip(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;

--- a/libarchive/archive_write_set_options.c
+++ b/libarchive/archive_write_set_options.c
@@ -36,7 +36,7 @@ static int	archive_set_filter_option(struct archive *a,
 static int	archive_set_option(struct archive *a,
 		    const char *m, const char *o, const char *v);
 
-int
+__LA_DECL int
 archive_write_set_format_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -45,7 +45,7 @@ archive_write_set_format_option(struct archive *a, const char *m, const char *o,
 	    archive_set_format_option);
 }
 
-int
+__LA_DECL int
 archive_write_set_filter_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -54,7 +54,7 @@ archive_write_set_filter_option(struct archive *a, const char *m, const char *o,
 	    archive_set_filter_option);
 }
 
-int
+__LA_DECL int
 archive_write_set_option(struct archive *a, const char *m, const char *o,
     const char *v)
 {
@@ -63,7 +63,7 @@ archive_write_set_option(struct archive *a, const char *m, const char *o,
 	    archive_set_option);
 }
 
-int
+__LA_DECL int
 archive_write_set_options(struct archive *a, const char *options)
 {
 	return _archive_set_options(a, options,

--- a/libarchive/archive_write_set_passphrase.c
+++ b/libarchive/archive_write_set_passphrase.c
@@ -31,7 +31,7 @@ __FBSDID("$FreeBSD$");
 #endif
 #include "archive_write_private.h"
 
-int
+__LA_DECL int
 archive_write_set_passphrase(struct archive *_a, const char *p)
 {
 	struct archive_write *a = (struct archive_write *)_a;
@@ -55,7 +55,7 @@ archive_write_set_passphrase(struct archive *_a, const char *p)
 }
 
 
-int
+__LA_DECL int
 archive_write_set_passphrase_callback(struct archive *_a, void *client_data,
     archive_passphrase_callback *cb)
 {


### PR DESCRIPTION
Hi,

Okay, this one's a bit of a doozy.  While trying to add the library symbols file to the Debian package of libarchive (a kind of external-to-the-library symbol versioning scheme - a file that lists each symbol and the library version that first started providing it in its current form), I noticed that the shared library of libarchive contains a lot of internal symbols - functions and variables used only by the libarchive routines themselves, not part of the library's public API.  This is not really a bad thing in and of itself, but it does make it just a little bit harder to do all kinds of API compliance checks on the library, as these internal symbols may appear and disappear without affecting anything, but still be noted as changes in the ELF library's symbol table.

So... what do you think of this change - use GCC's (and Clang's) -fvisibility command-line option to hide all the symbols by default, and then explicitly mark the public API ones by using the "visibility(default)" function attribute?  Yes, this touches many files, but the changes to the vast majority of them are pretty trivial - add __LA_DECL before the function definition; the main changes are in the configure script and in the libarchive/archive.h and libarchive/archive_entry.h files.

Of course, this brings up another question; now that the __LA_DECL definition is actually exposed to consumers of the header files, should it really be prefixed with a double underscore, or should it be renamed to something in the public namespace.  When I helped with the same kind of change in libwebsockets last year, the new preprocessor definition was named LWS_VISIBLE, so if you'd like me to, I can rename __LA_DECL to LA_VISIBLE or LA_PUBLIC or something like that.

Of course, it's ultimately your call whether this change is useful or whether you'd like it done in a different way.

Thanks again for everything you do for libarchive and FreeBSD in general, and keep up the great work!

G'luck,
Peter
