### PR TITLE
Fix scoping error with "disk" variable

### DIFF
--- a/examples/minitar/minitar.c
+++ b/examples/minitar/minitar.c
@@ -222,7 +222,6 @@ static void
 create(const char *filename, int compress, const char **argv)
 {
 	struct archive *a;
-	struct archive *disk;
 	struct archive_entry *entry;
 	ssize_t len;
 	int fd;
@@ -253,12 +252,11 @@ create(const char *filename, int compress, const char **argv)
 		filename = NULL;
 	archive_write_open_filename(a, filename);
 
-	disk = archive_read_disk_new();
-#ifndef NO_LOOKUP
-	archive_read_disk_set_standard_lookup(disk);
-#endif
 	while (*argv != NULL) {
 		struct archive *disk = archive_read_disk_new();
+#ifndef NO_LOOKUP
+		archive_read_disk_set_standard_lookup(disk);
+#endif
 		int r;
 
 		r = archive_read_disk_open(disk, *argv);


### PR DESCRIPTION
The variable named 'disk' inside the loop was hiding the variable named
'disk' at the outer level.  The outer variable was never used, get rid
of it.

Move the call to archive_read_disk_set_standard_lookup(disk) inside the
loop so that it Does What It Should.

See [this comment](https://github.com/libarchive/libarchive/issues/786#issuecomment-250366852) in #786.