### PR TITLE
libarchive/archive_entry_stat.3: typo nlinks -> nlink

### DIFF
--- a/libarchive/archive_entry_stat.3
+++ b/libarchive/archive_entry_stat.3
@@ -215,9 +215,9 @@ and
 set and unset the size, respectively.
 .Pp
 The number of references (hardlinks) can be obtained by calling
-.Fn archive_entry_nlinks
+.Fn archive_entry_nlink
 and set with
-.Fn archive_entry_set_nlinks .
+.Fn archive_entry_set_nlink .
 .Ss Identifying unique files
 The functions
 .Fn archive_entry_dev


### PR DESCRIPTION
Fixed a small typo in the man page. The functions are not called *_nlinks but *_link.