### PR TITLE
Add support for the 64-bit ar format

### DIFF
--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -388,9 +388,10 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 
 	/*
 	 * "/" is the SVR4/GNU archive symbol table.
+	 * "/SYM64/" is the SVR4/GNU 64-bit variant archive symbol table.
 	 */
-	if (strcmp(filename, "/") == 0) {
-		archive_entry_copy_pathname(entry, "/");
+	if (strcmp(filename, "/") == 0 || strcmp(filename, "/SYM64/") == 0) {
+		archive_entry_copy_pathname(entry, filename);
 		/* Parse the time, owner, mode, size fields. */
 		r = ar_parse_common_header(ar, entry, h);
 		/* Force the file type to a regular file. */

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -187,6 +187,11 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 		buff[AR_name_offset] = '/';
 		goto stat;
 	}
+	if (strcmp(pathname, "/SYM64/") == 0) {
+		/* Entry is archive symbol table in GNU 64-bit format */
+		memcpy(buff + AR_name_offset, "/SYM64/", 7);
+		goto stat;
+	}
 	if (strcmp(pathname, "__.SYMDEF") == 0) {
 		/* Entry is archive symbol table in BSD format */
 		memcpy(buff + AR_name_offset, "__.SYMDEF", 9);


### PR DESCRIPTION
Add support for reading and writing the [64-bit variant of the ar](https://en.wikipedia.org/wiki/Ar_(Unix)#64-bit_variant) format.

Currently, treats the 64-bit variant identically to the GNU format.