### PR TITLE
flush pending chdirs prior to processing mtree files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -972,8 +972,8 @@ bsdtar_test_SOURCES= \
 	tar/test/test_help.c \
 	tar/test/test_leading_slash.c \
 	tar/test/test_missing_file.c \
-	tar/test/test_option_C_upper.c \
 	tar/test/test_option_C_mtree.c \
+	tar/test/test_option_C_upper.c \
 	tar/test/test_option_H_upper.c \
 	tar/test/test_option_L_upper.c \
 	tar/test/test_option_O_upper.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -973,6 +973,7 @@ bsdtar_test_SOURCES= \
 	tar/test/test_leading_slash.c \
 	tar/test/test_missing_file.c \
 	tar/test/test_option_C_upper.c \
+	tar/test/test_option_C_mtree.c \
 	tar/test/test_option_H_upper.c \
 	tar/test/test_option_L_upper.c \
 	tar/test/test_option_O_upper.c \

--- a/tar/test/CMakeLists.txt
+++ b/tar/test/CMakeLists.txt
@@ -28,6 +28,7 @@ IF(ENABLE_TAR AND ENABLE_TEST)
     test_leading_slash.c
     test_missing_file.c
     test_option_C_upper.c
+    test_option_C_mtree.c
     test_option_H_upper.c
     test_option_L_upper.c
     test_option_O_upper.c

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -33,19 +33,24 @@ DEFINE_TEST(test_option_C_mtree)
 	char *p0;
 	size_t s;
 	int r;
-
 	p0 = NULL;
-
 	char *content = "./foo type=file uname=root gname=root mode=0755\n";
+	char *filename = "output.tar";
 
+	/* an absolute path to mtree file */ 
+	char *mtree_file = "/METALOG.mtree";	
+	char *absolute_path = malloc(strlen(testworkdir) + strlen(mtree_file) + 1);
+	strcpy(absolute_path, testworkdir);
+	strcat(absolute_path, mtree_file );
+	
 	/* Create an archive using an mtree file. */
-	assertMakeFile("/tmp/METALOG.mtree", 0777, content);
+	assertMakeFile(absolute_path, 0777, content);
 	assertMakeDir("bar", 0775);
 	assertMakeFile("bar/foo", 0777, "abc");
 
-	r = systemf("%s -cf output.tar -C bar @/tmp/METALOG.mtree >step1.out 2>step1.err", testprog);
+	r = systemf("%s -cf %s -C bar @%s >step1.out 2>step1.err", testprog, filename, absolute_path);
 
-	failure("Error invoking %s -cf output.tar -C bar @/tmp/METALOG.mtree", testprog);
+	failure("Error invoking %s -cf %s -C bar @%s", testprog, filename, absolute_path);
 	assertEqualInt(r, 0);
 	assertEmptyFile("step1.out");
 	assertEmptyFile("step1.err");

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -1,0 +1,70 @@
+/*-
+ * Copyright (c) 2018 Arshan Khanifar
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+__FBSDID("$FreeBSD$");
+
+DEFINE_TEST(test_option_C_mtree)
+{
+	char *buff;
+	char *p0;
+	size_t s;
+	int r;
+
+	buff = NULL;
+	p0 = NULL;
+
+	char *content = "./foo type=file uname=root gname=root mode=0755\n";
+
+	/* Create an archive using an mtree file. */
+	assertMakeFile("/tmp/METALOG.mtree", 0777, content);
+	assertMakeDir("bar", 0775);
+	assertMakeFile("bar/foo", 0777, "abc");
+
+	r = systemf("%s -cf output.tar -C bar @/tmp/METALOG.mtree >step1.out 2>step1.err", testprog);
+
+	failure("Error invoking %s -cf output.tar -C bar @/tmp/METALOG.mtree", testprog);
+	assertEqualInt(r, 0);
+	assertEmptyFile("step1.out");
+	assertEmptyFile("step1.err");
+
+	/* Do validation of the constructed archive. */
+
+	p0 = slurpfile(&s, "output.tar");
+	if (!assert(p0 != NULL))
+		goto done;
+	if (!assert(s >= 2048))
+		goto done;
+	assertEqualMem(p0 + 0, "./foo", 5);
+	assertEqualMem(p0 + 512, "abc", 3);
+	assertEqualMem(p0 + 1024, "\0\0\0\0\0\0\0\0", 8);
+	assertEqualMem(p0 + 1536, "\0\0\0\0\0\0\0\0", 8);
+
+	free(p0);
+done:
+	free(buff);
+	free(p0);
+}
+
+

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2007-2018 The FreeBSD Foundation
+ * Copyright (c) 2018 The FreeBSD Foundation
  * All rights reserved.
  * 
  * This software was developed by Arshan Khanifar <arshankhanifar@gmail.com>
