### PR TITLE
Fix MinGW match time test failure

### DIFF
--- a/libarchive/test/test_archive_match_time.c
+++ b/libarchive/test/test_archive_match_time.c
@@ -321,6 +321,11 @@ test_newer_ctime_than_file_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -434,6 +439,11 @@ test_newer_ctime_than_file_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -782,6 +792,11 @@ test_older_ctime_than_file_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -896,6 +911,11 @@ test_older_ctime_than_file_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -1073,6 +1093,11 @@ test_ctime_between_files_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -1131,6 +1156,11 @@ test_ctime_between_files_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;


### PR DESCRIPTION
On Windows, the ctime (metadata change time) cannot be set, which causes `test_archive_match_time` to fail. This pull requests skips the match time tests involving ctime in order to get a passing result when building with MinGW and running the tests in WINE.