### PR TITLE
Fix a 7zip crash and a ISO9660 infinite loop

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2964,13 +2964,7 @@ get_uncompressed_data(struct archive_read *a, const void **buff, size_t size,
 	if (zip->codec == _7Z_COPY && zip->codec2 == (unsigned long)-1) {
 		/* Copy mode. */
 
-		/*
-		 * Note: '1' here is a performance optimization.
-		 * Recall that the decompression layer returns a count of
-		 * available bytes; asking for more than that forces the
-		 * decompressor to combine reads by copying data.
-		 */
-		*buff = __archive_read_ahead(a, 1, &bytes_avail);
+		*buff = __archive_read_ahead(a, minimum, &bytes_avail);
 		if (bytes_avail <= 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -2102,6 +2102,7 @@ parse_rockridge(struct archive_read *a, struct file_info *file,
     const unsigned char *p, const unsigned char *end)
 {
 	struct iso9660 *iso9660;
+	int entry_seen = 0;
 
 	iso9660 = (struct iso9660 *)(a->format->data);
 
@@ -2257,8 +2258,16 @@ parse_rockridge(struct archive_read *a, struct file_info *file,
 		}
 
 		p += p[2];
+		entry_seen = 1;
 	}
-	return (ARCHIVE_OK);
+
+	if (entry_seen)
+		return (ARCHIVE_OK);
+	else {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+				  "Tried to parse Rockridge extensions, but none found");
+		return (ARCHIVE_WARN);
+	}
 }
 
 static int


### PR DESCRIPTION
Fuzzing found two further file-format specific issues - a read-only segfault in 7z, and an infinite loop in ISO9660. Full details are in the commit messages.

Test cases are (tested on Ubuntu bionic and git head):
 - for the 7zip crash: [crash.7z.txt](https://github.com/libarchive/libarchive/files/2762797/crash.7z.txt)
 - for the ISO9660 infinite loop: [rrforever.iso.txt](https://github.com/libarchive/libarchive/files/2762827/rrforever.iso.txt)

In order to allow me to upload them to GitHub, I have converted them to text with `xxd`.  To replicate:

 ```
xxd -r rrforever.iso.txt rrforever.iso
bsdtar -Oxf rrforever.iso
```
(and likewise for `crash.7z`)

Fuzzing was done with AFL, FairFuzz (afl-rb) and a little bit of qsym.