### PR TITLE
zstd filter writer: add threads option

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -387,7 +387,7 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 	if (data->threads != 0) {
 		struct archive_string as2;
 		archive_string_init(&as2);
-		archive_string_sprintf(&as, " --threads=%d", data->threads);
+		archive_string_sprintf(&as2, " --threads=%d", data->threads);
 		archive_string_concat(&as, &as2);
 		archive_string_free(&as2);
 	}

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -50,6 +50,7 @@ __FBSDID("$FreeBSD$");
 
 struct private_data {
 	int		 compression_level;
+	int      threads;
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 	ZSTD_CStream	*cstream;
 	int64_t		 total_in;
@@ -107,6 +108,7 @@ archive_write_add_filter_zstd(struct archive *_a)
 	f->code = ARCHIVE_FILTER_ZSTD;
 	f->name = "zstd";
 	data->compression_level = CLEVEL_DEFAULT;
+	data->threads = 0;
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 	data->cstream = ZSTD_createCStream();
 	if (data->cstream == NULL) {
@@ -204,6 +206,20 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		}
 		data->compression_level = level;
 		return (ARCHIVE_OK);
+	} else if (strcmp(key, "threads") == 0) {
+		int threads = atoi(value);
+		if (string_is_numeric(value) != ARCHIVE_OK) {
+			return (ARCHIVE_WARN);
+		}
+
+		int minimum = 0;
+
+		if (threads < minimum) {
+			return (ARCHIVE_WARN);
+		}
+
+		data->threads = threads;
+		return (ARCHIVE_OK);
 	}
 
 	/* Note: The "warn" return is just to inform the options
@@ -251,6 +267,8 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 		    "Internal error initializing zstd compressor object");
 		return (ARCHIVE_FATAL);
 	}
+
+	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_nbWorkers, data->threads);
 
 	return (ARCHIVE_OK);
 }
@@ -364,6 +382,14 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 
 	if (data->compression_level > CLEVEL_STD_MAX) {
 		archive_strcat(&as, " --ultra");
+	}
+
+	if (data->threads != 0) {
+		struct archive_string as2;
+		archive_string_init(&as2);
+		archive_string_sprintf(&as, " --threads=%d", data->threads);
+		archive_string_concat(&as, &as2);
+		archive_string_free(&as2);
 	}
 
 	f->write = archive_compressor_zstd_write;

--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -129,6 +129,10 @@ DEFINE_TEST(test_write_filter_zstd)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "-1")); */
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_set_filter_option(a, NULL, "compression-level", "7"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "threads", "-1")); /* negative */
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "threads", "4"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
 		sprintf(path, "file%03d", i);


### PR DESCRIPTION
Closes #1557 


Add threads option and a corresponding test. I also tested that it actually does affect thread utilization and compression time, and it does--not sure if there's a good way to integrate that. Also not sure how I can test the `archive_compressor_zstd_open` change.