### PR TITLE
distribute README.md

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ AM_CPPFLAGS=$(PLATFORMCPPFLAGS)
 #
 EXTRA_DIST= \
 	CMakeLists.txt \
+	README.md \
 	build/autogen.sh \
 	build/bump-version.sh \
 	build/clean.sh \


### PR DESCRIPTION
This issue happened because 'foreign' automake option is enabled,
and the file README was renamed as README.md (not included
automatically by automake).