### PR TITLE
fixed sometimes dereferencing null pointer

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -439,7 +439,8 @@ _7z_write_header(struct archive_write *a, struct archive_entry *entry)
 
 	r = file_new(a, entry, &file);
 	if (r < ARCHIVE_WARN) {
-		file_free(file);
+		if (file != NULL)
+			file_free(file);
 		return (r);
 	}
 	if (file->size == 0 && file->dir) {
@@ -818,7 +819,7 @@ _7z_close(struct archive_write *a)
 		header_offset = header_size = 0;
 		header_crc32 = 0;
 	}
-	
+
 	length = zip->temp_offset;
 
 	/*
@@ -1473,7 +1474,7 @@ file_cmp_node(const struct archive_rb_node *n1,
 		return (memcmp(f1->utf16name, f2->utf16name, f1->name_len));
 	return (f1->name_len > f2->name_len)?1:-1;
 }
-        
+
 static int
 file_cmp_key(const struct archive_rb_node *n, const void *key)
 {

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -819,7 +819,7 @@ _7z_close(struct archive_write *a)
 		header_offset = header_size = 0;
 		header_crc32 = 0;
 	}
-
+	
 	length = zip->temp_offset;
 
 	/*
@@ -1474,7 +1474,7 @@ file_cmp_node(const struct archive_rb_node *n1,
 		return (memcmp(f1->utf16name, f2->utf16name, f1->name_len));
 	return (f1->name_len > f2->name_len)?1:-1;
 }
-
+        
 static int
 file_cmp_key(const struct archive_rb_node *n, const void *key)
 {


### PR DESCRIPTION
clang analyzer flagged this issue.

file_new() sets file to NULL first.
when file_new() fails, file is set to NULL if it doesn't need to be freed

so, only free when need to. otherwise would deference a null pointer.