### PR TITLE
Fix full-pathname for extraction with UNC working directory on Windows

### DIFF
--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -474,6 +474,11 @@ permissive_name_w(struct archive_write_disk *a)
 	{
 		archive_wstrncpy(&(a->_name_data), wsp, l);
 	}
+	else if (l > 2 && wsp[0] == L'\\' && wsp[1] == L'\\' && wsp[2] != L'\\')
+	{
+		archive_wstrncpy(&(a->_name_data), L"\\\\?\\UNC\\", 8);
+		archive_wstrncat(&(a->_name_data), wsp+2, l-2);
+	}
 	else
 	{
 		archive_wstrncpy(&(a->_name_data), L"\\\\?\\", 4);


### PR DESCRIPTION
Extracting an archive with bsdtar -C option on windows fails, if the directory has been changed to an UNC path.

`Example: bsdtar.exe -C \\server\share\ -xf myarchive.tar`
`Can't create '\\\\?\\server\\share\\..`

Currently the prefix "\\\\?\\" is always pre-pended to the fullpath, but for an UNC path it must be "\\\\?\\UNC\\\".

A valid UNC path would be "\\\\?\\UNC\\server\\share", where "server" is the name of the computer and "share" is the name of the shared folder, cf. https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file