### PR TITLE
Use memmove instead of strcpy (src/dest may overlap).

### DIFF
--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1811,16 +1811,20 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 					break;
 				--rp;
 			}
-			if (rp > file->parentdir.s) {
+
+			/*
+			 * We should only roll-back up when:
+			 *  - previous component is not "..", as it means
+			 *    we did not manage to canonicalize it
+			 *    previously;
+			 *  - we are not back at the root of the path.
+			 */
+			if (strncmp(rp, "/..", 3) != 0 &&
+			    rp > file->parentdir.s) {
 				pathname += 3;
 				p = rp;
 				continue;
 			}
-
-			/*
-			 * We are back at top, we cannot canonicalize by
-			 * going up the path string further. Leave as-is.
-			 */
 		}
 		*p++ = *pathname++;
 	}

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1810,10 +1810,10 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 		if (p[0] == '/') {
 			if (p[1] == '/')
 				/* Convert '//' --> '/' */
-				strcpy(p, p+1);
+				memmove(p, p+1, len+1);
 			else if (p[1] == '.' && p[2] == '/')
 				/* Convert '/./' --> '/' */
-				strcpy(p, p+2);
+				memmove(p, p+2, len+1);
 			else if (p[1] == '.' && p[2] == '.' && p[3] == '/') {
 				/* Convert 'dir/dir1/../dir2/'
 				 *     --> 'dir/dir2/'
@@ -1825,10 +1825,10 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 					--rp;
 				}
 				if (rp > dirname) {
-					strcpy(rp, p+3);
+					memmove(rp, p+3, len+1);
 					p = rp;
 				} else {
-					strcpy(dirname, p+4);
+					memmove(dirname, p+4, len+1);
 					p = dirname;
 				}
 			} else

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1854,7 +1854,7 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 
 	/*
 	 * Find out the position which points to the last position of
-	 * path separator('/'). As we now string's length, use a shortcut
+	 * path separator('/'). As we know string's length, use a shortcut
 	 * and start from its end.
 	 */
 	slash = NULL;


### PR DESCRIPTION
The use of str{,n}cpy() for string shifting can be dangerous when buffers overlap. Use memmove() instead.
