### PR TITLE
Minor corrections to the formatting of manual pages

### DIFF
--- a/cat/bsdcat.1
+++ b/cat/bsdcat.1
@@ -34,16 +34,15 @@
 .Nm
 .Op options
 .Op files
-.Pp
 .Sh DESCRIPTION
 .Nm
 expands files to standard output.
 .Sh OPTIONS
 .Nm
 typically takes a filename as an argument or reads standard input when used in a
-pipe. In both cases decompressed data it written to standard output.
+pipe.
+In both cases decompressed data it written to standard output.
 .Sh EXAMPLES
-.Pp
 To decompress a file:
 .Pp
 .Dl bsdcat example.txt.gz > example.txt
@@ -55,8 +54,8 @@ To decompress standard input in a pipe:
 Both examples achieve the same results - a decompressed file by redirecting
 output.
 .Sh SEE ALSO
-.Xr uncompress 1 ,
-.Xr zcat 1 ,
 .Xr bzcat 1 ,
+.Xr uncompress 1 ,
 .Xr xzcat 1 ,
-.Xr libarchive-formats 5 ,
+.Xr zcat 1 ,
+.Xr libarchive-formats 5

--- a/contrib/shar/shar.1
+++ b/contrib/shar/shar.1
@@ -61,7 +61,8 @@ or
 The following options are available:
 .Bl -tag -width indent
 .It Fl b
-Use an alternative binary format.  Content of files will be uuencoded.
+Use an alternative binary format.
+Content of files will be uuencoded.
 This option should be used to archive binary files correctly.
 In this mode also file permissions will be stored to the archive.
 uudecode(1) is needed to extract archives created with this option.
@@ -72,8 +73,8 @@ Redirect output to
 If
 .Ar file
 given on command line is a directory the entire subtree will be archived.
-Symbolic links given on command line are followed.  Other symbolic links will
-be archived as such.
+Symbolic links given on command line are followed.
+Other symbolic links will be archived as such.
 .El
 .Sh EXAMPLES
 To create a shell archive of the program
@@ -111,7 +112,9 @@ The
 command makes no provisions for hard links.
 .Pp
 Files containing magic characters or files without a newline ('\\n') as the
-last character are not handled correctly with the default format.  Use the -b
+last character are not handled correctly with the default format.
+Use the
+.Fl b
 option for binary files.
 .Pp
 It is easy to insert trojan horses into

--- a/cpio/bsdcpio.1
+++ b/cpio/bsdcpio.1
@@ -75,7 +75,6 @@ Pass-through.
 Read a list of filenames from standard input and copy the files to the
 specified directory.
 .El
-.Pp
 .Sh OPTIONS
 Unless specifically stated otherwise, options are applicable in
 all operating modes.
@@ -385,10 +384,10 @@ For best compatibility, scripts should limit themselves to the
 standard syntax.
 .Sh SEE ALSO
 .Xr bzip2 1 ,
-.Xr tar 1 ,
 .Xr gzip 1 ,
 .Xr mt 1 ,
 .Xr pax 1 ,
+.Xr tar 1 ,
 .Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr libarchive-formats 5 ,

--- a/libarchive/archive_entry.3
+++ b/libarchive/archive_entry.3
@@ -32,7 +32,7 @@
 .Nm archive_entry_clear ,
 .Nm archive_entry_clone ,
 .Nm archive_entry_free ,
-.Nm archive_entry_new ,
+.Nm archive_entry_new
 .Nd functions for managing archive entry descriptions
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
@@ -126,7 +126,6 @@ using the current locale.
 Similarly, if you store a wide string and then store a
 narrow string for the same data, the previously-set wide string will
 be discarded in favor of the new data.
-.Pp
 .\" .Sh EXAMPLE
 .\" .Sh RETURN VALUES
 .\" .Sh ERRORS
@@ -134,8 +133,8 @@ be discarded in favor of the new data.
 .Xr archive_entry_acl 3 ,
 .Xr archive_entry_paths 3 ,
 .Xr archive_entry_perms 3 ,
-.Xr archive_entry_time 3
-.Xr libarchive 3 ,
+.Xr archive_entry_time 3 ,
+.Xr libarchive 3
 .Sh HISTORY
 The
 .Nm libarchive

--- a/libarchive/archive_entry_acl.3
+++ b/libarchive/archive_entry_acl.3
@@ -121,7 +121,8 @@ The
 extend the standard Unix permission model.
 The ACL interface of
 .Nm libarchive
-supports both POSIX.1e and NFSv4 style ACLs. Use of ACLs is restricted by
+supports both POSIX.1e and NFSv4 style ACLs.
+Use of ACLs is restricted by
 various levels of ACL support in operating systems, file systems and archive
 formats.
 .Ss POSIX.1e Access Control Lists
@@ -216,9 +217,10 @@ integer.
 .Pp
 NFSv4 ACE permissions and flags are stored in the same
 .Fa permset
