### PR TITLE
Remove unused variable to avoid compiler warning.

### DIFF
--- a/libarchive/archive_write_disk_acl.c
+++ b/libarchive/archive_write_disk_acl.c
@@ -145,7 +145,7 @@ set_acl(struct archive *a, int fd, const char *name,
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i, r;
+	int		 i;
 
 	ret = ARCHIVE_OK;
 	entries = archive_acl_reset(abstract_acl, ae_requested_type);

--- a/libarchive/archive_write_disk_acl.c
+++ b/libarchive/archive_write_disk_acl.c
@@ -138,6 +138,7 @@ set_acl(struct archive *a, int fd, const char *name,
 	acl_permset_t	 acl_permset;
 #ifdef ACL_TYPE_NFS4
 	acl_flagset_t	 acl_flagset;
+	int		 r;
 #endif
 	int		 ret;
 	int		 ae_type, ae_permset, ae_tag, ae_id;


### PR DESCRIPTION
This is a trivial patch to remove an unused variable, which gcc will complain about (and fail if -Werror is set, which is the default when using the supplied autoconf configure script).