### PR TITLE
Fill in Unknown for the system identifier

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -2178,7 +2178,8 @@ get_system_identitier(char *system_id, size_t size)
 	strncpy(system_id, "Windows", size-1);
 	system_id[size-1] = '\0';
 #else
-#error no way to get the system identifier on your platform.
+	strncpy(system_id, "Unknown", size-1);
+	system_id[size-1] = '\0';
 #endif
 }
 


### PR DESCRIPTION
Fill in Unknown for the system identifier if there is no utsname and not Windows. Newlib does not implement the function, so instead of a preprocessor error, put something else.