### PR TITLE
Document padding behavior of `archive_write_open`

### DIFF
--- a/libarchive/archive_write_open.3
+++ b/libarchive/archive_write_open.3
@@ -66,6 +66,9 @@ Freeze the settings, open the archive, and prepare for writing entries.
 This is the most generic form of this function, which accepts
 pointers to three callback functions which will be invoked by
 the compression layer to write the constructed archive.
+If you have not invoked
+.Fn archive_write_set_bytes_in_last_block ,
+then padding will be enabled.
 .It Fn archive_write_open_fd
 A convenience form of
 .Fn archive_write_open


### PR DESCRIPTION
Document the fact that `archive_write_open` by default includes padding up to `bytes_per_block` at the end unlike `archive_write_open_filename` (for regular files) or `archive_write_open_memory`.

I'm not sure this wording is very helpful and I also don't know the man-page format (not sure how to reference `bytes_per_block` or the archive_write_blocksize.3 ). So take this as more of a general suggestion than a finished patch.

This behavior was quite surprising to me and I'd like to save future users of this library the time of reading the source-code to figure out why there's a seemingly random padding up to the next 10KB.

The section where this is actually done is here: https://github.com/libarchive/libarchive/blob/54027a7ccd7b28dca995ef675b571241ff767c6c/libarchive/archive_write.c#L419-L432