### PR TITLE
fix memory leak with repeated header reads

### DIFF
--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -178,8 +178,11 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 				return (0);
 		} while (p[len - 1] != 0);
 
-		if (state)
+		if (state) {
+			/* Reset the name in case of repeat header reads. */
+			free(state->name);
 			state->name = strdup((const char *)&p[file_start]);
+		}
 	}
 
 	/* Null-terminated optional comment. */


### PR DESCRIPTION
Make sure the name field is reset/cleared when re-reading the header.

Closes #1176.