### PR TITLE
bsdtar: update manpage to show that git is a candidate for --exclude-vcs

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -213,7 +213,7 @@ version control systems
 .Sq RCS ,
 .Sq SCCS ,
 .Sq SVN ,
-.Sq git,
+.Sq git ,
 .Sq Arch ,
 .Sq Bazaar ,
 .Sq Mercurial

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -213,6 +213,7 @@ version control systems
 .Sq RCS ,
 .Sq SCCS ,
 .Sq SVN ,
+.Sq git,
 .Sq Arch ,
 .Sq Bazaar ,
 .Sq Mercurial


### PR DESCRIPTION
For proof, which also reflects VCS name ordering, see https://github.com/libarchive/libarchive/blob/master/tar/bsdtar.c#L141