### PR TITLE
bsdtar: don't ignore SIGPIPE on fast read

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -192,11 +192,6 @@ main(int argc, char **argv)
 		if (sigaction(SIGUSR1, &sa, NULL))
 			lafe_errc(1, errno, "sigaction(SIGUSR1) failed");
 #endif
-#ifdef SIGPIPE
-		/* Ignore SIGPIPE signals. */
-		sa.sa_handler = SIG_IGN;
-		sigaction(SIGPIPE, &sa, NULL);
-#endif
 	}
 #endif
 


### PR DESCRIPTION
avoid ignoring SIGPIPE to allow the SIGPIPE handline in
libarchive/archive_read_support_filter_program.c to be used, avoiding
errors when fast read is used and decompression is done by an external
program instead of a library

fixes #1118