### PR TITLE
windows: Support UTF-8 locale

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -1512,8 +1512,10 @@ get_current_codepage(void)
 	p = strrchr(locale, '.');
 	if (p == NULL)
 		return (GetACP());
+	if (strcmp(p+1, "utf8") == 0)
+		return CP_UTF8;
 	cp = my_atoi(p+1);
-	if (cp <= 0)
+	if ((int)cp <= 0)
 		return (GetACP());
 	return (cp);
 }


### PR DESCRIPTION
Newer versions of the Windows CRT can return locales that are suffixed
with .utf8 instead of an integer code page.