### PR TITLE
Delete unnecessary checks before some function calls

### DIFF
--- a/contrib/shar/tree.c
+++ b/contrib/shar/tree.c
@@ -530,8 +530,7 @@ tree_close(struct tree *t)
 	/* Release anything remaining in the stack. */
 	while (t->stack != NULL)
 		tree_pop(t);
-	if (t->buff)
-		free(t->buff);
+	free(t->buff);
 	/* chdir() back to where we started. */
 	if (t->initialDirFd >= 0) {
 		fchdir(t->initialDirFd);

--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -138,14 +138,10 @@ archive_acl_clear(struct archive_acl *acl)
 		free(acl->acl_head);
 		acl->acl_head = ap;
 	}
-	if (acl->acl_text_w != NULL) {
-		free(acl->acl_text_w);
-		acl->acl_text_w = NULL;
-	}
-	if (acl->acl_text != NULL) {
-		free(acl->acl_text);
-		acl->acl_text = NULL;
-	}
+	free(acl->acl_text_w);
+	acl->acl_text_w = NULL;
+	free(acl->acl_text);
+	acl->acl_text = NULL;
 	acl->acl_p = NULL;
 	acl->acl_types = 0;
 	acl->acl_state = 0; /* Not counting. */
@@ -324,14 +320,10 @@ acl_new_entry(struct archive_acl *acl,
 		return (NULL);
 	}
 
-	if (acl->acl_text_w != NULL) {
-		free(acl->acl_text_w);
-		acl->acl_text_w = NULL;
-	}
-	if (acl->acl_text != NULL) {
-		free(acl->acl_text);
-		acl->acl_text = NULL;
-	}
+	free(acl->acl_text_w);
+	acl->acl_text_w = NULL;
+	free(acl->acl_text);
+	acl->acl_text = NULL;
 
 	/*
 	 * If there's a matching entry already in the list, overwrite it.

--- a/libarchive/archive_disk_acl_sunos.c
+++ b/libarchive/archive_disk_acl_sunos.c
@@ -145,10 +145,8 @@ sunacl_get(int cmd, int *aclcnt, int fd, const char *path)
 					cnt = facl(fd, cmd, cnt, aclp);
 			}
 		} else {
-			if (aclp != NULL) {
-				free(aclp);
-				aclp = NULL;
-			}
+			free(aclp);
+			aclp = NULL;
 			break;
 		}
 	}

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1560,10 +1560,8 @@ archive_entry_acl_text_compat(int *flags)
 const wchar_t *
 archive_entry_acl_text_w(struct archive_entry *entry, int flags)
 {
-	if (entry->acl.acl_text_w != NULL) {
-		free(entry->acl.acl_text_w);
-		entry->acl.acl_text_w = NULL;
-	}
+	free(entry->acl.acl_text_w);
+	entry->acl.acl_text_w = NULL;
 	if (archive_entry_acl_text_compat(&flags) == 0)
 		entry->acl.acl_text_w = archive_acl_to_text_w(&entry->acl,
 		    NULL, flags, entry->archive);
@@ -1574,10 +1572,8 @@ archive_entry_acl_text_w(struct archive_entry *entry, int flags)
 const char *
 archive_entry_acl_text(struct archive_entry *entry, int flags)
 {
-	if (entry->acl.acl_text != NULL) {
-		free(entry->acl.acl_text);
-		entry->acl.acl_text = NULL;
-	}
+	free(entry->acl.acl_text);
+	entry->acl.acl_text = NULL;
 	if (archive_entry_acl_text_compat(&flags) == 0)
 		entry->acl.acl_text = archive_acl_to_text_l(&entry->acl, NULL,
 		    flags, NULL);
@@ -1590,10 +1586,8 @@ int
 _archive_entry_acl_text_l(struct archive_entry *entry, int flags,
     const char **acl_text, size_t *len, struct archive_string_conv *sc)
 {
-	if (entry->acl.acl_text != NULL) {
-		free(entry->acl.acl_text);
-		entry->acl.acl_text = NULL;
-        }
+	free(entry->acl.acl_text);
+	entry->acl.acl_text = NULL;
 
 	if (archive_entry_acl_text_compat(&flags) == 0)
 		entry->acl.acl_text = archive_acl_to_text_l(&entry->acl,

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -174,8 +174,7 @@ file_close(struct archive *a, void *client_data)
 	struct read_FILE_data *mine = (struct read_FILE_data *)client_data;
 
 	(void)a; /* UNUSED */
