### PR TITLE
Don't leak `entry` in file_to_archive if archive_read_disk_entry_from_file fails with ARCHIVE_FAILED

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -703,6 +703,7 @@ file_to_archive(struct cpio *cpio, const char *srcpath)
 		lafe_warnc(0, "%s",
 		    archive_error_string(cpio->archive_read_disk));
 	if (r <= ARCHIVE_FAILED) {
+		archive_entry_free(entry);
 		cpio->return_value = 1;
 		return (r);
 	}


### PR DESCRIPTION
This greatly reduces memory usage when the call fails, e.g. a file cannot be stat'ed

Confirmed with the following snippet:

% d=/tmp/cpio_test
% mkdir -p $d
% while : ; do echo /nonexistent ; done | cpio -dump $d 2>/dev/null

Reported by:	Coverity
CID:		1016757