### PR TITLE
Add --transform long option

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -617,7 +617,7 @@ Extract files as sparse files.
 For every block on disk, check first if it contains only NULL bytes and seek
 over it otherwise.
 This works similar to the conv=sparse option of dd.
-.It Fl s Ar pattern
+.It Fl s Ar pattern , Fl Fl transform Ar pattern
 Modify file or archive member names according to
 .Pa pattern .
 The pattern has the format

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -141,6 +141,7 @@ static const struct bsdtar_option {
 	{ "strip-components",	  1, OPTION_STRIP_COMPONENTS },
 	{ "to-stdout",            0, 'O' },
 	{ "totals",		  0, OPTION_TOTALS },
+	{ "transform",            1, 's' },
 	{ "uid",		  1, OPTION_UID },
 	{ "uname",		  1, OPTION_UNAME },
 	{ "uncompress",           0, 'Z' },


### PR DESCRIPTION
GNU tar has a `--transform` option to do `ed(1)`-style transforms. I think this is at least extremely close to the `-s` option in bsdtar, if not equivalent.

I'd like to see bsdtar recognize `--transform` as the long variant of `-s` for compatibility with GNU tar.