-	if (mine->buffer != NULL)
-		free(mine->buffer);
+	free(mine->buffer);
 	free(mine);
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3317,8 +3317,7 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 	 * Release the memory which the previous folder used for BCJ2.
 	 */
 	for (i = 0; i < 3; i++) {
-		if (zip->sub_stream_buff[i] != NULL)
-			free(zip->sub_stream_buff[i]);
+		free(zip->sub_stream_buff[i]);
 		zip->sub_stream_buff[i] = NULL;
 	}
 

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -138,8 +138,7 @@ archive_read_format_ar_cleanup(struct archive_read *a)
 	struct ar *ar;
 
 	ar = (struct ar *)(a->format->data);
-	if (ar->strtab)
-		free(ar->strtab);
+	free(ar->strtab);
 	free(ar);
 	(a->format->data) = NULL;
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -955,8 +955,7 @@ archive_read_format_cpio_cleanup(struct archive_read *a)
         while (cpio->links_head != NULL) {
                 struct links_entry *lp = cpio->links_head->next;
 
-                if (cpio->links_head->name)
-                        free(cpio->links_head->name);
+                free(cpio->links_head->name);
                 free(cpio->links_head);
                 cpio->links_head = lp;
         }

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -1724,8 +1724,7 @@ archive_read_format_iso9660_cleanup(struct archive_read *a)
 	free(iso9660->read_ce_req.reqs);
 	archive_string_free(&iso9660->pathname);
 	archive_string_free(&iso9660->previous_pathname);
-	if (iso9660->pending_files.files)
-		free(iso9660->pending_files.files);
+	free(iso9660->pending_files.files);
 #ifdef HAVE_ZLIB_H
 	free(iso9660->entry_zisofs.uncompressed_buffer);
 	free(iso9660->entry_zisofs.block_pointers);
