### PR TITLE
BUGFIX: First switch did not have default case.

### DIFF
--- a/libarchive/archive_string_sprintf.c
+++ b/libarchive/archive_string_sprintf.c
@@ -123,9 +123,6 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 			long_flag = *p;
 			p++;
 			break;
-		}
-
-		switch (*p) {
 		case '%':
 			archive_strappend_char(as, '%');
 			break;


### PR DESCRIPTION
The first switch case did not have default case, which caused failures in some platforms.