### PR TITLE
archive_write_disk_{posix,windows}.c: Don't modify attributes for…

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1981,6 +1981,10 @@ restore_entry(struct archive_write_disk *a)
 	if ((en == EISDIR || en == EEXIST)
 	    && (a->flags & ARCHIVE_EXTRACT_NO_OVERWRITE)) {
 		/* If we're not overwriting, we're done. */
+		if (S_ISDIR(a->mode)) {
+			/* Don't overwrite any settings on existing directories. */
+			a->todo = 0;
+		}
 		archive_entry_unset_size(a->entry);
 		return (ARCHIVE_OK);
 	}

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1325,6 +1325,10 @@ restore_entry(struct archive_write_disk *a)
 	if ((en == EISDIR || en == EEXIST)
 	    && (a->flags & ARCHIVE_EXTRACT_NO_OVERWRITE)) {
 		/* If we're not overwriting, we're done. */
+		if (S_ISDIR(a->mode)) {
+			/* Don't overwrite any settings on existing directories. */
+			a->todo = 0;
+		}
 		archive_entry_unset_size(a->entry);
 		return (ARCHIVE_OK);
 	}

--- a/libarchive/test/test_write_disk_perms.c
+++ b/libarchive/test/test_write_disk_perms.c
@@ -131,6 +131,8 @@ DEFINE_TEST(test_write_disk_perms)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct stat st;
+	uid_t original_uid;
+	uid_t try_to_change_uid;
 
 	assertUmask(UMASK);
 
@@ -203,46 +205,34 @@ DEFINE_TEST(test_write_disk_perms)
 
 	/* For dir, the owner should get left when not overwritting. */
 	assertMakeDir("dir_owner", 0744);
+
 	if (getuid() == 0) {
-		assertEqualInt(0, chown("dir_owner", getuid()+1, getgid()));
-		/* Check original owner. */
-		assertEqualInt(0, stat("dir_owner", &st));
-		failure("dir_owner: st.st_uid=%d", st.st_uid);
-		assertEqualInt(st.st_uid, getuid()+1);
-		/* Shouldn't edit the owner when no overwrite option is set. */
-		assert((ae = archive_entry_new()) != NULL);
-		archive_entry_copy_pathname(ae, "dir_owner");
-		archive_entry_set_mode(ae, S_IFDIR | 0744);
-		archive_entry_set_uid(ae, getuid());
-		archive_write_disk_set_options(a,
-			ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_NO_OVERWRITE);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
-		archive_entry_free(ae);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_finish_entry(a));
-		/* Make sure they're unchanged. */
-		assertEqualInt(0, stat("dir_owner", &st));
-		failure("dir_owner: st.st_uid=%d", st.st_uid);
-		assertEqualInt(st.st_uid, getuid()+1);
+		original_uid = getuid() + 1;
+		try_to_change_uid = getuid();
+		assertEqualInt(0, chown("dir_owner", original_uid, getgid()));
 	} else {
-		/* Check original owner. */
-		assertEqualInt(0, stat("dir_owner", &st));
-		failure("dir_owner: st.st_uid=%d", st.st_uid);
-		assertEqualInt(st.st_uid, getuid());
-		/* Shouldn't fail to set owner when no overwrite option is set. */
-		assert((ae = archive_entry_new()) != NULL);
-		archive_entry_copy_pathname(ae, "dir_owner");
-		archive_entry_set_mode(ae, S_IFDIR | 0744);
-		archive_entry_set_uid(ae, getuid()+1);
-		archive_write_disk_set_options(a,
-			ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_NO_OVERWRITE);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
-		archive_entry_free(ae);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_finish_entry(a));
-		/* Make sure they're unchanged. */
-		assertEqualInt(0, stat("dir_owner", &st));
-		failure("dir_owner: st.st_uid=%d", st.st_uid);
-		assertEqualInt(st.st_uid, getuid());
+		original_uid = getuid();
+		try_to_change_uid = getuid() + 1;
 	}
+
+	/* Check original owner. */
+	assertEqualInt(0, stat("dir_owner", &st));
+	failure("dir_owner: st.st_uid=%d", st.st_uid);
+	assertEqualInt(st.st_uid, original_uid);
+	/* Shouldn't try to edit the owner when no overwrite option is set. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "dir_owner");
+	archive_entry_set_mode(ae, S_IFDIR | 0744);
+	archive_entry_set_uid(ae, try_to_change_uid);
+	archive_write_disk_set_options(a,
+	    ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_NO_OVERWRITE);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_finish_entry(a));
+	/* Make sure they're unchanged. */
+	assertEqualInt(0, stat("dir_owner", &st));
+	failure("dir_owner: st.st_uid=%d", st.st_uid);
+	assertEqualInt(st.st_uid, original_uid);
 
 	/* Write a regular file with SUID bit, but don't use _EXTRACT_PERM. */
 	assert((ae = archive_entry_new()) != NULL);


### PR DESCRIPTION
…existing directories when ARCHIVE_EXTRACT_NO_OVERWRITE is set

Enables unpacking multiple archives into a single directory whose permissions,
owner, and other attributes are pre-configured or otherwise determined ahead
of time by a single archive without the need to repeat the same attributes in
every archive, such as in package installation scenarios.

The specific use case is for the [opkg package manager](https://code.google.com/archive/p/opkg/) to preserve attributes for directories created by one package while installing additional files from another package, such as for modular applications. opkg passes ARCHIVE_EXTRACT_NO_OVERWRITE, which preserves directory permissions, but directory owner is still modified. Tracked by [opkg bug 9887](https://bugzilla.yoctoproject.org/show_bug.cgi?id=9887#c2).