### PR TITLE
Fix compiler warning about unused cache variable

### DIFF
--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -231,8 +231,8 @@ lookup_uname_helper(struct name_cache *cache, id_t id)
 static const char *
 lookup_uname_helper(struct name_cache *cache, id_t id)
 {
-	(void)cache; /* UNUSED */
 	struct passwd	*result;
+	(void)cache; /* UNUSED */
 
 	result = getpwuid((uid_t)id);
 
@@ -298,8 +298,8 @@ lookup_gname_helper(struct name_cache *cache, id_t id)
 static const char *
 lookup_gname_helper(struct name_cache *cache, id_t id)
 {
-	(void)cache; /* UNUSED */
 	struct group	*result;
+	(void)cache; /* UNUSED */
 
 	result = getgrgid((gid_t)id);
 

--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -231,6 +231,7 @@ lookup_uname_helper(struct name_cache *cache, id_t id)
 static const char *
 lookup_uname_helper(struct name_cache *cache, id_t id)
 {
+	(void)cache; /* UNUSED */
 	struct passwd	*result;
 
 	result = getpwuid((uid_t)id);
@@ -297,6 +298,7 @@ lookup_gname_helper(struct name_cache *cache, id_t id)
 static const char *
 lookup_gname_helper(struct name_cache *cache, id_t id)
 {
+	(void)cache; /* UNUSED */
 	struct group	*result;
 
 	result = getgrgid((gid_t)id);


### PR DESCRIPTION
Given that warning are turned into errors this problem make the build fail.