### PR TITLE
Fix mutual check in tar sparse handling

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1906,7 +1906,7 @@ pax_attribute(struct archive_read *a, struct tar *tar,
 		}
 		if (strcmp(key, "GNU.sparse.numbytes") == 0) {
 			tar->sparse_numbytes = tar_atol10(value, strlen(value));
-			if (tar->sparse_numbytes != -1) {
+			if (tar->sparse_offset != -1) {
 				if (gnu_add_sparse_entry(a, tar,
 				    tar->sparse_offset, tar->sparse_numbytes)
 				    != ARCHIVE_OK)


### PR DESCRIPTION
GNU.sparse.numbytes and GNU.sparse.offset both have to be set before
gnu_add_sparse_entry can be called.

The GNU.sparse.numbytes parser checks for tar->sparse_numbytes.
This has to be tar->sparse_offset instead to work just like the
GNU.sparse.offset parser.