### PR TITLE
zstd: Add support for files created with pzstd

### DIFF
--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -119,6 +119,8 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 
 	/* Zstd frame magic values */
 	const unsigned zstd_magic = 0xFD2FB528U;
+	const unsigned zstd_magic_skippable_start = 0x184D2A50U;
+	const unsigned zstd_magic_skippable_mask = 0xFFFFFFF0;
 
 	(void) self; /* UNUSED */
 
@@ -128,6 +130,8 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 
 	prefix = archive_le32dec(buffer);
 	if (prefix == zstd_magic)
+		return (32);
+	if ((prefix & zstd_magic_skippable_mask) == zstd_magic_skippable_start)
 		return (32);
 
 	return (0);


### PR DESCRIPTION
Hello,
I have found out, that libarchive is not supporting zstd files created with pzstd, as they are not starting with default zstd magic, but instead they are starting with skippable frame magic, then there are some bytes and after that there is zstd magic you were expecting. So I created patch to check for zstd magic and if it is not found then it tries zstd skippable frame magic, but it needs to be masked according to what I found in zstd code.