### PR TITLE
Add support for building with OpenSSL 1.1 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,6 +118,8 @@ libarchive_la_SOURCES= \
 	libarchive/archive_hmac.c \
 	libarchive/archive_hmac_private.h \
 	libarchive/archive_match.c \
+	libarchive/archive_openssl_evp_private.h \
+	libarchive/archive_openssl_hmac_private.h \
 	libarchive/archive_options.c \
 	libarchive/archive_options_private.h \
 	libarchive/archive_pack_dev.h \

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -38,6 +38,8 @@ SET(libarchive_SOURCES
   archive_hmac.c
   archive_hmac_private.h
   archive_match.c
+  archive_openssl_evp_private.h
+  archive_openssl_hmac_private.h
   archive_options.c
   archive_options_private.h
   archive_pack_dev.h

--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -302,6 +302,7 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 static int
 aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
 {
+	ctx->ctx = EVP_CIPHER_CTX_new();
 
 	switch (key_len) {
 	case 16: ctx->type = EVP_aes_128_ecb(); break;
@@ -314,7 +315,7 @@ aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
 	memcpy(ctx->key, key, key_len);
 	memset(ctx->nonce, 0, sizeof(ctx->nonce));
 	ctx->encr_pos = AES_BLOCK_SIZE;
-	EVP_CIPHER_CTX_init(&ctx->ctx);
+	EVP_CIPHER_CTX_init(ctx->ctx);
 	return 0;
 }
 
@@ -324,10 +325,10 @@ aes_ctr_encrypt_counter(archive_crypto_ctx *ctx)
 	int outl = 0;
 	int r;
 
-	r = EVP_EncryptInit_ex(&ctx->ctx, ctx->type, NULL, ctx->key, NULL);
+	r = EVP_EncryptInit_ex(ctx->ctx, ctx->type, NULL, ctx->key, NULL);
 	if (r == 0)
 		return -1;
-	r = EVP_EncryptUpdate(&ctx->ctx, ctx->encr_buf, &outl, ctx->nonce,
+	r = EVP_EncryptUpdate(ctx->ctx, ctx->encr_buf, &outl, ctx->nonce,
 	    AES_BLOCK_SIZE);
 	if (r == 0 || outl != AES_BLOCK_SIZE)
 		return -1;
@@ -337,7 +338,7 @@ aes_ctr_encrypt_counter(archive_crypto_ctx *ctx)
 static int
 aes_ctr_release(archive_crypto_ctx *ctx)
 {
-	EVP_CIPHER_CTX_cleanup(&ctx->ctx);
+	EVP_CIPHER_CTX_free(ctx->ctx);
 	memset(ctx->key, 0, ctx->key_len);
 	memset(ctx->nonce, 0, sizeof(ctx->nonce));
 	return 0;

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -104,7 +104,7 @@ typedef struct {
 #define AES_MAX_KEY_SIZE 32
 
 typedef struct {
-	EVP_CIPHER_CTX	ctx;
+	EVP_CIPHER_CTX	*ctx;
 	const EVP_CIPHER *type;
 	uint8_t		key[AES_MAX_KEY_SIZE];
 	unsigned	key_len;

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -99,7 +99,7 @@ typedef struct {
 } archive_crypto_ctx;
 
 #elif defined(HAVE_LIBCRYPTO)
-#include <openssl/evp.h>
+#include "archive_openssl_evp_private.h"
 #define AES_BLOCK_SIZE	16
 #define AES_MAX_KEY_SIZE 32
 

--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -207,7 +207,9 @@ __archive_nettle_md5final(archive_md5_ctx *ctx, void *md)
 static int
 __archive_openssl_md5init(archive_md5_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_md5());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_md5());
   return (ARCHIVE_OK);
 }
 
@@ -215,7 +217,7 @@ static int
 __archive_openssl_md5update(archive_md5_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
@@ -226,8 +228,11 @@ __archive_openssl_md5final(archive_md5_ctx *ctx, void *md)
    * this is meant to cope with that. Real fix is probably to fix
    * archive_write_set_format_xar.c
    */
-  if (ctx->digest)
-    EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 
@@ -359,7 +364,9 @@ __archive_nettle_ripemd160final(archive_rmd160_ctx *ctx, void *md)
 static int
 __archive_openssl_ripemd160init(archive_rmd160_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_ripemd160());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_ripemd160());
   return (ARCHIVE_OK);
 }
 
@@ -367,14 +374,18 @@ static int
 __archive_openssl_ripemd160update(archive_rmd160_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
 static int
 __archive_openssl_ripemd160final(archive_rmd160_ctx *ctx, void *md)
 {
-  EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 
@@ -509,7 +520,9 @@ __archive_nettle_sha1final(archive_sha1_ctx *ctx, void *md)
 static int
 __archive_openssl_sha1init(archive_sha1_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_sha1());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_sha1());
   return (ARCHIVE_OK);
 }
 
@@ -517,7 +530,7 @@ static int
 __archive_openssl_sha1update(archive_sha1_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
@@ -528,8 +541,11 @@ __archive_openssl_sha1final(archive_sha1_ctx *ctx, void *md)
    * this is meant to cope with that. Real fix is probably to fix
    * archive_write_set_format_xar.c
    */
-  if (ctx->digest)
-    EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 
@@ -733,7 +749,9 @@ __archive_nettle_sha256final(archive_sha256_ctx *ctx, void *md)
 static int
 __archive_openssl_sha256init(archive_sha256_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_sha256());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_sha256());
   return (ARCHIVE_OK);
 }
 
@@ -741,14 +759,18 @@ static int
 __archive_openssl_sha256update(archive_sha256_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
 static int
 __archive_openssl_sha256final(archive_sha256_ctx *ctx, void *md)
 {
-  EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 
@@ -928,7 +950,9 @@ __archive_nettle_sha384final(archive_sha384_ctx *ctx, void *md)
 static int
 __archive_openssl_sha384init(archive_sha384_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_sha384());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_sha384());
   return (ARCHIVE_OK);
 }
 
@@ -936,14 +960,18 @@ static int
 __archive_openssl_sha384update(archive_sha384_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
 static int
 __archive_openssl_sha384final(archive_sha384_ctx *ctx, void *md)
 {
-  EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 
@@ -1147,7 +1175,9 @@ __archive_nettle_sha512final(archive_sha512_ctx *ctx, void *md)
 static int
 __archive_openssl_sha512init(archive_sha512_ctx *ctx)
 {
-  EVP_DigestInit(ctx, EVP_sha512());
+  if ((*ctx = EVP_MD_CTX_new()) == NULL)
+	return (ARCHIVE_FAILED);
+  EVP_DigestInit(*ctx, EVP_sha512());
   return (ARCHIVE_OK);
 }
 
@@ -1155,14 +1185,18 @@ static int
 __archive_openssl_sha512update(archive_sha512_ctx *ctx, const void *indata,
     size_t insize)
 {
-  EVP_DigestUpdate(ctx, indata, insize);
+  EVP_DigestUpdate(*ctx, indata, insize);
   return (ARCHIVE_OK);
 }
 
 static int
 __archive_openssl_sha512final(archive_sha512_ctx *ctx, void *md)
 {
-  EVP_DigestFinal(ctx, md, NULL);
+  if (*ctx) {
+    EVP_DigestFinal(*ctx, md, NULL);
+    EVP_MD_CTX_free(*ctx);
+    *ctx = NULL;
+  }
   return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_digest_private.h
+++ b/libarchive/archive_digest_private.h
@@ -134,7 +134,7 @@
   defined(ARCHIVE_CRYPTO_SHA384_OPENSSL) ||\
   defined(ARCHIVE_CRYPTO_SHA512_OPENSSL)
 #define	ARCHIVE_CRYPTO_OPENSSL 1
-#include <openssl/evp.h>
+#include "archive_openssl_evp_private.h"
 #endif
 
 /* Windows crypto headers */

--- a/libarchive/archive_digest_private.h
+++ b/libarchive/archive_digest_private.h
@@ -161,7 +161,7 @@ typedef CC_MD5_CTX archive_md5_ctx;
 #elif defined(ARCHIVE_CRYPTO_MD5_NETTLE)
 typedef struct md5_ctx archive_md5_ctx;
 #elif defined(ARCHIVE_CRYPTO_MD5_OPENSSL)
-typedef EVP_MD_CTX archive_md5_ctx;
+typedef EVP_MD_CTX *archive_md5_ctx;
 #elif defined(ARCHIVE_CRYPTO_MD5_WIN)
 typedef Digest_CTX archive_md5_ctx;
 #else
@@ -175,7 +175,7 @@ typedef RIPEMD160_CTX archive_rmd160_ctx;
 #elif defined(ARCHIVE_CRYPTO_RMD160_NETTLE)
 typedef struct ripemd160_ctx archive_rmd160_ctx;
 #elif defined(ARCHIVE_CRYPTO_RMD160_OPENSSL)
-typedef EVP_MD_CTX archive_rmd160_ctx;
+typedef EVP_MD_CTX *archive_rmd160_ctx;
 #else
 typedef unsigned char archive_rmd160_ctx;
 #endif
@@ -189,7 +189,7 @@ typedef CC_SHA1_CTX archive_sha1_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA1_NETTLE)
 typedef struct sha1_ctx archive_sha1_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA1_OPENSSL)
-typedef EVP_MD_CTX archive_sha1_ctx;
+typedef EVP_MD_CTX *archive_sha1_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA1_WIN)
 typedef Digest_CTX archive_sha1_ctx;
 #else
@@ -209,7 +209,7 @@ typedef CC_SHA256_CTX archive_sha256_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA256_NETTLE)
 typedef struct sha256_ctx archive_sha256_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA256_OPENSSL)
