### PR TITLE
Moved oss-fuzz files from oss-fuzz to Libarchives repository

### DIFF
--- a/contrib/oss-fuzz/libarchive_fuzzer.cc
+++ b/contrib/oss-fuzz/libarchive_fuzzer.cc
@@ -1,0 +1,49 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+
+#include "archive.h"
+
+struct Buffer {
+  const uint8_t *buf;
+  size_t len;
+};
+
+ssize_t reader_callback(struct archive *a, void *client_data,
+                        const void **block) {
+  Buffer *buffer = reinterpret_cast<Buffer *>(client_data);
+  *block = buffer->buf;
+  ssize_t len = buffer->len;
+  buffer->len = 0;
+  return len;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
+  int ret;
+  ssize_t r;
+  struct archive *a = archive_read_new();
+
+  archive_read_support_filter_all(a);
+  archive_read_support_format_all(a);
+
+  Buffer buffer = {buf, len};
+  archive_read_open(a, &buffer, NULL, reader_callback, NULL);
+
+  std::vector<uint8_t> data_buffer(getpagesize(), 0);
+  struct archive_entry *entry;
+  while(1) {
+    ret = archive_read_next_header(a, &entry);
+    if (ret == ARCHIVE_EOF || ret == ARCHIVE_FATAL)
+      break;
+    if (ret == ARCHIVE_RETRY)
+      continue;
+    while ((r = archive_read_data(a, data_buffer.data(),
+            data_buffer.size())) > 0)
+      ;
+    if (r == ARCHIVE_FATAL)
+      break;
+  }
+
+  archive_read_free(a);
+  return 0;
+}

--- a/contrib/oss-fuzz/oss-fuzz-build.sh
+++ b/contrib/oss-fuzz/oss-fuzz-build.sh
@@ -1,0 +1,16 @@
+# build the project
+./build/autogen.sh
+./configure
+make -j$(nproc) all
+
+# build seed
+cp $SRC/libarchive/contrib/oss-fuzz/corpus.zip\
+       	$OUT/libarchive_fuzzer_seed_corpus.zip
+
+# build fuzzer(s)
+$CXX $CXXFLAGS -Ilibarchive \
+    $SRC/libarchive/contrib/oss-fuzz/libarchive_fuzzer.cc \
+     -o $OUT/libarchive_fuzzer $LIB_FUZZING_ENGINE \
+    .libs/libarchive.a -Wl,-Bstatic -lbz2 -llzo2  \
+    -lxml2 -llzma -lz -lcrypto -llz4 -licuuc \
+    -licudata -Wl,-Bdynamic


### PR DESCRIPTION
This PR moves over the libarchive_fuzzer.cc and the oss-fuzz build script to Libarchives own repository. 
No changes have been made to the code except for removing the license header which won't be necessary.

Having the build file and fuzzers in Libarchives own repository makes it easier to maintain the fuzzers.

I will apply the necessary updates to Libarchives project folder on oss-fuzz. The idea is that the oss-fuzz-build.sh script will be called similarly to [libreoffice's build file](https://github.com/google/oss-fuzz/blob/master/projects/libreoffice/build.sh). 