### PR TITLE
Update archive_read_support_format_rar5 for older Visual Studio

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2538,7 +2538,6 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 
 		if(num < 18) {
 			/* 16..17: repeat previous code */
-			uint16_t n;
 			if(ARCHIVE_OK != read_bits_16(rar, p, &n))
 				return ARCHIVE_EOF;
 


### PR DESCRIPTION
A patch to make this compile in older Visual Studio.
Moving variable declaration up for C89 standard.