### PR TITLE
Add missing header file include

### DIFF
--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -60,6 +60,9 @@ __RCSID("$NetBSD$");
 #ifdef HAVE_SYS_SYSMACROS_H
 #include <sys/sysmacros.h>
 #endif
+#ifdef HAVE_SYS_MKDEV_H
+#include <sys/mkdev.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
When building current version 3.3.3 on Solaris, the build fails with undefined symbol error (because of mkdev function). Addition of the

    #include <sys/mkdev.h>

fixes this problem. Since the configure is already checking for this header and uses it in other places, this change is pretty simple.