### PR TITLE
cmake: Set CMP0074 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 #
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) #3.12.0 `find_package()`` uses ``<PackageName>_ROOT`` variables.
+endif()
 #
 PROJECT(libarchive C)
 #


### PR DESCRIPTION
This is to address the following configuration warning reported
when configuring LibArchive against a version of zlib providing
a ZLIBConfig.cmake file:

```
  CMake Warning (dev) at CMakeLists.txt:393 (FIND_PACKAGE):
    Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
    Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.

    CMake variable ZLIB_ROOT is set to:

      /path/to/zlib-install

    For compatibility, CMake is ignoring the variable.
  This warning is for project developers.  Use -Wno-dev to suppress it.
```

For similar commit, see https://github.com/malaterre/GDCM/pull/62 and https://github.com/vxl/vxl/pull/503