### PR TITLE
Fix gcc 8 warning about strncpy

### DIFF
--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -180,7 +180,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	}
 
 	memset(buff, ' ', 60);
-	strncpy(&buff[AR_fmag_offset], "`\n", 2);
+	memcpy(&buff[AR_fmag_offset], "`\n", 2);
 
 	if (strcmp(pathname, "/") == 0 ) {
 		/* Entry is archive symbol table in GNU format */
@@ -189,7 +189,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	}
 	if (strcmp(pathname, "__.SYMDEF") == 0) {
 		/* Entry is archive symbol table in BSD format */
-		strncpy(buff + AR_name_offset, "__.SYMDEF", 9);
+		memcpy(buff + AR_name_offset, "__.SYMDEF", 9);
 		goto stat;
 	}
 	if (strcmp(pathname, "//") == 0) {
@@ -225,7 +225,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 		 * actually 15 bytes.
 		 */
 		if (strlen(filename) <= 15) {
-			strncpy(&buff[AR_name_offset], 
+			memcpy(&buff[AR_name_offset],
 			    filename, strlen(filename));
 			buff[AR_name_offset + strlen(filename)] = '/';
 		} else {
@@ -248,7 +248,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 				return (ARCHIVE_FATAL);
 			}
 
-			strncpy(se, filename, strlen(filename));
+			memcpy(se, filename, strlen(filename));
 			strcpy(se + strlen(filename), "/\n");
 
 			ss = strstr(ar->strtab, se);
@@ -285,11 +285,11 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 		 * archive header.
 		 */
 		if (strlen(filename) <= 16 && strchr(filename, ' ') == NULL) {
-			strncpy(&buff[AR_name_offset], filename, strlen(filename));
+			memcpy(&buff[AR_name_offset], filename, strlen(filename));
 			buff[AR_name_offset + strlen(filename)] = ' ';
 		}
 		else {
-			strncpy(buff + AR_name_offset, "#1/", 3);
+			memcpy(buff + AR_name_offset, "#1/", 3);
 			if (format_decimal(strlen(filename),
 			    buff + AR_name_offset + 3,
 			    AR_name_size - 3)) {


### PR DESCRIPTION
Use memcpy instead.

Fix #1020