### PR TITLE
Fix a potential NULL pointer dereference of `tar` in archive_read_support_format_tar when HAVE_COPYFILE_H is defined

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -251,15 +251,15 @@ archive_read_support_format_tar(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_read_support_format_tar");
 
 	tar = (struct tar *)calloc(1, sizeof(*tar));
-#ifdef HAVE_COPYFILE_H
-	/* Set this by default on Mac OS. */
-	tar->process_mac_extensions = 1;
-#endif
 	if (tar == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate tar data");
 		return (ARCHIVE_FATAL);
 	}
+#ifdef HAVE_COPYFILE_H
+	/* Set this by default on Mac OS. */
+	tar->process_mac_extensions = 1;
+#endif
 
 	r = __archive_read_register_format(a, tar, "tar",
 	    archive_read_format_tar_bid,


### PR DESCRIPTION
If HAVE_COPYFILE_H is defined and allocating tar via calloc fails, tar
would be dereferenced before the tar == NULL check is done, causing a
NULL pointer dereference. Move the HAVE_COPYFILE_H block after the NULL
dereference check.