### PR TITLE
Fix uninitialized size in rar5_read_data

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3906,8 +3906,8 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 	int ret;
 	struct rar5* rar = get_context(a);
 
-	*offset = 0;
-	*size = 0;
+	if (size)
+		*size = 0;
 
 	if(rar->file.dir > 0) {
 		/* Don't process any data if this file entry was declared

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3906,6 +3906,9 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 	int ret;
 	struct rar5* rar = get_context(a);
 
+	*offset = 0;
+	*size = 0;
+
 	if(rar->file.dir > 0) {
 		/* Don't process any data if this file entry was declared
 		 * as a directory. This is needed, because entries marked as


### PR DESCRIPTION
I see some errors in valgrind when unpacking rar5 archive:
```
==78454== Conditional jump or move depends on uninitialised value(s)
==78454==    at 0x46FC8A: write_data_block (archive_write_disk_posix.c:920)
==78454==    by 0x470098: _archive_write_disk_data_block (archive_write_disk_posix.c:1623)
==78454==    by 0x46D9A6: archive_write_data_block (archive_virtual.c:143)
==78454==    by 0x427FC6: copy_data (archive_read_extract2.c:143)
==78454==    by 0x427EA5: archive_read_extract2 (archive_read_extract2.c:100)
==78454==    by 0x410E7D: read_archive (read.c:371)
==78454==    by 0x410390: tar_mode_x (read.c:112)
==78454==    by 0x40F152: main (bsdtar.c:925)
```

That aslo affects on random errors "write error" or "seek error":
```
lseek(4, 35343435554824, SEEK_SET)     = -1 EINVAL (Invalid argument)
```