-bitfield. Some permissions share the same constant and permission character but
-have different effect on directories than on files. The following ACE
-permissions are supported:
+bitfield.
+Some permissions share the same constant and permission character
+but have different effect on directories than on files.
+The following ACE permissions are supported:
 .Bl -tag -offset indent -compact -width ARCHIV
 .It Dv ARCHIVE_ENTRY_ACL_READ_DATA ( Sy r )
 Read data (file).
@@ -265,7 +267,8 @@ Inherit parent directory ACE to subdirectories.
 .It Dv ARCHIVE_ENTRY_ACL_ENTRY_INHERIT_ONLY ( Sy i )
 Only inherit, do not apply the permission on the directory itself.
 .It Dv ARCHIVE_ENTRY_ACL_ENTRY_NO_PROPAGATE_INHERIT ( Sy n )
-Do not propagate inherit flags. Only first-level entries inherit ACLs.
+Do not propagate inherit flags.
+Only first-level entries inherit ACLs.
 .It Dv ARCHIVE_ENTRY_ACL_ENTRY_SUCCESSFUL_ACCESS ( Sy S )
 Trigger alarm or audit on successful access.
 .It Dv ARCHIVE_ENTRY_ACL_ENTRY_FAILED_ACCESS ( Sy F )
@@ -279,8 +282,8 @@ and
 .Fn archive_entry_acl_add_entry_w
 add a single ACL entry.
 For the access ACL and non-extended principals, the classic Unix permissions
-are updated. An archive entry cannot contain both POSIX.1e and NFSv4 ACL
-entries.
+are updated.
+An archive entry cannot contain both POSIX.1e and NFSv4 ACL entries.
 .Pp
 .Fn archive_entry_acl_clear
 removes all ACL entries and resets the enumeration pointer.
@@ -300,7 +303,8 @@ for POSIX.1e ACLs and
 .It Dv ARCHIVE_ENTRY_ACL_TYPE_AUDIT
 .It Dv ARCHIVE_ENTRY_ACL_TYPE_ALARM
 .El
-for NFSv4 ACLs. For POSIX.1e ACLs if
+for NFSv4 ACLs.
+For POSIX.1e ACLs if
 .Dv ARCHIVE_ENTRY_ACL_TYPE_ACCESS
 is included and at least one extended ACL entry is found,
 the three non-extended ACLs are added.
@@ -312,7 +316,8 @@ add new
 .Pq or merge with existing
 ACL entries from
 .Pq wide
-text. The argument
+text.
+The argument
 .Fa type
 may take one of the following values:
 .Bl -tag -offset indent -compact -width "ARCHIVE_ENTRY_ACL_TYPE_DEFAULT"
@@ -324,9 +329,11 @@ Supports all formats that can be created with
 .Fn archive_entry_acl_to_text
 or respectively
 .Fn archive_entry_acl_to_text_w .
-Existing ACL entries are preserved. To get a clean new ACL from text
+Existing ACL entries are preserved.
+To get a clean new ACL from text
 .Fn archive_entry_acl_clear
-must be called first. Entries prefixed with
+must be called first.
+Entries prefixed with
 .Dq default:
 are treated as
 .Dv ARCHIVE_ENTRY_ACL_TYPE_DEFAULT
@@ -367,7 +374,8 @@ and
 .Fn archive_entry_acl_to_text_w
 convert the ACL entries for the given type into a
 .Pq wide
-string of ACL entries separated by newline. If the pointer
+string of ACL entries separated by newline.
+If the pointer
 .Fa len_p
 is not NULL, then the function shall return the length of the string
 .Pq not including the NULL terminator
@@ -415,7 +423,8 @@ are prefixed with
 .Dq default: .
 .Pp
 .Fn archive_entry_acl_types
-get ACL entry types contained in an archive entry's ACL. As POSIX.1e and NFSv4
+get ACL entry types contained in an archive entry's ACL.
+As POSIX.1e and NFSv4
 ACL entries cannot be mixed, this function is a very efficient way to detect if
 an ACL already contains POSIX.1e or NFSv4 ACL entries.
 .Sh RETURN VALUES

--- a/libarchive/archive_entry_misc.3
+++ b/libarchive/archive_entry_misc.3
@@ -28,7 +28,7 @@
 .Sh NAME
 .Nm archive_entry_symlink_type ,
 .Nm archive_entry_set_symlink_type
-.Nd miscellaneous functions for manipulating properties of archive_entry.
+.Nd miscellaneous functions for manipulating properties of archive_entry
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
 .Sh SYNOPSIS
@@ -42,7 +42,8 @@ The function
 .Fn archive_entry_symlink_type
 returns and the function
 .Fn archive_entry_set_symlink_type
-sets the type of the symbolic link stored in an archive entry. These functions
+sets the type of the symbolic link stored in an archive entry.
+These functions
 have special meaning on operating systems that support multiple symbolic link
 types (e.g. Microsoft Windows).
 .Pp

--- a/libarchive/archive_entry_paths.3
+++ b/libarchive/archive_entry_paths.3
@@ -146,8 +146,8 @@ hardlink or symlink destination.
 It doesn't have a corresponding get accessor function.
 .Pp
 .Fn archive_entry_set_XXX
