### PR TITLE
New ASCII format: fix hard link description

### DIFF
--- a/libarchive/cpio.5
+++ b/libarchive/cpio.5
@@ -244,7 +244,7 @@ Note that this format supports only 4 gigabyte files (unlike the
 older ASCII format, which supports 8 gigabyte files).
 .Pp
 In this format, hardlinked files are handled by setting the
-filesize to zero for each entry except the last one that
+filesize to zero for each entry except the first one that
 appears in the archive.
 .Ss New CRC Format
 The CRC format is identical to the new ASCII format described


### PR DESCRIPTION
The description of how hard links are handled in the 'new ASCII format' is wrong. Cpio stores the *first*, not *last* copy of the file with its entire contents, followed by entries with filesize set to zero for each subsequent entry that is hard linked. While creating the archive, how would it ever know it was processing the last one!