### PR TITLE
Multiple bugfixes for setup_acls()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1600,6 +1600,7 @@ IF(ENABLE_ACL)
   # test for specific permissions in a permset.)  Linux uses the obvious
   # name, FreeBSD adds _np to mark it as "non-Posix extension."
   # Test for both as a double-check that we really have POSIX-style ACL support.
+  CHECK_FUNCTION_EXISTS(acl_get_fd_np HAVE_ACL_GET_FD_NP)
   CHECK_FUNCTION_EXISTS(acl_get_perm HAVE_ACL_GET_PERM)
   CHECK_FUNCTION_EXISTS(acl_get_perm_np HAVE_ACL_GET_PERM_NP)
   CHECK_FUNCTION_EXISTS(acl_get_link HAVE_ACL_GET_LINK)

--- a/libarchive/config_freebsd.h
+++ b/libarchive/config_freebsd.h
@@ -28,6 +28,7 @@
 /* FreeBSD 5.0 and later have ACL and extattr support. */
 #if __FreeBSD__ > 4
 #define	HAVE_ACL_CREATE_ENTRY 1
+#define	HAVE_ACL_GET_FD_NP 1
 #define	HAVE_ACL_GET_LINK_NP 1
 #define	HAVE_ACL_GET_PERM_NP 1
 #define	HAVE_ACL_INIT 1


### PR DESCRIPTION
Multiple bugfixes for setup_acls(), see comments in the commit.

How to reproduce the main error? Simply create a directory, put a file in it, set POSIX.1e ACLs on the file. Now create a tar. All files and directories within directories won't get ACLs properly saved because their basenames are looked up in the starting directory (serious bug).