### PR TITLE
Off-by-one in zip creation

### DIFF
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1460,9 +1460,8 @@ copy_path(struct archive_entry *entry, unsigned char *p)
 	memcpy(p, path, pathlen);
 
 	/* Folders are recognized by a trailing slash. */
-	if ((type == AE_IFDIR) & (path[pathlen - 1] != '/')) {
+	if ((type == AE_IFDIR) && (path[pathlen - 1] != '/')) {
 		p[pathlen] = '/';
-		p[pathlen + 1] = '\0';
 	}
 }
 


### PR DESCRIPTION
Fix off-by-one.  The change from & to && is irrelevant but eliminates confusion.