### PR TITLE
Adding support for extraction with CAP_CHOWN capability on Linux.

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -3131,9 +3131,10 @@ create_dir(struct archive_write_disk *a, char *path)
 static int
 set_ownership(struct archive_write_disk *a)
 {
-#ifndef __CYGWIN__
-/* unfortunately, on win32 there is no 'root' user with uid 0,
-   so we just have to try the chown and see if it works */
+#if !defined(__CYGWIN__) && !defined(__linux__)
+/* Unfortunately, on win32 there is no 'root' user with uid 0,
+   and on Linux, a 'non-root' user can still chown if it has the
+   CAP_CHOWN capability, so we just have to try the chown and see if it works. */
 
 	/* If we know we can't change it, don't bother trying. */
 	if (a->user_uid != 0  &&  a->user_uid != a->uid) {


### PR DESCRIPTION
Hello,

We encounter an issue with extracting and changing owner of a process that is not root, but still have the CAP_CHOWN capability. In this case the extraction will failed even thought it can be done. Without this patch the solution is to the change into root, which IMHO is not recommended.

Let me know if you have any comments about this.

Thanks,
Avi

