### PR TITLE
calling strlen() with null pointer

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -372,7 +372,7 @@ archive_wstrncat(struct archive_wstring *as, const wchar_t *p, size_t n)
 struct archive_string *
 archive_strcat(struct archive_string *as, const void *p)
 {
-	/* strcat is just strncat without an effective limit.
+	/* strcat is just strncat without an effective limit. 
 	 * Assert that we'll never get called with a source
 	 * string over 16MB.
 	 * TODO: Review all uses of strcat in the source
@@ -855,7 +855,7 @@ archive_string_append_from_wcs(struct archive_string *as,
 static struct archive_string_conv *
 find_sconv_object(struct archive *a, const char *fc, const char *tc)
 {
-	struct archive_string_conv *sc;
+	struct archive_string_conv *sc; 
 
 	if (a == NULL)
 		return (NULL);
@@ -874,7 +874,7 @@ find_sconv_object(struct archive *a, const char *fc, const char *tc)
 static void
 add_sconv_object(struct archive *a, struct archive_string_conv *sc)
 {
-	struct archive_string_conv **psc;
+	struct archive_string_conv **psc; 
 
 	/* Add a new sconv to sconv list. */
 	psc = &(a->sconv);
@@ -1116,7 +1116,7 @@ static struct archive_string_conv *
 create_sconv_object(const char *fc, const char *tc,
     unsigned current_codepage, int flag)
 {
-	struct archive_string_conv *sc;
+	struct archive_string_conv *sc; 
 
 	sc = calloc(1, sizeof(*sc));
 	if (sc == NULL)
@@ -1800,8 +1800,8 @@ archive_string_default_conversion_for_write(struct archive *a)
 void
 archive_string_conversion_free(struct archive *a)
 {
-	struct archive_string_conv *sc;
-	struct archive_string_conv *sc_next;
+	struct archive_string_conv *sc; 
+	struct archive_string_conv *sc_next; 
 
 	for (sc = a->sconv; sc != NULL; sc = sc_next) {
 		sc_next = sc->next;
@@ -2537,7 +2537,7 @@ utf16_to_unicode(uint32_t *pwc, const char *s, size_t n, int be)
 	else
 		uc = archive_le16dec(utf16);
 	utf16 += 2;
-
+		
 	/* If this is a surrogate pair, assemble the full code point.*/
 	if (IS_HIGH_SURROGATE_LA(uc)) {
 		unsigned uc2;
@@ -4050,7 +4050,7 @@ archive_mstring_copy_utf8(struct archive_mstring *aes, const char *utf8)
 {
   if (utf8 == NULL) {
     aes->aes_set = 0;
-		return (0);
+    return (0);
   }
   aes->aes_set = AES_SET_UTF8;
   archive_string_empty(&(aes->aes_mbs));
@@ -4114,7 +4114,7 @@ archive_mstring_copy_mbs_len_l(struct archive_mstring *aes,
 
 		/*
 		 * Translate multi-bytes from some character-set to UTF-8.
-		 */
+		 */ 
 		sc->cd = sc->cd_w;
 		r = archive_strncpy_l(&(aes->aes_utf8), mbs, len, sc);
 		sc->cd = cd;
@@ -4126,7 +4126,7 @@ archive_mstring_copy_mbs_len_l(struct archive_mstring *aes,
 
 		/*
 		 * Append the UTF-8 string into wstring.
-		 */
+		 */ 
 		flag = sc->flag;
 		sc->flag &= ~(SCONV_NORMALIZATION_C
 				| SCONV_TO_UTF16| SCONV_FROM_UTF16);

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -372,7 +372,7 @@ archive_wstrncat(struct archive_wstring *as, const wchar_t *p, size_t n)
 struct archive_string *
 archive_strcat(struct archive_string *as, const void *p)
 {
-	/* strcat is just strncat without an effective limit. 
+	/* strcat is just strncat without an effective limit.
 	 * Assert that we'll never get called with a source
 	 * string over 16MB.
 	 * TODO: Review all uses of strcat in the source
@@ -855,7 +855,7 @@ archive_string_append_from_wcs(struct archive_string *as,
 static struct archive_string_conv *
 find_sconv_object(struct archive *a, const char *fc, const char *tc)
 {
-	struct archive_string_conv *sc; 
+	struct archive_string_conv *sc;
 
 	if (a == NULL)
 		return (NULL);
@@ -874,7 +874,7 @@ find_sconv_object(struct archive *a, const char *fc, const char *tc)
 static void
 add_sconv_object(struct archive *a, struct archive_string_conv *sc)
 {
-	struct archive_string_conv **psc; 
+	struct archive_string_conv **psc;
 
 	/* Add a new sconv to sconv list. */
 	psc = &(a->sconv);
@@ -1116,7 +1116,7 @@ static struct archive_string_conv *
 create_sconv_object(const char *fc, const char *tc,
     unsigned current_codepage, int flag)
 {
-	struct archive_string_conv *sc; 
+	struct archive_string_conv *sc;
 
 	sc = calloc(1, sizeof(*sc));
 	if (sc == NULL)
@@ -1800,8 +1800,8 @@ archive_string_default_conversion_for_write(struct archive *a)
 void
 archive_string_conversion_free(struct archive *a)
 {
-	struct archive_string_conv *sc; 
-	struct archive_string_conv *sc_next; 
+	struct archive_string_conv *sc;
+	struct archive_string_conv *sc_next;
 
 	for (sc = a->sconv; sc != NULL; sc = sc_next) {
 		sc_next = sc->next;
@@ -2537,7 +2537,7 @@ utf16_to_unicode(uint32_t *pwc, const char *s, size_t n, int be)
 	else
 		uc = archive_le16dec(utf16);
 	utf16 += 2;
-		
+
 	/* If this is a surrogate pair, assemble the full code point.*/
 	if (IS_HIGH_SURROGATE_LA(uc)) {
 		unsigned uc2;
@@ -4050,6 +4050,7 @@ archive_mstring_copy_utf8(struct archive_mstring *aes, const char *utf8)
 {
   if (utf8 == NULL) {
     aes->aes_set = 0;
+		return (0);
   }
   aes->aes_set = AES_SET_UTF8;
   archive_string_empty(&(aes->aes_mbs));
@@ -4064,6 +4065,7 @@ archive_mstring_copy_wcs_len(struct archive_mstring *aes, const wchar_t *wcs,
 {
 	if (wcs == NULL) {
 		aes->aes_set = 0;
+		return (0);
 	}
 	aes->aes_set = AES_SET_WCS; /* Only WCS form set. */
 	archive_string_empty(&(aes->aes_mbs));
@@ -4112,7 +4114,7 @@ archive_mstring_copy_mbs_len_l(struct archive_mstring *aes,
 
 		/*
 		 * Translate multi-bytes from some character-set to UTF-8.
-		 */ 
+		 */
 		sc->cd = sc->cd_w;
 		r = archive_strncpy_l(&(aes->aes_utf8), mbs, len, sc);
 		sc->cd = cd;
@@ -4124,7 +4126,7 @@ archive_mstring_copy_mbs_len_l(struct archive_mstring *aes,
 
 		/*
 		 * Append the UTF-8 string into wstring.
-		 */ 
+		 */
 		flag = sc->flag;
 		sc->flag &= ~(SCONV_NORMALIZATION_C
 				| SCONV_TO_UTF16| SCONV_FROM_UTF16);


### PR DESCRIPTION
clang analyzer found this issue.

other archive_mstring_copy_* has the pattern:

```
if (xxx == NULL) {
  aes->aes_set = 0;
  return (0);
}
```

`archive_mstring_copy_utf8()` didn't follow that pattern, so if NULL is passed in, it will call strlen(NULL).

Noticed that `archive_mstring_copy_wcs_len()` doesn't follow the pattern either.