@@ -61,8 +61,6 @@ DEFINE_TEST(test_option_C_mtree)
 	assertEqualMem(p0 + 512, "abc", 3);
 	assertEqualMem(p0 + 1024, "\0\0\0\0\0\0\0\0", 8);
 	assertEqualMem(p0 + 1536, "\0\0\0\0\0\0\0\0", 8);
-
-	free(p0);
 done:
 	free(p0);
 }

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -48,7 +48,7 @@ DEFINE_TEST(test_option_C_mtree)
 	assertMakeDir("bar", 0775);
 	assertMakeFile("bar/foo", 0777, "abc");
 
-	r = systemf("%s -cf %s -C bar @%s >step1.out 2>step1.err", testprog, filename, absolute_path);
+	r = systemf("%s -cf %s -C bar \"@%s\" >step1.out 2>step1.err", testprog, filename, absolute_path);
 
 	failure("Error invoking %s -cf %s -C bar @%s", testprog, filename, absolute_path);
 	assertEqualInt(r, 0);

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -1,6 +1,9 @@
 /*-
- * Copyright (c) 2018 Arshan Khanifar
+ * Copyright (c) 2007-2018 The FreeBSD Foundation
  * All rights reserved.
+ * 
+ * This software was developed by Arshan Khanifar <arshankhanifar@gmail.com>
+ * under sponsorship from the FreeBSD Foundation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +30,10 @@ __FBSDID("$FreeBSD$");
 
 DEFINE_TEST(test_option_C_mtree)
 {
-	char *buff;
 	char *p0;
 	size_t s;
 	int r;
 
-	buff = NULL;
 	p0 = NULL;
 
 	char *content = "./foo type=file uname=root gname=root mode=0755\n";
@@ -63,7 +64,6 @@ DEFINE_TEST(test_option_C_mtree)
 
 	free(p0);
 done:
-	free(buff);
 	free(p0);
 }
 

--- a/tar/write.c
+++ b/tar/write.c
@@ -503,10 +503,9 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 			}
 			set_chdir(bsdtar, arg);
 		} else {
-			if (*arg != '/' && (arg[0] != '@' || arg[1] != '/'))
+			if (*arg != '/')
 				do_chdir(bsdtar); /* Handle a deferred -C */
 			if (*arg == '@') {
-				do_chdir(bsdtar); /* Handle a deferred -C */
 				if (append_archive_filename(bsdtar, a,
 				    arg + 1) != 0)
 					break;

--- a/tar/write.c
+++ b/tar/write.c
@@ -506,6 +506,7 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 			if (*arg != '/' && (arg[0] != '@' || arg[1] != '/'))
 				do_chdir(bsdtar); /* Handle a deferred -C */
 			if (*arg == '@') {
+				do_chdir(bsdtar); /* Handle a deferred -C */
 				if (append_archive_filename(bsdtar, a,
 				    arg + 1) != 0)
 					break;


### PR DESCRIPTION
This is a proposed fix to [this issue](https://github.com/libarchive/libarchive/issues/991). 

When `bsdtar` is used in conjunction with an @mtree mode, it will ignore all the pending `chdir`s.

The added line flushes the pending `chdir`s so that the relative path specified in the @mtree file is relative to wherever we intended to go using `-C` option.  

For example, if the @mtree file has `./foo/bar.txt` specified, and we use the @mtree file in conjunction with the `-C baz` option, `bsdtar` will look at `./baz/foo/bar.txt`. 

Previously, it would ignore the `-C baz` option.