@@ -3038,8 +3037,7 @@ heap_add_entry(struct archive_read *a, struct heap_queue *heap,
 		if (heap->allocated)
 			memcpy(new_pending_files, heap->files,
 			    heap->allocated * sizeof(new_pending_files[0]));
-		if (heap->files != NULL)
-			free(heap->files);
+		free(heap->files);
 		heap->files = new_pending_files;
 		heap->allocated = new_size;
 	}

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -588,8 +588,7 @@ static int run_filter(struct archive_read* a, struct filter_info* flt) {
     int ret;
     struct rar5* rar = get_context(a);
 
-    if(rar->cstate.filtered_buf)
-        free(rar->cstate.filtered_buf);
+    free(rar->cstate.filtered_buf);
 
     rar->cstate.filtered_buf = malloc(flt->block_length);
     if(!rar->cstate.filtered_buf) {
@@ -772,7 +771,7 @@ static void free_filters(struct rar5* rar) {
         struct filter_info* f = NULL;
 
         /* Pop_front will also decrease the collection's size. */
-        if(CDE_OK == cdeque_pop_front(d, cdeque_filter_p(&f)) && f != NULL)
+        if (CDE_OK == cdeque_pop_front(d, cdeque_filter_p(&f)))
             free(f);
     }
 
@@ -1847,11 +1846,9 @@ static void init_unpack(struct rar5* rar) {
     else
         rar->cstate.window_mask = 0;
 
-    if(rar->cstate.window_buf)
-        free(rar->cstate.window_buf);
+    free(rar->cstate.window_buf);
 
-    if(rar->cstate.filtered_buf)
-        free(rar->cstate.filtered_buf);
+    free(rar->cstate.filtered_buf);
 
     rar->cstate.window_buf = calloc(1, rar->cstate.window_size);
     rar->cstate.filtered_buf = calloc(1, rar->cstate.window_size);
@@ -3411,14 +3408,11 @@ static int64_t rar5_seek_data(struct archive_read *a, int64_t offset,
 static int rar5_cleanup(struct archive_read *a) {
     struct rar5* rar = get_context(a);
 
-    if(rar->cstate.window_buf)
-        free(rar->cstate.window_buf);
+    free(rar->cstate.window_buf);
 
-    if(rar->cstate.filtered_buf)
-        free(rar->cstate.filtered_buf);
+    free(rar->cstate.filtered_buf);
 
-    if(rar->vol.push_buf)
-        free(rar->vol.push_buf);
+    free(rar->vol.push_buf);
 
     free_filters(rar);
     cdeque_free(&rar->cstate.filters);

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1229,8 +1229,7 @@ heap_add_entry(struct archive_read *a,
 		}
 		memcpy(new_pending_files, heap->files,
 		    heap->allocated * sizeof(new_pending_files[0]));
-		if (heap->files != NULL)
-			free(heap->files);
+		free(heap->files);
 		heap->files = new_pending_files;
 		heap->allocated = new_size;
 	}

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1408,8 +1408,7 @@ zipx_xz_init(struct archive_read *a, struct zip *zip)
 
 	zip->zipx_lzma_valid = 1;
 
-	if(zip->uncompressed_buffer)
-		free(zip->uncompressed_buffer);
+	free(zip->uncompressed_buffer);
 
 	zip->uncompressed_buffer_size = 256 * 1024;
 	zip->uncompressed_buffer =
@@ -1806,8 +1805,7 @@ zipx_ppmd8_init(struct archive_read *a, struct zip *zip)
 	__archive_ppmd8_functions.Ppmd8_Init(&zip->ppmd8, order, restore_method);
 
 	/* Allocate the buffer that will hold uncompressed data. */
-	if(zip->uncompressed_buffer)
-		free(zip->uncompressed_buffer);
+	free(zip->uncompressed_buffer);
 
 	zip->uncompressed_buffer_size = 256 * 1024;
 	zip->uncompressed_buffer =
@@ -1926,8 +1924,7 @@ zipx_bzip2_init(struct archive_read *a, struct zip *zip)
 	zip->bzstream_valid = 1;
 
 	/* (Re)allocate the buffer that will contain decompressed bytes. */
-	if(zip->uncompressed_buffer)
-		free(zip->uncompressed_buffer);
+	free(zip->uncompressed_buffer);
 
 	zip->uncompressed_buffer_size = 256 * 1024;
 	zip->uncompressed_buffer =
@@ -2741,8 +2738,7 @@ archive_read_format_zip_cleanup(struct archive_read *a)
 	}
 #endif
 
-	if (zip->uncompressed_buffer)
-		free(zip->uncompressed_buffer);
+	free(zip->uncompressed_buffer);
 
 	if (zip->ppmd8_valid)
 		__archive_ppmd8_functions.Ppmd8_Free(&zip->ppmd8);

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1791,10 +1791,8 @@ finish_metadata:
 		a->fd = -1;
 	}
 	/* If there's an entry, we can release it now. */
-	if (a->entry) {
-		archive_entry_free(a->entry);
-		a->entry = NULL;
-	}
+	archive_entry_free(a->entry);
+	a->entry = NULL;
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	return (ret);
 }
@@ -2398,8 +2396,7 @@ _archive_write_disk_free(struct archive *_a)
 	ret = _archive_write_disk_close(&a->archive);
 	archive_write_disk_set_group_lookup(&a->archive, NULL, NULL, NULL);
 	archive_write_disk_set_user_lookup(&a->archive, NULL, NULL, NULL);
-	if (a->entry)
-		archive_entry_free(a->entry);
+	archive_entry_free(a->entry);
 	archive_string_free(&a->_name_data);
 	archive_string_free(&a->archive.error_string);
 	archive_string_free(&a->path_safe);

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -114,8 +114,7 @@ lookup_gid(void *private_data, const char *gname, int64_t gid)
 		return ((gid_t)b->id);
 
 	/* Free the cache slot for a new entry. */
-	if (b->name != NULL)
-		free(b->name);
+	free(b->name);
 	b->name = strdup(gname);
 	/* Note: If strdup fails, that's okay; we just won't cache. */
 	b->hash = h;
@@ -184,8 +183,7 @@ lookup_uid(void *private_data, const char *uname, int64_t uid)
 		return ((uid_t)b->id);
 
 	/* Free the cache slot for a new entry. */
-	if (b->name != NULL)
-		free(b->name);
+	free(b->name);
 	b->name = strdup(uname);
 	/* Note: If strdup fails, that's okay; we just won't cache. */
 	b->hash = h;

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -696,10 +696,8 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	a->pst = NULL;
 	a->current_fixup = NULL;
 	a->deferred = 0;
-	if (a->entry) {
-		archive_entry_free(a->entry);
-		a->entry = NULL;
-	}
+	archive_entry_free(a->entry);
+	a->entry = NULL;
 	a->entry = archive_entry_clone(entry);
 	a->fh = INVALID_HANDLE_VALUE;
 	a->fd_offset = 0;
@@ -1145,10 +1143,8 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		a->fh = INVALID_HANDLE_VALUE;
 	}
 	/* If there's an entry, we can release it now. */
