### PR TITLE
More format supports in archive_read_support_format_by_code

### DIFF
--- a/libarchive/archive_read_set_format.c
+++ b/libarchive/archive_read_set_format.c
@@ -61,6 +61,9 @@ archive_read_set_format(struct archive *_a, int code)
     case ARCHIVE_FORMAT_CPIO:
       strcpy(str, "cpio");
       break;
+    case ARCHIVE_FORMAT_EMPTY:
+      strcpy(str, "empty");
+      break;
     case ARCHIVE_FORMAT_ISO9660:
       strcpy(str, "iso9660");
       break;
@@ -76,8 +79,14 @@ archive_read_set_format(struct archive *_a, int code)
     case ARCHIVE_FORMAT_RAR_V5:
       strcpy(str, "rar5");
       break;
+    case ARCHIVE_FORMAT_RAW:
+      strcpy(str, "raw");
+      break;
     case ARCHIVE_FORMAT_TAR:
       strcpy(str, "tar");
+      break;
+    case ARCHIVE_FORMAT_WARC:
+      strcpy(str, "warc");
       break;
     case ARCHIVE_FORMAT_XAR:
       strcpy(str, "xar");

--- a/libarchive/archive_read_support_format_by_code.c
+++ b/libarchive/archive_read_support_format_by_code.c
@@ -48,6 +48,9 @@ archive_read_support_format_by_code(struct archive *a, int format_code)
 	case ARCHIVE_FORMAT_CPIO:
 		return archive_read_support_format_cpio(a);
 		break;
+	case ARCHIVE_FORMAT_EMPTY:
+		return archive_read_support_format_empty(a);
+		break;
 	case ARCHIVE_FORMAT_ISO9660:
 		return archive_read_support_format_iso9660(a);
 		break;
@@ -63,8 +66,14 @@ archive_read_support_format_by_code(struct archive *a, int format_code)
 	case ARCHIVE_FORMAT_RAR_V5:
 		return archive_read_support_format_rar5(a);
 		break;
+	case ARCHIVE_FORMAT_RAW:
+		return archive_read_support_format_raw(a);
+		break;
 	case ARCHIVE_FORMAT_TAR:
 		return archive_read_support_format_tar(a);
+		break;
+	case ARCHIVE_FORMAT_WARC:
+		return archive_read_support_format_warc(a);
 		break;
 	case ARCHIVE_FORMAT_XAR:
 		return archive_read_support_format_xar(a);

--- a/libarchive/archive_read_support_format_empty.c
+++ b/libarchive/archive_read_support_format_empty.c
@@ -47,7 +47,7 @@ archive_read_support_format_empty(struct archive *_a)
 
 	r = __archive_read_register_format(a,
 	    NULL,
-	    NULL,
+	    "empty",
 	    archive_read_format_empty_bid,
 	    NULL,
 	    archive_read_format_empty_read_header,

--- a/libarchive/test/test_archive_read_next_header_empty.c
+++ b/libarchive/test/test_archive_read_next_header_empty.c
@@ -44,14 +44,9 @@ test_empty_file1(void)
 }
 
 static void
