### PR TITLE
RAR5 reader: Added missing config.h entries for libb2

### DIFF
--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -680,6 +680,12 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `bz2' library (-lbz2). */
 #cmakedefine HAVE_LIBBZ2 1
 
+/* Define to 1 if you have the `b2' library (-lb2). */
+#cmakedefine HAVE_LIBB2 1
+
+/* Define to 1 if you have the <blake2.h> header file. */
+#cmakedefine HAVE_BLAKE2_H 1
+
 /* Define to 1 if you have the `charset' library (-lcharset). */
 #cmakedefine HAVE_LIBCHARSET 1
 


### PR DESCRIPTION
I've noticed that when using CMake build to compile current master branch of libarchive, and using system libb2, the RAR5 unpacker overwrites some memory, causing a crash on exit.

This is due to linking the system `libb2.so` and using internal `archive_blake2.h` file instead of `/usr/include/blake2.h`. The internal file is included by the RAR5 reader because the `HAVE_BLAKE2_H` symbol is not defined, even if system `libb2.so` will be found.

The commit adds missing symbols to `build/cmake/config.h.in`, so that CMake will populate the `config.h` with the missing `HAVE_BLAKE2_H` symbol, together with `HAVE_LIBB2`.

After this commit, the RAR5 reader properly includes system blake2 header when system libb2 is used, and includes internal blake2 header when internal implementation of blake2 is used, not causing any crashes on exit anymore.