### PR TITLE
Silence stderr in test_read_append_filter_program

### DIFF
--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -201,6 +201,11 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
 {
   struct archive_entry *ae;
   struct archive *a;
+#if !defined(_WIN32) || defined(__CYGWIN__)
+  FILE * fp;
+  int fd;
+  fpos_t pos;
+#endif
 
   /*
    * If we have "bunzip2 -q", try using that.
@@ -209,6 +214,14 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
     skipping("Can't run bunzip2 program on this platform");
     return;
   }
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+  /* bunzip2 will write to stderr, redirect it to a file */
+  fflush(stderr);
+  fgetpos(stderr, &pos);
+  assert((fd = dup(fileno(stderr))) != -1);
+  fp = freopen("stderr1", "w", stderr);
+#endif
 
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
@@ -219,4 +232,15 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
   assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
   assertEqualIntA(a, ARCHIVE_WARN, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+  /* restore stderr */
+  if (fp != NULL) {
+    fflush(stderr);
+    dup2(fd, fileno(stderr));
+    clearerr(stderr);
+    (void)fsetpos(stderr, &pos);
+  }
+  close(fd);
+#endif
 }


### PR DESCRIPTION
When the FreeBSD testsuite runs the libarchive tests it checks that stderr
is empty. Since #1382 this is no longer the case. This change restores
the behaviour of silencing bunzip2 stderr but doesn't bring back the
output text check.

Partially reverts 2e7aa5d9