### PR TITLE
Extract common transfer setting code for statfs and statvfs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1421,6 +1421,10 @@ CHECK_C_SOURCE_COMPILES(
   "#include <sys/types.h>\n#include <sys/mount.h>\nint main(void) { struct xvfsconf v; return sizeof(v);}"
   HAVE_STRUCT_XVFSCONF)
 
+CHECK_C_SOURCE_COMPILES(
+  "#include <sys/types.h>\n#include <sys/mount.h>\nint main(void) { struct statfs s; return sizeof(s);}"
+  HAVE_STRUCT_STATFS)
+
 # Make sure we have the POSIX version of readdir_r, not the
 # older 2-argument version.
 CHECK_C_SOURCE_COMPILES(
@@ -1496,9 +1500,14 @@ CHECK_STRUCT_HAS_MEMBER("struct tm" tm_gmtoff
 CHECK_STRUCT_HAS_MEMBER("struct tm" __tm_gmtoff
     "time.h" HAVE_STRUCT_TM___TM_GMTOFF)
 
+IF(HAVE_STRUCT_STATFS)
 # Check for f_namemax in struct statfs
 CHECK_STRUCT_HAS_MEMBER("struct statfs" f_namemax
     "sys/param.h;sys/mount.h" HAVE_STRUCT_STATFS_F_NAMEMAX)
+# Check for f_iosize in struct statfs
+CHECK_STRUCT_HAS_MEMBER("struct statfs" f_iosize
+    "sys/param.h;sys/mount.h" HAVE_STRUCT_STATFS_F_IOSIZE)
+ENDIF(HAVE_STRUCT_STATFS)
 
 # Check for birthtime in struct stat
 CHECK_STRUCT_HAS_MEMBER("struct stat" st_birthtime

--- a/configure.ac
+++ b/configure.ac
@@ -566,6 +566,13 @@ AC_CHECK_MEMBERS([struct statfs.f_namemax],,,
 #include <sys/mount.h>
 ])
 
+# Check for f_iosize in struct statfs
+AC_CHECK_MEMBERS([struct statfs.f_iosize],,,
+[
+#include <sys/param.h>
+#include <sys/mount.h>
+])
+
 # Check for f_iosize in struct statvfs
 AC_CHECK_MEMBERS([struct statvfs.f_iosize],,,
 [

--- a/configure.ac
+++ b/configure.ac
@@ -685,6 +685,13 @@ AC_CHECK_TYPES(struct xvfsconf,,,
 	#include <sys/mount.h>
 	])
 
+AC_CHECK_TYPES(struct statfs,,,
+	[#if HAVE_SYS_TYPES_H
+	#include <sys/types.h>
+	#endif
+	#include <sys/mount.h>
+	])
+
 # There are several variants of readdir_r around; we only
 # accept the POSIX-compliant version.
 AC_COMPILE_IFELSE(

--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -46,6 +46,13 @@
 #define	__LA_DEAD
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ > 2 || \
+			  (__GNUC__ == 2 && __GNUC_MINOR__ >= 7))
+#define	__LA_UNUSED	__attribute__((__unused__))
+#else
+#define	__LA_UNUSED
+#endif
+
 #define	ARCHIVE_WRITE_MAGIC	(0xb0c5c0deU)
 #define	ARCHIVE_READ_MAGIC	(0xdeb0c5U)
 #define	ARCHIVE_WRITE_DISK_MAGIC (0xc001b0c5U)

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1532,8 +1532,8 @@ set_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 	fs->min_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
 	fs->incr_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
 #else
-	fs->min_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
-	fs->incr_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
+	fs->min_xfer_size = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
+	fs->incr_xfer_size = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
 #endif
 }
 #endif

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1523,7 +1523,7 @@ get_xfer_size(struct tree *t, int fd, const char *path)
 #endif
 
 #if defined(HAVE_STATVFS)
-static inline void
+static inline __LA_UNUSED void
 set_statvfs_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 {
 	fs->xfer_align = sfs->f_frsize > 0 ? (long)sfs->f_frsize : -1;
@@ -1539,7 +1539,7 @@ set_statvfs_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 #endif
 
 #if defined(HAVE_STATFS)
-static inline void
+static inline __LA_UNUSED void
 set_statfs_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 {
 	fs->xfer_align = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1523,7 +1523,7 @@ get_xfer_size(struct tree *t, int fd, const char *path)
 #endif
 
 #if defined(HAVE_STATVFS)
-static void
+static inline void
 set_statvfs_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 {
 	fs->xfer_align = sfs->f_frsize > 0 ? (long)sfs->f_frsize : -1;
@@ -1539,7 +1539,7 @@ set_statvfs_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 #endif
 
 #if defined(HAVE_STATFS)
-static void
+static inline void
 set_statfs_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 {
 	fs->xfer_align = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1544,8 +1544,13 @@ set_statfs_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 {
 	fs->xfer_align = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
 	fs->max_xfer_size = -1;
+#if defined(HAVE_STRUCT_STATFS_F_IOSIZE)
 	fs->min_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
 	fs->incr_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
+#else
+	fs->min_xfer_size = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
+	fs->incr_xfer_size = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
+#endif
 }
 #endif
 

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1522,6 +1522,22 @@ get_xfer_size(struct tree *t, int fd, const char *path)
 }
 #endif
 
+#if defined(HAVE_STATVFS)
+static void
+set_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
+{
+	fs->xfer_align = sfs->f_frsize > 0 ? (long)sfs->f_frsize : -1;
+	fs->max_xfer_size = -1;
+#if defined(HAVE_STRUCT_STATVFS_F_IOSIZE)
+	fs->min_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
+	fs->incr_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
+#else
+	fs->min_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
+	fs->incr_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
+#endif
+}
+#endif
+
 #if defined(HAVE_STATFS) && defined(HAVE_FSTATFS) && defined(MNT_LOCAL) \
 	&& !defined(ST_LOCAL)
 
@@ -1656,20 +1672,6 @@ setup_current_filesystem(struct archive_read_disk *a)
 }
 
 #elif (defined(HAVE_STATVFS) || defined(HAVE_FSTATVFS)) && defined(ST_LOCAL)
-
-static void
-set_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
-{
-	fs->xfer_align = sfs->f_frsize > 0 ? (long)sfs->f_frsize : -1;
-	fs->max_xfer_size = -1;
-#if defined(HAVE_STRUCT_STATVFS_F_IOSIZE)
-	fs->min_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
-	fs->incr_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
-#else
-	fs->min_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
-	fs->incr_xfer_size = sfs->f_bsize > 0 : (long)sfs->f_bsize : -1;
-#endif
-}
 
 /*
  * Gather current filesystem properties on NetBSD

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1528,7 +1528,7 @@ get_xfer_size(struct tree *t, int fd, const char *path)
 static void
 set_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 {
-	fs->xfer_align = sfs->f_bsize > 0 ? (long)sfs->fs_bsize : -1;
+	fs->xfer_align = sfs->f_bsize > 0 ? (long)sfs->f_bsize : -1;
 	fs->max_xfer_size = -1;
 	fs->min_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;
 	fs->incr_xfer_size = sfs->f_iosize > 0 ? (long)sfs->f_iosize : -1;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1538,7 +1538,7 @@ set_statvfs_transfer_size(struct filesystem *fs, const struct statvfs *sfs)
 }
 #endif
 
-#if defined(HAVE_STATFS)
+#if defined(HAVE_STRUCT_STATFS)
 static inline __LA_UNUSED void
 set_statfs_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 {
@@ -1554,8 +1554,8 @@ set_statfs_transfer_size(struct filesystem *fs, const struct statfs *sfs)
 }
 #endif
 
-#if defined(HAVE_STATFS) && defined(HAVE_FSTATFS) && defined(MNT_LOCAL) \
-	&& !defined(ST_LOCAL)
+#if defined(HAVE_STRUCT_STATFS) && defined(HAVE_STATFS) && \
+    defined(HAVE_FSTATFS) && defined(MNT_LOCAL) && !defined(ST_LOCAL)
 
 /*
  * Gather current filesystem properties on FreeBSD, OpenBSD and Mac OS X.

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1074,7 +1074,7 @@ read_mtree(struct archive_read *a, struct mtree *mtree)
 			continue;
 		/* Non-printable characters are not allowed */
 		for (s = p;s < p + len - 1; s++) {
-			if (!isprint(*s)) {
+			if (!isprint((unsigned char)*s)) {
 				r = ARCHIVE_FATAL;
 				break;
 			}


### PR DESCRIPTION
1. Makes detection of f_iosize constent.
2. Avoid infinite loops by detecting 0 sizes and converting to -1.
   This happens with FUSE. NetBSD PR/56083.