-typedef EVP_MD_CTX archive_sha256_ctx;
+typedef EVP_MD_CTX *archive_sha256_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA256_WIN)
 typedef Digest_CTX archive_sha256_ctx;
 #else
@@ -227,7 +227,7 @@ typedef CC_SHA512_CTX archive_sha384_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA384_NETTLE)
 typedef struct sha384_ctx archive_sha384_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA384_OPENSSL)
-typedef EVP_MD_CTX archive_sha384_ctx;
+typedef EVP_MD_CTX *archive_sha384_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA384_WIN)
 typedef Digest_CTX archive_sha384_ctx;
 #else
@@ -247,7 +247,7 @@ typedef CC_SHA512_CTX archive_sha512_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA512_NETTLE)
 typedef struct sha512_ctx archive_sha512_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA512_OPENSSL)
-typedef EVP_MD_CTX archive_sha512_ctx;
+typedef EVP_MD_CTX *archive_sha512_ctx;
 #elif defined(ARCHIVE_CRYPTO_SHA512_WIN)
 typedef Digest_CTX archive_sha512_ctx;
 #else

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -176,8 +176,10 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)
 {
-	HMAC_CTX_init(ctx);
-	HMAC_Init(ctx, key, key_len, EVP_sha1());
+	*ctx = HMAC_CTX_new();
+	if (*ctx == NULL)
+		return -1;
+	HMAC_Init_ex(*ctx, key, key_len, EVP_sha1(), NULL);
 	return 0;
 }
 
