### PR TITLE
Android.mk: update libarchive sources

### DIFF
--- a/contrib/android/Android.mk
+++ b/contrib/android/Android.mk
@@ -94,9 +94,9 @@ libarchive_src_files := libarchive/archive_acl.c \
 						libarchive/archive_string.c \
 						libarchive/archive_string_sprintf.c \
 						libarchive/archive_util.c \
+						libarchive/archive_version_details.c \
 						libarchive/archive_virtual.c \
 						libarchive/archive_write.c \
-						libarchive/archive_write_disk_acl.c \
 						libarchive/archive_write_disk_posix.c \
 						libarchive/archive_write_disk_set_standard_lookup.c \
 						libarchive/archive_write_open_fd.c \


### PR DESCRIPTION
Remove non existent file and add missing file the list of libarchive
sources in Android.mk.

Signed-off-by: Anthony Brandon <anthony@amarulasolutions.com>