### PR TITLE
Cleanup child handling

### DIFF
--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -401,6 +401,7 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	char *out_buf;
 	const char *prefix = "Program: ";
 	pid_t child;
+	int ret;
 	size_t l;
 
 	l = strlen(prefix) + strlen(cmd) + 1;
@@ -426,9 +427,9 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	state->out_buf = out_buf;
 	state->out_buf_len = out_buf_len;
 
-	child = __archive_create_child(cmd, &state->child_stdin,
-	    &state->child_stdout);
-	if (child == -1) {
+	ret = __archive_create_child(cmd, &state->child_stdin,
+	    &state->child_stdout, &child);
+	if (ret != ARCHIVE_OK) {
 		free(state->out_buf);
 		archive_string_free(&state->description);
 		free(state);

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -400,7 +400,6 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	static const size_t out_buf_len = 65536;
 	char *out_buf;
 	const char *prefix = "Program: ";
-	pid_t child;
 	int ret;
 	size_t l;
 
@@ -428,7 +427,7 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	state->out_buf_len = out_buf_len;
 
 	ret = __archive_create_child(cmd, &state->child_stdin,
-	    &state->child_stdout, &child);
+	    &state->child_stdout, &state->child);
 	if (ret != ARCHIVE_OK) {
 		free(state->out_buf);
 		archive_string_free(&state->description);
@@ -438,21 +437,6 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 		    cmd);
 		return (ARCHIVE_FATAL);
 	}
-#if defined(_WIN32) && !defined(__CYGWIN__)
-	state->child = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, child);
-	if (state->child == NULL) {
-		child_stop(self, state);
-		free(state->out_buf);
-		archive_string_free(&state->description);
-		free(state);
-		archive_set_error(&self->archive->archive, EINVAL,
-		    "Can't initialize filter; unable to run program \"%s\"",
-		    cmd);
-		return (ARCHIVE_FATAL);
-	}
-#else
-	state->child = child;
-#endif
 
 	self->data = state;
 	self->read = program_filter_read;

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -211,7 +211,6 @@ int
 __archive_write_program_open(struct archive_write_filter *f,
     struct archive_write_program_data *data, const char *cmd)
 {
-	pid_t child;
 	int ret;
 
 	if (data->child_buf == NULL) {
@@ -227,26 +226,12 @@ __archive_write_program_open(struct archive_write_filter *f,
 	}
 
 	ret = __archive_create_child(cmd, &data->child_stdin,
-		    &data->child_stdout, &child);
+		    &data->child_stdout, &data->child);
 	if (ret != ARCHIVE_OK) {
 		archive_set_error(f->archive, EINVAL,
 		    "Can't launch external program: %s", cmd);
 		return (ARCHIVE_FATAL);
 	}
-#if defined(_WIN32) && !defined(__CYGWIN__)
-	data->child = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, child);
-	if (data->child == NULL) {
-		close(data->child_stdin);
-		data->child_stdin = -1;
-		close(data->child_stdout);
-		data->child_stdout = -1;
-		archive_set_error(f->archive, EINVAL,
-		    "Can't launch external program: %s", cmd);
-		return (ARCHIVE_FATAL);
-	}
-#else
-	data->child = child;
-#endif
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -196,10 +196,6 @@ __archive_write_program_free(struct archive_write_program_data *data)
 {
 
 	if (data) {
-#if defined(_WIN32) && !defined(__CYGWIN__)
-		if (data->child)
-			CloseHandle(data->child);
-#endif
 		free(data->program_name);
 		free(data->child_buf);
 		free(data);

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -212,6 +212,7 @@ __archive_write_program_open(struct archive_write_filter *f,
     struct archive_write_program_data *data, const char *cmd)
 {
 	pid_t child;
+	int ret;
 
 	if (data->child_buf == NULL) {
 		data->child_buf_len = 65536;
@@ -225,9 +226,9 @@ __archive_write_program_open(struct archive_write_filter *f,
 		}
 	}
 
-	child = __archive_create_child(cmd, &data->child_stdin,
-		    &data->child_stdout);
-	if (child == -1) {
+	ret = __archive_create_child(cmd, &data->child_stdin,
+		    &data->child_stdout, &child);
+	if (ret != ARCHIVE_OK) {
 		archive_set_error(f->archive, EINVAL,
 		    "Can't launch external program: %s", cmd);
 		return (ARCHIVE_FATAL);

--- a/libarchive/filter_fork.h
+++ b/libarchive/filter_fork.h
@@ -34,7 +34,11 @@
 
 int
 __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	HANDLE *out_child);
+#else
 	pid_t *out_child);
+#endif
 
 void
 __archive_check_child(int in, int out);

--- a/libarchive/filter_fork.h
+++ b/libarchive/filter_fork.h
@@ -32,8 +32,9 @@
 #error This header is only to be used internally to libarchive.
 #endif
 
-pid_t
-__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout);
+int
+__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
+	pid_t *out_child);
 
 void
 __archive_check_child(int in, int out);

--- a/libarchive/filter_fork_posix.c
+++ b/libarchive/filter_fork_posix.c
@@ -72,8 +72,9 @@ __FBSDID("$FreeBSD: head/lib/libarchive/filter_fork.c 182958 2008-09-12 05:33:00
 
 #include "filter_fork.h"
 
-pid_t
-__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout)
+int
+__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
+		pid_t *out_child)
 {
 	pid_t child;
 	int stdin_pipe[2], stdout_pipe[2], tmp;
@@ -177,7 +178,8 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout)
 	fcntl(*child_stdout, F_SETFL, O_NONBLOCK);
 	__archive_cmdline_free(cmdline);
 
-	return child;
+	*out_child = child;
+	return ARCHIVE_OK;
 
 #if HAVE_POSIX_SPAWNP
 actions_inited:
@@ -192,7 +194,7 @@ stdin_opened:
 	close(stdin_pipe[1]);
 state_allocated:
 	__archive_cmdline_free(cmdline);
-	return -1;
+	return ARCHIVE_FAILED;
 }
 
 void

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -31,8 +31,9 @@
 
 #include "filter_fork.h"
 
-pid_t
-__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout)
+int
+__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
+		pid_t *out_child)
 {
 	HANDLE childStdout[2], childStdin[2],childStderr;
 	SECURITY_ATTRIBUTES secAtts;
@@ -160,7 +161,8 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout)
 	archive_string_free(&cmdline);
 	archive_string_free(&fullpath);
 	__archive_cmdline_free(acmd);
-	return (childInfo.dwProcessId);
+	*out_child = childInfo.dwProcessId;
+	return ARCHIVE_OK;
 
 fail:
 	if (childStdout[0] != INVALID_HANDLE_VALUE)
@@ -176,7 +178,7 @@ fail:
 	archive_string_free(&cmdline);
 	archive_string_free(&fullpath);
 	__archive_cmdline_free(acmd);
-	return (-1);
+	return ARCHIVE_FAILED;
 }
 
 void


### PR DESCRIPTION
Few small patches to remove some duplication and simplify the current child handling.
With a fix on top - a seemingly incorrect call to CloseHandle() was removed.