### PR TITLE
fix f_flag usage in statfs

### DIFF
--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1840,7 +1840,7 @@ setup_current_filesystem(struct archive_read_disk *a)
 #if defined(HAVE_STATVFS)
 	if (svfs.f_flag & ST_NOATIME)
 #else
-	if (sfs.f_flag & ST_NOATIME)
+	if (sfs.f_flags & ST_NOATIME)
 #endif
 		t->current_filesystem->noatime = 1;
 	else
@@ -1925,7 +1925,7 @@ setup_current_filesystem(struct archive_read_disk *a)
 	}
 
 #if defined(ST_NOATIME)
-	if (sfs.f_flag & ST_NOATIME)
+	if (sfs.f_flags & ST_NOATIME)
 		t->current_filesystem->noatime = 1;
 	else
 #endif


### PR DESCRIPTION
`statfs` has a `f_flags` field, not `f_flag` [1]
`statvfs` is the one with the `f_flag` field [2]

Some Android NDKs don't have `statvfs` but do have `statvfs`.

[1] https://github.com/torvalds/linux/blob/master/fs/statfs.c
[2] http://man7.org/linux/man-pages/man3/statvfs.3.html