### PR TITLE
Fix two tests when ZIP compression unsupported

### DIFF
--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -139,7 +139,7 @@ verify_basic(struct archive *a, int seek_checks)
 	} else {
 		assertEqualInt(ARCHIVE_FAILED, archive_read_data(a, buff, 19));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 
@@ -162,7 +162,7 @@ verify_basic(struct archive *a, int seek_checks)
 	} else {
 		assertEqualInt(ARCHIVE_FAILED, archive_read_data(a, buff, 19));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	assertEqualInt(ARCHIVE_EOF, archive_read_next_header(a, &ae));
@@ -231,7 +231,7 @@ verify_info_zip_ux(struct archive *a, int seek_checks)
 	} else {
 		assertEqualInt(ARCHIVE_FAILED, archive_read_data(a, buff, 19));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
@@ -302,7 +302,7 @@ verify_extract_length_at_end(struct archive *a, int seek_checks)
 	} else {
 		assertEqualIntA(a, ARCHIVE_FAILED, archive_read_extract(a, ae, 0));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 

--- a/libarchive/test/test_read_format_zip_traditional_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_traditional_encryption_data.c
@@ -130,7 +130,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 		assertEqualInt(ARCHIVE_FAILED,
 		    archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	
@@ -148,7 +148,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 		assertEqualInt(ARCHIVE_FAILED,
 		    archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	


### PR DESCRIPTION
It appears the ZIP compression unsupported message has changed since the test was originally created.  This change updates two tests to follow this change.