### PR TITLE
RAR5 reader: invalid window buffer read in E8E9 filter

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -450,16 +450,6 @@ static inline struct rar5* get_context(struct archive_read* a) {
 
 /* Convenience functions used by filter implementations. */
 
-static uint32_t read_filter_data(struct rar5* rar, uint32_t offset) {
-    return archive_le32dec(&rar->cstate.window_buf[offset]);
-}
-
-static void write_filter_data(struct rar5* rar, uint32_t offset,
-        uint32_t value)
-{
-    archive_le32enc(&rar->cstate.filtered_buf[offset], value);
-}
-
 static void circular_memcpy(uint8_t* dst, uint8_t* window, const int mask,
         int64_t start, int64_t end)
 {
@@ -472,6 +462,19 @@ static void circular_memcpy(uint8_t* dst, uint8_t* window, const int mask,
     } else {
         memcpy(dst, &window[start & mask], (size_t) (end - start));
     }
+}
+
+static uint32_t read_filter_data(struct rar5* rar, uint32_t offset) {
+    uint8_t linear_buf[4];
+    circular_memcpy(linear_buf, rar->cstate.window_buf, rar->cstate.window_mask,
+        offset, offset + 4);
+    return archive_le32dec(linear_buf);
+}
+
+static void write_filter_data(struct rar5* rar, uint32_t offset,
+        uint32_t value)
+{
+    archive_le32enc(&rar->cstate.filtered_buf[offset], value);
 }
 
 /* Allocates a new filter descriptor and adds it to the filter array. */


### PR DESCRIPTION
The E8E9 filter was accessing the window buffer with a direct memory read. But since the window buffer is a circular buffer, some of its data can span between the end of the buffer and beginning of the buffer. This means that accessing the window buffer needs to be done always by a reading function that is aware of the fact that the window buffer is circular.

The commit changes direct memory read to the access through the circular_memcpy() function.

This fixes some edge cases when the E8E9 filter data (4 bytes) is spanned between the end of the window buffer and the beginning of the buffer. This situation can happen in archives compressed with a small dictionary size.