### PR TITLE
Windows: Use full path including prefix when looking up file handle

### DIFF
--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1844,7 +1844,7 @@ tree_next(struct tree *t)
 					continue;
 				return (r);
 			} else {
-				HANDLE h = FindFirstFileW(d, &t->_findData);
+				HANDLE h = FindFirstFileW(t->stack->full_path.s, &t->_findData);
 				if (h == INVALID_HANDLE_VALUE) {
 					la_dosmaperr(GetLastError());
 					t->tree_errno = errno;


### PR DESCRIPTION
This fixes Issue #1523 

It just seems to be an oversight, where the normal version of the file path (`name`) is being used for the Windows API lookup, rather than the `full_path` which contains the long path prefix