### PR TITLE
Don't include inttypes if compiling for Mac/iOS

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -52,7 +52,7 @@
  */
 #if defined(__BORLANDC__) && __BORLANDC__ >= 0x560
 # include <stdint.h>
-#elif !defined(__WATCOMC__) && !defined(_MSC_VER) && !defined(__INTERIX) && !defined(__BORLANDC__) && !defined(_SCO_DS) && !defined(__osf__)
+#elif !defined(__WATCOMC__) && !defined(_MSC_VER) && !defined(__INTERIX) && !defined(__BORLANDC__) && !defined(_SCO_DS) && !defined(__osf__) && !defined(__CLANG_INTTYPES_H)
 # include <inttypes.h>
 #endif
 


### PR DESCRIPTION
Similar pull request and discussion for libgit2: https://github.com/libgit2/libgit2/pull/3636

libarchive fails to build as a Mac/iOS framework with the error: `Include of non-modular header inside framework module 'LibArchive.archive'` and the error points to `# include <inttypes.h>` in archive.h.

Here is a sample Xcode project that reproduces the issue (requires mac+Xcode): https://github.com/MaximeLM/libarchive-inttypes
Switching the libarchive submodule from master to my PR fixes the build issue.