### PR TITLE
Fix memory leak from passphrase callback

### DIFF
--- a/libarchive/archive_read_add_passphrase.c
+++ b/libarchive/archive_read_add_passphrase.c
@@ -57,6 +57,10 @@ insert_passphrase_to_head(struct archive_read *a,
 {
 	p->next = a->passphrases.first;
 	a->passphrases.first = p;
+	if (&a->passphrases.first == a->passphrases.last) {
+		a->passphrases.last = &p->next;
+		p->next = NULL;
+	}
 }
 
 static struct archive_read_passphrase *


### PR DESCRIPTION
There is a bug in the linked list implementation for passphrases. The insert to
head function does not account for the tail==head case and causes a leak. The
first entry into the list is lost when the second entry is added. The second
and beyond entries are are released properly, but the first is lost entirely.

Fixes libarchive/libarchive#1377