### PR TITLE
Another patch to UTF-16 endian problem.

### DIFF
--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -1289,17 +1289,16 @@ lha_read_file_extended_header(struct archive_read *a, struct lha *lha,
 				 * Convert directory delimiter from 0xFFFF
 				 * to '/' for local system.
 				 */
-				uint16_t dirSep = '/';	/* UTF-16LE */
-				/* UTF-16LE character */
-				uint16_t *utf16name = (uint16_t *)lha->dirname.s;
+				unsigned char* p = (unsigned char*)lha->dirname.s;
 				for (i = 0; i < lha->dirname.length / 2; i++) {
-					if (utf16name[i] == 0xFFFF)
-						utf16name[i] = dirSep;
+					if (p[i * 2 + 0] == 0xFF && p[i * 2 + 1] == 0xFF){
+						p[i * 2 + 0] = '/';
+						p[i * 2 + 1] = 0x00;
+					}else if(i == lha->dirname.length / 2 - 1)
+						/* last character must be directory separator */
+						/* invalid directory data */
+						goto invalid;
 				}
-				/* Is last character directory separator? */
-				if (utf16name[lha->dirname.length / 2 - 1] != dirSep)
-					/* invalid directory data */
-					goto invalid;
 			}
 			break;
 		case EXT_DOS_ATTR:


### PR DESCRIPTION
Another patch to fix #1307

Now the code writes to raw byte stream, to be independent from endians.
This is because casting UTF-16LE string to uint16_t* seems to be the source of this bug.