### PR TITLE
Cygwin msys2 fixes

### DIFF
--- a/build/autoconf/config.rpath
+++ b/build/autoconf/config.rpath
@@ -63,7 +63,7 @@ else
     aix*)
       wl='-Wl,'
       ;;
-    mingw* | cygwin* | pw32* | os2* | cegcc*)
+    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
       ;;
     hpux9* | hpux10* | hpux11*)
       wl='-Wl,'
@@ -155,7 +155,7 @@ hardcode_direct=no
 hardcode_minus_L=no
 
 case "$host_os" in
-  cygwin* | mingw* | pw32* | cegcc*)
+  cygwin* | msys* | mingw* | pw32* | cegcc*)
     # FIXME: the MSVC++ port hasn't been tested in a loooong time
     # When not using gcc, we currently assume that we are using
     # Microsoft Visual C++.
@@ -204,7 +204,7 @@ if test "$with_gnu_ld" = yes; then
         ld_shlibs=no
       fi
       ;;
-    cygwin* | mingw* | pw32* | cegcc*)
+    cygwin* | msys* | mingw* | pw32* | cegcc*)
       # hardcode_libdir_flag_spec is actually meaningless, as there is
       # no search path for DLLs.
       hardcode_libdir_flag_spec='-L$libdir'
@@ -354,7 +354,7 @@ else
       ;;
     bsdi[45]*)
       ;;
-    cygwin* | mingw* | pw32* | cegcc*)
+    cygwin* | msys* | mingw* | pw32* | cegcc*)
       # When not using gcc, we currently assume that we are using
       # Microsoft Visual C++.
       # hardcode_libdir_flag_spec is actually meaningless, as there is
@@ -543,7 +543,7 @@ case "$host_os" in
   bsdi[45]*)
     library_names_spec='$libname$shrext'
     ;;
-  cygwin* | mingw* | pw32* | cegcc*)
+  cygwin* | msys* | mingw* | pw32* | cegcc*)
     shrext=.dll
     library_names_spec='$libname.dll.a $libname.lib'
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ inc_windows_files=no
 inc_cygwin_files=no
 case "$host_os" in
   *mingw* ) inc_windows_files=yes ;;
-  *cygwin*) inc_cygwin_files=yes ;;
+  *cygwin* | *msys*) inc_cygwin_files=yes ;;
 esac
 AM_CONDITIONAL([INC_WINDOWS_FILES], [test $inc_windows_files = yes])
 AM_CONDITIONAL([INC_CYGWIN_FILES], [test $inc_cygwin_files = yes])
@@ -243,7 +243,7 @@ AM_CONDITIONAL([STATIC_BSDCPIO], [ test "$static_bsdcpio" = yes ])
 
 # Set up defines needed before including any headers
 case $host in
-  *mingw* | *cygwin* )
+  *mingw* | *cygwin* | *msys*  )
   AC_DEFINE([_WIN32_WINNT], 0x0502, [Define to '0x0502' for Windows Server 2003 APIs.])
   AC_DEFINE([WINVER], 0x0502, [Define to '0x0502' for Windows Server 2003 APIs.])
   AC_DEFINE([NTDDI_VERSION], 0x05020000, [Define to '0x05020000' for Windows Server 2003 APIs.])
@@ -302,7 +302,7 @@ AC_ARG_WITH([bz2lib],
 if test "x$with_bz2lib" != "xno"; then
   AC_CHECK_HEADERS([bzlib.h])
   case "$host_os" in
-    *mingw* | *cygwin*)
+    *mingw* | *cygwin* | *msys*)
       dnl AC_CHECK_LIB cannot be used on the Windows port of libbz2, therefore
 	  dnl use AC_LINK_IFELSE.
 	  AC_MSG_CHECKING([for BZ2_bzDecompressInit in -lbz2])
@@ -786,7 +786,7 @@ main(int argc, char **argv)
 ])
 
 case "$host_os" in
-  *mingw* | *cygwin*)
+  *mingw* | *cygwin* | *msys*)
 	;;
   *)
 	CRYPTO_CHECK(MD5, LIBC, md5)
@@ -829,7 +829,7 @@ if test "x$with_openssl" != "xno"; then
     AC_CHECK_HEADERS([openssl/evp.h])
     saved_LIBS=$LIBS
     case "$host_os" in
-      *mingw* | *cygwin*)
+      *mingw* | *cygwin* | *msys*)
         case "$host_cpu" in
           x86_64)
             AC_CHECK_LIB(eay64,OPENSSL_config)
@@ -875,7 +875,7 @@ if test "x$found_LIBMD" != "xyes"; then
 fi
 
 case "$host_os" in
-  *mingw* | *cygwin*)
+  *mingw* | *cygwin* | *msys*)
 	CRYPTO_CHECK_WIN(MD5, CALG_MD5)
 	CRYPTO_CHECK_WIN(SHA1, CALG_SHA1)
 	CRYPTO_CHECK_WIN(SHA256, CALG_SHA_256)

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2625,7 +2625,7 @@ check_symlinks(struct archive_write_disk *a)
  * See also : http://msdn.microsoft.com/en-us/library/aa365247.aspx
  */
 static void
-cleanup_pathname_win(struct archive_write_disk *a)
+cleanup_pathname_win(char *path)
 {
 	wchar_t wc;
 	char *p;
@@ -2636,7 +2636,7 @@ cleanup_pathname_win(struct archive_write_disk *a)
 	mb = 0;
 	complete = 1;
 	utf8 = (strcmp(nl_langinfo(CODESET), "UTF-8") == 0)? 1: 0;
-	for (p = a->name; *p != '\0'; p++) {
+	for (p = path; *p != '\0'; p++) {
 		++alen;
 		if (*p == '\\') {
 			/* If previous byte is smaller than 128,
@@ -2661,7 +2661,7 @@ cleanup_pathname_win(struct archive_write_disk *a)
 	/*
 	 * Convert path separator in wide-character.
 	 */
-	p = a->name;
+	p = path;
 	while (*p != '\0' && alen) {
 		l = mbtowc(&wc, p, alen);
 		if (l == (size_t)-1) {
@@ -2703,7 +2703,7 @@ cleanup_pathname_fsobj(char *path, int *error_number, struct archive_string *err
 	}
 
 #if defined(__CYGWIN__)
-	cleanup_pathname_win(a);
+	cleanup_pathname_win(path);
 #endif
 	/* Skip leading '/'. */
 	if (*src == '/') {


### PR DESCRIPTION
This ifixes a compile error with MSYS and CYGWIN.  I also included some files from libarchive-3.2.0-msys2.patch that are used to libarchive for the MSYS2 environment   In GCC this also is supported with the CYGWIN symbol.