### PR TITLE
ensure ar strtab is null terminated

### DIFF
--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -374,13 +374,14 @@ archive_write_ar_data(struct archive_write *a, const void *buff, size_t s)
 			return (ARCHIVE_WARN);
 		}
 
-		ar->strtab = (char *)malloc(s);
+		ar->strtab = (char *)malloc(s + 1);
 		if (ar->strtab == NULL) {
 			archive_set_error(&a->archive, ENOMEM,
 			    "Can't allocate strtab buffer");
 			return (ARCHIVE_FATAL);
 		}
 		strncpy(ar->strtab, buff, s);
+		ar->strtab[s] = '\0';
 		ar->has_strtab = 1;
 	}
 


### PR DESCRIPTION
ar support calls strstr() on the strtab, which requres that its
arguments are null terminated.