### PR TITLE
Fix a rar crash

### DIFF
--- a/libarchive/archive_ppmd7.c
+++ b/libarchive/archive_ppmd7.c
@@ -862,6 +862,8 @@ static void PpmdRAR_RangeDec_CreateVTable(CPpmd7z_RangeDec *p)
 static int Ppmd7_DecodeSymbol(CPpmd7 *p, IPpmd7_RangeDec *rc)
 {
   size_t charMask[256 / sizeof(size_t)];
+  if (p->Base == 0)
+      return -1;
   if (p->MinContext->NumStats != 1)
   {
     CPpmd_State *s = Ppmd7_GetStats(p, p->MinContext);


### PR DESCRIPTION
On certain rars, I can get an "Invalid symbol" error, and a segfault
immediately afterwards. The error is caused by Ppmd7_DecodeSymbol()
returning an error. If the API user tries to continue decompression
after the error, Ppmd7_DecodeSymbol is called again then the
Ppmd7_GetStats call (immediately following the code touched by the
patch) gets an invalid pointer. Work around the cause of the crash. I'm
not sure about the deeper reason for this.
