### PR TITLE
Avoid getcwd(0, PATH_MAX) for GNU libc

### DIFF
--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -528,7 +528,7 @@ test_basic(void)
 	 */
 
 	/* Save current working directory. */
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	initial_cwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	initial_cwd = getcwd(NULL, 0);
@@ -560,7 +560,7 @@ test_basic(void)
 	failure(
 	    "Current working directory does not return to the initial"
 	    "directory");
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	cwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	cwd = getcwd(NULL, 0);

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -577,7 +577,7 @@ DEFINE_TEST(test_sparse_basic)
 
 	/* Check if the filesystem where CWD on can
 	 * report the number of the holes of a sparse file. */
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	cwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	cwd = getcwd(NULL, 0);
@@ -637,7 +637,7 @@ DEFINE_TEST(test_fully_sparse_files)
 
 	/* Check if the filesystem where CWD on can
 	 * report the number of the holes of a sparse file. */
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	cwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	cwd = getcwd(NULL, 0);

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3680,7 +3680,7 @@ get_refdir(const char *d)
 	}
 
 	/* Get the current dir. */
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	pwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	pwd = getcwd(NULL, 0);
@@ -3775,7 +3775,7 @@ main(int argc, char **argv)
 	(void)argc; /* UNUSED */
 
 	/* Get the current dir. */
-#ifdef PATH_MAX
+#if defined(PATH_MAX) && !defined(__GLIBC__)
 	pwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */
 #else
 	pwd = getcwd(NULL, 0);


### PR DESCRIPTION
Recent versions of GNU libc and GCC produce a warning on getcwd(0, PATH_MAX):

 test_main.c: In function ‘get_refdir’:
 test_main.c:3684:8: error: argument 1 is null but the corresponding size argument 2 value is 4096 [-Werror=nonnull]
   3684 |  pwd = getcwd(NULL, PATH_MAX);/* Solaris getcwd needs the size. */

This is because getcwd() is marked with the 'write_only (1, 2)' attribute.

Using the alternate getcwd(NULL, 0) path which is supported by GNU libc avoids this.