### PR TITLE
Improve osf1 support

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -52,7 +52,7 @@
  */
 #if defined(__BORLANDC__) && __BORLANDC__ >= 0x560
 # include <stdint.h>
-#elif !defined(__WATCOMC__) && !defined(_MSC_VER) && !defined(__INTERIX) && !defined(__BORLANDC__) && !defined(_SCO_DS) && !defined(__osf__)
+#elif !defined(__WATCOMC__) && !defined(_MSC_VER) && !defined(__INTERIX) && !defined(__BORLANDC__) && !defined(_SCO_DS)
 # include <inttypes.h>
 #endif
 
@@ -67,7 +67,7 @@
 typedef __int64 la_int64_t;
 # else
 # include <unistd.h>  /* ssize_t */
-#  if defined(_SCO_DS) || defined(__osf__)
+#  if defined(_SCO_DS)
 typedef long long la_int64_t;
 #  else
 typedef int64_t la_int64_t;

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -58,7 +58,7 @@
 typedef __int64 la_int64_t;
 # else
 #include <unistd.h>
-#  if defined(_SCO_DS) || defined(__osf__)
+#  if defined(_SCO_DS)
 typedef long long la_int64_t;
 #  else
 typedef int64_t la_int64_t;


### PR DESCRIPTION
See:
-----------------------------------------------------------------------------------
libarchive/archive_match.c: In function 'add_pattern_from_file':
libarchive/archive_match.c:611: warning: passing argument 4 of 'archive_read_data_block' from incompatible pointer type
libarchive/archive.h:596: note: expected 'la_int64_t *' but argument is of type 'int64_t *'
libarchive/archive_match.c: At top level:
libarchive/archive_match.c:1585: error: conflicting types for 'archive_match_include_uid'
libarchive/archive.h:1167: note: previous declaration of 'archive_match_include_uid' was here
libarchive/archive_match.c:1596: error: conflicting types for 'archive_match_include_gid'
libarchive/archive.h:1168: note: previous declaration of 'archive_match_include_gid' was here
-----------------------------------------------------------------------------------
Probably very old versions of Tru64 UNIX is not supported int64_t.
(Released before 1999/10/18?) 

Recent versions of Tru64 UNIX is supported int64_t.
http://h41361.www4.hpe.com/dtk/Compaq_C_Compiler/doc/lrm/DOCU0006.HTM#data_types_ch.

ds15> uname -a
OSF1 ds15 V5.1 2650 alpha
ds15> pwd
/usr/include
ds15> find . -type f -print | xargs grep int64_t
./inttypes.h:typedef signed long int64_t;
./inttypes.h:typedef unsigned long uint64_t;

Please revert this commit.
https://github.com/libarchive/libarchive/commit/7f3fc930723dfe47318475aeb6e8e9c619953062