### PR TITLE
archve_write_set_format_zip.c: fix possible heap corruption

### DIFF
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1463,7 +1463,6 @@ copy_path(struct archive_entry *entry, unsigned char *p)
 	/* Folders are recognized by a trailing slash. */
 	if ((type == AE_IFDIR) & (path[pathlen - 1] != '/')) {
 		p[pathlen] = '/';
-		p[pathlen + 1] = '\0';
 	}
 }
 


### PR DESCRIPTION
When building the central directory it is possible to corrupt the heap
by writing one byte off the end of zip->central_directory_last->buff.
This occurs when the last alloc in the segment exactly fills the 64k buffer

The cause of the error is copy_path(). For each entry the length of the path
is calculated with path_length(). In the case of a directory  that does not
end with / this function adds one to the length and that is what is allocated
from the segment. However in copy_path if it is a directory that doesn't end
in / then it writes two additional bytes, the / and the null terminator

Normally this writing of the extra byte is benign. After the next call to
cd_alloc new data overwrites that byte, as explained above the heap
corruption only occurs when you allocate exactly to the end fo the segment
buffer.

It appears that the write of the null terminator is not needed. The zip file
header includes the length of the string without the terminator and seems
to generate valid zip files. Because of this the fix appears to be just to
remove the write of the null terminator byte