### PR TITLE
Add null check to string in archive_pathmatch

### DIFF
--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -384,6 +384,8 @@ __archive_pathmatch(const char *p, const char *s, int flags)
 	/* Empty pattern only matches the empty string. */
 	if (p == NULL || *p == '\0')
 		return (s == NULL || *s == '\0');
+	else if (s == NULL)
+		return (0);
 
 	/* Leading '^' anchors the start of the pattern. */
 	if (*p == '^') {
@@ -424,6 +426,8 @@ __archive_pathmatch_w(const wchar_t *p, const wchar_t *s, int flags)
 	/* Empty pattern only matches the empty string. */
 	if (p == NULL || *p == L'\0')
 		return (s == NULL || *s == L'\0');
+	else if (s == NULL)
+		return (0);
 
 	/* Leading '^' anchors the start of the pattern. */
 	if (*p == L'^') {

--- a/libarchive/test/test_archive_pathmatch.c
+++ b/libarchive/test/test_archive_pathmatch.c
@@ -52,6 +52,10 @@ DEFINE_TEST(test_archive_pathmatch)
 	assertEqualInt(0, archive_pathmatch("a/b/c", "a/b/", 0));
 	assertEqualInt(0, archive_pathmatch("a/b/c", "a/b", 0));
 
+    /* Null string and non-empty pattern returns false. */
+	assertEqualInt(0, archive_pathmatch("a/b/c", NULL, 0));
+	assertEqualInt(0, archive_pathmatch_w(L"a/b/c", NULL, 0));
+
 	/* Empty pattern only matches empty string. */
 	assertEqualInt(1, archive_pathmatch("","", 0));
 	assertEqualInt(0, archive_pathmatch("","a", 0));


### PR DESCRIPTION
Adds a null check for the string parameter in archive_pathmatch
and archive_pathmatch_w to prevent a null pointer dereference.

Reported in github issue #1483.