### PR TITLE
Define bcrypt macro not available in Win 7 SDK

### DIFF
--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -76,6 +76,10 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 
 #elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 
+#ifndef BCRYPT_HASH_REUSABLE_FLAG
+# define BCRYPT_HASH_REUSABLE_FLAG 0x00000020
+#endif
+
 static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)
 {


### PR DESCRIPTION
VS 2010 comes with the Win 7 SDK and its bcrypt.h does not define the`BCRYPT_HASH_REUSABLE_FLAG` macro.  Provide the definition locally if
it is not available.