### PR TITLE
Fixing resource cleanup in minitar

### DIFF
--- a/examples/minitar/minitar.c
+++ b/examples/minitar/minitar.c
@@ -398,6 +398,9 @@ extract(const char *filename, int do_extract, int flags)
 	}
 	archive_read_close(a);
 	archive_read_free(a);
+
+	archive_write_close(ext);
+  	archive_write_free(ext);
 	exit(0);
 }
 


### PR DESCRIPTION
The extract method in `minitar.c` was missing the cleanup on `ext` as done in https://github.com/kwojcicki/libarchive/blob/master/examples/untar.c#L194. Not a particularly big problem in minitar as the program immediately exits afterwards. But as minitar serves as an example of using libarchive, it should show the process of doing the correct cleanup process.

Tested by building a new minitar and ensuring extracting works as expected :smile: 