-	if (a->entry) {
-		archive_entry_free(a->entry);
-		a->entry = NULL;
-	}
+	archive_entry_free(a->entry);
+	a->entry = NULL;
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	return (ret);
 }
@@ -1690,8 +1686,7 @@ _archive_write_disk_free(struct archive *_a)
 	ret = _archive_write_disk_close(&a->archive);
 	archive_write_disk_set_group_lookup(&a->archive, NULL, NULL, NULL);
 	archive_write_disk_set_user_lookup(&a->archive, NULL, NULL, NULL);
-	if (a->entry)
-		archive_entry_free(a->entry);
+	archive_entry_free(a->entry);
 	archive_wstring_free(&a->_name_data);
 	archive_string_free(&a->archive.error_string);
 	archive_wstring_free(&a->path_safe);

--- a/libarchive/archive_write_set_format_cpio.c
+++ b/libarchive/archive_write_set_format_cpio.c
@@ -408,8 +408,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		}
 	}
 exit_write_header:
-	if (entry_main)
-		archive_entry_free(entry_main);
+	archive_entry_free(entry_main);
 	return (ret_final);
 }
 

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -366,8 +366,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		}
 	}
 exit_write_header:
-	if (entry_main)
-		archive_entry_free(entry_main);
+	archive_entry_free(entry_main);
 	return (ret_final);
 }
 

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -565,8 +565,7 @@ archive_write_gnutar_header(struct archive_write *a,
 	gnutar->entry_bytes_remaining = archive_entry_size(entry);
 	gnutar->entry_padding = 0x1ff & (-(int64_t)gnutar->entry_bytes_remaining);
 exit_write_header:
-	if (entry_main)
-		archive_entry_free(entry_main);
+	archive_entry_free(entry_main);
 	return (ret);
 }
 

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -289,8 +289,7 @@ archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 			    "mkdir -p %s > /dev/null 2>&1\n",
 			    shar->quoted_name.s);
 			/* Record that we just created this directory. */
-			if (shar->last_dir != NULL)
-				free(shar->last_dir);
+			free(shar->last_dir);
 
 			shar->last_dir = strdup(name);
 			/* Trim a trailing '/'. */

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -169,8 +169,7 @@ archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 	}
 
 	/* Save the entry for the closing. */
