### PR TITLE
Avoid performing dummy operations with len=0

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -892,15 +892,16 @@ archive_read_data(struct archive *_a, void *buff, size_t s)
 			len = a->read_data_remaining;
 			if (len > s)
 				len = s;
-			if (len)
+			if (len) {
 				memcpy(dest, a->read_data_block, len);
-			s -= len;
-			a->read_data_block += len;
-			a->read_data_remaining -= len;
-			a->read_data_output_offset += len;
-			a->read_data_offset += len;
-			dest += len;
-			bytes_read += len;
+				s -= len;
+				a->read_data_block += len;
+				a->read_data_remaining -= len;
+				a->read_data_output_offset += len;
+				a->read_data_offset += len;
+				dest += len;
+				bytes_read += len;
+			}
 		}
 	}
 	a->read_data_is_posix_read = 0;


### PR DESCRIPTION
Operations with a variable += or -= 0 have no effect.

Additionally they trigger LLVM UBSan for NULL pointer arithmetic.