-is an alias for 
+is an alias for
 .Fn archive_entry_copy_XXX .
 .Sh SEE ALSO
-.Xr archive_entry 3
-.Xr libarchive 3 ,
+.Xr archive_entry 3 ,
+.Xr libarchive 3

--- a/libarchive/archive_entry_perms.3
+++ b/libarchive/archive_entry_perms.3
@@ -148,7 +148,7 @@ character strings at the same time.
 .El
 .Pp
 .Fn archive_entry_set_XXX
-is an alias for 
+is an alias for
 .Fn archive_entry_copy_XXX .
 .Ss File Flags
 File flags are transparently converted between a bitmap
@@ -197,8 +197,8 @@ which stops parsing at the first unrecognized name.)
 .Xr archive_entry 3 ,
 .Xr archive_entry_acl 3 ,
 .Xr archive_read_disk 3 ,
-.Xr archive_write_disk 3
-.Xr libarchive 3 ,
+.Xr archive_write_disk 3 ,
+.Xr libarchive 3
 .Sh BUGS
 The platform types
 .Vt uid_t

--- a/libarchive/archive_entry_stat.3
+++ b/libarchive/archive_entry_stat.3
@@ -54,7 +54,7 @@
 .Nm archive_entry_rdevmajor ,
 .Nm archive_entry_set_rdevmajor ,
 .Nm archive_entry_rdevminor ,
-.Nm archive_entry_set_rdevminor ,
+.Nm archive_entry_set_rdevminor
 .Nd accessor functions for manipulating archive entry descriptions
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
@@ -267,8 +267,8 @@ platforms.
 Some archive formats use the combined form, while other formats use
 the split form.
 .Sh SEE ALSO
+.Xr stat 2 ,
 .Xr archive_entry_acl 3 ,
 .Xr archive_entry_perms 3 ,
 .Xr archive_entry_time 3 ,
-.Xr libarchive 3 ,
-.Xr stat 2
+.Xr libarchive 3

--- a/libarchive/archive_entry_time.3
+++ b/libarchive/archive_entry_time.3
@@ -48,7 +48,7 @@
 .Nm archive_entry_mtime_nsec ,
 .Nm archive_entry_mtime_is_set ,
 .Nm archive_entry_set_mtime ,
-.Nm archive_entry_unset_mtime ,
+.Nm archive_entry_unset_mtime
 .Nd functions for manipulating times in archive entry descriptions
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
@@ -113,8 +113,8 @@ The current state can be queried using
 .Fn XXX_is_set .
 Unset time fields have a second and nanosecond field of 0.
 .Sh SEE ALSO
-.Xr archive_entry 3
-.Xr libarchive 3 ,
+.Xr archive_entry 3 ,
+.Xr libarchive 3
 .Sh HISTORY
 The
 .Nm libarchive

--- a/libarchive/archive_read.3
+++ b/libarchive/archive_read.3
@@ -155,7 +155,7 @@ to close the archive, then call
 .Fn archive_read_free
 to release all resources, including all memory allocated by the library.
 .\"
-.Sh EXAMPLE
+.Sh EXAMPLES
 The following illustrates basic usage of the library.
 In this example,
 the callback functions are simply wrappers around the standard
@@ -217,16 +217,16 @@ myclose(struct archive *a, void *client_data)
 .\" .Sh ERRORS
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
-.Xr archive_read_new 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_extract 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_format 3 ,
 .Xr archive_read_header 3 ,
+.Xr archive_read_new 3 ,
 .Xr archive_read_open 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5
 .Sh HISTORY
 The

--- a/libarchive/archive_read_add_passphrase.3
+++ b/libarchive/archive_read_add_passphrase.3
@@ -59,7 +59,7 @@ or empty, this function will do nothing and
 will be returned.
 Otherwise,
 .Cm ARCHIVE_OK
-will be returned. 
+will be returned.
 .It Fn archive_read_set_passphrase_callback
 Register a callback function that will be invoked to get a passphrase 
 for decryption after trying all the passphrases registered by the
@@ -69,6 +69,6 @@ function failed.
 .\" .Sh ERRORS
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
-.Xr archive_read_set_options 3
+.Xr archive_read_set_options 3 ,
+.Xr libarchive 3

--- a/libarchive/archive_read_data.3
+++ b/libarchive/archive_read_data.3
@@ -28,7 +28,7 @@
 .Dt ARCHIVE_READ_DATA 3
 .Os
 .Sh NAME
-.Nm archive_read_data
+.Nm archive_read_data ,
 .Nm archive_read_data_block ,
 .Nm archive_read_data_skip ,
 .Nm archive_read_data_into_fd
@@ -118,7 +118,6 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_extract 3 ,
 .Xr archive_read_filter 3 ,
@@ -127,4 +126,5 @@ functions.
 .Xr archive_read_open 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5

--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -101,7 +101,8 @@ following values:
 Skip files and directories with the nodump file attribute (file flag) set.
 By default, the nodump file attribute is ignored.
 .It Cm ARCHIVE_READDISK_MAC_COPYFILE
