### PR TITLE
archive_entry.h: Fix missing int64_t type on musl libc

### DIFF
--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -42,6 +42,7 @@
 
 #include <sys/types.h>
 #include <stddef.h>  /* for wchar_t */
+#include <stdint.h>
 #include <time.h>
 
 #if defined(_WIN32) && !defined(__CYGWIN__)


### PR DESCRIPTION
This fixes an issue when using the archive_entry.h header that only seems to crop up on musl libc systems. So far I had only encountered it with appstream-glib; a [patch for this error was submitted](https://github.com/hughsie/appstream-glib/pull/217), but it appears to be mistargeted towards appstream-glib, because there's no use of int64_t in the project.

This patch fixes it, and I haven't observed any package build failures.