### PR TITLE
Add sync after extract support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,6 +319,14 @@ AC_CHECK_HEADERS([wincrypt.h winioctl.h],[],[],
 ]])
 
 # Checks for libraries.
+AC_ARG_WITH([nosync],
+  AS_HELP_STRING([--without-nosync], [Enable sync after extract support]))
+
+if test "x$with_nosync" != "xno"; then
+  AC_DEFINE([NO_SYNC], [1], [Define to 1 if NO_SYNC needs to be defined.])
+fi
+
+# Checks for libraries.
 AC_ARG_WITH([zlib],
   AS_HELP_STRING([--without-zlib], [Don't build support for gzip through zlib]))
 

--- a/libarchive/archive_read_extract.c
+++ b/libarchive/archive_read_extract.c
@@ -30,6 +30,10 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <errno.h>
 #endif
 
+#ifndef NO_SYNC
+#include <unistd.h>
+#endif
+
 #include "archive.h"
 #include "archive_entry.h"
 #include "archive_private.h"
@@ -56,5 +60,8 @@ archive_read_extract(struct archive *_a, struct archive_entry *entry, int flags)
 	}
 
 	archive_write_disk_set_options(extract->ad, flags);
+  # ifndef NO_SYNC
+  sync();
+  #endif
 	return (archive_read_extract2(&a->archive, entry, extract->ad));
 }

--- a/libarchive/archive_read_extract.c
+++ b/libarchive/archive_read_extract.c
@@ -30,7 +30,7 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <errno.h>
 #endif
 
-#ifdef __posix
+#ifndef __posix
 #define NO_SYNC 1
 #endif
 

--- a/libarchive/archive_read_extract.c
+++ b/libarchive/archive_read_extract.c
@@ -30,6 +30,10 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <errno.h>
 #endif
 
+#ifdef __posix
+#define NO_SYNC 1
+#endif
+
 #ifndef NO_SYNC
 #include <unistd.h>
 #endif

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -36,6 +36,10 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <string.h>
 #endif
 
+#ifdef __posix
+#define NO_SYNC 1
+#endif
+
 #ifndef NO_SYNC
 #include <unistd.h>
 #endif

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -36,7 +36,7 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <string.h>
 #endif
 
-#ifdef __posix
+#ifndef __posix
 #define NO_SYNC 1
 #endif
 

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -36,6 +36,10 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_extract.c,v 1.61 2008/05/26 
 #include <string.h>
 #endif
 
+#ifndef NO_SYNC
+#include <unistd.h>
+#endif
+
 #include "archive.h"
 #include "archive_entry.h"
 #include "archive_private.h"
@@ -59,6 +63,9 @@ __archive_read_get_extract(struct archive_read *a)
 		}
 		a->cleanup_archive_extract = archive_read_extract_cleanup;
 	}
+  # ifndef NO_SYNC
+  sync();
+  #endif
 	return (a->extract);
 }
 
@@ -107,6 +114,9 @@ archive_read_extract2(struct archive *_a, struct archive_entry *entry,
 	/* Use the worst error return. */
 	if (r2 < r)
 		r = r2;
+  # ifndef NO_SYNC
+  sync();
+  #endif
 	return (r);
 }
 


### PR DESCRIPTION
Some users need to sync after extract. This feature enabled by default but I added to disable this feature `--with-nosync` parameter.