### PR TITLE
Whitespace reformatting in RAR5 reader, ZIP reader.

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -517,10 +517,10 @@ static int run_e8e9_filter(struct rar5* rar, struct filter_info* flt,
     const uint32_t file_size = 0x1000000;
     ssize_t i;
 
-	const int mask = (int)rar->cstate.window_mask;
+    const int mask = (int)rar->cstate.window_mask;
     circular_memcpy(rar->cstate.filtered_buf,
         rar->cstate.window_buf,
-		mask,
+        mask,
         rar->cstate.solid_offset + flt->block_start,
         rar->cstate.solid_offset + flt->block_start + flt->block_length);
 
@@ -563,7 +563,7 @@ static int run_arm_filter(struct rar5* rar, struct filter_info* flt) {
 
     circular_memcpy(rar->cstate.filtered_buf,
         rar->cstate.window_buf,
-		mask,
+        mask,
         rar->cstate.solid_offset + flt->block_start,
         rar->cstate.solid_offset + flt->block_start + flt->block_length);
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1902,7 +1902,7 @@ zipx_bzip2_init(struct archive_read *a, struct zip *zip)
 {
 	int r;
 
-	/* Deallocate already existing BZ2 decompression context if it 
+	/* Deallocate already existing BZ2 decompression context if it
 	 * exists. */
 	if(zip->bzstream_valid) {
 		BZ2_bzDecompressEnd(&zip->bzstream);

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -110,13 +110,13 @@ int extract_one(struct archive* a, struct archive_entry* ae, uint32_t crc) {
     computed_crc = crc32(0, buf, fsize);
     assertEqualInt(computed_crc, crc);
     ret = 0;
-    
+
 fn_exit:
     free(buf);
     return ret;
 }
 
-DEFINE_TEST(test_read_format_rar5_stored) 
+DEFINE_TEST(test_read_format_rar5_stored)
 {
     const char helloworld_txt[] = "hello libarchive test suite!\n";
     la_ssize_t file_size = sizeof(helloworld_txt) - 1;
@@ -173,7 +173,7 @@ DEFINE_TEST(test_read_format_rar5_multiple_files)
     assertEqualInt(DATA_SIZE, archive_entry_size(ae));
     assertA(DATA_SIZE == archive_read_data(a, buff, DATA_SIZE));
     assertA(verify_data(buff, 1, DATA_SIZE));
-    
+
     assertA(0 == archive_read_next_header(a, &ae));
     assertEqualString("test2.bin", archive_entry_pathname(ae));
     assertEqualInt(DATA_SIZE, archive_entry_size(ae));
@@ -216,7 +216,7 @@ DEFINE_TEST(test_read_format_rar5_multiple_files_solid)
     assertEqualInt(DATA_SIZE, archive_entry_size(ae));
     assertA(DATA_SIZE == archive_read_data(a, buff, DATA_SIZE));
     assertA(verify_data(buff, 1, DATA_SIZE));
-    
+
     assertA(0 == archive_read_next_header(a, &ae));
     assertEqualString("test2.bin", archive_entry_pathname(ae));
     assertEqualInt(DATA_SIZE, archive_entry_size(ae));
@@ -598,7 +598,7 @@ DEFINE_TEST(test_read_format_rar5_multiarchive_solid_skip_all_but_last)
     EPILOGUE();
 }
 
-DEFINE_TEST(test_read_format_rar5_solid_skip_all) 
+DEFINE_TEST(test_read_format_rar5_solid_skip_all)
 {
     const char* reffile = "test_read_format_rar5_solid.rar";
 
@@ -623,7 +623,7 @@ DEFINE_TEST(test_read_format_rar5_solid_skip_all)
     EPILOGUE();
 }
 
-DEFINE_TEST(test_read_format_rar5_solid_skip_all_but_first) 
+DEFINE_TEST(test_read_format_rar5_solid_skip_all_but_first)
 {
     const char* reffile = "test_read_format_rar5_solid.rar";
 
@@ -649,7 +649,7 @@ DEFINE_TEST(test_read_format_rar5_solid_skip_all_but_first)
     EPILOGUE();
 }
 
-DEFINE_TEST(test_read_format_rar5_solid_skip_all_but_second) 
+DEFINE_TEST(test_read_format_rar5_solid_skip_all_but_second)
 {
     const char* reffile = "test_read_format_rar5_solid.rar";
 


### PR DESCRIPTION
The commit does not contain any functional changes, just some reformatting.

Changed indent of some lines from tabs to spaces (because the whole file is using space indenting, so having one line using tabs surrounded by other lines using spaces simply stands out) in RAR5 reader,

Removed some superfluous space characters from end of some lines in RAR5 reader and ZIP reader.