### PR TITLE
Fix -Werror=implicit-fallthrough= for GCC 7.

### DIFF
--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -1159,6 +1159,7 @@ archive_acl_from_text_w(struct archive_acl *acl, const wchar_t *text,
 	switch (want_type) {
 	case ARCHIVE_ENTRY_ACL_TYPE_POSIX1E:
 		want_type = ARCHIVE_ENTRY_ACL_TYPE_ACCESS;
+		__LA_FALLTHROUGH;
 	case ARCHIVE_ENTRY_ACL_TYPE_ACCESS:
 	case ARCHIVE_ENTRY_ACL_TYPE_DEFAULT:
 		numfields = 5;
@@ -1626,6 +1627,7 @@ archive_acl_from_text_l(struct archive_acl *acl, const char *text,
 	switch (want_type) {
 	case ARCHIVE_ENTRY_ACL_TYPE_POSIX1E:
 		want_type = ARCHIVE_ENTRY_ACL_TYPE_ACCESS;
+		__LA_FALLTHROUGH;
 	case ARCHIVE_ENTRY_ACL_TYPE_ACCESS:
 	case ARCHIVE_ENTRY_ACL_TYPE_DEFAULT:
 		numfields = 5;

--- a/libarchive/archive_platform.h
+++ b/libarchive/archive_platform.h
@@ -191,4 +191,10 @@
 #define	ARCHIVE_ERRNO_MISC (-1)
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ >= 7)
+#define	__LA_FALLTHROUGH	__attribute__((fallthrough))
+#else
+#define	__LA_FALLTHROUGH
+#endif
+
 #endif /* !ARCHIVE_PLATFORM_H_INCLUDED */

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1627,7 +1627,8 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 	switch (whence) {
 	case SEEK_CUR:
 		/* Adjust the offset and use SEEK_SET instead */
-		offset += filter->position;			
+		offset += filter->position;
+		__LA_FALLTHROUGH;
 	case SEEK_SET:
 		cursor = 0;
 		while (1)

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2555,6 +2555,7 @@ read_Header(struct archive_read *a, struct _7z_header_info *h,
 		case kDummy:
 			if (ll == 0)
 				break;
+			__LA_FALLTHROUGH;
 		default:
 			if (header_bytes(a, ll) == NULL)
 				return (-1);

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1499,6 +1499,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 		}
 		if (strcmp(key, "cksum") == 0)
 			break;
+		__LA_FALLTHROUGH;
 	case 'd':
 		if (strcmp(key, "device") == 0) {
 			/* stat(2) st_rdev field, e.g. the major/minor IDs
@@ -1512,12 +1513,14 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 				archive_entry_set_rdev(entry, dev);
 			return r;
 		}
+		__LA_FALLTHROUGH;
 	case 'f':
 		if (strcmp(key, "flags") == 0) {
 			*parsed_kws |= MTREE_HAS_FFLAGS;
 			archive_entry_copy_fflags_text(entry, val);
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'g':
 		if (strcmp(key, "gid") == 0) {
 			*parsed_kws |= MTREE_HAS_GID;
@@ -1529,16 +1532,19 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 			archive_entry_copy_gname(entry, val);
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'i':
 		if (strcmp(key, "inode") == 0) {
 			archive_entry_set_ino(entry, mtree_atol(&val, 10));
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'l':
 		if (strcmp(key, "link") == 0) {
 			archive_entry_copy_symlink(entry, val);
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'm':
 		if (strcmp(key, "md5") == 0 || strcmp(key, "md5digest") == 0)
 			break;
@@ -1555,6 +1561,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 			}
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'n':
 		if (strcmp(key, "nlink") == 0) {
 			*parsed_kws |= MTREE_HAS_NLINK;
@@ -1562,6 +1569,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 				(unsigned int)mtree_atol(&val, 10));
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'r':
 		if (strcmp(key, "resdevice") == 0) {
 			/* stat(2) st_dev field, e.g. the device ID where the
@@ -1577,6 +1585,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 		if (strcmp(key, "rmd160") == 0 ||
 		    strcmp(key, "rmd160digest") == 0)
 			break;
+		__LA_FALLTHROUGH;
 	case 's':
 		if (strcmp(key, "sha1") == 0 || strcmp(key, "sha1digest") == 0)
 			break;
@@ -1593,6 +1602,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 			archive_entry_set_size(entry, mtree_atol(&val, 10));
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 't':
 		if (strcmp(key, "tags") == 0) {
 			/*
@@ -1635,18 +1645,21 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 					archive_entry_set_filetype(entry, AE_IFBLK);
 					break;
 				}
+				__LA_FALLTHROUGH;
 			case 'c':
 				if (strcmp(val, "char") == 0) {
 					archive_entry_set_filetype(entry,
 						AE_IFCHR);
 					break;
 				}
+				__LA_FALLTHROUGH;
 			case 'd':
 				if (strcmp(val, "dir") == 0) {
 					archive_entry_set_filetype(entry,
 						AE_IFDIR);
 					break;
 				}
+				__LA_FALLTHROUGH;
 			case 'f':
 				if (strcmp(val, "fifo") == 0) {
 					archive_entry_set_filetype(entry,
@@ -1658,12 +1671,14 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 						AE_IFREG);
 					break;
 				}
+				__LA_FALLTHROUGH;
 			case 'l':
 				if (strcmp(val, "link") == 0) {
 					archive_entry_set_filetype(entry,
 						AE_IFLNK);
 					break;
 				}
+				__LA_FALLTHROUGH;
 			default:
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
@@ -1675,6 +1690,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 			*parsed_kws |= MTREE_HAS_TYPE;
 			break;
 		}
+		__LA_FALLTHROUGH;
 	case 'u':
 		if (strcmp(key, "uid") == 0) {
 			*parsed_kws |= MTREE_HAS_UID;
@@ -1686,6 +1702,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 			archive_entry_copy_uname(entry, val);
 			break;
 		}
+		__LA_FALLTHROUGH;
 	default:
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Unrecognized key %s=%s", key, val);

--- a/libarchive/test/read_open_memory.c
+++ b/libarchive/test/read_open_memory.c
@@ -91,9 +91,11 @@ read_open_memory_internal(struct archive *a, const void *buff,
 	switch (level) {
 	case 3:
 		archive_read_set_seek_callback(a, memory_read_seek);
+		__LA_FALLTHROUGH;
 	case 2:
 		archive_read_set_open_callback(a, memory_read_open);
 		archive_read_set_skip_callback(a, memory_read_skip);
+		__LA_FALLTHROUGH;
 	case 1:
 		mine = malloc(sizeof(*mine));
 		if (mine == NULL) {

--- a/libarchive/test/test.h
+++ b/libarchive/test/test.h
@@ -33,4 +33,10 @@
 #define	EXTRA_ERRNO(x)	archive_errno((struct archive *)(x))
 #define	EXTRA_VERSION	archive_version_details()
 
+#if defined(__GNUC__) && (__GNUC__ >= 7)
+#define	__LA_FALLTHROUGH	__attribute__((fallthrough))
+#else
+#define	__LA_FALLTHROUGH
+#endif
+
 #include "test_common.h"


### PR DESCRIPTION
Not sure when will we need to do the same thing to clang and/or VC, so I put this in a macro.

I guess the proper place for the macro definition is `archive_private.h`, but since `read_open_memory.c` also need this macro, and test files do not seem to allow to include private headers.