### PR TITLE
Don't #undef stat and #define stat().

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -1232,7 +1232,7 @@ set_timefilter_pathname_mbs(struct archive_match *a, int timetype,
 		archive_set_error(&(a->archive), EINVAL, "pathname is empty");
 		return (ARCHIVE_FAILED);
 	}
-	if (stat(path, &st) != 0) {
+	if (la_stat(path, &st) != 0) {
 		archive_set_error(&(a->archive), errno, "Failed to stat()");
 		return (ARCHIVE_FAILED);
 	}

--- a/libarchive/archive_platform.h
+++ b/libarchive/archive_platform.h
@@ -69,6 +69,8 @@
  * either Windows or Posix APIs. */
 #if (defined(__WIN32__) || defined(_WIN32) || defined(__WIN32)) && !defined(__CYGWIN__)
 #include "archive_windows.h"
+#else
+#define la_stat(path,stref)		stat(path,stref)
 #endif
 
 /*

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -188,7 +188,7 @@ archive_read_disk_entry_from_file(struct archive *_a,
 				}
 			} else
 #endif
-			if (stat(path, &s) != 0) {
+			if (la_stat(path, &s) != 0) {
 				archive_set_error(&a->archive, errno,
 				    "Can't stat %s", path);
 				return (ARCHIVE_FAILED);

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -2450,7 +2450,7 @@ tree_current_stat(struct tree *t)
 #else
 		if (tree_enter_working_dir(t) != 0)
 			return NULL;
-		if (stat(tree_current_access_path(t), &t->st) != 0)
+		if (la_stat(tree_current_access_path(t), &t->st) != 0)
 #endif
 			return NULL;
 		t->flags |= hasStat;

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -449,7 +449,7 @@ __archive_mktemp(const char *tmpdir)
 		temp_name.s[temp_name.length-1] = '\0';
 		temp_name.length --;
 	}
-	if (stat(temp_name.s, &st) < 0)
+	if (la_stat(temp_name.s, &st) < 0)
 		goto exit_tmpfile;
 	if (!S_ISDIR(st.st_mode)) {
 		errno = ENOTDIR;

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -112,10 +112,7 @@
 #if !defined(__BORLANDC__) && !defined(__WATCOMC__)
 #define setmode		_setmode
 #endif
-#ifdef stat
-#undef stat
-#endif
-#define	stat(path,stref)		__la_stat(path,stref)
+#define	la_stat(path,stref)		__la_stat(path,stref)
 #if !defined(__WATCOMC__)
 #if !defined(__BORLANDC__)
 #define	strdup		_strdup

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2018,7 +2018,7 @@ restore_entry(struct archive_write_disk *a)
 		 * follow the symlink if we're creating a dir.
 		 */
 		if (S_ISDIR(a->mode))
-			r = stat(a->name, &a->st);
+			r = la_stat(a->name, &a->st);
 		/*
 		 * If it's not a dir (or it's a broken symlink),
 		 * then don't follow it.
@@ -2184,7 +2184,7 @@ create_filesystem_object(struct archive_write_disk *a)
 #ifdef HAVE_LSTAT
 			r = lstat(a->name, &st);
 #else
-			r = stat(a->name, &st);
+			r = la_stat(a->name, &st);
 #endif
 			if (r != 0)
 				r = errno;
@@ -2687,7 +2687,7 @@ check_symlinks_fsobj(char *path, int *a_eno, struct archive_string *a_estr,
 				 * This is needed to extract hardlinks over
 				 * symlinks.
 				 */
-				r = stat(head, &st);
+				r = la_stat(head, &st);
 				if (r != 0) {
 					tail[0] = c;
 					if (errno == ENOENT) {
@@ -3027,7 +3027,7 @@ create_dir(struct archive_write_disk *a, char *path)
 	 * here loses the ability to extract through symlinks.  Also note
 	 * that this should not use the a->st cache.
 	 */
-	if (stat(path, &st) == 0) {
+	if (la_stat(path, &st) == 0) {
 		if (S_ISDIR(st.st_mode))
 			return (ARCHIVE_OK);
 		if ((a->flags & ARCHIVE_EXTRACT_NO_OVERWRITE)) {
@@ -3085,7 +3085,7 @@ create_dir(struct archive_write_disk *a, char *path)
 	 * don't add it to the fixup list here, as it's already been
 	 * added.
 	 */
-	if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
+	if (la_stat(path, &st) == 0 && S_ISDIR(st.st_mode))
 		return (ARCHIVE_OK);
 
 	archive_set_error(&a->archive, errno, "Failed to create dir '%s'",


### PR DESCRIPTION
`stat` is one of those unfortunate identifiers for which there is both a struct and a function. MinGW uses a `#define` for setting `stat` to be the right struct, so doing `#undef stat` to clear the way for a `#define` for `stat()` the function inadvertently clobbers the selected `stat` struct. To avoid this, we define `la_stat()` to `_la_stat` on Windows and `stat()` elsewhere, and then use `la_stat()` instead of `stat()`.

Without this change, `test_entry` fails with 64-bit MinGW as follows: 

```
test_entry

libarchive/test/test_entry.c:661: archive_entry_atime(e) != 456789
      archive_entry_atime(e)=123456789 (0x75bcd15, 0726746425)
      456789=456789 (0x6f855, 01574125)
libarchive/test/test_entry.c:662: archive_entry_ctime(e) != 345678
      archive_entry_ctime(e)=234567 (0x39447, 0712107)
      345678=345678 (0x5464e, 01243116)
libarchive/test/test_entry.c:667: archive_entry_mtime(e) != 234567
      archive_entry_mtime(e)=456789 (0x6f855, 01574125)
      234567=234567 (0x39447, 0712107)
libarchive/test/test_entry.c:669: archive_entry_size(e) != 123456789
      archive_entry_size(e)=0 (0x0, 00)
      123456789=123456789 (0x75bcd15, 0726746425)
libarchive/test/test_entry.c:702: pst->st_atime != 456789
      pst->st_atime=234567 (0x39447, 0712107)
      456789=456789 (0x6f855, 01574125)
libarchive/test/test_entry.c:703: pst->st_ctime != 345678
      pst->st_ctime=2317494707427085609 (0x20296528650a0d29, 0200513122414502406451)
      345678=345678 (0x5464e, 01243116)
libarchive/test/test_entry.c:708: pst->st_mtime != 234567
      pst->st_mtime=345678 (0x5464e, 01243116)
      234567=234567 (0x39447, 0712107)
libarchive/test/test_entry.c:710: pst->st_size != 123456789
      pst->st_size=456789 (0x6f855, 01574125)
      123456789=123456789 (0x75bcd15, 0726746425)
libarchive/test/test_entry.c:724: pst->st_atime != 456788
      pst->st_atime=234567 (0x39447, 0712107)
      456788=456788 (0x6f854, 01574124)
libarchive/test/test_entry.c:729: pst->st_ctime != 345677
      pst->st_ctime=2317494707427085609 (0x20296528650a0d29, 0200513122414502406451)
      345677=345677 (0x5464d, 01243115)
libarchive/test/test_entry.c:754: pst->st_mtime != 234566
      pst->st_mtime=345677 (0x5464d, 01243115)
      234566=234566 (0x39446, 0712106)
libarchive/test/test_entry.c:764: pst->st_size != 123456788
      pst->st_size=456788 (0x6f854, 01574124)
      123456788=123456788 (0x75bcd14, 0726746424)
```

This is due to the wrong struct being picked up for `struct stat`, after the correct one was `#undef`d away.