### PR TITLE
Fixes to handling sparse files

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -844,7 +844,8 @@ archive_read_data(struct archive *_a, void *buff, size_t s)
 	dest = (char *)buff;
 
 	while (s > 0) {
-		if (a->read_data_remaining == 0) {
+		if (a->read_data_offset == a->read_data_output_offset &&
+		    a->read_data_remaining == 0) {
 			read_buf = a->read_data_block;
 			a->read_data_is_posix_read = 1;
 			a->read_data_requested = s;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1143,6 +1143,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
 		t->entry_fd = -1;
 	}
 
+	archive_entry_clear(entry);
+
 	for (;;) {
 		r = next_entry(a, t, entry);
 		if (t->entry_fd >= 0) {

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1126,6 +1126,8 @@ _archive_read_next_header2(struct archive *_a, struct archive_entry *entry)
 		t->entry_fh = INVALID_HANDLE_VALUE;
 	}
 
+	archive_entry_clear(entry);
+
 	while ((r = next_entry(a, t, entry)) == ARCHIVE_RETRY)
 		archive_entry_clear(entry);
 


### PR DESCRIPTION
This fixes 2 issues:

- premature EOF when using archive_read_data() with a file that ends with a hole
- mishandling files when a directory contains both sparse and non-sparse files because information about sparse extents gets carried over from previous archive_entry to the new one.

Thanks!