### PR TITLE
Initialize subst rule->result pointer to NULL

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -84,6 +84,7 @@ add_substitution(struct bsdtar *bsdtar, const char *rule_text)
 	if (rule == NULL)
 		lafe_errc(1, errno, "Out of memory");
 	rule->next = NULL;
+	rule->result = NULL;
 
 	if (subst->last_rule == NULL)
 		subst->first_rule = rule;


### PR DESCRIPTION
This is not directly useful in libarchive at the present time, but
it might be in the future.  If a project which uses this code adds
an atexit(3) handler to clean up memory, and somebody runs:

    bsdtar somestring -t

then "omestring" will be interpreted as an (invalid) substitution
rule and call lafe_errc().  However, if the atexit() handler then
calls cleanup_substition(), it will try to free(rule->result)
which was not initialized.

Sponsored by:	Tarsnap Backup Inc.