### PR TITLE
warc: Fix undefined behaviour in deconst() function

### DIFF
--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -443,7 +443,7 @@ _warc_skip(struct archive_read *a)
 static void*
 deconst(const void *c)
 {
-	return (char *)0x1 + (((const char *)c) - (const char *)0x1);
+	return (void *)(uintptr_t)c;
 }
 
 static char*


### PR DESCRIPTION
Creating a pointer by adding an offset to 0x1 is undefined behaviour and
results in an invalid pointer when running on CHERI systems. Use a
standards-compliant cast via uintptr_t instead.

This was found due to a crash while running the libarchive test suite on a
CHERI-RISC-V system.