### PR TITLE
RAR5 reader bugfixes

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -726,3 +726,44 @@ DEFINE_TEST(test_read_format_rar5_extract_win32)
     assertA(0 == extract_one(a, ae, 0x36A448FF));
     EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_block_by_block)
+{
+    /* This test uses strange buffer sizes intentionally. */
+
+    struct archive_entry *ae;
+    struct archive *a;
+    uint8_t buf[173];
+    int bytes_read;
+    uint32_t computed_crc = 0;
+
+    extract_reference_file("test_read_format_rar5_compressed.rar");
+    assert((a = archive_read_new()) != NULL);
+    assertA(0 == archive_read_support_filter_all(a));
+    assertA(0 == archive_read_support_format_all(a));
+    assertA(0 == archive_read_open_filename(a, "test_read_format_rar5_compressed.rar", 130));
+    assertA(0 == archive_read_next_header(a, &ae));
+    assertEqualString("test.bin", archive_entry_pathname(ae));
+    assertEqualInt(1200, archive_entry_size(ae));
+
+    /* File size is 1200 bytes, we're reading it using a buffer of 173 bytes.
+     * Libarchive is configured to use a buffer of 130 bytes. */
+
+    while(1) {
+        /* archive_read_data should return one of:
+         * a) 0, if there is no more data to be read,
+         * b) negative value, if there was an error,
+         * c) positive value, meaning how many bytes were read.
+         */
+
+        bytes_read = archive_read_data(a, buf, sizeof(buf));
+        assertA(bytes_read >= 0);
+        if(bytes_read <= 0)
+            break;
+
+        computed_crc = crc32(computed_crc, buf, bytes_read);
+    }
+
+    assertEqualInt(computed_crc, 0x7CCA70CD);
+    EPILOGUE();
+}


### PR DESCRIPTION
- Fixed a bug during a block-by-block reading loop. Added a test that checks for the existence of this bug.

The RAR reader did not work well when trying to read i.e. 4096 bytes when there was only i.e. 1024 bytes of data available. This commit fixes this issue.

- Fixed 2 unlimited loops encountered when unpacking corrupted data.

Those unlimited loops were encountered during fuzzing. They shouldn't happen on valid RAR5 archives but the fix was needed anyway.

- Removed some 'maybe uninitialized' warnings.

Some warnings popped up when compiling under `afl-gcc`. No reason to leave them unresolved.