### PR TITLE
ZIP reader: fixed 2 bugs: unlimited loop and a crash, triggered by invalid files

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1984,6 +1984,15 @@ zip_read_data_zipx_bzip2(struct archive_read *a, const void **buff,
 	}
 
 	in_bytes = zipmin(zip->entry_bytes_remaining, bytes_avail);
+	if(in_bytes < 1) {
+		/* libbz2 doesn't complain when caller feeds avail_in == 0. It will
+		 * actually return success in this case, which is undesirable. This is
+		 * why we need to make this check manually. */
+
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Truncated bzip2 file body");
+		return (ARCHIVE_FATAL);
+	}
 
 	/* Setup buffer boundaries. */
 	zip->bzstream.next_in = (char*)(uintptr_t) compressed_buff;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -194,6 +194,7 @@ struct zip {
 	ssize_t			zipx_ppmd_read_compressed;
 	CPpmd8			ppmd8;
 	char			ppmd8_valid;
+	char			ppmd8_stream_failed;
 
 	struct archive_string_conv *sconv;
 	struct archive_string_conv *sconv_default;
@@ -254,9 +255,15 @@ ppmd_read(void* p) {
 	/* Get the handle to current decompression context. */
 	struct archive_read *a = ((IByteIn*)p)->a;
 	struct zip *zip = (struct zip*) a->format->data;
+	ssize_t bytes_avail = 0;
 
 	/* Fetch next byte. */
-	const uint8_t* data = __archive_read_ahead(a, 1, NULL);
+	const uint8_t* data = __archive_read_ahead(a, 1, &bytes_avail);
+	if(bytes_avail < 1) {
+		zip->ppmd8_stream_failed = 1;
+		return 0;
+	}
+
 	__archive_read_consume(a, 1);
 
 	/* Increment the counter. */
@@ -1750,6 +1757,7 @@ zipx_ppmd8_init(struct archive_read *a, struct zip *zip)
 
 	/* Create a new decompression context. */
 	__archive_ppmd8_functions.Ppmd8_Construct(&zip->ppmd8);
+	zip->ppmd8_stream_failed = 0;
 
 	/* Setup function pointers required by Ppmd8 decompressor. The
 	 * 'ppmd_read' function will feed new bytes to the decompressor,
@@ -1867,6 +1875,14 @@ zip_read_data_zipx_ppmd(struct archive_read *a, const void **buff,
 		if(sym < 0) {
 			zip->end_of_entry = 1;
 			break;
+		}
+
+		/* This field is set by ppmd_read() when there was no more data
+		 * to be read. */
+		if(zip->ppmd8_stream_failed) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+				"Truncated PPMd8 file body");
+			return (ARCHIVE_FATAL);
 		}
 
 		zip->uncompressed_buffer[consumed_bytes] = (uint8_t) sym;

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -771,6 +771,28 @@ DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 100));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+
+	/* This file shouldn't be properly decompressed, because it's invalid.
+	 * However, unpacker should return an error during unpacking. Without the
+	 * proper fix, the unpacker was entering an unlimited loop. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 1));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+}
+
+DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
+{
+	const char *refname = "test_read_format_zip_bz2_hang.zip";
+	struct archive *a;
+	struct archive_entry *ae;
+	char buf[8];
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 37));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -759,3 +759,45 @@ DEFINE_TEST(test_read_format_zip_xz_multi_blockread)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
 }
+
+DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
+{
+	const char *refname = "test_read_format_zip_ppmd8_crash_2.zipx";
+	struct archive *a;
+	struct archive_entry *ae;
+	char buf[64];
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 37));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+
+	/* The file `refname` is invalid in this case, so this call should fail.
+	 * But it shouldn't crash. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+}
+
+DEFINE_TEST(test_read_format_zip_ppmd8_crash_2)
+{
+	const char *refname = "test_read_format_zip_ppmd8_crash_2.zipx";
+	struct archive *a;
+	struct archive_entry *ae;
+	char buf[64];
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 37));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+
+	/* The file `refname` is invalid in this case, so this call should fail.
+	 * But it shouldn't crash. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_zip_bz2_hang.zip.uu
+++ b/libarchive/test/test_read_format_zip_bz2_hang.zip.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_zip_bz2_hang.zip
+M4$L#!)LP,#`,,#`P,#`P,#`P,#`P,#`P,#`$`!P`,#`P,#`P"0`P,#`P,#`P
+1,#!U>`L`8(0P,#`P,#`P,#``
+`
+end

--- a/libarchive/test/test_read_format_zip_ppmd8_crash_1.zipx.uu
+++ b/libarchive/test/test_read_format_zip_ppmd8_crash_1.zipx.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_format_zip_ppmd8_crash_1.zipx
+K4$L'"(=02P,$\+N.O&*A>*\+."U``$H`````````@``````#````6(0`````
+`
+end

--- a/libarchive/test/test_read_format_zip_ppmd8_crash_2.zipx.uu
+++ b/libarchive/test/test_read_format_zip_ppmd8_crash_2.zipx.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_format_zip_ppmd8_crash_2.zipx
+L4$L'"(=02P,$\+N.O&*A>*\+.2U`@$H`````````@``````#````````````
+`
+end


### PR DESCRIPTION
There are 2 commits on this branch: one fixes a crash in PPMd8 decompressor in ZIP reader, the second one fixes an unlimited loop in BZIP2 decompressor, also in the ZIP reader.

Files that were triggering those bugs were found during fuzzing.

For both cases I've added relevant tests with files that were triggering the bugs.