-Mac OS X specific. Read metadata (ACLs and extended attributes) with
+Mac OS X specific.
+Read metadata (ACLs and extended attributes) with
 .Xr copyfile 3 .
 By default, metadata is read using
 .Xr copyfile 3 .
@@ -226,7 +227,7 @@ More information about the
 object and the overall design of the library can be found in the
 .Xr libarchive 3
 overview.
-.Sh EXAMPLE
+.Sh EXAMPLES
 The following illustrates basic usage of the library by
 showing how to use it to copy an item on disk into an archive.
 .Bd -literal -offset indent
@@ -291,11 +292,11 @@ and
 functions.
 .\"
 .Sh SEE ALSO
+.Xr tar 1 ,
 .Xr archive_read 3 ,
 .Xr archive_util 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_disk 3 ,
-.Xr tar 1 ,
 .Xr libarchive 3
 .Sh HISTORY
 The

--- a/libarchive/archive_read_extract.3
+++ b/libarchive/archive_read_extract.3
@@ -126,7 +126,6 @@ and
 functions.
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_filter 3 ,
@@ -134,4 +133,5 @@ functions.
 .Xr archive_read_open 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5

--- a/libarchive/archive_read_filter.3
+++ b/libarchive/archive_read_filter.3
@@ -147,8 +147,8 @@ and
 functions.
 .\"
 .Sh SEE ALSO
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_format 3 ,
-.Xr archive_read_format 3
+.Xr archive_read_format 3 ,
+.Xr libarchive 3

--- a/libarchive/archive_read_format.3
+++ b/libarchive/archive_read_format.3
@@ -102,7 +102,7 @@ For example,
 .Fn archive_read_support_format_tar
 enables support for a variety of standard tar formats, old-style tar,
 ustar, pax interchange format, and many common variants.
-.It Fn archive_read_support_format_all 
+.It Fn archive_read_support_format_all
 Enables support for all available formats except the
 .Dq raw
 format (see below).
@@ -125,7 +125,7 @@ it is not possible to accurately determine a format for
 an empty file based purely on contents.
 So empty files are treated by libarchive as a distinct
 format.
-.It Fn archive_read_support_format_raw 
+.It Fn archive_read_support_format_raw
 The
 .Dq raw
 format handler allows libarchive to be used to read arbitrary data.
@@ -153,11 +153,11 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5
 .Sh BUGS
 Many traditional archiver programs treat

--- a/libarchive/archive_read_free.3
+++ b/libarchive/archive_read_free.3
@@ -83,11 +83,11 @@ and
 functions.
 .\"
 .Sh SEE ALSO
-.Xr libarchive 3 ,
-.Xr archive_read_new 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_format 3 ,
+.Xr archive_read_new 3 ,
 .Xr archive_read_open 3 ,
 .Xr archive_read_set_options 3 ,
-.Xr archive_util 3
+.Xr archive_util 3 ,
+.Xr libarchive 3

--- a/libarchive/archive_read_header.3
+++ b/libarchive/archive_read_header.3
@@ -79,7 +79,6 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_extract 3 ,
@@ -88,4 +87,5 @@ functions.
 .Xr archive_read_open 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5

--- a/libarchive/archive_read_new.3
+++ b/libarchive/archive_read_new.3
@@ -50,10 +50,10 @@ object can be found in the overview manual page for
 .\" .Sh ERRORS
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_format 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5

--- a/libarchive/archive_read_open.3
+++ b/libarchive/archive_read_open.3
@@ -205,7 +205,7 @@ On failure, the callback should invoke
 .Fn archive_set_error
 to register an error code and message and
 return
-.Cm ARCHIVE_FATAL.
+.Cm ARCHIVE_FATAL .
 .\" .Sh EXAMPLE
 .\"
 .Sh RETURN VALUES
@@ -223,11 +223,11 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_data 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_format 3 ,
 .Xr archive_read_set_options 3 ,
 .Xr archive_util 3 ,
+.Xr libarchive 3 ,
 .Xr tar 5

--- a/libarchive/archive_read_set_options.3
+++ b/libarchive/archive_read_set_options.3
@@ -212,7 +212,8 @@ Use
 to disable.
 .It Cm read_concatenated_archives
 Ignore zeroed blocks in the archive, which occurs when multiple tar archives
-have been concatenated together.  Without this option, only the contents of
+have been concatenated together.
+Without this option, only the contents of
 the first concatenated archive would be read.
 .El
 .El
@@ -226,6 +227,6 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
+.Xr archive_read 3 ,
 .Xr archive_write_set_options 3 ,
-.Xr archive_read 3
+.Xr libarchive 3

--- a/libarchive/archive_util.3
+++ b/libarchive/archive_util.3
@@ -92,10 +92,10 @@ Clears any error information left over from a previous call.
 Not generally used in client code.
 .It Fn archive_compression
 Synonym for
-.Fn archive_filter_code(a, 0) .
+.Fn archive_filter_code a 0 .
 .It Fn archive_compression_name
 Synonym for
-.Fn archive_filter_name(a, 0) .
+.Fn archive_filter_name a 0 .
 .It Fn archive_copy_error
 Copies error information from one archive to another.
 .It Fn archive_errno
