### PR TITLE
Issue 1104: Explicitly limit the printed string to 12 characters

### DIFF
--- a/cpio/test/test_option_t.c
+++ b/cpio/test/test_option_t.c
@@ -88,11 +88,11 @@ DEFINE_TEST(test_option_t)
 	setlocale(LC_ALL, "");
 #endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
-	strftime(date2, sizeof(date), "%b %d  %Y", localtime(&mtime));
-	_snprintf(date, sizeof(date)-1, "%12s file", date2);
+	strftime(date2, sizeof(date2)-1, "%b %d  %Y", localtime(&mtime));
+	_snprintf(date, sizeof(date)-1, "%12.12s file", date2);
 #else
-	strftime(date2, sizeof(date), "%b %e  %Y", localtime(&mtime));
-	snprintf(date, sizeof(date)-1, "%12s file", date2);
+	strftime(date2, sizeof(date2)-1, "%b %e  %Y", localtime(&mtime));
+	snprintf(date, sizeof(date)-1, "%12.12s file", date2);
 #endif
 	assertEqualMem(p + 42, date, strlen(date));
 	free(p);


### PR DESCRIPTION
GCC8 tries to diagnose `snprintf()` overflows but isn't quite
smart enough for this case, so emits a false-positive warning.

Remember that `%12s` only specifies the minimum number of bytes.  GCC8
conservatively assumes this might result in writing the full length of
`date2`.  (Which will never be longer than 12 bytes, but GCC8
apparently can't reason about `strftime` format specifiers yet.)
Changing the specifier here to `%12.12s` explicitly truncates to 12
bytes and should help the compiler understand that this will never
overflow.

While I'm here, correct a minor typo in the previous line; it used
`sizeof(date)` instead of `sizeof(date2)`.  (Both are the same
size, so this had no functional impact.)