### PR TITLE
Fix segfault when using bsdcat in pipe mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1267,6 +1267,7 @@ bsdcat_test_SOURCES= \
 	cat/test/test_expand_mixed.c \
 	cat/test/test_expand_plain.c \
 	cat/test/test_expand_xz.c \
+	cat/test/test_stdin.c \
 	cat/test/test_help.c \
 	cat/test/test_version.c
 

--- a/cat/bsdcat.c
+++ b/cat/bsdcat.c
@@ -135,15 +135,16 @@ main(int argc, char **argv)
 	if (*bsdcat->argv == NULL) {
 		bsdcat_current_path = "<stdin>";
 		bsdcat_read_to_stdout(NULL);
-	} else
+	} else {
 		while (*bsdcat->argv) {
 			bsdcat_current_path = *bsdcat->argv++;
 			bsdcat_read_to_stdout(bsdcat_current_path);
 			bsdcat_next();
 		}
+		if (a != NULL)
+			archive_read_free(a);
+    }
 
-	if (a != NULL)
-		archive_read_free(a);
 
 	exit(exit_status);
 }

--- a/cat/test/CMakeLists.txt
+++ b/cat/test/CMakeLists.txt
@@ -21,6 +21,7 @@ IF(ENABLE_CAT AND ENABLE_TEST)
     test_expand_mixed.c
     test_expand_plain.c
     test_expand_xz.c
+    test_stdin.c
     test_help.c
     test_version.c
   )

--- a/cat/test/test_stdin.c
+++ b/cat/test/test_stdin.c
@@ -1,0 +1,42 @@
+/*-
+ * Copyright (c) 2017 Sean Purcell
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+#define DEV_NULL "/dev/null"
+#else
+#define DEV_NULL "NUL"
+#endif
+
+DEFINE_TEST(test_stdin)
+{
+	int f;
+
+	f = systemf("%s <%s >test.out 2>test.err", testprog, DEV_NULL);
+	assertEqualInt(0, f);
+	assertEmptyFile("test.out");
+	assertEmptyFile("test.err");
+}
+


### PR DESCRIPTION
Reproducible with `./bsdcat < /dev/null`

(gdb) bt
0  0x0000000000000000 in  ()
1  0x0000000000415681 in archive_free (a=0x632010) at libarchive/archive_virtual.c:62
2  0x000000000041572f in archive_read_free (a=0x632010) at libarchive/archive_virtual.c:102
3  0x0000000000401fbd in main (argc=1, argv=0x7fffffffdd98) at cat/bsdcat.c:146

archive_read_free in a->vtable was NULL after read_archive_free
in bsdcat_read_to_stdout.