@@ -142,13 +142,13 @@ filter 0 is the gunzip filter,
 filter 1 is the uudecode filter,
 and filter 2 is the pseudo-filter that wraps the archive read functions.
 In this case, requesting
-.Fn archive_position(a, -1)
+.Fn archive_position a -1
 would be a synonym for
-.Fn archive_position(a, 2)
+.Fn archive_position a 2
 which would return the number of bytes currently read from the archive, while
-.Fn archive_position(a, 1)
+.Fn archive_position a 1
 would return the number of bytes after uudecoding, and
-.Fn archive_position(a, 0)
+.Fn archive_position a 0
 would return the number of bytes after decompression.
 .It Fn archive_filter_name
 Returns a textual name identifying the indicated filter.
@@ -170,9 +170,9 @@ A textual description of the format of the current entry.
 .It Fn archive_position
 Returns the number of bytes read from or written to the indicated filter.
 In particular,
-.Fn archive_position(a, 0)
+.Fn archive_position a 0
 returns the number of bytes read or written by the format handler, while
-.Fn archive_position(a, -1)
+.Fn archive_position a -1
 returns the number of bytes read or written to the archive.
 See
 .Fn archive_filter_count

--- a/libarchive/archive_write.3
+++ b/libarchive/archive_write.3
@@ -118,7 +118,7 @@ After all entries have been written, use the
 .Fn archive_write_free
 function to release all resources.
 .\"
-.Sh EXAMPLE
+.Sh EXAMPLES
 The following sketch illustrates basic usage of the library.
 In this example,
 the callback functions are simply wrappers around the standard