@@ -185,22 +187,22 @@ static void
 __hmac_sha1_update(archive_hmac_sha1_ctx *ctx, const uint8_t *data,
     size_t data_len)
 {
-	HMAC_Update(ctx, data, data_len);
+	HMAC_Update(*ctx, data, data_len);
 }
 
 static void
 __hmac_sha1_final(archive_hmac_sha1_ctx *ctx, uint8_t *out, size_t *out_len)
 {
 	unsigned int len = (unsigned int)*out_len;
-	HMAC_Final(ctx, out, &len);
+	HMAC_Final(*ctx, out, &len);
 	*out_len = len;
 }
 
 static void
 __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 {
-	HMAC_CTX_cleanup(ctx);
-	memset(ctx, 0, sizeof(*ctx));
+	HMAC_CTX_free(*ctx);
+	*ctx = NULL;
 }
 
 #else

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -70,7 +70,7 @@ typedef struct {
 typedef	struct hmac_sha1_ctx archive_hmac_sha1_ctx;
 
 #elif defined(HAVE_LIBCRYPTO)
-#include <openssl/hmac.h>
+#include "archive_openssl_hmac_private.h"
 
 typedef	HMAC_CTX archive_hmac_sha1_ctx;
 

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -72,7 +72,7 @@ typedef	struct hmac_sha1_ctx archive_hmac_sha1_ctx;
 #elif defined(HAVE_LIBCRYPTO)
 #include "archive_openssl_hmac_private.h"
 
-typedef	HMAC_CTX archive_hmac_sha1_ctx;
+typedef	HMAC_CTX* archive_hmac_sha1_ctx;
 
 #else
 

--- a/libarchive/archive_openssl_evp_private.h
+++ b/libarchive/archive_openssl_evp_private.h
@@ -1,0 +1,51 @@
+/*-
+ * Copyright (c) 2003-2007 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ARCHIVE_OPENSSL_EVP_PRIVATE_H_INCLUDED
+#define ARCHIVE_OPENSSL_EVP_PRIVATE_H_INCLUDED
+
+#include <openssl/evp.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#include <stdlib.h> /* malloc, free */
+#include <string.h> /* memset */
+static inline EVP_MD_CTX *EVP_MD_CTX_new(void)
+{
+	EVP_MD_CTX *ctx = (EVP_MD_CTX *)malloc(sizeof(EVP_MD_CTX));
+	if (ctx != NULL) {
+		memset(ctx, 0, sizeof(*ctx));
+	}
+	return ctx;
+}
+
+static inline void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{
+	EVP_MD_CTX_cleanup(ctx);
+	memset(ctx, 0, sizeof(*ctx));
+	free(ctx);
+}
+#endif
+
+#endif

--- a/libarchive/archive_openssl_hmac_private.h
+++ b/libarchive/archive_openssl_hmac_private.h
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (c) 2003-2007 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef ARCHIVE_OPENSSL_HMAC_PRIVATE_H_INCLUDED
+#define ARCHIVE_OPENSSL_HMAC_PRIVATE_H_INCLUDED
+
+#include <openssl/hmac.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#include <stdlib.h> /* malloc, free */
+#include <string.h> /* memset */
+static inline HMAC_CTX *HMAC_CTX_new(void)
+{
+	HMAC_CTX *ctx = (HMAC_CTX *)malloc(sizeof(HMAC_CTX));
+	if (ctx != NULL) {
+		memset(ctx, 0, sizeof(*ctx));
+		HMAC_CTX_init(ctx);
+	}
+	return ctx;
+}
+
+static inline void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+	HMAC_CTX_cleanup(ctx);
+	memset(ctx, 0, sizeof(*ctx));
+	free(ctx);
+}
+#endif
+
+#endif


### PR DESCRIPTION
OpenSSL 1.1 made some CTX structures opaque.  Port our code to use the structures only through pointers and add an adaption layer to make this work with OpenSSL 1.0 and below.

Closes: #810
Patch-from: https://bugzilla.redhat.com/1383744
