### PR TITLE
RAR5 reader: fix a potential SIGSEGV on 32-bit builds

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1039,7 +1039,8 @@ DEFINE_TEST(test_read_format_rar5_invalid_dict_reference)
 
 	PROLOGUE("test_read_format_rar5_invalid_dict_reference.rar");
 
-	assertA(0 == archive_read_next_header(a, &ae));
+	/* This test should fail on parsing the header. */
+	assertA(archive_read_next_header(a, &ae) != ARCHIVE_OK);
 
 	/* This archive is invalid. However, processing it shouldn't cause any
 	 * errors related to buffer underflow when using -fsanitize. */


### PR DESCRIPTION
The reader was causing a SIGSEGV when the file has been declaring a specific dictionary size. Dictionary sizes above 0xFFFFFFFF bytes are overflowing size_t type on 32-bit builds. In case the file has been declaring dictionary size of 0x100000000 (so, UINT_MAX+1), the window_size variable effectively contained value of 0. Later, the memory allocation function was skipping actual allocation of 0 bytes, but still tried to unpack the data.

This commit limits the dictionary window size buffer to 64MB (RAR5 seems to use this limit as well during creation of archives), so it always fits in a size_t variable, and disallows a zero dictionary size for files in the header processing stage.

One unit test had to be modified after this change.