### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ When creating archives, the result can be filtered with any of the following:
   * lzop compression
   * zstandard compression
 
+## Building libarchive - Using vcpkg
+
+You can download and install libarchive using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libarchive
+
+The libarchive port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Notes about the Library Design
 
 The following notes address many of the most common


### PR DESCRIPTION
Libarchive is available as a port in vcpkg, a C++ library manager that simplifies installation for libarchive and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libarchive, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.