### PR TITLE
Fix test clean-up

### DIFF
--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -1833,6 +1833,8 @@ test_parent(void)
 	}
 
 	assertChdir("..");
+	assertChmod("lock", 0755);
+	assertChmod("lock/lock2", 0755);
 
 	/* Destroy the disk object. */
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));

--- a/test_utils/test_common.h
+++ b/test_utils/test_common.h
@@ -169,6 +169,9 @@
 /* chdir() and error if it fails */
 #define assertChdir(path)  \
   assertion_chdir(__FILE__, __LINE__, path)
+/* change file/directory permissions and errors if it fails */
+#define assertChmod(pathname, mode)				\
+  assertion_chmod(__FILE__, __LINE__, pathname, mode)
 /* Assert two files have the same file flags */
 #define assertEqualFflags(patha, pathb)	\
   assertion_compare_fflags(__FILE__, __LINE__, patha, pathb, 0)
@@ -282,6 +285,7 @@
 void failure(const char *fmt, ...) __LA_PRINTFLIKE(1, 2);
 int assertion_assert(const char *, int, int, const char *, void *);
 int assertion_chdir(const char *, int, const char *);
+int assertion_chmod(const char *, int, const char *, int);
 int assertion_compare_fflags(const char *, int, const char *, const char *,
     int);
 int assertion_empty_file(const char *, int, const char *);

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -597,6 +597,19 @@ assertion_chdir(const char *file, int line, const char *pathname)
 
 }
 
+/* change file/directory permissions and errors if it fails */
+int
+assertion_chmod(const char *file, int line, const char *pathname, int mode)
+{
+	assertion_count(file, line);
+	if (chmod(pathname, mode) == 0)
+		return (1);
+	failure_start(file, line, "chmod(\"%s\", %4.o)", pathname, mode);
+	failure_finish(NULL);
+	return (0);
+
+}
+
 /* Verify two integers are equal. */
 int
 assertion_equal_int(const char *file, int line,


### PR DESCRIPTION
On test clean-up an 'rm -rf' will fail because 'lock' and 'lock/lock2'
directories have 0311 permissions.  Change these permissions on exit so
that the directories can be deleted on success.