### PR TITLE
Fix MinGW mtree test failure

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1218,7 +1218,10 @@ parse_file(struct archive_read *a, struct archive_entry *entry,
 			mtree->fd = open(path, O_RDONLY | O_BINARY | O_CLOEXEC);
 			__archive_ensure_cloexec_flag(mtree->fd);
 			if (mtree->fd == -1 &&
-				(errno != ENOENT ||
+                            /* On Windows, attempting to open a file with an invalid name
+                             * result in EINVAL (Error 22)
+                             */
+				((errno != ENOENT && errno != EINVAL) ||
 				 archive_strlen(&mtree->contents_name) > 0)) {
 				archive_set_error(&a->archive, errno,
 						"Can't open %s", path);


### PR DESCRIPTION
This fixes a test failure when building libarchive with MinGW and running under Wine.

The failing test is: `test_read_format_mtree`. Part of that test includes reading from a file, `dir2/dir3b/filename\\with_esc\b\t\fapes`, which doesn't exist. This is expected to fail with ENOENT, but on Windows, fails with EINVAL because the file name is not valid.