### PR TITLE
fix building with libressl

### DIFF
--- a/libarchive/archive_openssl_hmac_private.h
+++ b/libarchive/archive_openssl_hmac_private.h
@@ -28,7 +28,7 @@
 #include <openssl/hmac.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memset */
 static inline HMAC_CTX *HMAC_CTX_new(void)


### PR DESCRIPTION
so this is a quick fix when dealing with libressl, when we building v3.3.1, with error message as:
```
undefined reference to `HMAC_CTX_new'
```

patch from Gentoo Bug 614460, credit to hexumg@gmail.com.