### PR TITLE
memory.h is a non-standard header, so use stdlib.h instead

### DIFF
--- a/libarchive/archive_ppmd7.c
+++ b/libarchive/archive_ppmd7.c
@@ -4,7 +4,7 @@ This code is based on PPMd var.H (2001): Dmitry Shkarin : Public domain */
 
 #include "archive_platform.h"
 
-#include <memory.h>
+#include <stdlib.h>
 
 #include "archive_ppmd7_private.h"
 


### PR DESCRIPTION
Older versions of newlib and some other libc libraries do not have the non-standard `memory.h` header. Instead, include the `stdlib.h` header.