### PR TITLE
7z: PackInfo Digests are prefixed by kCRC, not kSize

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1787,7 +1787,7 @@ read_PackInfo(struct archive_read *a, struct _7z_pack_info *pi)
 		return (0);
 	}
 
-	if (*p != kSize)
+	if (*p != kCRC)
 		return (-1);
 
 	if (read_Digests(a, &(pi->digest), (size_t)pi->numPackStreams) < 0)


### PR DESCRIPTION
7z1900-src/DOC/7zFormat.txt says:

```
PackInfo
~~~~~~~~~~~~
  BYTE NID::kPackInfo  (0x06)
  UINT64 PackPos
  UINT64 NumPackStreams

  []
  BYTE NID::kSize    (0x09)
  UINT64 PackSizes[NumPackStreams]
  []

  []
  BYTE NID::kCRC      (0x0A)
  PackStreamDigests[NumPackStreams]
  []

  BYTE NID::kEnd
```

this means the check before read_Digests should be kCRC, not kSize.

- jetbrains teamcity creates this kind of 7z archives as built artifact.
- I found this by double-clicking downloaded artifact on GNOME Nautilus.
- tested the fix by contrib/archivetest.c against libarchive before/after this modification.
    - also checked the problematic archives can now be extracted by copying the built libarchive.so to system.