### PR TITLE
b64encode: avoid name conflict with Solaris built-in function

### DIFF
--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -60,7 +60,7 @@ static int archive_filter_b64encode_write(struct archive_write_filter *,
     const void *, size_t);
 static int archive_filter_b64encode_close(struct archive_write_filter *);
 static int archive_filter_b64encode_free(struct archive_write_filter *);
-static void b64_encode(struct archive_string *, const unsigned char *, size_t);
+static void la_b64_encode(struct archive_string *, const unsigned char *, size_t);
 static int64_t atol8(const char *, size_t);
 
 static const char base64[] = {
@@ -180,7 +180,7 @@ archive_filter_b64encode_open(struct archive_write_filter *f)
 }
 
 static void
-b64_encode(struct archive_string *as, const unsigned char *p, size_t len)
+la_b64_encode(struct archive_string *as, const unsigned char *p, size_t len)
 {
 	int c;
 
@@ -234,12 +234,12 @@ archive_filter_b64encode_write(struct archive_write_filter *f, const void *buff,
 		}
 		if (state->hold_len < LBYTES)
 			return (ret);
-		b64_encode(&state->encoded_buff, state->hold, LBYTES);
+		la_b64_encode(&state->encoded_buff, state->hold, LBYTES);
 		state->hold_len = 0;
 	}
 
 	for (; length >= LBYTES; length -= LBYTES, p += LBYTES)
-		b64_encode(&state->encoded_buff, p, LBYTES);
+		la_b64_encode(&state->encoded_buff, p, LBYTES);
 
 	/* Save remaining bytes. */
 	if (length > 0) {
@@ -270,7 +270,7 @@ archive_filter_b64encode_close(struct archive_write_filter *f)
 
 	/* Flush remaining bytes. */
 	if (state->hold_len != 0)
-		b64_encode(&state->encoded_buff, state->hold, state->hold_len);
+		la_b64_encode(&state->encoded_buff, state->hold, state->hold_len);
 	archive_string_sprintf(&state->encoded_buff, "====\n");
 	/* Write the last block */
 	archive_write_set_bytes_in_last_block(f->archive, 1);


### PR DESCRIPTION
Solaris 11.4 has a built-in function named `b64_encode`.  Add a `la_` prefix to our internal function to avoid conflict.