@@ -192,7 +192,7 @@ write_archive(const char *outname, const char **filename)
   if (archive_write_set_format_filter_by_ext(a, outname) != ARCHIVE_OK)  {
     archive_write_add_filter_gzip(a);
     archive_write_set_format_ustar(a);
-  }  
+  }
   archive_write_open(a, mydata, myopen, mywrite, myclose);
   while (*filename) {
     stat(*filename, &st);
@@ -225,8 +225,8 @@ int main(int argc, const char **argv)
 .Ed
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_blocksize.3
+++ b/libarchive/archive_write_blocksize.3
@@ -107,8 +107,8 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_data.3
+++ b/libarchive/archive_write_data.3
@@ -82,9 +82,9 @@ and consider any non-negative value as success.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_finish_entry 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_disk.3
+++ b/libarchive/archive_write_disk.3
@@ -113,7 +113,8 @@ or
 .Pq FreeBSD, Mac OS X
 for more information on file attributes.
 .It Cm ARCHIVE_EXTRACT_MAC_METADATA
-Mac OS X specific. Restore metadata using
+Mac OS X specific.
+Restore metadata using
 .Xr copyfile 3 .
 By default,
 .Xr copyfile 3
@@ -264,9 +265,9 @@ and
 functions.
 .\"
 .Sh SEE ALSO
+.Xr tar 1 ,
 .Xr archive_read 3 ,
 .Xr archive_write 3 ,
-.Xr tar 1 ,
 .Xr libarchive 3
 .Sh HISTORY
 The

--- a/libarchive/archive_write_filter.3
+++ b/libarchive/archive_write_filter.3
@@ -43,7 +43,7 @@
 .Nm archive_write_add_filter_program ,
 .Nm archive_write_add_filter_uuencode ,
 .Nm archive_write_add_filter_xz ,
-.Nm archive_write_add_filter_zstd ,
+.Nm archive_write_add_filter_zstd
 .Nd functions enabling output filters
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
@@ -125,10 +125,10 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_format 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_finish_entry.3
+++ b/libarchive/archive_write_finish_entry.3
@@ -71,9 +71,9 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_data 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_format.3
+++ b/libarchive/archive_write_format.3
@@ -52,7 +52,7 @@
 .Nm archive_write_set_format_v7tar ,
 .Nm archive_write_set_format_warc ,
 .Nm archive_write_set_format_xar ,
-.Nm archive_write_set_format_zip ,
+.Nm archive_write_set_format_zip
 .Nd functions for creating archives
 .Sh LIBRARY
 Streaming Archive Library (libarchive, -larchive)
@@ -166,9 +166,9 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr libarchive-formats 5 ,
 .Xr mtree 5 ,

--- a/libarchive/archive_write_free.3
+++ b/libarchive/archive_write_free.3
@@ -56,7 +56,7 @@ after calling this function, the only call that can succeed is
 to release the resources.
 This can be used to speed recovery when the archive creation
 must be aborted.
-Note that the created archive is likely to be malformed in this case; 
+Note that the created archive is likely to be malformed in this case;
 .It Fn archive_write_close
 Complete the archive and invoke the close callback.
 .It Fn archive_write_finish
@@ -89,8 +89,8 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_header.3
+++ b/libarchive/archive_write_header.3
@@ -66,8 +66,8 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_new.3
+++ b/libarchive/archive_write_new.3
@@ -50,9 +50,9 @@ object can be found in the overview manual page for
 .\" .Sh ERRORS
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_open.3
+++ b/libarchive/archive_write_open.3
@@ -200,7 +200,7 @@ On failure, the callback should invoke
 .Fn archive_set_error
 to register an error code and message and
 return
-.Cm ARCHIVE_FATAL.
+.Cm ARCHIVE_FATAL .
 .Pp
 Note that if the client-provided write callback function
 returns a non-zero value, that error will be propagated back to the caller
@@ -234,13 +234,13 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_blocksize 3 ,
 .Xr archive_write_filter 3 ,
 .Xr archive_write_format 3 ,
 .Xr archive_write_new 3 ,
 .Xr archive_write_set_options 3 ,
+.Xr libarchive 3 ,
 .Xr cpio 5 ,
 .Xr mtree 5 ,
 .Xr tar 5

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -203,22 +203,28 @@ These options are used to set standard ISO9660 metadata.
 .Bl -tag -compact -width indent
 .It Cm abstract-file Ns = Ns Ar filename
 The file with the specified name will be identified in the ISO9660 metadata
-as holding the abstract for this volume.  Default: none.
+as holding the abstract for this volume.
+Default: none.
 .It Cm application-id Ns = Ns Ar filename
 The file with the specified name will be identified in the ISO9660 metadata
-as holding the application identifier for this volume.  Default: none.
+as holding the application identifier for this volume.
+Default: none.
 .It Cm biblio-file Ns = Ns Ar filename
 The file with the specified name will be identified in the ISO9660 metadata
-as holding the bibliography for this volume.  Default: none.
+as holding the bibliography for this volume.
+Default: none.
 .It Cm copyright-file Ns = Ns Ar filename
 The file with the specified name will be identified in the ISO9660 metadata
-as holding the copyright for this volume.  Default: none.
+as holding the copyright for this volume.
+Default: none.
 .It Cm publisher Ns = Ns Ar filename
 The file with the specified name will be identified in the ISO9660 metadata
-as holding the publisher information for this volume.  Default: none.
+as holding the publisher information for this volume.
+Default: none.
 .It Cm volume-id Ns = Ns Ar string
 The specified string will be used as the Volume Identifier in the ISO9660 metadata.
-It is limited to 32 bytes. Default: none.
+It is limited to 32 bytes.
+Default: none.
 .El
 .It Format iso9660 - boot support
 These options are used to make an ISO9660 image that can be directly
@@ -266,7 +272,7 @@ If the boot image is exactly 1.2MB, 1.44MB, or 2.88MB, then
 the default is
 .Cm fd ,
 otherwise the default is
-.Cm no-emulation.
+.Cm no-emulation .
 .El
 .It Format iso9660 - filename and size extensions
 Various extensions to the base ISO9660 format.
@@ -495,9 +501,9 @@ functions.
 .\"
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_read_set_options 3 ,
-.Xr archive_write 3
+.Xr archive_write 3 ,
+.Xr libarchive 3
 .Sh HISTORY
 The
 .Nm libarchive

--- a/libarchive/archive_write_set_passphrase.3
+++ b/libarchive/archive_write_set_passphrase.3
@@ -59,7 +59,7 @@ or empty, this function will do nothing and
 will be returned.
 Otherwise,
 .Cm ARCHIVE_OK
-will be returned. 
+will be returned.
 .It Fn archive_write_set_passphrase_callback
 Register a callback function that will be invoked to get a passphrase
 for encryption if the passphrase was not set by the
@@ -69,6 +69,6 @@ function.
 .\" .Sh ERRORS
 .Sh SEE ALSO
 .Xr tar 1 ,
-.Xr libarchive 3 ,
 .Xr archive_write 3 ,
-.Xr archive_write_set_options 3
+.Xr archive_write_set_options 3 ,
+.Xr libarchive 3

--- a/libarchive/libarchive_changes.3
+++ b/libarchive/libarchive_changes.3
@@ -35,7 +35,6 @@
 This page describes user-visible changes in libarchive3, and lists
 public functions and other symbols changed, deprecated or removed
 in libarchive3, along with their replacements if any.
-.Pp
 .\"
 .Ss Multiple Filters
 .\"
@@ -330,13 +329,13 @@ or
 .Li 10240
 .El
 .Sh SEE ALSO
-.Xr libarchive 3 ,
 .Xr archive_read 3 ,
 .Xr archive_read_filter 3 ,
 .Xr archive_read_format 3 ,
 .Xr archive_read_set_options 3 ,
+.Xr archive_util 3 ,
 .Xr archive_write 3 ,
 .Xr archive_write_filter 3 ,
 .Xr archive_write_format 3 ,
 .Xr archive_write_set_options 3 ,
-.Xr archive_util 3
+.Xr libarchive 3

--- a/libarchive/libarchive_internals.3
+++ b/libarchive/libarchive_internals.3
@@ -350,8 +350,8 @@ as a dedicated ZIP program.
 .Xr archive_entry 3 ,
 .Xr archive_read 3 ,
 .Xr archive_write 3 ,
-.Xr archive_write_disk 3
-.Xr libarchive 3 ,
+.Xr archive_write_disk 3 ,
+.Xr libarchive 3
 .Sh HISTORY
 The
 .Nm libarchive

--- a/libarchive/mtree.5
+++ b/libarchive/mtree.5
@@ -133,7 +133,6 @@ or
 .Sy char
 file types.
 The value must be one of the following forms:
-.Pp
 .Bl -tag -width 4n
 .It Ar format , Ns Ar major , Ns Ar minor Ns Bo , Ns Ar subunit Bc
 A device with
@@ -165,8 +164,8 @@ are recognized:
 .Sy solaris ,
 .Sy sunos ,
 .Sy svr3 ,
-.Sy svr4 ,  
-and 
+.Sy svr4 ,
+and
 .Sy ultrix .
 .Pp
 See
@@ -288,12 +287,10 @@ The file owner as a numeric value.
 .It Cm uname
 The file owner as a symbolic name.
 .El
-.Pp
 .Sh SEE ALSO
 .Xr cksum 1 ,
 .Xr find 1 ,
 .Xr mtree 8
-.Sh BUGS
 .Sh HISTORY
 The
 .Nm

--- a/libarchive/tar.5
+++ b/libarchive/tar.5
@@ -441,7 +441,7 @@ archives to store files much larger than the historic 8GB limit.
 Vendor-specific attributes used by Joerg Schilling's
 .Nm star
 implementation.
-.It Cm SCHILY.acl.access , Cm SCHILY.acl.default, Cm SCHILY.acl.ace
+.It Cm SCHILY.acl.access , Cm SCHILY.acl.default , Cm SCHILY.acl.ace
 Stores the access, default and NFSv4 ACLs as textual strings in a format
 that is an extension of the format specified by POSIX.1e draft 17.
 In particular, each user or group access specification can include
@@ -456,7 +456,7 @@ The file flags.
 .It Cm SCHILY.realsize
 The full size of the file on disk.
 XXX explain? XXX
-.It Cm SCHILY.dev, Cm SCHILY.ino , Cm SCHILY.nlinks
+.It Cm SCHILY.dev , Cm SCHILY.ino , Cm SCHILY.nlinks
 The device number, inode number, and link count for the entry.
 In particular, note that a pax interchange format archive using Joerg
 Schilling's
@@ -473,7 +473,7 @@ The time when the file was created.
 .Dq ctime
 attribute, which refers to the time when the file
 metadata was last changed.)
