### PR TITLE
Add Cirrus-CI config for FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,17 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  ARCH: amd64
+  CPPFLAGS: -I/usr/local/include
+  LDFLAGS: -L/usr/local/lib
+
+task:
+  freebsd_instance:
+    matrix:
+      image: freebsd-12-0-release-amd64
+      image: freebsd-11-2-release-amd64
+  install_script:
+    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+    - pkg upgrade -y
+    - pkg install -y autoconf automake libiconv libtool pkgconf
+  script:
+    - ./build/ci_build.sh


### PR DESCRIPTION
Currently the test case test_compat_pax_libarchive_2x fails, but it is still good to do building tests and might also help debugging.