### PR TITLE
Windows build fix

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -632,7 +632,7 @@ static int run_arm_filter(struct rar5* rar, struct filter_info* flt) {
 			/* 0xEB = ARM's BL (branch + link) instruction. */
 			offset = read_filter_data(rar,
 			    (rar->cstate.solid_offset + flt->block_start + i) &
-			     rar->cstate.window_mask) & 0x00ffffff;
+			     (uint32_t)rar->cstate.window_mask) & 0x00ffffff;
 
 			offset -= (uint32_t) ((i + flt->block_start) / 4);
 			offset = (offset & 0x00ffffff) | 0xeb000000;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1186,7 +1186,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 		{
 			// symlink target string appeared to be compressed
 			int status = ARCHIVE_FATAL;
-			const void *uncompressed_buffer;
+			const void *uncompressed_buffer = NULL;
 
 			switch (zip->entry->compression)
 			{

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -745,7 +745,7 @@ archive_string_append_from_wcs_in_codepage(struct archive_string *as,
 				dp = &defchar_used;
 			count = WideCharToMultiByte(to_cp, 0, ws, wslen,
 			    as->s + as->length,
-			    (int)as->buffer_length - as->length - 1, NULL, dp);
+			    (int)as->buffer_length - (int)as->length - 1, NULL, dp);
 			if (count == 0 &&
 			    GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
 				/* Expand the MBS buffer and retry. */

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -628,7 +628,7 @@ la_CreateSymbolicLinkW(const wchar_t *linkname, const wchar_t *target,
 	static BOOLEAN (WINAPI *f)(LPCWSTR, LPCWSTR, DWORD);
 	static int set;
 	wchar_t *ttarget, *p;
-	int len;
+	size_t len;
 	DWORD attrs = 0;
 	DWORD flags = 0;
 	DWORD newflags = 0;

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -441,7 +441,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		ret_final = ARCHIVE_FATAL;
 		goto exit_write_header;
 	}
-	h.h_ino = la_swap16(ino);
+	h.h_ino = la_swap16((uint16_t)ino);
 
 	h.h_mode = archive_entry_mode(entry);
 	if (((h.h_mode & AE_IFMT) == AE_IFSOCK) || ((h.h_mode & AE_IFMT) == AE_IFIFO)) {
@@ -462,9 +462,9 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	}
 	h.h_mode = la_swap16(h.h_mode);
 
-	h.h_uid = la_swap16(archive_entry_uid(entry));
-	h.h_gid = la_swap16(archive_entry_gid(entry));
-	h.h_nlink = la_swap16(archive_entry_nlink(entry));
+	h.h_uid = la_swap16((uint16_t)archive_entry_uid(entry));
+	h.h_gid = la_swap16((uint16_t)archive_entry_gid(entry));
+	h.h_nlink = la_swap16((uint16_t)archive_entry_nlink(entry));
 
 	if (archive_entry_filetype(entry) == AE_IFBLK
 	    || archive_entry_filetype(entry) == AE_IFCHR)
@@ -472,7 +472,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	else
 		h.h_majmin = 0;
 
-	h.h_mtime = la_swap32(archive_entry_mtime(entry));
+	h.h_mtime = la_swap32((uint32_t)archive_entry_mtime(entry));
 	h.h_namesize = la_swap16(pathlength);
 
 	/* Non-regular files don't store bodies. */
@@ -502,7 +502,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 			ret_final = ARCHIVE_FATAL;
 			goto exit_write_header;
 		}
-		h.h_filesize = la_swap32(strlen(p)); /* symlink */
+		h.h_filesize = la_swap32((uint32_t)strlen(p)); /* symlink */
 	} else {
 		if ((a->archive.archive_format == ARCHIVE_FORMAT_CPIO_PWB) &&
 		    (archive_entry_size(entry) > 256*256*256-1)) {
@@ -516,7 +516,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 			ret_final = ARCHIVE_FAILED;
 			goto exit_write_header;
 		}
-		h.h_filesize = la_swap32(archive_entry_size(entry)); /* file */
+		h.h_filesize = la_swap32((uint32_t)archive_entry_size(entry)); /* file */
 	}
 
 	ret = __archive_write_output(a, &h, HSIZE);


### PR DESCRIPTION
Avoid conversion warnings preventing to build on Windows.
Initialize variable before using it.