### PR TITLE
Fix 710 openssl11 opaque evp cipher ctx

### DIFF
--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -104,7 +104,11 @@ typedef struct {
 #define AES_MAX_KEY_SIZE 32
 
 typedef struct {
+#ifdef HAVE_EVP_CIPHER_CTX_NEW
+	void		*ctx;
+#else
 	EVP_CIPHER_CTX	ctx;
+#endif
 	const EVP_CIPHER *type;
 	uint8_t		key[AES_MAX_KEY_SIZE];
 	unsigned	key_len;

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -173,7 +173,7 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 
 #elif defined(HAVE_LIBCRYPTO)
 #ifdef HAVE_HMAC_CTX_NEW
-#define HMAC_CTX_INIT(ctx) HMAC_CTX *tmp = HMC_CTX_new(); \
+#define HMAC_CTX_INIT(ctx) HMAC_CTX *tmp = HMAC_CTX_new(); \
 	HMAC_CTX_copy(ctx, tmp); \
 	HMAC_CTX_free(tmp);
 #define HMAC_CTX_CLEANUP(ctx) HMAC_CTX_free(ctx); ctx = NULL;

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -172,11 +172,21 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 }
 
 #elif defined(HAVE_LIBCRYPTO)
+#ifdef HAVE_HMAC_CTX_NEW
+#define HMAC_CTX_INIT(ctx) HMAC_CTX *tmp = HMC_CTX_new(); \
+	HMAC_CTX_copy(ctx, tmp); \
+	HMAC_CTX_free(tmp);
+#define HMAC_CTX_CLEANUP(ctx) HMAC_CTX_free(ctx); ctx = NULL;
+#else
+#define HMAC_CTX_INIT HMAC_CTX_init
+#define HMAC_CTX_CLEANUP(ctx) HMAC_CTX_cleanup(ctx); \
+	memset(ctx, 0, sizeof(*ctx));
+#endif
 
 static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)
 {
-	HMAC_CTX_init(ctx);
+	HMAC_CTX_INIT(ctx);
 	HMAC_Init(ctx, key, key_len, EVP_sha1());
 	return 0;
 }