-.It Cm LIBARCHIVE.xattr. Ns Ar namespace Ns . Ns Ar key
+.It Cm LIBARCHIVE.xattr . Ns Ar namespace . Ns Ar key
 Libarchive stores POSIX.1e-style extended attributes using
 keys of this form.
 The
@@ -890,7 +890,8 @@ GNU tar long pathname for the following header.
 .It Cm M
 GNU tar multivolume marker, indicating the file is a continuation of a file from the previous volume.
 .It Cm N
-GNU tar long filename support.  Deprecated.
+GNU tar long filename support.
+Deprecated.
 .It Cm S
 GNU tar sparse regular file.
 .It Cm V

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -167,12 +167,14 @@ if it is unknown suffix or no suffix, creates a new archive with
 restricted pax format and bzip2 compression.
 .It Fl Fl acls
 (c, r, u, x modes only)
-Archive or extract POSIX.1e or NFSv4 ACLs. This is the reverse of
+Archive or extract POSIX.1e or NFSv4 ACLs.
+This is the reverse of
 .Fl Fl no-acls
 and the default behavior in c, r, and u modes (except on Mac OS X) or if
 .Nm
-is run in x mode as root. On Mac OS X this option translates extended ACLs
-to NFSv4 ACLs. To store extended ACLs the
+is run in x mode as root.
+On Mac OS X this option translates extended ACLs to NFSv4 ACLs.
+To store extended ACLs the
 .Fl Fl mac-metadata
 option is preferred.
 .It Fl B , Fl Fl read-full-blocks
@@ -390,10 +392,12 @@ Do not extract modification time.
 By default, the modification time is set to the time stored in the archive.
 .It Fl Fl mac-metadata
 (c, r, u and x mode only)
-Mac OS X specific. Archive or extract extended ACLs and extended file
+Mac OS X specific.
+Archive or extract extended ACLs and extended file
 attributes using
 .Xr copyfile 3
-in AppleDouble format. This is the reverse of
+in AppleDouble format.
+This is the reverse of
 .Fl Fl no-mac-metadata .
 and the default behavior in c, r, and u modes or if
 .Nm
@@ -439,24 +443,28 @@ option to
 .Xr find 1 .
 .It Fl Fl no-acls
 (c, r, u, x modes only)
-Do not archive or extract POSIX.1e or NFSv4 ACLs. This is the reverse of
+Do not archive or extract POSIX.1e or NFSv4 ACLs.
+This is the reverse of
 .Fl Fl acls
 and the default behavior if
 .Nm
 is run as non-root in x mode (on Mac OS X as any user in c, r, u and x modes).
 .It Fl Fl no-fflags
 (c, r, u, x modes only)
