### PR TITLE
Always create files owner-writable.

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1712,7 +1712,8 @@ _archive_write_disk_finish_entry(struct archive *_a)
 	 * which may be the state after set_mode(). Perform
 	 * set_xattrs() first based on these constraints.
 	 */
-	if (a->user_uid && (a->todo & TODO_XATTR)) {
+	if (a->user_uid != 0 &&
+	    (a->todo & TODO_XATTR)) {
 		int r2 = set_xattrs(a);
 		if (r2 < ret) ret = r2;
 	}
@@ -1732,7 +1733,8 @@ _archive_write_disk_finish_entry(struct archive *_a)
 	 * since they're implicitly removed by other file changes.
 	 * We do this last only when root.
 	 */
-	if (!a->user_uid && (a->todo & TODO_XATTR)) {
+	if (a->user_uid == 0 &&
+	    (a->todo & TODO_XATTR)) {
 		int r2 = set_xattrs(a);
 		if (r2 < ret) ret = r2;
 	}
@@ -2237,9 +2239,12 @@ create_filesystem_object(struct archive_write_disk *a)
 	 */
 	mode = final_mode & 0777 & ~a->user_umask;
 
-	if (a->todo & (TODO_HFS_COMPRESSION | 
-		       TODO_XATTR)) {
-		/* Always create writable such that [f]setxattr() works */
+	/* 
+	 * Always create writable such that [f]setxattr() works if we're not
+	 * root.
+	 */
+	if (a->user_uid != 0 &&
+	    a->todo & (TODO_HFS_COMPRESSION | TODO_XATTR)) {
 		mode |= 0200;
 	}
 

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2223,6 +2223,13 @@ create_filesystem_object(struct archive_write_disk *a)
 	 */
 	mode = final_mode & 0777 & ~a->user_umask;
 
+	if (a->todo & (TODO_HFS_COMPRESSION | 
+		       TODO_XATTR |
+	               TODO_MAC_METADATA)) {
+		/* Always create writable such that [f]setxattr() works */
+		mode |= 0200;
+	}
+
 	switch (a->mode & AE_IFMT) {
 	default:
 		/* POSIX requires that we fall through here. */


### PR DESCRIPTION
Keeps TODO_MODE around if final_mode isn't owner writable, but lets
fsetxattr() succeed for non-root users. (Required for HFS+ compression.)

This is an attempt at fixing #497 but certainly needs attention from the maintainers. I'm making use of the fact that if mode != final_mode at the end of create_filesystem_object(), then TODO_MODE is left set and cleaned up later. If the final mode includes 0200, this should make no additional system calls. Tries to only have the new behavior when needed (I know it's needed for non-root HFS extraction of read-only files, I'm guessing from the issue report it may be needed elsewhere for [f]setxattr() calls.

On my (OSX 10.13.4) platform, `make check` return the same set of failures with and without these changes. (Clearly extracting read-only HFS-compressed files isn't tested.) On my reproducer of HFS extraction failures (non-root, read-only files) this fixes the issue.