### PR TITLE
Correct some typographical and grammatical errors.

### DIFF
--- a/libarchive/archive_entry_acl.3
+++ b/libarchive/archive_entry_acl.3
@@ -118,7 +118,7 @@ Streaming Archive Library (libarchive, -larchive)
 .Sh DESCRIPTION
 The
 .Dq Access Control Lists (ACLs)
-extend the standard Unix perssion model.
+extend the standard Unix permission model.
 The ACL interface of
 .Nm libarchive
 supports both POSIX.1e and NFSv4 style ACLs. Use of ACLs is restricted by
@@ -126,7 +126,7 @@ various levels of ACL support in operating systems, file systems and archive
 formats.
 .Ss POSIX.1e Access Control Lists
 A POSIX.1e ACL consists of a number of independent entries.
-Each entry specifies the permission set as bitmask of basic permissions.
+Each entry specifies the permission set as a bitmask of basic permissions.
 Valid permissions in the
 .Fa permset
 are:
@@ -147,13 +147,13 @@ The user specified by the name field.
 .It Dv ARCHIVE_ENTRY_ACL_USER_OBJ
 The owner of the file.
 .It Dv ARCHIVE_ENTRY_ACL_GROUP
-The group specied by the name field.
+The group specified by the name field.
 .It Dv ARCHIVE_ENTRY_ACL_GROUP_OBJ
-The group who owns the file.
+The group which owns the file.
 .It Dv ARCHIVE_ENTRY_ACL_MASK
 The maximum permissions to be obtained via group permissions.
 .It Dv ARCHIVE_ENTRY_ACL_OTHER
-Any principal who is not file owner or a member of the owning group.
+Any principal who is not the file owner or a member of the owning group.
 .El
 .Pp
 The principals
@@ -164,12 +164,12 @@ and
 are equivalent to user, group and other in the classic Unix permission
 model and specify non-extended ACL entries.
 .Pp
-All files with have an access ACL
+All files have an access ACL
 .Pq Dv ARCHIVE_ENTRY_ACL_TYPE_ACCESS .
 This specifies the permissions required for access to the file itself.
 Directories have an additional ACL
 .Pq Dv ARCHIVE_ENTRY_ACL_TYPE_DEFAULT ,
-which controls the initial access ACL for newly created directory entries.
+which controls the initial access ACL for newly-created directory entries.
 .Ss NFSv4 Access Control Lists
 A NFSv4 ACL consists of multiple individual entries called Access Control
 Entries (ACEs).
@@ -197,11 +197,11 @@ The user specified by the name field.
 .It Dv ARCHIVE_ENTRY_ACL_USER_OBJ
 The owner of the file.
 .It Dv ARCHIVE_ENTRY_ACL_GROUP
-The group specied by the name field.
+The group specified by the name field.
 .It Dv ARCHIVE_ENTRY_ACL_GROUP_OBJ
-The group who owns the file.
+The group which owns the file.
 .It Dv ARCHIVE_ENTRY_ACL_EVERYONE
-Any principal who is not file owner or a member of the owning group.
+Any principal who is not the file owner or a member of the owning group.
 .El
 .Pp
 Entries with the
@@ -322,7 +322,7 @@ may take one of the following values:
 .El
 Supports all formats that can be created with
 .Fn archive_entry_acl_to_text
-or respective
+or respectively
 .Fn archive_entry_acl_to_text_w .
 Existing ACL entries are preserved. To get a clean new ACL from text
 .Fn archive_entry_acl_clear
@@ -354,7 +354,7 @@ prepare reading the list of ACL entries with
 .Fn archive_entry_acl_next
 or
 .Fn archive_entry_acl_next_w .
-The function returns either 0, if no non-extended ACLs are found.
+The function returns 0 if no non-extended ACLs are found.
 In this case, the access permissions should be obtained by
 .Xr archive_entry_mode 3
 or set using

--- a/libarchive/archive_entry_paths.3
+++ b/libarchive/archive_entry_paths.3
@@ -133,7 +133,7 @@ The accessor functions are named
 .Fn XXX_w .
 .It UTF-8
 Unicode strings encoded as UTF-8.
