### PR TITLE
fix use-after-free in delayed newc link processing

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -540,8 +540,7 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 			lafe_warnc(archive_errno(disk),
 			    "%s", archive_error_string(disk));
 			bsdtar->return_value = 1;
-			archive_entry_free(entry);
-			continue;
+			goto next_entry;
 		}
 
 		/*
@@ -559,13 +558,13 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 				bsdtar->return_value = 1;
 			else
 				archive_read_close(disk);
-			archive_entry_free(entry);
-			continue;
+			goto next_entry;
 		}
 
 		write_file(bsdtar, a, entry);
-		archive_entry_free(entry);
 		archive_read_close(disk);
+next_entry:
+		archive_entry_free(entry);
 		entry = NULL;
 		archive_entry_linkify(bsdtar->resolver, &entry, &sparse_entry);
 	}


### PR DESCRIPTION
If some of the delayed links happened to disappear or become
unreadable for some reason (in background), the code free()d the
'entry' and continued to the next loop with freed entry variable,
leading to crash.