### PR TITLE
Fix two minor complaints by cppcheck.

### DIFF
--- a/libarchive/archive_ppmd7_private.h
+++ b/libarchive/archive_ppmd7_private.h
@@ -19,7 +19,7 @@ If you need the compatibility with original PPMd var.H, you can use external Ran
 #define PPMD7_MAX_ORDER 64
 
 #define PPMD7_MIN_MEM_SIZE (1 << 11)
-#define PPMD7_MAX_MEM_SIZE (0xFFFFFFFF - 12 * 3)
+#define PPMD7_MAX_MEM_SIZE (0xFFFFFFFFu - 12 * 3)
 
 struct CPpmd7_Context_;
 

--- a/libarchive/test/test_fuzz.c
+++ b/libarchive/test/test_fuzz.c
@@ -110,13 +110,17 @@ test_fuzz(const struct files *filesets)
 			for (i = 0; filesets[n].names[i] != NULL; ++i)
 			{
 				tmp = slurpfile(&size, filesets[n].names[i]);
-				rawimage = (char *)realloc(rawimage, oldsize + size);
+				char *newraw = (char *)realloc(rawimage, oldsize + size);
+				if (!assert(newraw != NULL))
+				{
+					free(rawimage);
+					continue;
+				}
+				rawimage = newraw;
 				memcpy(rawimage + oldsize, tmp, size);
 				oldsize += size;
 				size = oldsize;
 				free(tmp);
-				if (!assert(rawimage != NULL))
-					continue;
 			}
 		}
 		if (size == 0)


### PR DESCRIPTION
Hi,

Thanks again for the wonderful libarchive!

What do you think about the attached patch that fixes two complaints by cppcheck?  Namely:

[libarchive/archive_read_support_format_7zip.c:1259]: (error) Signed integer overflow for expression '4294967295-36'.

[libarchive/test/test_fuzz.c:113]: (error) Common realloc mistake: 'rawimage' nulled but not freed upon failure

And now I'm off to isolate and file false positive bug reports for some of the other "issues" that cppcheck reported with the libarchive code; those were indeed the only genuine ones, impressive! :)

G'luck,
Peter
