### PR TITLE
Set an error message for setting invalid format by code on readers

### DIFF
--- a/libarchive/archive_read_support_format_by_code.c
+++ b/libarchive/archive_read_support_format_by_code.c
@@ -26,6 +26,10 @@
 #include "archive_platform.h"
 __FBSDID("$FreeBSD$");
 
+#ifdef HAVE_ERRNO_H
+#include <errno.h>
+#endif
+
 #include "archive.h"
 #include "archive_private.h"
 
@@ -73,5 +77,7 @@ archive_read_support_format_by_code(struct archive *a, int format_code)
 		return archive_read_support_format_zip(a);
 		break;
 	}
+	archive_set_error(a, ARCHIVE_ERRNO_PROGRAMMER,
+	    "Invalid format code specified");
 	return (ARCHIVE_FATAL);
 }


### PR DESCRIPTION
The error message is consistent with `archive_read_set_format`.
The absense of an error message here also means that the error message
in `archive_read_set_format` is actually never used.

Writer functions does not seem to have the same issue.