-This are convience functions to update both the multibyte and wide
+These are convenience functions to update both the multibyte and wide
 character strings at the same time.
 .El
 .Pp
@@ -141,7 +141,7 @@ The sourcepath is a pure filesystem concept and never stored in an
 archive directly.
 .Pp
 For that reason, it is only available as multibyte string.
-The link path is a convience function for conditionally setting
+The link path is a convenience function for conditionally setting
 hardlink or symlink destination.
 It doesn't have a corresponding get accessor function.
 .Pp

--- a/libarchive/archive_entry_perms.3
+++ b/libarchive/archive_entry_perms.3
@@ -126,7 +126,7 @@ The corresponding functions
 and
 .Fn archive_entry_set_perm
 store the given user id, group id and permission in the entry.
-The permission is also set as side effect of calling
+The permission is also set as a side effect of calling
 .Fn archive_entry_set_mode .
 .Pp
 .Fn archive_entry_strmode
@@ -143,7 +143,7 @@ The accessor functions are named
 .Fn XXX_w .
 .It UTF-8
 Unicode strings encoded as UTF-8.
-This are convience functions to update both the multibyte and wide
+These are convenience functions to update both the multibyte and wide
 character strings at the same time.
 .El
 .Pp
@@ -182,7 +182,7 @@ The
 .Fn archive_entry_copy_fflags_text
 and
 .Fn archive_entry_copy_fflags_text_w
-functions parse the provided text and sets the internal bitmap values.
+functions parse the provided text and set the internal bitmap values.
 This is a platform-specific operation; names that are not meaningful
 on the current platform will be ignored.
 The function returns a pointer to the start of the first name that was not

--- a/libarchive/archive_read_add_passphrase.3
+++ b/libarchive/archive_read_add_passphrase.3
@@ -61,8 +61,8 @@ Otherwise,
 .Cm ARCHIVE_OK
 will be returned. 
 .It Fn archive_read_set_passphrase_callback
-Register callback function that will be invoked to get a passphrase 
-for decrption after trying all passphrases registered by the
+Register a callback function that will be invoked to get a passphrase 
+for decryption after trying all the passphrases registered by the
 .Fn archive_read_add_passphrase
 function failed.
 .El

--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -99,7 +99,7 @@ following values:
 .Bl -tag -compact -width "indent"
 .It Cm ARCHIVE_READDISK_HONOR_NODUMP
 Skip files and directories with the nodump file attribute (file flag) set.
-By default, the nodump file atrribute is ignored.
+By default, the nodump file attribute is ignored.
 .It Cm ARCHIVE_READDISK_MAC_COPYFILE
 Mac OS X specific. Read metadata (ACLs and extended attributes) with
 .Xr copyfile 3 .
@@ -120,7 +120,7 @@ or
 for more information on file attributes.
 .It Cm ARCHIVE_READDISK_NO_TRAVERSE_MOUNTS
 Do not traverse mount points.
-By defaut, moint points are traversed.
+By default, mount points are traversed.
 .It Cm ARCHIVE_READDISK_NO_XATTR
 Do not read extended file attributes (xattrs).
 By default, extended file attributes are read from disk.
@@ -216,7 +216,7 @@ of some other operation.
 (For example, directory traversal libraries often provide this information.)
 .Pp
 Where necessary, user and group ids are converted to user and group names
-using the currently registered lookup functions above.
+using the currently-registered lookup functions above.
 This affects the file ownership fields and ACL values in the
 .Tn struct archive_entry
 object.

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -460,7 +460,7 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 
 	__archive_read_filter_consume(self->upstream, descriptor_bytes);
 
