### PR TITLE
libarchive: Fix detection of 'major' on Solaris 11.4

### DIFF
--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -57,11 +57,12 @@ __RCSID("$NetBSD$");
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#ifdef HAVE_SYS_SYSMACROS_H
-#include <sys/sysmacros.h>
-#endif
-#ifdef HAVE_SYS_MKDEV_H
+#if MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
+#define HAVE_MAJOR
+#elif MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#define HAVE_MAJOR
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
In `archive_pack_dev.c` there is code checking the `HAVE_MAJOR` macro,
but it is not computed.  Port the equivalent logic from
`archive_entry.c` to define the macro.