-Do not archive or extract file attributes or file flags. This is the reverse of
+Do not archive or extract file attributes or file flags.
+This is the reverse of
 .Fl Fl fflags
 and the default behavior if
 .Nm
 is run as non-root in x mode.
 .It Fl Fl no-mac-metadata
 (x mode only)
-Mac OS X specific. Do not archive or extract ACLs and extended file attributes
+Mac OS X specific.
+Do not archive or extract ACLs and extended file attributes
 using
 .Xr copyfile 3
-in AppleDouble format. This is the reverse of
+in AppleDouble format.
+This is the reverse of
 .Fl Fl mac-metadata .
 and the default behavior if
 .Nm
@@ -480,7 +488,8 @@ and the default behavior if
 is run as non-root.
 .It Fl Fl no-xattrs
 (c, r, u, x modes only)
-Do not archive or extract extended file attributes. This is the reverse of
+Do not archive or extract extended file attributes.
+This is the reverse of
 .Fl Fl xattrs
 and the default behavior if
 .Nm
@@ -577,7 +586,8 @@ to disable.
 .It Cm gzip:compression-level
 A decimal integer from 1 to 9 specifying the gzip compression level.
 .It Cm gzip:timestamp
-Store timestamp. This is enabled by default, use
+Store timestamp.
+This is enabled by default, use
 .Cm !timestamp
 or
 .Cm gzip:!timestamp
@@ -593,7 +603,8 @@ A decimal integer from 1 to 9 specifying the lrzip compression level.
 .It Cm lz4:compression-level
 A decimal integer from 1 to 9 specifying the lzop compression level.
 .It Cm lz4:stream-checksum
-Enable stream checksum. This is by default, use
+Enable stream checksum.
+This is by default, use
 .Cm lz4:!stream-checksum
 to disable.
 .It Cm lz4:block-checksum
@@ -646,9 +657,10 @@ Supported values are zipcrypt (traditional zip encryption),
 aes128 (WinZip AES-128 encryption) and aes256 (WinZip AES-256 encryption).
 .It Cm read_concatenated_archives
 Ignore zeroed blocks in the archive, which occurs when multiple tar archives
-have been concatenated together.  Without this option, only the contents of
-the first concatenated archive would be read.  This option is comparable to
-the
+have been concatenated together.
+Without this option, only the contents of
+the first concatenated archive would be read.
+This option is comparable to the
 .Fl i , Fl Fl ignore-zeros
 option of GNU tar.
 .El
@@ -670,11 +682,13 @@ This option suppresses these behaviors.
 Preserve file permissions.
 Attempt to restore the full permissions, including file modes, file attributes
 or file flags, extended file attributes and ACLs, if available, for each item
-extracted from the archive. This is the reverse of
+extracted from the archive.
+This is the reverse of
 .Fl Fl no-same-permissions
 and the default if
 .Nm
-is being run as root. It can be partially overridden by also specifying
+is being run as root.
+It can be partially overridden by also specifying
 .Fl Fl no-acls ,
 .Fl Fl no-fflags ,
 .Fl Fl no-mac-metadata
@@ -845,7 +859,8 @@ See
 for more information about the handling of exclusions.
 .It Fl Fl xattrs
 (c, r, u, x modes only)
-Archive or extract extended file attributes. This is the reverse of
+Archive or extract extended file attributes.
+This is the reverse of
 .Fl Fl no-xattrs
 and the default behavior in c, r, and u modes or if
 .Nm
@@ -937,9 +952,9 @@ To examine the contents of an ISO 9660 cdrom image:
 To move file hierarchies, invoke
 .Nm
 as
-.Dl Nm Fl cf Pa - Fl C Pa srcdir\ . | Nm Fl xpf Pa - Fl C Pa destdir
+.Dl Nm Fl cf Pa - Fl C Pa srcdir \&. | Nm Fl xpf Pa - Fl C Pa destdir
 or more traditionally
-.Dl cd srcdir \&; Nm Fl cf Pa -\ . | ( cd destdir \&; Nm Fl xpf Pa - )
+.Dl cd srcdir \&; Nm Fl cf Pa - \&. | ( cd destdir \&; Nm Fl xpf Pa - )
 .Pp
 In create mode, the list of files and directories to be archived
 can also include directory change instructions of the form
@@ -967,7 +982,6 @@ An input file in
 .Xr mtree 5
 format can be used to create an output archive with arbitrary ownership,
 permissions, or names that differ from existing data on disk:
-.Pp
 .Bd -literal -offset indent
 $ cat input.mtree
 #mtree


### PR DESCRIPTION
Found with mandoc -Tlint; fixing the following messages:

WARNING: bad NAME section content
WARNING: missing comma before name
WARNING: new sentence, new line
WARNING: parenthesis in function name
WARNING: skipping no-space macro
WARNING: skipping paragraph macro
WARNING: unusual Xr order
WARNING: unusual Xr punctuation
STYLE: no blank before trailing delimiter
STYLE: possible typo in section name
STYLE: trailing delimiter
STYLE: whitespace at end of input line

For the meaning of the messages, see:
https://man.openbsd.org/mandoc#DIAGNOSTICS