### PR TITLE
Fix ZIP format names

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1061,6 +1061,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 		zip->end_of_entry = 1;
 
 	/* Set up a more descriptive format name. */
+        archive_string_empty(&zip->format_name);
 	archive_string_sprintf(&zip->format_name, "ZIP %d.%d (%s)",
 	    version / 10, version % 10,
 	    compression_name(zip->entry->compression));

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -41,6 +41,7 @@ verify_basic(struct archive *a, int seek_checks)
 	int64_t o;
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+        assertEqualString("ZIP 1.0 (uncompressed)", archive_format_name(a));
 	assertEqualString("dir/", archive_entry_pathname(ae));
 	assertEqualInt(1179604249, archive_entry_mtime(ae));
 	assertEqualInt(0, archive_entry_size(ae));
@@ -53,6 +54,7 @@ verify_basic(struct archive *a, int seek_checks)
 	assertEqualInt((int)s, 0);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+        assertEqualString("ZIP 2.0 (deflation)", archive_format_name(a));
 	assertEqualString("file1", archive_entry_pathname(ae));
 	assertEqualInt(1179604289, archive_entry_mtime(ae));
 	if (seek_checks)
@@ -72,6 +74,7 @@ verify_basic(struct archive *a, int seek_checks)
 	}
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+        assertEqualString("ZIP 2.0 (deflation)", archive_format_name(a));
 	assertEqualString("file2", archive_entry_pathname(ae));
 	assertEqualInt(1179605932, archive_entry_mtime(ae));
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
@@ -93,6 +96,7 @@ verify_basic(struct archive *a, int seek_checks)
 		assert(archive_errno(a) != 0);
 	}
 	assertEqualInt(ARCHIVE_EOF, archive_read_next_header(a, &ae));
+        assertEqualString("ZIP 2.0 (deflation)", archive_format_name(a));
 	/* Verify the number of files read. */
 	failure("the archive file has three files");
 	assertEqualInt(3, archive_file_count(a));


### PR DESCRIPTION
Fixes an issue in ZIP format names: the format name is appended to the format name of all of the preceding entries.