### PR TITLE
libarchive.pc.in: add Cflags.private for static linking

### DIFF
--- a/build/pkgconfig/libarchive.pc.in
+++ b/build/pkgconfig/libarchive.pc.in
@@ -7,5 +7,6 @@ Name: libarchive
 Description: library that can create and read several streaming archive formats
 Version: @VERSION@
 Cflags: -I${includedir}
+Cflags.private: -DLIBARCHIVE_STATIC
 Libs: -L${libdir} -larchive
 Libs.private: @LIBS@


### PR DESCRIPTION
`pkgconf` supports a `Cflags.private` that simplifies static linking
for windows (mingw cross) builds. Users of `pkg-config` will be
unaffected by this as existing build scripts will already set the
`-DLIBARCHIVE_STATIC` as required.