### PR TITLE
Issue 696: ppc64le mache ckech failure

### DIFF
--- a/cpio/test/test_option_lz4.c
+++ b/cpio/test/test_option_lz4.c
@@ -63,6 +63,13 @@ DEFINE_TEST(test_option_lz4)
 			    "but no such program is available on this system.");
 			return;
 		}
+		/* On some systems the error won't be detected until closing
+		   time, by a 127 exit error returned by waitpid. */
+		if (strstr(p, "Error closing") != NULL && !canLz4()) {
+			skipping("This version of bsdcpio uses an external lz4 program "
+			    "but no such program is available on this system.");
+			return;
+		}
 		failure("--lz4 option is broken: %s", p);
 		assertEqualInt(r, 0);
 		return;

--- a/tar/test/test_option_lz4.c
+++ b/tar/test/test_option_lz4.c
@@ -63,6 +63,13 @@ DEFINE_TEST(test_option_lz4)
 			    "but no such program is available on this system.");
 			return;
 		}
+		/* On some systems the error won't be detected until closing
+		   time, by a 127 exit error returned by waitpid. */
+		if (strstr(p, "Error closing") != NULL && !canLz4()) {
+			skipping("This version of bsdcpio uses an external lz4 program "
+			    "but no such program is available on this system.");
+			return;
+		}
 		failure("--lz4 option is broken: %s", p);
 		assertEqualInt(r, 0);
 		return;


### PR DESCRIPTION
This issue is not ppc64le specific. I have experienced on my
4.4.22-gnu #1 SMP 1 i686 GNU/Linux. Might be dependant on kernel
version and/or machine load. POSIX says errors after posix_spawnp
returns can be signaled by child exitting with an 127 exit code.
