### PR TITLE
fix build with LibreSSL 2.7

### DIFF
--- a/libarchive/archive_openssl_hmac_private.h
+++ b/libarchive/archive_openssl_hmac_private.h
@@ -28,7 +28,8 @@
 #include <openssl/hmac.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memset */
 static inline HMAC_CTX *HMAC_CTX_new(void)


### PR DESCRIPTION
LibreSSL 2.7 adds OpenSSL 1.1 API leading to conflicts on method names

See also: https://bugs.freebsd.org/226853
See also: https://github.com/Sp1l/LibreBSD/commit/f8e3cac50f2b9d5246c230418671e4186e47484c
Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>