@@ -199,8 +209,7 @@ __hmac_sha1_final(archive_hmac_sha1_ctx *ctx, uint8_t *out, size_t *out_len)
 static void
 __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 {
-	HMAC_CTX_cleanup(ctx);
-	memset(ctx, 0, sizeof(*ctx));
+	HMAC_CTX_CLEANUP(ctx);
 }
 
 #else

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -208,7 +208,7 @@ struct zip {
 #define HMAC_CTX_PTR(z) (z->hctx)
 #else
 	archive_hmac_sha1_ctx	hctx;
-#define HMAC_CTX_PTR(z) &(z->hctx)
+#define HMAC_CTX_PTR(z) (&(z->hctx))
 #endif
 	char			hctx_valid;
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -203,7 +203,13 @@ struct zip {
 	/* Contexts used for AES decryption. */
 	archive_crypto_ctx	cctx;
 	char			cctx_valid;
+#if defined(HAVE_LIBCRYPTO) && defined(HAVE_HMAC_CTX_NEW)
+	archive_hmac_sha1_ctx	*hctx;
+#define HMAC_CTX_PTR(z) (z->hctx)
+#else
 	archive_hmac_sha1_ctx	hctx;
+#define HMAC_CTX_PTR(z) &(z->hctx)
+#endif
 	char			hctx_valid;
 
 	/* Strong encryption's decryption header information. */
@@ -1058,7 +1064,8 @@ check_authentication_code(struct archive_read *a, const void *_p)
 		size_t hmac_len = 20;
 		int cmp;
 
-		archive_hmac_sha1_final(&zip->hctx, hmac, &hmac_len);
+		archive_hmac_sha1_final(HMAC_CTX_PTR(zip), hmac,
+			&hmac_len);
 		if (_p == NULL) {
 			/* Read authentication code. */
 			p = __archive_read_ahead(a, AUTH_CODE_SIZE, NULL);
@@ -1223,7 +1230,7 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 			    zip->decrypted_buffer, dec_size);
 		} else {
 			size_t dsize = dec_size;
-			archive_hmac_sha1_update(&zip->hctx,
+			archive_hmac_sha1_update(HMAC_CTX_PTR(zip),
 			    (const uint8_t *)buff, dec_size);
 			archive_decrypto_aes_ctr_update(&zip->cctx,
 			    (const uint8_t *)buff, dec_size,
@@ -1400,7 +1407,7 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 	}
 	/* Calculate compressed data as much as we used.*/
 	if (zip->hctx_valid)
-		archive_hmac_sha1_update(&zip->hctx, sp, bytes_avail);
+		archive_hmac_sha1_update(HMAC_CTX_PTR(zip), sp, bytes_avail);
 	__archive_read_consume(a, bytes_avail);
 	zip->entry_bytes_remaining -= bytes_avail;
 	zip->entry_compressed_bytes_read += bytes_avail;
@@ -1796,7 +1803,8 @@ init_WinZip_AES_decryption(struct archive_read *a)
 		    "Decryption is unsupported due to lack of crypto library");
 		return (ARCHIVE_FAILED);
 	}
-	r = archive_hmac_sha1_init(&zip->hctx, derived_key + key_len, key_len);
+	r = archive_hmac_sha1_init(HMAC_CTX_PTR(zip), derived_key + key_len,
+		key_len);
 	if (r != 0) {
 		archive_decrypto_aes_ctr_release(&zip->cctx);
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
@@ -1954,7 +1962,7 @@ archive_read_format_zip_cleanup(struct archive_read *a)
 	if (zip->cctx_valid)
 		archive_decrypto_aes_ctr_release(&zip->cctx);
 	if (zip->hctx_valid)
-		archive_hmac_sha1_cleanup(&zip->hctx);
+		archive_hmac_sha1_cleanup(HMAC_CTX_PTR(zip));
 	free(zip->iv);
 	free(zip->erd);
 	free(zip->v_data);

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1655,7 +1655,7 @@ is_winzip_aes_encryption_supported(int encryption)
 	uint8_t derived_key[MAX_DERIVED_KEY_BUF_SIZE];
 	archive_crypto_ctx cctx;
 #if defined(HAVE_LIBCRYPTO) && defined(HAVE_HMAC_CTX_NEW)
-	archive_hmac_sha1_ctx *htcx;
+	archive_hmac_sha1_ctx *hctx;
 #define CTX_PTR(c) (c)
 #else
 	archive_hmac_sha1_ctx hctx;

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1654,7 +1654,13 @@ is_winzip_aes_encryption_supported(int encryption)
 	uint8_t salt[16 + 2];
 	uint8_t derived_key[MAX_DERIVED_KEY_BUF_SIZE];
 	archive_crypto_ctx cctx;
+#if defined(HAVE_LIBCRYPTO) && defined(HAVE_HMAC_CTX_NEW)
+	archive_hmac_sha1_ctx *htcx;
+#define CTX_PTR(c) (c)
+#else
 	archive_hmac_sha1_ctx hctx;
+#define CTX_PTR(c) (&c)
+#endif
 	int ret;
 
 	if (encryption == ENCRYPTION_WINZIP_AES128) {
@@ -1675,11 +1681,11 @@ is_winzip_aes_encryption_supported(int encryption)
 	ret = archive_encrypto_aes_ctr_init(&cctx, derived_key, key_len);
 	if (ret != 0)
 		return (0);
-	ret = archive_hmac_sha1_init(&hctx, derived_key + key_len,
+	ret = archive_hmac_sha1_init(CTX_PTR(hctx), derived_key + key_len,
 	    key_len);
 	archive_encrypto_aes_ctr_release(&cctx);
 	if (ret != 0)
 		return (0);
-	archive_hmac_sha1_cleanup(&hctx);
+	archive_hmac_sha1_cleanup(CTX_PTR(hctx));
 	return (1);
 }


### PR DESCRIPTION
[Gist to test FreeBSD port](https://gist.github.com/melvyn-sopacua/f66152c790ca759b20beb110a8b9366a)

I've set this up to be a temporary compatibility fix - the real fix will need decisions best made by the author on how to proceed with handling of these now opaque types.