### PR TITLE
Reduce test_write_format_7zip_large_lzma1 buffer size

### DIFF
--- a/libarchive/test/test_write_format_7zip_large.c
+++ b/libarchive/test/test_write_format_7zip_large.c
@@ -27,7 +27,7 @@
 #include "test.h"
 __FBSDID("$FreeBSD$");
 
-#define LARGE_SIZE	(16*1024*1024)
+#define LARGE_SIZE	(1*1024*1024)
 static void
 test_large(const char *compression_type)
 {


### PR DESCRIPTION
Some of the test_write_format_7zip_large take longer than 10 minutes to
run on QEMU-RISC-V and therefore time out when run as part of the FreeBSD
test suite. This is even more noticeable when running on a CHERI-enabled
QEMU since the emulation of tagged memory makes it run slower.

On my local machine the impact is not as extreme, but
test_write_format_7zip_large_lzma1 takes 375ms when TEST_SLOW_HOST is set
and 8.2 seconds normally (i.e. 22 times slower).

The other alternative would be to skip these tests when not running on
real hardware, but it seems to me that compressing a smaller amount of
random data is preferable.