### PR TITLE
strtoul: set errno before the call

### DIFF
--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -392,6 +392,7 @@ archive_compressor_xz_options(struct archive_write_filter *f,
 	} else if (strcmp(key, "threads") == 0) {
 		if (value == NULL)
 			return (ARCHIVE_WARN);
+		errno = 0;
 		data->threads = (int)strtoul(value, NULL, 10);
 		if (data->threads == 0 && errno != 0) {
 			data->threads = 1;

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -498,6 +498,7 @@ xar_options(struct archive_write *a, const char *key, const char *value)
 	if (strcmp(key, "threads") == 0) {
 		if (value == NULL)
 			return (ARCHIVE_FAILED);
+		errno = 0;
 		xar->opt_threads = (int)strtoul(value, NULL, 10);
 		if (xar->opt_threads == 0 && errno != 0) {
 			xar->opt_threads = 1;


### PR DESCRIPTION
As described in `strtoul(3)`:

    Since strtoul() can legitimately return 0 or ULONG_MAX (ULLONG_MAX
    for strtoull()) on both success and failure, the calling program
    should set errno to 0 before the call, and then determine if an
    error occurred by checking whether errno has a nonzero value after
    the call.

Fixes: 41c4da484d3a21ea5be6dbf10d3bf5786caed9dc

---
Introduced in #107.