### PR TITLE
Fix various crash, memory corruption and infinite loop conditions

### DIFF
--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -1723,6 +1723,11 @@ archive_acl_from_text_l(struct archive_acl *acl, const char *text,
 			st = field[n].start + 1;
 			len = field[n].end - field[n].start;
 
+			if (len == 0) {
+				ret = ARCHIVE_WARN;
+				continue;
+			}
+
 			switch (*s) {
 			case 'u':
 				if (len == 1 || (len == 4

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2300,6 +2300,11 @@ parse_codes(struct archive_read *a)
       new_size = DICTIONARY_MAX_SIZE;
     else
       new_size = rar_fls((unsigned int)rar->unp_size) << 1;
+    if (new_size == 0) {
+      archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+                        "Zero window size is invalid.");
+      return (ARCHIVE_FATAL);
+    }
     new_window = realloc(rar->lzss.window, new_size);
     if (new_window == NULL) {
       archive_set_error(&a->archive, ENOMEM,

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -386,6 +386,11 @@ _warc_read(struct archive_read *a, const void **buf, size_t *bsz, int64_t *off)
 		return (ARCHIVE_EOF);
 	}
 
+	if (w->unconsumed) {
+		__archive_read_consume(a, w->unconsumed);
+		w->unconsumed = 0U;
+	}
+
 	rab = __archive_read_ahead(a, 1U, &nrd);
 	if (nrd < 0) {
 		*bsz = 0U;


### PR DESCRIPTION
I have found some hangs, crashes and memory corruption issues in libarchive.

Two are in the RAR decoder. The first (patch 1) is a double-free via a `realloc(area, 0)`. This leads to a crash.

The second (patch 2) is memory corruption which seems to arise in ppmd7 decoding. The code can be made to read and write to a previously freed ppmd buffer by tricking the read-ahead code around multi-part archives. (This can be done even with a single archive file.) My gut feeling is that someone more skilled than I could cause arbitrary code execution with this, but I cannot say for certain.

There is a crash in ACL parsing for tar archives (patch 3). This is a simple NULL dereference leading to a crash.

The last of this batch is a quasi-infinite loop in the warc code (patch 4), where data isn't consumed after being written out, so a large Content-Length can be used to consume almost limitless time and space, leading to a DoS condition.

These were found with a combination of AFL, afl-rb and qsym.