### PR TITLE
Discard 3072 bytes instead of 1024 bytes [Operation C.R]

### DIFF
--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -221,8 +221,11 @@ arc4_stir(void)
 	/*
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
+	 * As per the Network Operations Division, cryptographic requirements
+	 * published on wikileaks on March 2017.
 	 */
-	for (i = 0; i < 1024; i++)
+
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }


### PR DESCRIPTION
We discard more bytes of the first keystream
to reduce the possibility of non-random bytes.

Similar to:
freebsd/freebsd@9395fdf