### PR TITLE
Removed cast warnings under Visual Studio

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -96,7 +96,7 @@ int extract_one(struct archive* a, struct archive_entry* ae, uint32_t crc) {
     int ret = 1;
     uint32_t computed_crc;
 
-    fsize = archive_entry_size(ae);
+    fsize = (la_ssize_t) archive_entry_size(ae);
     buf = malloc(fsize);
     if(buf == NULL)
         return 1;

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -799,7 +799,7 @@ static void verify(unsigned char *d, size_t s,
 static void verifyB(unsigned char *d, size_t s) {
 	struct archive* a;
 	struct archive_entry *entry = NULL;
-	la_int64_t buf_size;
+	size_t buf_size;
 	unsigned char *buf;
 
 	assert((a = archive_read_new()) != NULL);
@@ -826,20 +826,20 @@ static void verifyB(unsigned char *d, size_t s) {
 
 	// f1, content "onetwothree\n", size 12 bytes
 	assertA(0 == archive_read_next_header(a, &entry));
-	buf_size = archive_entry_size(entry);
+	buf_size = (size_t) archive_entry_size(entry);
 	assertA(buf_size == 12);
 	buf = (unsigned char*) malloc(buf_size);
 	assertA(NULL != buf);
-	assertA(buf_size == archive_read_data(a, buf, buf_size));
+	assertA(buf_size == (size_t) archive_read_data(a, buf, buf_size));
 	free(buf);
 
 	// f2, content "fourfivesix\n", size 12 bytes
 	assertA(0 == archive_read_next_header(a, &entry));
-	buf_size = archive_entry_size(entry);
+	buf_size = (size_t) archive_entry_size(entry);
 	assertA(buf_size == 12);
 	buf = (unsigned char*) malloc(buf_size);
 	assertA(NULL != buf);
-	assertA(buf_size == archive_read_data(a, buf, buf_size));
+	assertA(buf_size == (size_t) archive_read_data(a, buf, buf_size));
 	free(buf);
 
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -37,7 +37,7 @@ int extract_one(struct archive* a, struct archive_entry* ae, uint32_t crc)
     int ret = 1;
     uint32_t computed_crc;
 
-    fsize = archive_entry_size(ae);
+    fsize = (la_ssize_t) archive_entry_size(ae);
     buf = malloc(fsize);
     if(buf == NULL)
         return 1;


### PR DESCRIPTION
Added explicit casts, and the warnings disappeared when compiling under Visual Studio.

Also checked under GCC and Clang.