### PR TITLE
test_read_append_filter_wrong_program: Do not check stderr

### DIFF
--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -201,11 +201,6 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
 {
   struct archive_entry *ae;
   struct archive *a;
-#if !defined(_WIN32) || defined(__CYGWIN__)
-  FILE * fp;
-  int fd;
-  fpos_t pos;
-#endif
 
   /*
    * If we have "bunzip2 -q", try using that.
@@ -214,14 +209,6 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
     skipping("Can't run bunzip2 program on this platform");
     return;
   }
-
-#if !defined(_WIN32) || defined(__CYGWIN__)
-  /* bunzip2 will write to stderr, redirect it to a file */
-  fflush(stderr);
-  fgetpos(stderr, &pos);
-  assert((fd = dup(fileno(stderr))) != -1);
-  fp = freopen("stderr1", "w", stderr);
-#endif
 
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
@@ -232,16 +219,4 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
   assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
   assertEqualIntA(a, ARCHIVE_WARN, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-
-#if !defined(_WIN32) || defined(__CYGWIN__)
-  /* restore stderr and verify results */
-  if (fp != NULL) {
-    fflush(stderr);
-    dup2(fd, fileno(stderr));
-    clearerr(stderr);
-    (void)fsetpos(stderr, &pos);
-  }
-  close(fd);
-  assertTextFileContents("bunzip2: (stdin) is not a bzip2 file.\n", "stderr1");
-#endif
 }


### PR DESCRIPTION
Do not assert on specific output of bunzip2.  This wrongly assumes
that all systems will be using the reference implementation of bzip2,
and it fails when an implementation with another output is used
(e.g. lbzip2).

Fixes #1380