### PR TITLE
Tests fixes

### DIFF
--- a/libarchive/test/test_archive_write_set_format_filter_by_ext.c
+++ b/libarchive/test/test_archive_write_set_format_filter_by_ext.c
@@ -30,7 +30,7 @@ __FBSDID("$FreeBSD$");
 
 static void
 test_format_filter_by_ext(const char *output_file, 
-    int format_id, int filter_id, int dot_stored, char * def_ext)
+    int format_id, int filter_id, int dot_stored, const char * def_ext)
 {
 	struct archive_entry *ae;
 	struct archive *a;

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -87,7 +87,7 @@ test_copy(int use_open_fd)
  * An archive file has no entry.
  */
 static void
-test_empty_archive()
+test_empty_archive(void)
 {
 	const char *refname = "test_read_format_7zip_empty_archive.7z";
 	struct archive_entry *ae;
@@ -119,7 +119,7 @@ test_empty_archive()
  * in the archive file except for a header.
  */
 static void
-test_empty_file()
+test_empty_file(void)
 {
 	const char *refname = "test_read_format_7zip_empty_file.7z";
 	struct archive_entry *ae;
@@ -609,7 +609,7 @@ test_bcj(const char *refname)
  * Extract a file compressed with PPMd.
  */
 static void
-test_ppmd()
+test_ppmd(void)
 {
 	const char *refname = "test_read_format_7zip_ppmd.7z";
 	struct archive_entry *ae;
@@ -663,7 +663,7 @@ test_ppmd()
 }
 
 static void
-test_symname()
+test_symname(void)
 {
 	const char *refname = "test_read_format_7zip_symbolic_name.7z";
 	struct archive_entry *ae;

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -472,7 +472,7 @@ verify_sparse_file2(struct archive *a, const char *path,
 }
 
 static void
-test_sparse_whole_file_data()
+test_sparse_whole_file_data(void)
 {
 	struct archive_entry *ae;
 	int64_t offset;

--- a/libarchive/test/test_write_format_zip_file.c
+++ b/libarchive/test/test_write_format_zip_file.c
@@ -84,7 +84,7 @@ DEFINE_TEST(test_write_format_zip_file)
 	unsigned char *central_header, *local_header, *eocd, *eocd_record;
 	unsigned char *extension_start, *extension_end;
 	char file_data[] = {'1', '2', '3', '4', '5', '6', '7', '8'};
-	char *file_name = "file";
+	const char *file_name = "file";
 
 #ifndef HAVE_ZLIB_H
 	zip_version = 10;

--- a/libarchive/test/test_write_format_zip_file_zip64.c
+++ b/libarchive/test/test_write_format_zip_file_zip64.c
@@ -86,7 +86,7 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 	unsigned char *central_header, *local_header, *eocd, *eocd_record;
 	unsigned char *extension_start, *extension_end;
 	char file_data[] = {'1', '2', '3', '4', '5', '6', '7', '8'};
-	char *file_name = "file";
+	const char *file_name = "file";
 
 #ifndef HAVE_ZLIB_H
 	zip_compression = 0;

--- a/test_utils/test_common.h
+++ b/test_utils/test_common.h
@@ -38,6 +38,9 @@
 #elif defined(__FreeBSD__)
 /* Building as part of FreeBSD system requires a pre-built config.h. */
 #include "config_freebsd.h"
+#elif defined(__NetBSD__)
+/* Building as part of NetBSD system requires a pre-built config.h. */
+#include "config_netbsd.h"
 #elif defined(_WIN32) && !defined(__CYGWIN__)
 /* Win32 can't run the 'configure' script. */
 #include "config_windows.h"

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -2480,7 +2480,7 @@ canBzip2(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("bzip2 -d -V %s", redirectArgs) == 0)
+		if (systemf("bzip2 --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2510,7 +2510,7 @@ canGzip(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("gzip -V %s", redirectArgs) == 0)
+		if (systemf("gzip --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2552,7 +2552,7 @@ canLz4(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("lz4 -V %s", redirectArgs) == 0)
+		if (systemf("lz4 --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2567,7 +2567,7 @@ canZstd(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("zstd -V %s", redirectArgs) == 0)
+		if (systemf("zstd --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2582,7 +2582,7 @@ canLzip(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("lzip -V %s", redirectArgs) == 0)
+		if (systemf("lzip --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2597,7 +2597,7 @@ canLzma(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("lzma -V %s", redirectArgs) == 0)
+		if (systemf("lzma %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2612,7 +2612,7 @@ canLzop(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("lzop -V %s", redirectArgs) == 0)
+		if (systemf("lzop --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -2627,7 +2627,7 @@ canXz(void)
 	static int tested = 0, value = 0;
 	if (!tested) {
 		tested = 1;
-		if (systemf("xz -V %s", redirectArgs) == 0)
+		if (systemf("xz --help %s", redirectArgs) == 0)
 			value = 1;
 	}
 	return (value);
@@ -3499,9 +3499,9 @@ static int
 test_run(int i, const char *tmpdir)
 {
 #ifdef PATH_MAX
-	char workdir[PATH_MAX];
+	char workdir[PATH_MAX * 2];
 #else
-	char workdir[1024];
+	char workdir[1024 * 2];
 #endif
 	char logfilename[64];
 	int failures_before = failures;


### PR DESCRIPTION
- ANSI-C prototypes
- Add missing const
- Add a NetBSD-specific config.h
- Use --help to test instead of -V when -V exits with non-zero exit code.
- Double the string size to prevent truncation warnings