-	/* Make sure we have an enough buffer for uncompressed data. */
+	/* Make sure we have a large enough buffer for uncompressed data. */
 	if (lz4_allocate_out_block(self) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 	if (state->flags.stream_checksum)
@@ -520,7 +520,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	if (read_buf == NULL)
 		goto truncated_error;
 
-	/* Optional process, checking a block sum. */
+	/* Optional processing, checking a block sum. */
 	if (checksum_size) {
 		unsigned int chsum = __archive_xxhash.XXH32(
 			read_buf + 4, (int)compressed_size, 0);
@@ -640,7 +640,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 	if (ret == 0 && *p == NULL)
 		state->stage = SELECT_STREAM;
 
-	/* Optional process, checking a stream sum. */
+	/* Optional processing, checking a stream sum. */
 	if (state->flags.stream_checksum) {
 		if (state->stage == SELECT_STREAM) {
 			unsigned int checksum;
@@ -660,7 +660,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 			if (checksum != checksum_stream) {
 				archive_set_error(&self->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
-				    "lz4 stream cheksum error");
+				    "lz4 stream checksum error");
 				return (ARCHIVE_FATAL);
 			}
 		} else if (ret > 0)

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -487,7 +487,7 @@ process_extra(struct archive_read *a, struct archive_entry *entry,
 		/* Some ZIP files may have trailing 0 bytes. Let's check they
 		 * are all 0 and ignore them instead of returning an error.
 		 *
-		 * This is not techincally correct, but some ZIP files look
+		 * This is not technically correct, but some ZIP files look
 		 * like this and other tools support those files - so let's
 		 * also  support them.
 		 */
@@ -1053,7 +1053,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 
 	/* Make sure that entries with a trailing '/' are marked as directories
 	 * even if the External File Attributes contains bogus values.  If this
-	 * is not a directory and there is no type, assume regularfile. */
+	 * is not a directory and there is no type, assume a regular file. */
 	if ((zip_entry->mode & AE_IFMT) != AE_IFDIR) {
 		int has_slash;
 
@@ -1104,7 +1104,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 	}
 
 	if (zip_entry->flags & LA_FROM_CENTRAL_DIRECTORY) {
-		/* If this came from the central dir, it's size info
+		/* If this came from the central dir, its size info
 		 * is definitive, so ignore the length-at-end flag. */
 		zip_entry->zip_flags &= ~ZIP_LENGTH_AT_END;
 		/* If local header is missing a value, use the one from

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -458,7 +458,7 @@ archive_wstring_append_from_mbs_in_codepage(struct archive_wstring *dest,
 
 	if (from_cp == CP_C_LOCALE) {
 		/*
-		 * "C" locale special process.
+		 * "C" locale special processing.
 		 */
 		wchar_t *ws;
 		const unsigned char *mp;
@@ -680,7 +680,7 @@ archive_string_append_from_wcs_in_codepage(struct archive_string *as,
 
 	if (to_cp == CP_C_LOCALE) {
 		/*
-		 * "C" locale special process.
+		 * "C" locale special processing.
 		 */
 		const wchar_t *wp = ws;
 		char *p;
@@ -889,7 +889,7 @@ add_converter(struct archive_string_conv *sc, int (*converter)
      struct archive_string_conv *))
 {
 	if (sc == NULL || sc->nconverter >= 2)
-		__archive_errx(1, "Programing error");
+		__archive_errx(1, "Programming error");
 	sc->converter[sc->nconverter++] = converter;
 }
 

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -3650,7 +3650,7 @@ wb_consume(struct archive_write *a, size_t size)
 	if (size > iso9660->wbuff_remaining ||
 	    iso9660->wbuff_remaining == 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-		    "Internal Programing error: iso9660:wb_consume()"
+		    "Internal Programming error: iso9660:wb_consume()"
 		    " size=%jd, wbuff_remaining=%jd",
 		    (intmax_t)size, (intmax_t)iso9660->wbuff_remaining);
 		return (ARCHIVE_FATAL);
@@ -3671,7 +3671,7 @@ wb_set_offset(struct archive_write *a, int64_t off)
 
 	if (iso9660->wbuff_type != WB_TO_TEMP) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-		    "Internal Programing error: iso9660:wb_set_offset()");
+		    "Internal Programming error: iso9660:wb_set_offset()");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -8128,7 +8128,7 @@ zisofs_write_to_temp(struct archive_write *a, const void *buff, size_t s)
 {
 	(void)buff; /* UNUSED */
 	(void)s; /* UNUSED */
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC, "Programing error");
+	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC, "Programming error");
 	return (ARCHIVE_FATAL);
 }
 

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -186,7 +186,7 @@ struct mtree_writer {
 #endif
 	/* Keyword options */
 	int keys;
-#define	F_CKSUM		0x00000001		/* check sum */
+#define	F_CKSUM		0x00000001		/* checksum */
 #define	F_DEV		0x00000002		/* device type */
 #define	F_DONE		0x00000004		/* directory done */
 #define	F_FLAGS		0x00000008		/* file flags */
@@ -371,7 +371,7 @@ mtree_quote(struct archive_string *s, const char *str)
 }
 
 /*
- * Indent a line as mtree utility to be readable for people.
+ * Indent a line as the mtree utility does so it is readable for people.
  */
 static void
 mtree_indent(struct mtree_writer *mtree)
@@ -446,8 +446,8 @@ mtree_indent(struct mtree_writer *mtree)
 
 /*
  * Write /set keyword.
- * Set most used value of uid,gid,mode and fflags, which are
- * collected by attr_counter_set_collect() function.
+ * Set the most used value of uid, gid, mode and fflags, which are
+ * collected by the attr_counter_set_collect() function.
  */
 static void
 write_global(struct mtree_writer *mtree)
@@ -649,7 +649,7 @@ attr_counter_inc(struct attr_counter **top, struct attr_counter *ac,
 }
 
 /*
- * Tabulate uid,gid,mode and fflags of a entry in order to be used for /set.
+ * Tabulate uid, gid, mode and fflags of a entry in order to be used for /set.
  */
 static int
 attr_counter_set_collect(struct mtree_writer *mtree, struct mtree_entry *me)
@@ -912,7 +912,7 @@ archive_write_mtree_header(struct archive_write *a,
 
 	/* If the current file is a regular file, we have to
 	 * compute the sum of its content.
-	 * Initialize a bunch of sum check context. */
+	 * Initialize a bunch of checksum context. */
 	if (mtree_entry->reg_info)
 		sum_init(mtree);
 
@@ -1265,7 +1265,7 @@ archive_write_mtree_free(struct archive_write *a)
 	if (mtree == NULL)
 		return (ARCHIVE_OK);
 
-	/* Make sure we dot not leave any entries. */
+	/* Make sure we do not leave any entries. */
 	mtree_entry_register_free(mtree);
 	archive_string_free(&mtree->cur_dirstr);
 	archive_string_free(&mtree->ebuf);
@@ -2024,7 +2024,7 @@ mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 
 	if (file->parentdir.length == 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-		    "Internal programing error "
+		    "Internal programming error "
 		    "in generating canonical name for %s",
 		    file->pathname.s);
 		return (ARCHIVE_FAILED);

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -70,7 +70,7 @@ specific write modules.
 .Fn archive_write_set_filter_option ,
 .Fn archive_write_set_format_option
 .Xc
-Specifies an option that will be passed to currently-registered
+Specifies an option that will be passed to the currently-registered
 filters (including decompression filters) or format readers.
 .Pp
 If
@@ -138,7 +138,7 @@ If either function returns
 .Cm ARCHIVE_FATAL
 will be returned
 immediately.
-Otherwise, greater of the two values will be returned.
+Otherwise, the greater of the two values will be returned.
 .\"
 .It Fn archive_write_set_options
 .Ar options
@@ -290,7 +290,7 @@ This does not impact names stored in the Rockridge or Joliet extension area.
 Default: disabled.
 .It Cm allow-period
 If enabled, allows filenames to contain trailing period characters, in violation of the ISO9660 specification.
-If disabled,trailing periods will be converted to underscore characters.
+If disabled, trailing periods will be converted to underscore characters.
 This does not impact names stored in the Rockridge or Joliet extension area.
 Default: disabled.
 .It Cm allow-pvd-lowercase
@@ -416,7 +416,7 @@ and other special entries.
 The value is interpreted as a decimal integer specifying the
 compression level.
 Values between 0 and 9 are supported.
-The interpretation of the compression level depends on the choosen
+The interpretation of the compression level depends on the chosen
 compression method.
 .El
 .It Format zip

--- a/libarchive/archive_write_set_passphrase.3
+++ b/libarchive/archive_write_set_passphrase.3
@@ -49,7 +49,7 @@ Streaming Archive Library (libarchive, -larchive)
 .Sh DESCRIPTION
 .Bl -tag -width indent
 .It Fn archive_write_set_passphrase
-Set a passphrase for writing an encryption archive.
+Set a passphrase for writing an encrypted archive.
 If
 .Ar passphrase
 is
@@ -61,8 +61,8 @@ Otherwise,
 .Cm ARCHIVE_OK
 will be returned. 
 .It Fn archive_write_set_passphrase_callback
-Register callback function that will be invoked to get a passphrase
-for encrption if the passphrase was not set by the
+Register a callback function that will be invoked to get a passphrase
+for encryption if the passphrase was not set by the
 .Fn archive_write_set_passphrase
 function.
 .El

--- a/libarchive/test/test_archive_write_add_filter_by_name.c
+++ b/libarchive/test/test_archive_write_add_filter_by_name.c
@@ -48,7 +48,7 @@ test_filter_by_name(const char *filter_name, int filter_code,
 	r = archive_write_add_filter_by_name(a, filter_name);
 	if (r == ARCHIVE_WARN) {
 		if (!can_filter_prog()) {
-			skipping("%s filter not suported on this platform",
+			skipping("%s filter not supported on this platform",
 			    filter_name);
 			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 			free(buff);
@@ -59,7 +59,7 @@ test_filter_by_name(const char *filter_name, int filter_code,
 		   "lzma compression not supported on this platform") == 0 ||
 	     strcmp(archive_error_string(a),
 		   "xz compression not supported on this platform") == 0)) {
-		skipping("%s filter not suported on this platform", filter_name);
+		skipping("%s filter not supported on this platform", filter_name);
 		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		return;

--- a/libarchive/test/test_archive_write_set_format_filter_by_ext.c
+++ b/libarchive/test/test_archive_write_set_format_filter_by_ext.c
@@ -61,7 +61,7 @@ test_format_filter_by_ext(const char *output_file,
 	     strcmp(archive_error_string(a),
 		   "xz compression not supported on this platform") == 0)) {
                 const char *filter_name = archive_filter_name(a, 0);
-		skipping("%s filter not suported on this platform", filter_name);
+		skipping("%s filter not supported on this platform", filter_name);
 		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		return;

--- a/tar/test/test_option_n.c
+++ b/tar/test/test_option_n.c
@@ -120,7 +120,7 @@ DEFINE_TEST(test_option_n)
 			      "d2/file4\n",
 			      "test5.out");
 
-	/* Test 6: -t without -n and non-existant directory selected */
+	/* Test 6: -t without -n and non-existent directory selected */
 	assertEqualInt(0,
 	    systemf("%s -tf partial-archive.tar d2 >test6.out 2>test6.err",
 	    testprog));
@@ -128,7 +128,7 @@ DEFINE_TEST(test_option_n)
 	assertTextFileContents("d2/file4\n",
 			      "test6.out");
 
-	/* Test 7: -t with -n and non-existant directory selected */
+	/* Test 7: -t with -n and non-existent directory selected */
 	status = systemf("%s -tnf partial-archive.tar d2 "
 	">test7.out 2>test7.err", testprog);
 	assert(status);

--- a/tar/test/test_option_xattrs.c
+++ b/tar/test/test_option_xattrs.c
@@ -28,7 +28,7 @@ __FBSDID("$FreeBSD$");
 DEFINE_TEST(test_option_xattrs)
 {
 #if !ARCHIVE_XATTR_SUPPORT
-        skipping("Extended atributes are not supported on this platform");
+        skipping("Extended attributes are not supported on this platform");
 #else	/* ARCHIVE_XATTR_SUPPORT */
 
 	const char *testattr = "user.libarchive.test";

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -298,7 +298,7 @@ my_CreateSymbolicLinkA(const char *linkname, const char *target,
 	ret = (*f)(src, tgt, tmpflags);
 	/*
 	 * Prior to Windows 10 the SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
-	 * is not undestood
+	 * is not understood
 	 */
 	if (!ret)
 		ret = (*f)(src, tgt, flags);


### PR DESCRIPTION
Hi,

Thanks a lot for maintaining libarchive!

What do you think about these minor spelling and grammar corrections? Th is is actually a change that I am applying to the Debian package of libarchive; the Debian patch (which also modifies some generated files, so it is a bit larger) is at https://salsa.debian.org/debian/libarchive/blob/master/debian/patches/typos.patch

G'luck,
Peter
