### PR TITLE
Fix compiler warning about comparison of integers of different signs

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -4044,10 +4044,10 @@ older(struct stat *st, struct archive_entry *entry)
 {
 	/* First, test the seconds and return if we have a definite answer. */
 	/* Definitely older. */
-	if (st->st_mtime < archive_entry_mtime(entry))
+	if ((time_t) st->st_mtime < archive_entry_mtime(entry))
 		return (1);
 	/* Definitely younger. */
-	if (st->st_mtime > archive_entry_mtime(entry))
+	if ((time_t) st->st_mtime > archive_entry_mtime(entry))
 		return (0);
 	/* If this platform supports fractional seconds, try those. */
 #if HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC


### PR DESCRIPTION
Here's the error:

```
libarchive/archive_write_disk_posix.c:3869:19: error: comparison of integers of different signs: 'unsigned long' and 'time_t' (aka 'long') [-Werror,-Wsign-compare]
        if (st->st_mtime < archive_entry_mtime(entry))
            ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
libarchive/archive_write_disk_posix.c:3872:19: error: comparison of integers of different signs: 'unsigned long' and 'time_t' (aka 'long') [-Werror,-Wsign-compare]
        if (st->st_mtime > archive_entry_mtime(entry))
            ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

st->st_mtime is an unsigned long on this platform while time_t is a long, so converting an unsigned long into a long might lose some precision, but on the other side this is the only object for which we know the type without having to know about portability.

Android seems to be the only platform where time_t is an unsigned long.
https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.7-4.6/+/jb-dev/sysroot/usr/include/asm/stat.h