-test_empty_file2(void)
+test_empty_file2_check(struct archive* a)
 {
-	struct archive* a = archive_read_new();
 	struct archive_entry* e;
-
-	/* Try opening an empty file with raw and empty handlers. */
-	assertEqualInt(ARCHIVE_OK, archive_read_support_format_raw(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_support_format_empty(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
@@ -64,6 +59,25 @@ test_empty_file2(void)
 	assertEqualString(NULL, archive_error_string(a));
 
 	archive_read_free(a);
+}
+
+static void
+test_empty_file2(void)
+{
+	struct archive* a = archive_read_new();
+
+	/* Try opening an empty file with raw and empty handlers. */
+	assertEqualInt(ARCHIVE_OK, archive_read_support_format_raw(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_support_format_empty(a));
+	test_empty_file2_check(a);
+
+	a = archive_read_new();
+	assertEqualInt(ARCHIVE_OK, archive_read_support_format_by_code(a, ARCHIVE_FORMAT_EMPTY));
+	test_empty_file2_check(a);
+
+	a = archive_read_new();
+	assertEqualInt(ARCHIVE_OK, archive_read_set_format(a, ARCHIVE_FORMAT_EMPTY));
+	test_empty_file2_check(a);
 }
 
 static void

--- a/libarchive/test/test_archive_read_support.c
+++ b/libarchive/test/test_archive_read_support.c
@@ -35,6 +35,17 @@ typedef struct archive *constructor(void);
 typedef int enabler(struct archive *);
 typedef int destructor(struct archive *);
 
+static int format_code = 0;
+static int format_code_enabler(struct archive *a)
+{
+	return archive_read_support_format_by_code(a, format_code);
+}
+
+static int format_code_setter(struct archive *a)
+{
+	return archive_read_set_format(a, format_code);
+}
+
 static void
 test_success(constructor new_, enabler enable_, destructor free_)
 {
@@ -84,6 +95,42 @@ DEFINE_TEST(test_archive_read_support)
 	test_filter_or_format(archive_read_support_format_tar);
 	test_filter_or_format(archive_read_support_format_xar);
 	test_filter_or_format(archive_read_support_format_zip);
+
+	int format_codes[] = {
+	    ARCHIVE_FORMAT_CPIO,
+	    ARCHIVE_FORMAT_CPIO_POSIX,
+	    ARCHIVE_FORMAT_CPIO_BIN_LE,
+	    ARCHIVE_FORMAT_CPIO_BIN_BE,
+	    ARCHIVE_FORMAT_CPIO_SVR4_NOCRC,
+	    ARCHIVE_FORMAT_CPIO_SVR4_CRC,
+	    ARCHIVE_FORMAT_CPIO_AFIO_LARGE,
+	    ARCHIVE_FORMAT_TAR,
+	    ARCHIVE_FORMAT_TAR_USTAR,
+	    ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE,
+	    ARCHIVE_FORMAT_TAR_PAX_RESTRICTED,
+	    ARCHIVE_FORMAT_TAR_GNUTAR,
+	    ARCHIVE_FORMAT_ISO9660,
+	    ARCHIVE_FORMAT_ISO9660_ROCKRIDGE,
+	    ARCHIVE_FORMAT_ZIP,
+	    ARCHIVE_FORMAT_EMPTY,
+	    ARCHIVE_FORMAT_AR,
+	    ARCHIVE_FORMAT_AR_GNU,
+	    ARCHIVE_FORMAT_AR_BSD,
+	    ARCHIVE_FORMAT_MTREE,
+	    ARCHIVE_FORMAT_RAW,
+	    ARCHIVE_FORMAT_XAR,
+	    ARCHIVE_FORMAT_LHA,
+	    ARCHIVE_FORMAT_CAB,
+	    ARCHIVE_FORMAT_RAR,
+	    ARCHIVE_FORMAT_7ZIP,
+	    ARCHIVE_FORMAT_WARC,
+	    ARCHIVE_FORMAT_RAR_V5,
+	};
+	for (unsigned i = 0; i < sizeof(format_codes) / sizeof(int); i++) {
+		format_code = format_codes[i];
+		test_filter_or_format(format_code_enabler);
+		test_filter_or_format(format_code_setter);
+	}
 
 	test_filter_or_format(archive_read_support_filter_all);
 	test_filter_or_format(archive_read_support_filter_bzip2);

--- a/libarchive/test/test_read_format_raw.c
+++ b/libarchive/test/test_read_format_raw.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_read_format_raw)
 	extract_reference_file(reffile2);
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_by_code(a, ARCHIVE_FORMAT_RAW));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_filename(a, reffile2, 1));
@@ -100,8 +100,7 @@ DEFINE_TEST(test_read_format_raw)
 	extract_reference_file(reffile3);
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_filename(a, reffile3, 1));
 


### PR DESCRIPTION
and archive_read_set_format.

AFAICT there's no reason to leave these out.
