### PR TITLE
Create libarchive.pc inside the cmake build dir

### DIFF
--- a/build/cmake/CreatePkgConfigFile.cmake
+++ b/build/cmake/CreatePkgConfigFile.cmake
@@ -24,10 +24,10 @@ ENDFOREACH()
 #	 thus there's a good chance it'll make some binutils versions unhappy...
 #	 This only affects Libs.private (looked up for static builds) though.
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc.in
-		${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc
+		${CMAKE_CURRENT_BINARY_DIR}/build/pkgconfig/libarchive.pc
 		@ONLY)
 # And install it, of course ;).
 IF(ENABLE_INSTALL)
-  INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/build/pkgconfig/libarchive.pc
+  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/build/pkgconfig/libarchive.pc
           DESTINATION "lib/pkgconfig")
 ENDIF()


### PR DESCRIPTION
In case that we don't have write access in the source dir, we have to
write generated files in the build dir.

Also in this way we don't populate the source dir with generated files.