### PR TITLE
zstd: Improve version checking

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -189,12 +189,13 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		}
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 		maximum = ZSTD_maxCLevel();
-#endif
-#if HAVE_ZSTD_H && HAVE_LIBZSTD && ZSTD_VERSION_NUMBER >= MINVER_MINCLEVEL
+#if ZSTD_VERSION_NUMBER >= MINVER_MINCLEVEL
 		if (ZSTD_versionNumber() >= MINVER_MINCLEVEL) {
 			minimum = ZSTD_minCLevel();
 		}
-		else if (ZSTD_versionNumber() < MINVER_NEGCLEVEL) {
+		else
+#endif
+		if (ZSTD_versionNumber() < MINVER_NEGCLEVEL) {
 			minimum = CLEVEL_STD_MIN;
 		}
 #endif


### PR DESCRIPTION
This is a small improvement to my last PR. It will correctly set the minimum compression level when:

* Building against zstd lib < 1.3.6 and running agains zstd lib < 1.3.4