### PR TITLE
fix format string error when printing RAR5 VERSION field

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1277,7 +1277,7 @@ static int parse_file_extra_version(struct archive_read* a,
 
 	/* Prepare a ;123 suffix for the filename, where '123' is the version
 	 * value of this file. */
-	archive_string_sprintf(&version_string, ";%ld", version);
+	archive_string_sprintf(&version_string, ";%zu", version);
 
 	/* Build the new filename. */
 	archive_strcat(&name_utf8_string, cur_filename);


### PR DESCRIPTION
Fixes: 4a94ef4eee112224ae19e05651caad28c7f04751 (#1182)

https://my.cdash.org/viewBuildError.php?onlydeltap&buildid=1643067