### PR TITLE
RAR5 reader: add support for 'version' field and ignore unknown fields

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -933,3 +933,20 @@ DEFINE_TEST(test_read_format_rar5_hardlink)
 
     EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_extra_field_version)
+{
+    PROLOGUE("test_read_format_rar5_extra_field_version.rar");
+
+    assertA(0 == archive_read_next_header(a, &ae));
+    assertEqualString("bin/2to3;1", archive_entry_pathname(ae));
+    assertA(0 == extract_one(a, ae, 0xF24181B7));
+
+    assertA(0 == archive_read_next_header(a, &ae));
+    assertEqualString("bin/2to3", archive_entry_pathname(ae));
+    assertA(0 == extract_one(a, ae, 0xF24181B7));
+
+    assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
+
+    EPILOGUE();
+}

--- a/libarchive/test/test_read_format_rar5_extra_field_version.rar.uu
+++ b/libarchive/test/test_read_format_rar5_extra_field_version.rar.uu
@@ -1,0 +1,10 @@
+begin 644 test_read_format_rar5_extra_field_version.rar
+M4F%R(1H'`0`SDK7E"@$%!@`%`0&`@`"BNGU4(0(#!%D&7^V#`I?:-URW@4'R
+M@`,!"&)I;B\R=&\S`P0``<7)5B550C]U!#WY13&:5TJ$=$IZ(*3`C\#F0%O\
+M)$)*@]X[RK.Z.G*HUT;V5FO&;:X/FDW,W`95I8T%@@C:DD="_8Z.9+CQH^IG
+M8!ZF0N)JSY2?R(W@25K`U&W)Q1X"`MD`!M\`[8,"E]HW7+>!0?*``P$(8FEN
+M+S)T;S/%R58E54(_=00]^44QFE=*A'1*>B"DP(_`YD!;_"1"2H/>.\JSNCIR
+MJ-=&]E9KQFVN#YI-S-P&5:6-!8((VI)'0OV.CF2X\:/J9V`>ID+B:L^4G\B-
+,X$E:P!UW5E$#!00`
+`
+end


### PR DESCRIPTION
This commit adds support for the VERSION extra field appended to FILE base block. This field allows to add version support for files inside the archive. If the file name is 'abc' and its version is 15, libarchive will unpack this file as 'abc;15'. Changing of file names is needed because there can be multiple files inside the archive with the same names and different versions. In order for the user to not be confused which file is which, RAR5 reader changes the name.

Also this commit contains a unit test for VERSION extra field support.

Another change this commit introduces is ignoring of unknown extra fields. Before applying the commit, RAR5 reader was failing to unpack the file if an unknown field was encountered. But since the reader knows the unknown field's size, it can skip it and ignore it, then proceed with parsing the structure. After applying this commit, RAR5 reader will skip and ignore unknown fields.

Unknown fields that are skipped include fields in FILE's extra header, as well as unsupported REDIR types.