### PR TITLE
Fix rdev field in cpio format for device nodes

### DIFF
--- a/libarchive/archive_write_set_format_cpio.c
+++ b/libarchive/archive_write_set_format_cpio.c
@@ -348,7 +348,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	format_octal(archive_entry_nlink(entry), h + c_nlink_offset, c_nlink_size);
 	if (archive_entry_filetype(entry) == AE_IFBLK
 	    || archive_entry_filetype(entry) == AE_IFCHR)
-	    format_octal(archive_entry_dev(entry), h + c_rdev_offset, c_rdev_size);
+	    format_octal(archive_entry_rdev(entry), h + c_rdev_offset, c_rdev_size);
 	else
 	    format_octal(0, h + c_rdev_offset, c_rdev_size);
 	format_octal(archive_entry_mtime(entry), h + c_mtime_offset, c_mtime_size);


### PR DESCRIPTION
Currently, the rdev field is set from archive_entry_dev, which is
the device number of the filesystem containing the device node, not
the device itself. It should instead use archive_entry_rdev.

Here's an example demonstrating the problem:

```
$ ls -l /dev/null
crw-rw-rw-    1 root     root        1,    3 May 26 02:03 /dev/null
$ bsdtar --format=cpio -cf null.cpio /dev/null
bsdtar: Removing leading '/' from member names
$ bsdtar -tvf null.cpio
crw-rw-rw-  1 0      0         0,6 May 26 02:03 dev/null
```