-	if (shar->entry)
-		archive_entry_free(shar->entry);
+	archive_entry_free(shar->entry);
 	shar->entry = archive_entry_clone(entry);
 	name = archive_entry_pathname(entry);
 

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -352,14 +352,12 @@ archive_write_ustar_header(struct archive_write *a, struct archive_entry *entry)
 #endif
 	ret = __archive_write_format_header_ustar(a, buff, entry, -1, 1, sconv);
 	if (ret < ARCHIVE_WARN) {
-		if (entry_main)
-			archive_entry_free(entry_main);
+		archive_entry_free(entry_main);
 		return (ret);
 	}
 	ret2 = __archive_write_output(a, buff, 512);
 	if (ret2 < ARCHIVE_WARN) {
-		if (entry_main)
-			archive_entry_free(entry_main);
+		archive_entry_free(entry_main);
 		return (ret2);
 	}
 	if (ret2 < ret)
@@ -367,8 +365,7 @@ archive_write_ustar_header(struct archive_write *a, struct archive_entry *entry)
 
 	ustar->entry_bytes_remaining = archive_entry_size(entry);
 	ustar->entry_padding = 0x1ff & (-(int64_t)ustar->entry_bytes_remaining);
-	if (entry_main)
-		archive_entry_free(entry_main);
+	archive_entry_free(entry_main);
 	return (ret);
 }
 

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -330,14 +330,12 @@ archive_write_v7tar_header(struct archive_write *a, struct archive_entry *entry)
 #endif
 	ret = format_header_v7tar(a, buff, entry, 1, sconv);
 	if (ret < ARCHIVE_WARN) {
-		if (entry_main)
-			archive_entry_free(entry_main);
+		archive_entry_free(entry_main);
 		return (ret);
 	}
 	ret2 = __archive_write_output(a, buff, 512);
 	if (ret2 < ARCHIVE_WARN) {
-		if (entry_main)
-			archive_entry_free(entry_main);
+		archive_entry_free(entry_main);
 		return (ret2);
 	}
 	if (ret2 < ret)
@@ -345,8 +343,7 @@ archive_write_v7tar_header(struct archive_write *a, struct archive_entry *entry)
 
 	v7tar->entry_bytes_remaining = archive_entry_size(entry);
 	v7tar->entry_padding = 0x1ff & (-(int64_t)v7tar->entry_bytes_remaining);
-	if (entry_main)
-		archive_entry_free(entry_main);
+	archive_entry_free(entry_main);
 	return (ret);
 }
 

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -564,10 +564,8 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	zip->entry_uses_zip64 = 0;
 	zip->entry_crc32 = zip->crc32func(0, NULL, 0);
 	zip->entry_encryption = 0;
-	if (zip->entry != NULL) {
-		archive_entry_free(zip->entry);
-		zip->entry = NULL;
-	}
+	archive_entry_free(zip->entry);
+	zip->entry = NULL;
 
 	if (zip->cctx_valid)
 		archive_encrypto_aes_ctr_release(&zip->cctx);

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -2590,10 +2590,8 @@ sunacl_get(int cmd, int *aclcnt, int fd, const char *path)
 					cnt = facl(fd, cmd, cnt, aclp);
 			}
 		} else {
-			if (aclp != NULL) {
-				free(aclp);
-				aclp = NULL;
-			}
+			free(aclp);
+			aclp = NULL;
 			break;
 		}
 	}


### PR DESCRIPTION
- [The function “free”](https://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
- [The function “archive_entry_free” is implemented in the way](https://github.com/libarchive/libarchive/blob/321bc20f2e1fe46dec66bd432793f25fc8d15be2/libarchive/archive_entry.c#L234 "Implementation of archive_entry_free()") that only two functions are called which tolerate the passing of null pointers.
  It is therefore not needed that a function caller repeats a corresponding check.