### PR TITLE
Fix #1486: build fails on Windows with VS2013 toolset (v120)

### DIFF
--- a/libarchive/xxhash.c
+++ b/libarchive/xxhash.c
@@ -150,7 +150,11 @@ typedef struct _U32_S { U32 v; } _PACKED U32_S;
 #if GCC_VERSION >= 409
 __attribute__((__no_sanitize_undefined__))
 #endif
-static inline U32 A32(const void * x)
+#if defined(_MSC_VER)
+static __inline U32 A32(const void * x)
+#else
+static inline U32 A32(const void* x)
+#endif
 {
     return (((const U32_S *)(x))->v);
 }


### PR DESCRIPTION
Build fails on compiling xxhash.c having a fuction with "inline" specifier.
"inline" is a c99 keyword and c99 is not yet (fully) supported with MSVC toolset v120:
"The inline keyword is available only in C++. The __inline and __forceinline
keywords are available in both C and C++. For compatibility with previous versions,
_inline is a synonym for __inline."
(Source: http://msdn.microsoft.com/en-us/library/z8y1yy88.aspx)

This fix adds a patch that replaces "inline" with "__inline" in xxhash.c