### PR TITLE
Fixes for using zstd binary

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -297,7 +297,8 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 	int r;
 
 	archive_string_init(&as);
-	archive_string_sprintf(&as, "zstd -%d", data->compression_level);
+	/* --no-check matches library default */
+	archive_string_sprintf(&as, "zstd -%d --no-check", data->compression_level);
 
 	f->write = archive_compressor_zstd_write;
 	r = __archive_write_program_open(f, data->pdata, as.s);

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -59,6 +59,8 @@ struct private_data {
 #endif
 };
 
+#define CLEVEL_STD_MAX 19 /* without using --ultra */
+
 static int archive_compressor_zstd_options(struct archive_write_filter *,
 		    const char *, const char *);
 static int archive_compressor_zstd_open(struct archive_write_filter *);
@@ -299,6 +301,10 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 	archive_string_init(&as);
 	/* --no-check matches library default */
 	archive_string_sprintf(&as, "zstd -%d --no-check", data->compression_level);
+
+	if (data->compression_level > CLEVEL_STD_MAX) {
+		archive_strcat(&as, " --ultra");
+	}
 
 	f->write = archive_compressor_zstd_write;
 	r = __archive_write_program_open(f, data->pdata, as.s);


### PR DESCRIPTION
After these fixes I am able to get identical files out of `bsdtar -cv --zstd --options zstd:compression-level=21 -f OUT IN` using the library and the executable (zstd v1.4.0).