### PR TITLE
7zip: Use compression settings from file also for file header

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -755,9 +755,9 @@ _7z_close(struct archive_write *a)
 		 */
 #if HAVE_LZMA_H
 		header_compression = _7Z_LZMA1;
-        if(zip->opt_compression == _7Z_LZMA2 ||
-           zip->opt_compression == _7Z_COPY)
-            header_compression = zip->opt_compression;
+		if(zip->opt_compression == _7Z_LZMA2 ||
+		   zip->opt_compression == _7Z_COPY)
+			header_compression = zip->opt_compression;
 
 		/* If the stored file is only one, do not encode the header.
 		 * This is the same way 7z command does. */
@@ -767,7 +767,7 @@ _7z_close(struct archive_write *a)
 		header_compression = _7Z_COPY;
 #endif
 		r = _7z_compression_init_encoder(a, header_compression,
-                                         zip->opt_compression_level);
+		                                 zip->opt_compression_level);
 		if (r < 0)
 			return (r);
 		zip->crc32flg = PRECODE_CRC32;

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -755,6 +755,10 @@ _7z_close(struct archive_write *a)
 		 */
 #if HAVE_LZMA_H
 		header_compression = _7Z_LZMA1;
+        if(zip->opt_compression == _7Z_LZMA2 ||
+           zip->opt_compression == _7Z_COPY)
+            header_compression = zip->opt_compression;
+
 		/* If the stored file is only one, do not encode the header.
 		 * This is the same way 7z command does. */
 		if (zip->total_number_entry == 1)
@@ -762,7 +766,8 @@ _7z_close(struct archive_write *a)
 #else
 		header_compression = _7Z_COPY;
 #endif
-		r = _7z_compression_init_encoder(a, header_compression, 6);
+		r = _7z_compression_init_encoder(a, header_compression,
+                                         zip->opt_compression_level);
 		if (r < 0)
 			return (r);
 		zip->crc32flg = PRECODE_CRC32;


### PR DESCRIPTION
The 7zip writer currently uses hard-coded values for the header compression (lzma1 if available and compression level 6).
This PR changes this behavior, so that the header is encoded in the same way as the rest of the archive.

I came across this when trying to read libarchive-created 7z file with the [Apache Commons Compress Java Library](https://commons.apache.org/proper/commons-compress). Because libarchive encoded the header differently then the rest of the file, the Java library failed with the error message "Compressed data is corrupt".

One could argue that this a bug with the Java library, but I think it's also a good thing for libarchive to use the same compression settings throughout the archive.

I have tried this version with different combinations of algorithm and compression level settings, and the files are all readable without problem with 7-zip.