### PR TITLE
Add missing .Nm to the NAME section.

### DIFF
--- a/libarchive/libarchive_changes.3
+++ b/libarchive/libarchive_changes.3
@@ -28,6 +28,7 @@
 .Dt LIBARCHIVE_CHANGES 3
 .Os
 .Sh NAME
+.Nm libarchive_changes
 .Nd changes in libarchive interface
 .\"
 .Sh CHANGES IN LIBARCHIVE 3


### PR DESCRIPTION
Without a proper NAME section, it is difficult for man page search utilities like whatis(1) and apropos(1) to index/search the man page.