### PR TITLE
Free p (the memory allocated via slurpfile) when done with the contents

### DIFF
--- a/cpio/test/test_option_J_upper.c
+++ b/cpio/test/test_option_J_upper.c
@@ -47,10 +47,13 @@ DEFINE_TEST(test_option_J_upper)
 		}
 		failure("-J option is broken");
 		assertEqualInt(r, 0);
-		return;
+		goto done;
 	}
+	free(p);
 	/* Check that the archive file has an xz signature. */
 	p = slurpfile(&s, "archive.out");
 	assert(s > 2);
 	assertEqualMem(p, "\3757zXZ", 5);
+done:
+	free(p);
 }

--- a/cpio/test/test_option_Z_upper.c
+++ b/cpio/test/test_option_Z_upper.c
@@ -47,10 +47,13 @@ DEFINE_TEST(test_option_Z_upper)
 		}
 		failure("-Z option is broken");
 		assertEqualInt(r, 0);
-		return;
+		goto done;
 	}
+	free(p);
 	/* Check that the archive file has a compress signature. */
 	p = slurpfile(&s, "archive.out");
 	assert(s > 2);
 	assertEqualMem(p, "\x1f\x9d", 2);
+done:
+	free(p);
 }

--- a/cpio/test/test_option_u.c
+++ b/cpio/test/test_option_u.c
@@ -49,6 +49,7 @@ DEFINE_TEST(test_option_u)
 	p = slurpfile(&s, "copy/f");
 	assertEqualInt(s, 1);
 	assertEqualMem(p, "a", 1);
+	free(p);
 
 	/* Recreate the file with a single "b" */
 	assertMakeFile("f", 0644, "b");
@@ -68,6 +69,7 @@ DEFINE_TEST(test_option_u)
 	p = slurpfile(&s, "copy/f");
 	assertEqualInt(s, 1);
 	assertEqualMem(p, "a", 1);
+	free(p);
 
 	/* Copy the file to the "copy" dir with -u (force) */
 	r = systemf("echo f| %s -pud copy >copy.out 2>copy.err",
@@ -78,4 +80,5 @@ DEFINE_TEST(test_option_u)
 	p = slurpfile(&s, "copy/f");
 	assertEqualInt(s, 1);
 	assertEqualMem(p, "b", 1);
+	free(p);
 }

--- a/cpio/test/test_option_y.c
+++ b/cpio/test/test_option_y.c
@@ -46,11 +46,14 @@ DEFINE_TEST(test_option_y)
 		}
 		failure("-y option is broken");
 		assertEqualInt(r, 0);
-		return;
+		goto done;
 	}
 	assertTextFileContents("1 block\n", "archive.err");
 	/* Check that the archive file has a bzip2 signature. */
+	free(p);
 	p = slurpfile(&s, "archive.out");
 	assert(s > 2);
 	assertEqualMem(p, "BZh9", 4);
+done:
+	free(p);
 }


### PR DESCRIPTION
Reported by:	Coverity
CID:		1331631, 1331632, 1331633, 1331646