### PR TITLE
Remove unreachable code in RAR reader

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3084,12 +3084,6 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 
 			continue;
 		}
-
-		/* The program counter shouldn't reach here. */
-		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
-		    "Unsupported block code: 0x%x", num);
-
-		return ARCHIVE_FATAL;
 	}
 
 	return ARCHIVE_OK;


### PR DESCRIPTION
When building Debug on Windows, the build fails because the warning for unreachable code is enabled and there is unreachable code in `archive_read_support_format_rar5.c`. This change removes the unreachable code.

Issue: #861 