### PR TITLE
Reader filter rework - simplification, robustness and deadcode removal

### DIFF
--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -112,9 +112,6 @@ struct archive {
 	int		  archive_format;
 	const char	 *archive_format_name;
 
-	int	  compression_code;	/* Currently active compression. */
-	const char *compression_name;
-
 	/* Number of file entries processed. */
 	int		  file_count;
 

--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -107,7 +107,7 @@ struct archive {
 	 * Some public API functions depend on the "real" type of the
 	 * archive object.
 	 */
-	struct archive_vtable *vtable;
+	const struct archive_vtable *vtable;
 
 	int		  archive_format;
 	const char	 *archive_format_name;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -486,10 +486,8 @@ archive_read_open1(struct archive *_a)
 	filter->upstream = NULL;
 	filter->archive = a;
 	filter->data = a->client.dataset[0].data;
-	filter->open = client_open_proxy;
 	filter->read = client_read_proxy;
 	filter->close = client_close_proxy;
-	filter->sswitch = client_switch_proxy;
 	filter->name = "none";
 	filter->code = ARCHIVE_FILTER_NONE;
 	filter->can_skip = 1;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -578,8 +578,6 @@ choose_filters(struct archive_read *a)
 				__archive_read_free_filters(a);
 				return (ARCHIVE_FATAL);
 			}
-			a->archive.compression_name = a->filter->name;
-			a->archive.compression_code = a->filter->code;
 			return (ARCHIVE_OK);
 		}
 

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1104,9 +1104,7 @@ _archive_read_free(struct archive *_a)
 	n = sizeof(a->bidders)/sizeof(a->bidders[0]);
 	for (i = 0; i < n; i++) {
 		if (a->bidders[i].free != NULL) {
-			int r1 = (a->bidders[i].free)(&a->bidders[i]);
-			if (r1 < r)
-				r = r1;
+			(a->bidders[i].free)(&a->bidders[i]);
 		}
 	}
 

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -488,11 +488,11 @@ archive_read_open1(struct archive *_a)
 	filter->data = a->client.dataset[0].data;
 	filter->open = client_open_proxy;
 	filter->read = client_read_proxy;
-	filter->skip = client_skip_proxy;
 	filter->close = client_close_proxy;
 	filter->sswitch = client_switch_proxy;
 	filter->name = "none";
 	filter->code = ARCHIVE_FILTER_NONE;
+	filter->can_skip = 1;
 	filter->can_seek = 1;
 
 	a->client.dataset[0].begin_position = 0;
@@ -1563,8 +1563,8 @@ advance_file_pointer(struct archive_read_filter *filter, int64_t request)
 		return (total_bytes_skipped);
 
 	/* If there's an optimized skip function, use it. */
-	if (filter->skip != NULL) {
-		bytes_skipped = (filter->skip)(filter, request);
+	if (filter->can_skip != 0) {
+		bytes_skipped = client_skip_proxy(filter, request);
 		if (bytes_skipped < 0) {	/* error */
 			filter->fatal = 1;
 			return (bytes_skipped);

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -58,7 +58,6 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_read.c 201157 2009-12-29 05:30:2
 static int	choose_filters(struct archive_read *);
 static int	choose_format(struct archive_read *);
 static int	close_filters(struct archive_read *);
-static struct archive_vtable *archive_read_vtable(void);
 static int64_t	_archive_filter_bytes(struct archive *, int);
 static int	_archive_filter_code(struct archive *, int);
 static const char *_archive_filter_name(struct archive *, int);
@@ -73,26 +72,18 @@ static int	_archive_read_next_header2(struct archive *,
 		    struct archive_entry *);
 static int64_t  advance_file_pointer(struct archive_read_filter *, int64_t);
 
-static struct archive_vtable *
-archive_read_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_filter_bytes = _archive_filter_bytes;
-		av.archive_filter_code = _archive_filter_code;
-		av.archive_filter_name = _archive_filter_name;
-		av.archive_filter_count = _archive_filter_count;
-		av.archive_read_data_block = _archive_read_data_block;
-		av.archive_read_next_header = _archive_read_next_header;
-		av.archive_read_next_header2 = _archive_read_next_header2;
-		av.archive_free = _archive_read_free;
-		av.archive_close = _archive_read_close;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_read_vtable = {
+	.archive_filter_bytes = _archive_filter_bytes,
+	.archive_filter_code = _archive_filter_code,
+	.archive_filter_name = _archive_filter_name,
+	.archive_filter_count = _archive_filter_count,
+	.archive_read_data_block = _archive_read_data_block,
+	.archive_read_next_header = _archive_read_next_header,
+	.archive_read_next_header2 = _archive_read_next_header2,
+	.archive_free = _archive_read_free,
+	.archive_close = _archive_read_close,
+};
 
 /*
  * Allocate, initialize and return a struct archive object.
@@ -109,7 +100,7 @@ archive_read_new(void)
 
 	a->archive.state = ARCHIVE_STATE_NEW;
 	a->entry = archive_entry_new2(&a->archive);
-	a->archive.vtable = archive_read_vtable();
+	a->archive.vtable = &archive_read_vtable;
 
 	a->passphrases.last = &a->passphrases.first;
 

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -489,11 +489,11 @@ archive_read_open1(struct archive *_a)
 	filter->open = client_open_proxy;
 	filter->read = client_read_proxy;
 	filter->skip = client_skip_proxy;
-	filter->seek = client_seek_proxy;
 	filter->close = client_close_proxy;
 	filter->sswitch = client_switch_proxy;
 	filter->name = "none";
 	filter->code = ARCHIVE_FILTER_NONE;
+	filter->can_seek = 1;
 
 	a->client.dataset[0].begin_position = 0;
 	if (!a->filter || !a->bypass_filter_bidding)
@@ -1633,7 +1633,7 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 
 	if (filter->closed || filter->fatal)
 		return (ARCHIVE_FATAL);
-	if (filter->seek == NULL)
+	if (filter->can_seek == 0)
 		return (ARCHIVE_FAILED);
 
 	client = &(filter->archive->client);

--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -135,7 +135,7 @@ archive_read_append_filter(struct archive *_a, int code)
     filter->archive = a;
     filter->upstream = a->filter;
     a->filter = filter;
-    r2 = (bidder->init)(a->filter);
+    r2 = (bidder->vtable->init)(a->filter);
     if (r2 != ARCHIVE_OK) {
       __archive_read_free_filters(a);
       return (ARCHIVE_FATAL);
@@ -192,7 +192,7 @@ archive_read_append_filter_program_signature(struct archive *_a,
   filter->archive = a;
   filter->upstream = a->filter;
   a->filter = filter;
-  r = (bidder->init)(a->filter);
+  r = (bidder->vtable->init)(a->filter);
   if (r != ARCHIVE_OK) {
     __archive_read_free_filters(a);
     return (ARCHIVE_FATAL);

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -369,22 +369,14 @@ static int	open_on_current_dir(struct tree *, const char *, int);
 static int	tree_dup(int);
 
 
-static struct archive_vtable *
-archive_read_disk_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_free = _archive_read_free;
-		av.archive_close = _archive_read_close;
-		av.archive_read_data_block = _archive_read_data_block;
-		av.archive_read_next_header = _archive_read_next_header;
-		av.archive_read_next_header2 = _archive_read_next_header2;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_read_disk_vtable = {
+	.archive_free = _archive_read_free,
+	.archive_close = _archive_read_close,
+	.archive_read_data_block = _archive_read_data_block,
+	.archive_read_next_header = _archive_read_next_header,
+	.archive_read_next_header2 = _archive_read_next_header2,
+};
 
 const char *
 archive_read_disk_gname(struct archive *_a, la_int64_t gid)
@@ -461,7 +453,7 @@ archive_read_disk_new(void)
 		return (NULL);
 	a->archive.magic = ARCHIVE_READ_DISK_MAGIC;
 	a->archive.state = ARCHIVE_STATE_NEW;
-	a->archive.vtable = archive_read_disk_vtable();
+	a->archive.vtable = &archive_read_disk_vtable;
 	a->entry = archive_entry_new2(&a->archive);
 	a->lookup_uname = trivial_lookup_uname;
 	a->lookup_gname = trivial_lookup_gname;

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -449,22 +449,14 @@ entry_symlink_from_pathw(struct archive_entry *entry, const wchar_t *path)
 	return;
 }
 
-static struct archive_vtable *
-archive_read_disk_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_free = _archive_read_free;
-		av.archive_close = _archive_read_close;
-		av.archive_read_data_block = _archive_read_data_block;
-		av.archive_read_next_header = _archive_read_next_header;
-		av.archive_read_next_header2 = _archive_read_next_header2;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_read_disk_vtable = {
+	.archive_free = _archive_read_free,
+	.archive_close = _archive_read_close,
+	.archive_read_data_block = _archive_read_data_block,
+	.archive_read_next_header = _archive_read_next_header,
+	.archive_read_next_header2 = _archive_read_next_header2,
+};
 
 const char *
 archive_read_disk_gname(struct archive *_a, la_int64_t gid)
@@ -541,7 +533,7 @@ archive_read_disk_new(void)
 		return (NULL);
 	a->archive.magic = ARCHIVE_READ_DISK_MAGIC;
 	a->archive.state = ARCHIVE_STATE_NEW;
-	a->archive.vtable = archive_read_disk_vtable();
+	a->archive.vtable = &archive_read_disk_vtable;
 	a->entry = archive_entry_new2(&a->archive);
 	a->lookup_uname = trivial_lookup_uname;
 	a->lookup_gname = trivial_lookup_gname;

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -243,8 +243,10 @@ int	__archive_read_register_format(struct archive_read *a,
 		int (*format_capabilities)(struct archive_read *),
 		int (*has_encrypted_entries)(struct archive_read *));
 
-int __archive_read_get_bidder(struct archive_read *a,
-    struct archive_read_filter_bidder **bidder);
+int __archive_read_register_bidder(struct archive_read *a,
+		void *bidder_data,
+		const char *name,
+		const struct archive_read_filter_bidder_vtable *vtable);
 
 const void *__archive_read_ahead(struct archive_read *, size_t, ssize_t *);
 const void *__archive_read_filter_ahead(struct archive_read_filter *,

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -42,6 +42,16 @@ struct archive_read;
 struct archive_read_filter_bidder;
 struct archive_read_filter;
 
+struct archive_read_filter_bidder_vtable {
+	/* Taste the upstream filter to see if we handle this. */
+	int (*bid)(struct archive_read_filter_bidder *,
+	    struct archive_read_filter *);
+	/* Initialize a newly-created filter. */
+	int (*init)(struct archive_read_filter *);
+	/* Release the bidder's configuration data. */
+	void (*free)(struct archive_read_filter_bidder *);
+};
+
 /*
  * How bidding works for filters:
  *   * The bid manager initializes the client-provided reader as the
@@ -62,13 +72,7 @@ struct archive_read_filter_bidder {
 	void *data;
 	/* Name of the filter */
 	const char *name;
-	/* Taste the upstream filter to see if we handle this. */
-	int (*bid)(struct archive_read_filter_bidder *,
-	    struct archive_read_filter *);
-	/* Initialize a newly-created filter. */
-	int (*init)(struct archive_read_filter *);
-	/* Release the bidder's configuration data. */
-	void (*free)(struct archive_read_filter_bidder *);
+	const struct archive_read_filter_bidder_vtable *vtable;
 };
 
 /*

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -91,8 +91,6 @@ struct archive_read_filter {
 	int (*open)(struct archive_read_filter *self);
 	/* Return next block. */
 	ssize_t (*read)(struct archive_read_filter *, const void **);
-	/* Skip forward this many bytes. */
-	int64_t (*skip)(struct archive_read_filter *self, int64_t request);
 	/* Close (just this filter) and free(self). */
 	int (*close)(struct archive_read_filter *self);
 	/* Function that handles switching from reading one block to the next/prev */
@@ -104,6 +102,7 @@ struct archive_read_filter {
 
 	const char	*name;
 	int		 code;
+	int		 can_skip;
 	int		 can_seek;
 
 	/* Used by reblocking logic. */

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -87,14 +87,10 @@ struct archive_read_filter {
 	struct archive_read_filter_bidder *bidder; /* My bidder. */
 	struct archive_read_filter *upstream; /* Who I read from. */
 	struct archive_read *archive; /* Associated archive. */
-	/* Open a block for reading */
-	int (*open)(struct archive_read_filter *self);
 	/* Return next block. */
 	ssize_t (*read)(struct archive_read_filter *, const void **);
 	/* Close (just this filter) and free(self). */
 	int (*close)(struct archive_read_filter *self);
-	/* Function that handles switching from reading one block to the next/prev */
-	int (*sswitch)(struct archive_read_filter *self, unsigned int iindex);
 	/* Read any header metadata if available. */
 	int (*read_header)(struct archive_read_filter *self, struct archive_entry *entry);
 	/* My private data. */

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -67,9 +67,6 @@ struct archive_read_filter_bidder {
 	    struct archive_read_filter *);
 	/* Initialize a newly-created filter. */
 	int (*init)(struct archive_read_filter *);
-	/* Set an option for the filter bidder. */
-	int (*options)(struct archive_read_filter_bidder *,
-	    const char *key, const char *value);
 	/* Release the bidder's configuration data. */
 	int (*free)(struct archive_read_filter_bidder *);
 };

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -75,6 +75,15 @@ struct archive_read_filter_bidder {
 	const struct archive_read_filter_bidder_vtable *vtable;
 };
 
+struct archive_read_filter_vtable {
+	/* Return next block. */
+	ssize_t (*read)(struct archive_read_filter *, const void **);
+	/* Close (just this filter) and free(self). */
+	int (*close)(struct archive_read_filter *self);
+	/* Read any header metadata if available. */
+	int (*read_header)(struct archive_read_filter *self, struct archive_entry *entry);
+};
+
 /*
  * This structure is allocated within the archive_read core
  * and initialized by archive_read and the init() method of the
@@ -87,12 +96,7 @@ struct archive_read_filter {
 	struct archive_read_filter_bidder *bidder; /* My bidder. */
 	struct archive_read_filter *upstream; /* Who I read from. */
 	struct archive_read *archive; /* Associated archive. */
-	/* Return next block. */
-	ssize_t (*read)(struct archive_read_filter *, const void **);
-	/* Close (just this filter) and free(self). */
-	int (*close)(struct archive_read_filter *self);
-	/* Read any header metadata if available. */
-	int (*read_header)(struct archive_read_filter *self, struct archive_entry *entry);
+	const struct archive_read_filter_vtable *vtable;
 	/* My private data. */
 	void *data;
 

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -93,8 +93,6 @@ struct archive_read_filter {
 	ssize_t (*read)(struct archive_read_filter *, const void **);
 	/* Skip forward this many bytes. */
 	int64_t (*skip)(struct archive_read_filter *self, int64_t request);
-	/* Seek to an absolute location. */
-	int64_t (*seek)(struct archive_read_filter *self, int64_t offset, int whence);
 	/* Close (just this filter) and free(self). */
 	int (*close)(struct archive_read_filter *self);
 	/* Function that handles switching from reading one block to the next/prev */
@@ -106,6 +104,7 @@ struct archive_read_filter {
 
 	const char	*name;
 	int		 code;
+	int		 can_seek;
 
 	/* Used by reblocking logic. */
 	char		*buffer;

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -68,7 +68,7 @@ struct archive_read_filter_bidder {
 	/* Initialize a newly-created filter. */
 	int (*init)(struct archive_read_filter *);
 	/* Release the bidder's configuration data. */
-	int (*free)(struct archive_read_filter_bidder *);
+	void (*free)(struct archive_read_filter_bidder *);
 };
 
 /*

--- a/libarchive/archive_read_set_options.c
+++ b/libarchive/archive_read_set_options.c
@@ -112,37 +112,15 @@ static int
 archive_set_filter_option(struct archive *_a, const char *m, const char *o,
     const char *v)
 {
-	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter *filter;
-	struct archive_read_filter_bidder *bidder;
-	int r, rv = ARCHIVE_WARN, matched_modules = 0;
+	(void)_a; /* UNUSED */
+	(void)o; /* UNUSED */
+	(void)v; /* UNUSED */
 
-	for (filter = a->filter; filter != NULL; filter = filter->upstream) {
-		bidder = filter->bidder;
-		if (bidder == NULL)
-			continue;
-		if (bidder->options == NULL)
-			/* This bidder does not support option */
-			continue;
-		if (m != NULL) {
-			if (strcmp(filter->name, m) != 0)
-				continue;
-			++matched_modules;
-		}
-
-		r = bidder->options(bidder, o, v);
-
-		if (r == ARCHIVE_FATAL)
-			return (ARCHIVE_FATAL);
-
-		if (r == ARCHIVE_OK)
-			rv = ARCHIVE_OK;
-	}
 	/* If the filter name didn't match, return a special code for
 	 * _archive_set_option[s]. */
-	if (m != NULL && matched_modules == 0)
+	if (m != NULL)
 		return ARCHIVE_WARN - 1;
-	return (rv);
+	return ARCHIVE_WARN;
 }
 
 static int

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -70,7 +70,6 @@ static int	bzip2_filter_close(struct archive_read_filter *);
  */
 static int	bzip2_reader_bid(struct archive_read_filter_bidder *, struct archive_read_filter *);
 static int	bzip2_reader_init(struct archive_read_filter *);
-static int	bzip2_reader_free(struct archive_read_filter_bidder *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
@@ -97,7 +96,7 @@ archive_read_support_filter_bzip2(struct archive *_a)
 	reader->name = "bzip2";
 	reader->bid = bzip2_reader_bid;
 	reader->init = bzip2_reader_init;
-	reader->free = bzip2_reader_free;
+	reader->free = NULL;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	return (ARCHIVE_OK);
 #else
@@ -105,12 +104,6 @@ archive_read_support_filter_bzip2(struct archive *_a)
 	    "Using external bzip2 program");
 	return (ARCHIVE_WARN);
 #endif
-}
-
-static int
-bzip2_reader_free(struct archive_read_filter_bidder *self){
-	(void)self; /* UNUSED */
-	return (ARCHIVE_OK);
 }
 
 /*

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -97,7 +97,6 @@ archive_read_support_filter_bzip2(struct archive *_a)
 	reader->name = "bzip2";
 	reader->bid = bzip2_reader_bid;
 	reader->init = bzip2_reader_init;
-	reader->options = NULL;
 	reader->free = bzip2_reader_free;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -80,6 +80,12 @@ archive_read_support_compression_bzip2(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+bzip2_bidder_vtable = {
+	.bid = bzip2_reader_bid,
+	.init = bzip2_reader_init,
+};
+
 int
 archive_read_support_filter_bzip2(struct archive *_a)
 {
@@ -94,9 +100,7 @@ archive_read_support_filter_bzip2(struct archive *_a)
 
 	reader->data = NULL;
 	reader->name = "bzip2";
-	reader->bid = bzip2_reader_bid;
-	reader->init = bzip2_reader_init;
-	reader->free = NULL;
+	reader->vtable = &bzip2_bidder_vtable;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -90,17 +90,11 @@ int
 archive_read_support_filter_bzip2(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *reader;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_bzip2");
-
-	if (__archive_read_get_bidder(a, &reader) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "bzip2",
+				&bzip2_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	reader->data = NULL;
-	reader->name = "bzip2";
-	reader->vtable = &bzip2_bidder_vtable;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -173,6 +173,12 @@ bzip2_reader_init(struct archive_read_filter *self)
 
 #else
 
+static const struct archive_read_filter_vtable
+bzip2_reader_vtable = {
+	.read = bzip2_filter_read,
+	.close = bzip2_filter_close,
+};
+
 /*
  * Setup the callbacks.
  */
@@ -199,8 +205,7 @@ bzip2_reader_init(struct archive_read_filter *self)
 	self->data = state;
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
-	self->read = bzip2_filter_read;
-	self->close = bzip2_filter_close;
+	self->vtable = &bzip2_reader_vtable;
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -200,7 +200,6 @@ bzip2_reader_init(struct archive_read_filter *self)
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
 	self->read = bzip2_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = bzip2_filter_close;
 
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -166,7 +166,6 @@ archive_read_support_filter_compress(struct archive *_a)
 	bidder->name = "compress (.Z)";
 	bidder->bid = compress_bidder_bid;
 	bidder->init = compress_bidder_init;
-	bidder->options = NULL;
 	bidder->free = compress_bidder_free;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -227,7 +227,6 @@ compress_bidder_init(struct archive_read_filter *self)
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
 	self->read = compress_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = compress_filter_close;
 
 	/* XXX MOVE THE FOLLOWING OUT OF INIT() XXX */

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -159,18 +159,9 @@ int
 archive_read_support_filter_compress(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_compress");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
-		return (ARCHIVE_FATAL);
-
-	bidder->data = NULL;
-	bidder->name = "compress (.Z)";
-	bidder->vtable = &compress_bidder_vtable;
-	return (ARCHIVE_OK);
+	return __archive_read_register_bidder(a, NULL, "compress (.Z)",
+			&compress_bidder_vtable);
 }
 
 /*

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -133,7 +133,6 @@ struct private_data {
 
 static int	compress_bidder_bid(struct archive_read_filter_bidder *, struct archive_read_filter *);
 static int	compress_bidder_init(struct archive_read_filter *);
-static int	compress_bidder_free(struct archive_read_filter_bidder *);
 
 static ssize_t	compress_filter_read(struct archive_read_filter *, const void **);
 static int	compress_filter_close(struct archive_read_filter *);
@@ -166,7 +165,7 @@ archive_read_support_filter_compress(struct archive *_a)
 	bidder->name = "compress (.Z)";
 	bidder->bid = compress_bidder_bid;
 	bidder->init = compress_bidder_init;
-	bidder->free = compress_bidder_free;
+	bidder->free = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -302,16 +301,6 @@ compress_filter_read(struct archive_read_filter *self, const void **pblock)
 
 	*pblock = start;
 	return (p - start);
-}
-
-/*
- * Clean up the reader.
- */
-static int
-compress_bidder_free(struct archive_read_filter_bidder *self)
-{
-	self->data = NULL;
-	return (ARCHIVE_OK);
 }
 
 /*

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -198,6 +198,12 @@ compress_bidder_bid(struct archive_read_filter_bidder *self,
 	return (bits_checked);
 }
 
+static const struct archive_read_filter_vtable
+compress_reader_vtable = {
+	.read = compress_filter_read,
+	.close = compress_filter_close,
+};
+
 /*
  * Setup the callbacks.
  */
@@ -226,8 +232,7 @@ compress_bidder_init(struct archive_read_filter *self)
 	self->data = state;
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
-	self->read = compress_filter_read;
-	self->close = compress_filter_close;
+	self->vtable = &compress_reader_vtable;
 
 	/* XXX MOVE THE FOLLOWING OUT OF INIT() XXX */
 

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -149,6 +149,12 @@ archive_read_support_compression_compress(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+compress_bidder_vtable = {
+	.bid = compress_bidder_bid,
+	.init = compress_bidder_init,
+};
+
 int
 archive_read_support_filter_compress(struct archive *_a)
 {
@@ -163,9 +169,7 @@ archive_read_support_filter_compress(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "compress (.Z)";
-	bidder->bid = compress_bidder_bid;
-	bidder->init = compress_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &compress_bidder_vtable;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -64,16 +64,11 @@ int
 archive_read_support_filter_grzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *reader;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_grzip");
-
-	if (__archive_read_get_bidder(a, &reader) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, NULL,
+				&grzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	reader->data = NULL;
-	reader->vtable = &grzip_bidder_vtable;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external grzip program for grzip decompression");

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -76,7 +76,6 @@ archive_read_support_filter_grzip(struct archive *_a)
 	reader->data = NULL;
 	reader->bid = grzip_bidder_bid;
 	reader->init = grzip_bidder_init;
-	reader->options = NULL;
 	reader->free = grzip_reader_free;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -54,6 +54,12 @@ static int	grzip_bidder_bid(struct archive_read_filter_bidder *,
 static int	grzip_bidder_init(struct archive_read_filter *);
 
 
+static const struct archive_read_filter_bidder_vtable
+grzip_bidder_vtable = {
+	.bid = grzip_bidder_bid,
+	.init = grzip_bidder_init,
+};
+
 int
 archive_read_support_filter_grzip(struct archive *_a)
 {
@@ -67,9 +73,7 @@ archive_read_support_filter_grzip(struct archive *_a)
 		return (ARCHIVE_FATAL);
 
 	reader->data = NULL;
-	reader->bid = grzip_bidder_bid;
-	reader->init = grzip_bidder_init;
-	reader->free = NULL;
+	reader->vtable = &grzip_bidder_vtable;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external grzip program for grzip decompression");

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -54,13 +54,6 @@ static int	grzip_bidder_bid(struct archive_read_filter_bidder *,
 static int	grzip_bidder_init(struct archive_read_filter *);
 
 
-static int
-grzip_reader_free(struct archive_read_filter_bidder *self)
-{
-	(void)self; /* UNUSED */
-	return (ARCHIVE_OK);
-}
-
 int
 archive_read_support_filter_grzip(struct archive *_a)
 {
@@ -76,7 +69,7 @@ archive_read_support_filter_grzip(struct archive *_a)
 	reader->data = NULL;
 	reader->bid = grzip_bidder_bid;
 	reader->init = grzip_bidder_init;
-	reader->free = grzip_reader_free;
+	reader->free = NULL;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external grzip program for grzip decompression");

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -110,7 +110,6 @@ archive_read_support_filter_gzip(struct archive *_a)
 	bidder->name = "gzip";
 	bidder->bid = gzip_bidder_bid;
 	bidder->init = gzip_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL; /* No data, so no cleanup necessary. */
 	/* Signal the extent of gzip support with the return value here. */
 #if HAVE_ZLIB_H

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -104,17 +104,11 @@ int
 archive_read_support_filter_gzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_gzip");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "gzip",
+				&gzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	bidder->data = NULL;
-	bidder->name = "gzip";
-	bidder->vtable = &gzip_bidder_vtable;
 	/* Signal the extent of gzip support with the return value here. */
 #if HAVE_ZLIB_H
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -288,6 +288,15 @@ gzip_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 	return (ARCHIVE_OK);
 }
 
+static const struct archive_read_filter_vtable
+gzip_reader_vtable = {
+	.read = gzip_filter_read,
+	.close = gzip_filter_close,
+#ifdef HAVE_ZLIB_H
+	.read_header = gzip_read_header,
+#endif
+};
+
 /*
  * Initialize the filter object.
  */
@@ -314,11 +323,7 @@ gzip_bidder_init(struct archive_read_filter *self)
 	self->data = state;
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
-	self->read = gzip_filter_read;
-	self->close = gzip_filter_close;
-#ifdef HAVE_ZLIB_H
-	self->read_header = gzip_read_header;
-#endif
+	self->vtable = &gzip_reader_vtable;
 
 	state->in_stream = 0; /* We're not actually within a stream yet. */
 

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -94,6 +94,12 @@ archive_read_support_compression_gzip(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+gzip_bidder_vtable = {
+	.bid = gzip_bidder_bid,
+	.init = gzip_bidder_init,
+};
+
 int
 archive_read_support_filter_gzip(struct archive *_a)
 {
@@ -108,9 +114,7 @@ archive_read_support_filter_gzip(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "gzip";
-	bidder->bid = gzip_bidder_bid;
-	bidder->init = gzip_bidder_init;
-	bidder->free = NULL; /* No data, so no cleanup necessary. */
+	bidder->vtable = &gzip_bidder_vtable;
 	/* Signal the extent of gzip support with the return value here. */
 #if HAVE_ZLIB_H
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -315,7 +315,6 @@ gzip_bidder_init(struct archive_read_filter *self)
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
 	self->read = gzip_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = gzip_filter_close;
 #ifdef HAVE_ZLIB_H
 	self->read_header = gzip_read_header;

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -76,7 +76,6 @@ archive_read_support_filter_lrzip(struct archive *_a)
 	reader->name = "lrzip";
 	reader->bid = lrzip_bidder_bid;
 	reader->init = lrzip_bidder_init;
-	reader->options = NULL;
 	reader->free = lrzip_reader_free;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -53,6 +53,12 @@ static int	lrzip_bidder_bid(struct archive_read_filter_bidder *,
 static int	lrzip_bidder_init(struct archive_read_filter *);
 
 
+static const struct archive_read_filter_bidder_vtable
+lrzip_bidder_vtable = {
+	.bid = lrzip_bidder_bid,
+	.init = lrzip_bidder_init,
+};
+
 int
 archive_read_support_filter_lrzip(struct archive *_a)
 {
@@ -67,9 +73,7 @@ archive_read_support_filter_lrzip(struct archive *_a)
 
 	reader->data = NULL;
 	reader->name = "lrzip";
-	reader->bid = lrzip_bidder_bid;
-	reader->init = lrzip_bidder_init;
-	reader->free = NULL;
+	reader->vtable = &lrzip_bidder_vtable;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external lrzip program for lrzip decompression");

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -63,17 +63,11 @@ int
 archive_read_support_filter_lrzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *reader;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_lrzip");
-
-	if (__archive_read_get_bidder(a, &reader) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "lrzip",
+				&lrzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	reader->data = NULL;
-	reader->name = "lrzip";
-	reader->vtable = &lrzip_bidder_vtable;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external lrzip program for lrzip decompression");

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -53,13 +53,6 @@ static int	lrzip_bidder_bid(struct archive_read_filter_bidder *,
 static int	lrzip_bidder_init(struct archive_read_filter *);
 
 
-static int
-lrzip_reader_free(struct archive_read_filter_bidder *self)
-{
-	(void)self; /* UNUSED */
-	return (ARCHIVE_OK);
-}
-
 int
 archive_read_support_filter_lrzip(struct archive *_a)
 {
@@ -76,7 +69,7 @@ archive_read_support_filter_lrzip(struct archive *_a)
 	reader->name = "lrzip";
 	reader->bid = lrzip_bidder_bid;
 	reader->init = lrzip_bidder_init;
-	reader->free = lrzip_reader_free;
+	reader->free = NULL;
 	/* This filter always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external lrzip program for lrzip decompression");

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -116,17 +116,11 @@ int
 archive_read_support_filter_lz4(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *reader;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_lz4");
-
-	if (__archive_read_get_bidder(a, &reader) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "lz4",
+				&lz4_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	reader->data = NULL;
-	reader->name = "lz4";
-	reader->vtable = &lz4_bidder_vtable;
 #if defined(HAVE_LIBLZ4)
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -208,6 +208,12 @@ lz4_reader_init(struct archive_read_filter *self)
 
 #else
 
+static const struct archive_read_filter_vtable
+lz4_reader_vtable = {
+	.read = lz4_filter_read,
+	.close = lz4_filter_close,
+};
+
 /*
  * Setup the callbacks.
  */
@@ -228,8 +234,7 @@ lz4_reader_init(struct archive_read_filter *self)
 
 	self->data = state;
 	state->stage = SELECT_STREAM;
-	self->read = lz4_filter_read;
-	self->close = lz4_filter_close;
+	self->vtable = &lz4_reader_vtable;
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -229,7 +229,6 @@ lz4_reader_init(struct archive_read_filter *self)
 	self->data = state;
 	state->stage = SELECT_STREAM;
 	self->read = lz4_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = lz4_filter_close;
 
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -99,7 +99,6 @@ static int	lz4_filter_close(struct archive_read_filter *);
  */
 static int	lz4_reader_bid(struct archive_read_filter_bidder *, struct archive_read_filter *);
 static int	lz4_reader_init(struct archive_read_filter *);
-static int	lz4_reader_free(struct archive_read_filter_bidder *);
 #if defined(HAVE_LIBLZ4)
 static ssize_t  lz4_filter_read_default_stream(struct archive_read_filter *,
 		    const void **);
@@ -123,7 +122,7 @@ archive_read_support_filter_lz4(struct archive *_a)
 	reader->name = "lz4";
 	reader->bid = lz4_reader_bid;
 	reader->init = lz4_reader_init;
-	reader->free = lz4_reader_free;
+	reader->free = NULL;
 #if defined(HAVE_LIBLZ4)
 	return (ARCHIVE_OK);
 #else
@@ -131,12 +130,6 @@ archive_read_support_filter_lz4(struct archive *_a)
 	    "Using external lz4 program");
 	return (ARCHIVE_WARN);
 #endif
-}
-
-static int
-lz4_reader_free(struct archive_read_filter_bidder *self){
-	(void)self; /* UNUSED */
-	return (ARCHIVE_OK);
 }
 
 /*

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -106,6 +106,12 @@ static ssize_t  lz4_filter_read_legacy_stream(struct archive_read_filter *,
 		    const void **);
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+lz4_bidder_vtable = {
+	.bid = lz4_reader_bid,
+	.init = lz4_reader_init,
+};
+
 int
 archive_read_support_filter_lz4(struct archive *_a)
 {
@@ -120,9 +126,7 @@ archive_read_support_filter_lz4(struct archive *_a)
 
 	reader->data = NULL;
 	reader->name = "lz4";
-	reader->bid = lz4_reader_bid;
-	reader->init = lz4_reader_init;
-	reader->free = NULL;
+	reader->vtable = &lz4_bidder_vtable;
 #if defined(HAVE_LIBLZ4)
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -123,7 +123,6 @@ archive_read_support_filter_lz4(struct archive *_a)
 	reader->name = "lz4";
 	reader->bid = lz4_reader_bid;
 	reader->init = lz4_reader_init;
-	reader->options = NULL;
 	reader->free = lz4_reader_free;
 #if defined(HAVE_LIBLZ4)
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -169,6 +169,13 @@ lzop_bidder_init(struct archive_read_filter *self)
 	return (r);
 }
 #else
+
+static const struct archive_read_filter_vtable
+lzop_reader_vtable = {
+	.read = lzop_filter_read,
+	.close = lzop_filter_close.
+};
+
 /*
  * Initialize the filter object.
  */
@@ -188,8 +195,7 @@ lzop_bidder_init(struct archive_read_filter *self)
 	}
 
 	self->data = state;
-	self->read = lzop_filter_read;
-	self->close = lzop_filter_close;
+	self->vtable = &lzop_reader_vtable;
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -111,16 +111,11 @@ int
 archive_read_support_filter_lzop(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *reader;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_lzop");
-
-	if (__archive_read_get_bidder(a, &reader) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, NULL,
+				&lzop_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	reader->data = NULL;
-	reader->vtable = &lzop_bidder_vtable;
 	/* Signal the extent of lzop support with the return value here. */
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -116,7 +116,6 @@ archive_read_support_filter_lzop(struct archive *_a)
 	reader->data = NULL;
 	reader->bid = lzop_bidder_bid;
 	reader->init = lzop_bidder_init;
-	reader->options = NULL;
 	reader->free = NULL;
 	/* Signal the extent of lzop support with the return value here. */
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -101,6 +101,12 @@ static int lzop_bidder_bid(struct archive_read_filter_bidder *,
     struct archive_read_filter *);
 static int lzop_bidder_init(struct archive_read_filter *);
 
+static const struct archive_read_filter_bidder_vtable
+lzop_bidder_vtable = {
+	.bid = lzop_bidder_bid,
+	.init = lzop_bidder_init,
+};
+
 int
 archive_read_support_filter_lzop(struct archive *_a)
 {
@@ -114,9 +120,7 @@ archive_read_support_filter_lzop(struct archive *_a)
 		return (ARCHIVE_FATAL);
 
 	reader->data = NULL;
-	reader->bid = lzop_bidder_bid;
-	reader->init = lzop_bidder_init;
-	reader->free = NULL;
+	reader->vtable = &lzop_bidder_vtable;
 	/* Signal the extent of lzop support with the return value here. */
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -189,7 +189,6 @@ lzop_bidder_init(struct archive_read_filter *self)
 
 	self->data = state;
 	self->read = lzop_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = lzop_filter_close;
 
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -98,7 +98,7 @@ struct program_bidder {
 static int	program_bidder_bid(struct archive_read_filter_bidder *,
 		    struct archive_read_filter *upstream);
 static int	program_bidder_init(struct archive_read_filter *);
-static int	program_bidder_free(struct archive_read_filter_bidder *);
+static void	program_bidder_free(struct archive_read_filter_bidder *);
 
 /*
  * The actual filter needs to track input and output data.
@@ -175,13 +175,12 @@ memerr:
 	return (ARCHIVE_FATAL);
 }
 
-static int
+static void
 program_bidder_free(struct archive_read_filter_bidder *self)
 {
 	struct program_bidder *state = (struct program_bidder *)self->data;
 
 	free_state(state);
-	return (ARCHIVE_OK);
 }
 
 static void

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -140,7 +140,6 @@ set_bidder_signature(struct archive_read_filter_bidder *bidder,
 	bidder->data = state;
 	bidder->bid = program_bidder_bid;
 	bidder->init = program_bidder_init;
-	bidder->options = NULL;
 	bidder->free = program_bidder_free;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -123,6 +123,13 @@ static ssize_t	program_filter_read(struct archive_read_filter *,
 static int	program_filter_close(struct archive_read_filter *);
 static void	free_state(struct program_bidder *);
 
+static const struct archive_read_filter_bidder_vtable
+program_bidder_vtable = {
+	.bid = program_bidder_bid,
+	.init = program_bidder_init,
+	.free = program_bidder_free,
+};
+
 static int
 set_bidder_signature(struct archive_read_filter_bidder *bidder,
     struct program_bidder *state, const void *signature, size_t signature_len)
@@ -138,9 +145,7 @@ set_bidder_signature(struct archive_read_filter_bidder *bidder,
 	 * Fill in the bidder object.
 	 */
 	bidder->data = state;
-	bidder->bid = program_bidder_bid;
-	bidder->init = program_bidder_init;
-	bidder->free = program_bidder_free;
+	bidder->vtable = &program_bidder_vtable;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -429,7 +429,6 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 
 	self->data = state;
 	self->read = program_filter_read;
-	self->skip = NULL;
 	self->close = program_filter_close;
 
 	/* XXX Check that we can read at least one byte? */

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -382,6 +382,12 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 	}
 }
 
+static const struct archive_read_filter_vtable
+program_reader_vtable = {
+	.read = program_filter_read,
+	.close = program_filter_close,
+};
+
 int
 __archive_read_program(struct archive_read_filter *self, const char *cmd)
 {
@@ -428,8 +434,7 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	}
 
 	self->data = state;
-	self->read = program_filter_read;
-	self->close = program_filter_close;
+	self->vtable = &program_reader_vtable;
 
 	/* XXX Check that we can read at least one byte? */
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -127,6 +127,12 @@ rpm_bidder_bid(struct archive_read_filter_bidder *self,
 	return (bits_checked);
 }
 
+static const struct archive_read_filter_vtable
+rpm_reader_vtable = {
+	.read = rpm_filter_read,
+	.close = rpm_filter_close,
+};
+
 static int
 rpm_bidder_init(struct archive_read_filter *self)
 {
@@ -134,8 +140,6 @@ rpm_bidder_init(struct archive_read_filter *self)
 
 	self->code = ARCHIVE_FILTER_RPM;
 	self->name = "rpm";
-	self->read = rpm_filter_read;
-	self->close = rpm_filter_close;
 
 	rpm = (struct rpm *)calloc(sizeof(*rpm), 1);
 	if (rpm == NULL) {
@@ -146,6 +150,7 @@ rpm_bidder_init(struct archive_read_filter *self)
 
 	self->data = rpm;
 	rpm->state = ST_LEAD;
+	self->vtable = &rpm_reader_vtable;
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -135,7 +135,6 @@ rpm_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_RPM;
 	self->name = "rpm";
 	self->read = rpm_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = rpm_filter_close;
 
 	rpm = (struct rpm *)calloc(sizeof(*rpm), 1);

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -88,7 +88,6 @@ archive_read_support_filter_rpm(struct archive *_a)
 	bidder->name = "rpm";
 	bidder->bid = rpm_bidder_bid;
 	bidder->init = rpm_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -82,18 +82,9 @@ int
 archive_read_support_filter_rpm(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_rpm");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
-		return (ARCHIVE_FATAL);
-
-	bidder->data = NULL;
-	bidder->name = "rpm";
-	bidder->vtable = &rpm_bidder_vtable;
-	return (ARCHIVE_OK);
+	return __archive_read_register_bidder(a, NULL, "rpm",
+			&rpm_bidder_vtable);
 }
 
 static int

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -72,6 +72,12 @@ archive_read_support_compression_rpm(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+rpm_bidder_vtable = {
+	.bid = rpm_bidder_bid,
+	.init = rpm_bidder_init,
+};
+
 int
 archive_read_support_filter_rpm(struct archive *_a)
 {
@@ -86,9 +92,7 @@ archive_read_support_filter_rpm(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "rpm";
-	bidder->bid = rpm_bidder_bid;
-	bidder->init = rpm_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &rpm_bidder_vtable;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -351,6 +351,12 @@ uudecode_bidder_bid(struct archive_read_filter_bidder *self,
 	return (0);
 }
 
+static const struct archive_read_filter_vtable
+uudecode_reader_vtable = {
+	.read = uudecode_filter_read,
+	.close = uudecode_filter_close,
+};
+
 static int
 uudecode_bidder_init(struct archive_read_filter *self)
 {
@@ -360,8 +366,6 @@ uudecode_bidder_init(struct archive_read_filter *self)
 
 	self->code = ARCHIVE_FILTER_UU;
 	self->name = "uu";
-	self->read = uudecode_filter_read;
-	self->close = uudecode_filter_close;
 
 	uudecode = (struct uudecode *)calloc(sizeof(*uudecode), 1);
 	out_buff = malloc(OUT_BUFF_SIZE);
@@ -381,6 +385,7 @@ uudecode_bidder_init(struct archive_read_filter *self)
 	uudecode->in_allocated = IN_BUFF_SIZE;
 	uudecode->out_buff = out_buff;
 	uudecode->state = ST_FIND_HEAD;
+	self->vtable = &uudecode_reader_vtable;
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -361,7 +361,6 @@ uudecode_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_UU;
 	self->name = "uu";
 	self->read = uudecode_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = uudecode_filter_close;
 
 	uudecode = (struct uudecode *)calloc(sizeof(*uudecode), 1);

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -76,6 +76,12 @@ archive_read_support_compression_uu(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+uudecode_bidder_vtable = {
+	.bid = uudecode_bidder_bid,
+	.init = uudecode_bidder_init,
+};
+
 int
 archive_read_support_filter_uu(struct archive *_a)
 {
@@ -90,9 +96,7 @@ archive_read_support_filter_uu(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "uu";
-	bidder->bid = uudecode_bidder_bid;
-	bidder->init = uudecode_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &uudecode_bidder_vtable;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -92,7 +92,6 @@ archive_read_support_filter_uu(struct archive *_a)
 	bidder->name = "uu";
 	bidder->bid = uudecode_bidder_bid;
 	bidder->init = uudecode_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -86,18 +86,9 @@ int
 archive_read_support_filter_uu(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_uu");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
-		return (ARCHIVE_FATAL);
-
-	bidder->data = NULL;
-	bidder->name = "uu";
-	bidder->vtable = &uudecode_bidder_vtable;
-	return (ARCHIVE_OK);
+	return __archive_read_register_bidder(a, NULL, "uu",
+			&uudecode_bidder_vtable);
 }
 
 static const unsigned char ascii[256] = {

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -108,6 +108,12 @@ archive_read_support_compression_xz(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+xz_bidder_vtable = {
+	.bid = xz_bidder_bid,
+	.init = xz_bidder_init,
+};
+
 int
 archive_read_support_filter_xz(struct archive *_a)
 {
@@ -122,9 +128,7 @@ archive_read_support_filter_xz(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "xz";
-	bidder->bid = xz_bidder_bid;
-	bidder->init = xz_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &xz_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else
@@ -142,6 +146,12 @@ archive_read_support_compression_lzma(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+lzma_bidder_vtable = {
+	.bid = lzma_bidder_bid,
+	.init = lzma_bidder_init,
+};
+
 int
 archive_read_support_filter_lzma(struct archive *_a)
 {
@@ -156,9 +166,7 @@ archive_read_support_filter_lzma(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "lzma";
-	bidder->bid = lzma_bidder_bid;
-	bidder->init = lzma_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &lzma_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else
@@ -177,6 +185,12 @@ archive_read_support_compression_lzip(struct archive *a)
 }
 #endif
 
+static const struct archive_read_filter_bidder_vtable
+lzip_bidder_vtable = {
+	.bid = lzip_bidder_bid,
+	.init = lzip_bidder_init,
+};
+
 int
 archive_read_support_filter_lzip(struct archive *_a)
 {
@@ -191,9 +205,7 @@ archive_read_support_filter_lzip(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "lzip";
-	bidder->bid = lzip_bidder_bid;
-	bidder->init = lzip_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &lzip_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -118,17 +118,11 @@ int
 archive_read_support_filter_xz(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_xz");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "xz",
+				&xz_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	bidder->data = NULL;
-	bidder->name = "xz";
-	bidder->vtable = &xz_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else
@@ -156,17 +150,11 @@ int
 archive_read_support_filter_lzma(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_lzma");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "lzma",
+				&lzma_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	bidder->data = NULL;
-	bidder->name = "lzma";
-	bidder->vtable = &lzma_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else
@@ -195,17 +183,11 @@ int
 archive_read_support_filter_lzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_lzip");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "lzip",
+				&lzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	bidder->data = NULL;
-	bidder->name = "lzip";
-	bidder->vtable = &lzip_bidder_vtable;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -486,7 +486,6 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
 	self->read = xz_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = xz_filter_close;
 
 	state->stream.avail_in = 0;

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -461,6 +461,12 @@ set_error(struct archive_read_filter *self, int ret)
 	}
 }
 
+static const struct archive_read_filter_vtable
+xz_lzma_reader_vtable = {
+	.read = xz_filter_read,
+	.close = xz_filter_close,
+};
+
 /*
  * Setup the callbacks.
  */
@@ -485,8 +491,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	self->data = state;
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
-	self->read = xz_filter_read;
-	self->close = xz_filter_close;
+	self->vtable = &xz_lzma_reader_vtable;
 
 	state->stream.avail_in = 0;
 

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -124,7 +124,6 @@ archive_read_support_filter_xz(struct archive *_a)
 	bidder->name = "xz";
 	bidder->bid = xz_bidder_bid;
 	bidder->init = xz_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
@@ -159,7 +158,6 @@ archive_read_support_filter_lzma(struct archive *_a)
 	bidder->name = "lzma";
 	bidder->bid = lzma_bidder_bid;
 	bidder->init = lzma_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);
@@ -195,7 +193,6 @@ archive_read_support_filter_lzip(struct archive *_a)
 	bidder->name = "lzip";
 	bidder->bid = lzip_bidder_bid;
 	bidder->init = lzip_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -89,17 +89,11 @@ int
 archive_read_support_filter_zstd(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter_bidder *bidder;
 
-	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_read_support_filter_zstd");
-
-	if (__archive_read_get_bidder(a, &bidder) != ARCHIVE_OK)
+	if (__archive_read_register_bidder(a, NULL, "zstd",
+				&zstd_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 
-	bidder->data = NULL;
-	bidder->name = "zstd";
-	bidder->vtable = &zstd_bidder_vtable;
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -79,6 +79,12 @@ static int	zstd_bidder_bid(struct archive_read_filter_bidder *,
 		    struct archive_read_filter *);
 static int	zstd_bidder_init(struct archive_read_filter *);
 
+static const struct archive_read_filter_bidder_vtable
+zstd_bidder_vtable = {
+	.bid = zstd_bidder_bid,
+	.init = zstd_bidder_init,
+};
+
 int
 archive_read_support_filter_zstd(struct archive *_a)
 {
@@ -93,9 +99,7 @@ archive_read_support_filter_zstd(struct archive *_a)
 
 	bidder->data = NULL;
 	bidder->name = "zstd";
-	bidder->bid = zstd_bidder_bid;
-	bidder->init = zstd_bidder_init;
-	bidder->free = NULL;
+	bidder->vtable = &zstd_bidder_vtable;
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 	return (ARCHIVE_OK);
 #else

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -95,7 +95,6 @@ archive_read_support_filter_zstd(struct archive *_a)
 	bidder->name = "zstd";
 	bidder->bid = zstd_bidder_bid;
 	bidder->init = zstd_bidder_init;
-	bidder->options = NULL;
 	bidder->free = NULL;
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -157,6 +157,12 @@ zstd_bidder_init(struct archive_read_filter *self)
 
 #else
 
+static const struct archive_read_filter_vtable
+zstd_reader_vtable = {
+	.read = zstd_filter_read,
+	.close = zstd_filter_close,
+};
+
 /*
  * Initialize the filter object
  */
@@ -189,8 +195,7 @@ zstd_bidder_init(struct archive_read_filter *self)
 	state->out_block_size = out_block_size;
 	state->out_block = out_block;
 	state->dstream = dstream;
-	self->read = zstd_filter_read;
-	self->close = zstd_filter_close;
+	self->vtable = &zstd_reader_vtable;
 
 	state->eof = 0;
 	state->in_frame = 0;

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -190,7 +190,6 @@ zstd_bidder_init(struct archive_read_filter *self)
 	state->out_block = out_block;
 	state->dstream = dstream;
 	self->read = zstd_filter_read;
-	self->skip = NULL; /* not supported */
 	self->close = zstd_filter_close;
 
 	state->eof = 0;

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -60,8 +60,6 @@ __FBSDID("$FreeBSD: head/lib/libarchive/archive_write.c 201099 2009-12-28 03:03:
 #include "archive_private.h"
 #include "archive_write_private.h"
 
-static struct archive_vtable *archive_write_vtable(void);
-
 static int	_archive_filter_code(struct archive *, int);
 static const char *_archive_filter_name(struct archive *, int);
 static int64_t	_archive_filter_bytes(struct archive *, int);
@@ -79,26 +77,18 @@ struct archive_none {
 	char *next;
 };
 
-static struct archive_vtable *
-archive_write_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_close = _archive_write_close;
-		av.archive_filter_bytes = _archive_filter_bytes;
-		av.archive_filter_code = _archive_filter_code;
-		av.archive_filter_name = _archive_filter_name;
-		av.archive_filter_count = _archive_write_filter_count;
-		av.archive_free = _archive_write_free;
-		av.archive_write_header = _archive_write_header;
-		av.archive_write_finish_entry = _archive_write_finish_entry;
-		av.archive_write_data = _archive_write_data;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_write_vtable = {
+	.archive_close = _archive_write_close,
+	.archive_filter_bytes = _archive_filter_bytes,
+	.archive_filter_code = _archive_filter_code,
+	.archive_filter_name = _archive_filter_name,
+	.archive_filter_count = _archive_write_filter_count,
+	.archive_free = _archive_write_free,
+	.archive_write_header = _archive_write_header,
+	.archive_write_finish_entry = _archive_write_finish_entry,
+	.archive_write_data = _archive_write_data,
+};
 
 /*
  * Allocate, initialize and return an archive object.
@@ -114,7 +104,7 @@ archive_write_new(void)
 		return (NULL);
 	a->archive.magic = ARCHIVE_WRITE_MAGIC;
 	a->archive.state = ARCHIVE_STATE_NEW;
-	a->archive.vtable = archive_write_vtable();
+	a->archive.vtable = &archive_write_vtable;
 	/*
 	 * The value 10240 here matches the traditional tar default,
 	 * but is otherwise arbitrary.

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -396,8 +396,6 @@ static struct fixup_entry *sort_dir_list(struct fixup_entry *p);
 static ssize_t	write_data_block(struct archive_write_disk *,
 		    const char *, size_t);
 
-static struct archive_vtable *archive_write_disk_vtable(void);
-
 static int	_archive_write_disk_close(struct archive *);
 static int	_archive_write_disk_free(struct archive *);
 static int	_archive_write_disk_header(struct archive *,
@@ -489,25 +487,16 @@ lazy_stat(struct archive_write_disk *a)
 	return (ARCHIVE_WARN);
 }
 
-static struct archive_vtable *
-archive_write_disk_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_close = _archive_write_disk_close;
-		av.archive_filter_bytes = _archive_write_disk_filter_bytes;
-		av.archive_free = _archive_write_disk_free;
-		av.archive_write_header = _archive_write_disk_header;
-		av.archive_write_finish_entry
-		    = _archive_write_disk_finish_entry;
-		av.archive_write_data = _archive_write_disk_data;
-		av.archive_write_data_block = _archive_write_disk_data_block;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_write_disk_vtable = {
+	.archive_close = _archive_write_disk_close,
+	.archive_filter_bytes = _archive_write_disk_filter_bytes,
+	.archive_free = _archive_write_disk_free,
+	.archive_write_header = _archive_write_disk_header,
+	.archive_write_finish_entry = _archive_write_disk_finish_entry,
+	.archive_write_data = _archive_write_disk_data,
+	.archive_write_data_block = _archive_write_disk_data_block,
+};
 
 static int64_t
 _archive_write_disk_filter_bytes(struct archive *_a, int n)
@@ -1956,7 +1945,7 @@ archive_write_disk_new(void)
 	a->archive.magic = ARCHIVE_WRITE_DISK_MAGIC;
 	/* We're ready to write a header immediately. */
 	a->archive.state = ARCHIVE_STATE_HEADER;
-	a->archive.vtable = archive_write_disk_vtable();
+	a->archive.vtable = &archive_write_disk_vtable;
 	a->start_time = time(NULL);
 	/* Query and restore the umask. */
 	umask(a->user_umask = umask(0));

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -238,8 +238,6 @@ static struct fixup_entry *sort_dir_list(struct fixup_entry *p);
 static ssize_t	write_data_block(struct archive_write_disk *,
 		    const char *, size_t);
 
-static struct archive_vtable *archive_write_disk_vtable(void);
-
 static int	_archive_write_disk_close(struct archive *);
 static int	_archive_write_disk_free(struct archive *);
 static int	_archive_write_disk_header(struct archive *,
@@ -759,25 +757,16 @@ lazy_stat(struct archive_write_disk *a)
 	return (ARCHIVE_WARN);
 }
 
-static struct archive_vtable *
-archive_write_disk_vtable(void)
-{
-	static struct archive_vtable av;
-	static int inited = 0;
-
-	if (!inited) {
-		av.archive_close = _archive_write_disk_close;
-		av.archive_filter_bytes = _archive_write_disk_filter_bytes;
-		av.archive_free = _archive_write_disk_free;
-		av.archive_write_header = _archive_write_disk_header;
-		av.archive_write_finish_entry
-		    = _archive_write_disk_finish_entry;
-		av.archive_write_data = _archive_write_disk_data;
-		av.archive_write_data_block = _archive_write_disk_data_block;
-		inited = 1;
-	}
-	return (&av);
-}
+static const struct archive_vtable
+archive_write_disk_vtable = {
+	.archive_close = _archive_write_disk_close,
+	.archive_filter_bytes = _archive_write_disk_filter_bytes,
+	.archive_free = _archive_write_disk_free,
+	.archive_write_header = _archive_write_disk_header,
+	.archive_write_finish_entry = _archive_write_disk_finish_entry,
+	.archive_write_data = _archive_write_disk_data,
+	.archive_write_data_block = _archive_write_disk_data_block,
+};
 
 static int64_t
 _archive_write_disk_filter_bytes(struct archive *_a, int n)
@@ -1373,7 +1362,7 @@ archive_write_disk_new(void)
 	a->archive.magic = ARCHIVE_WRITE_DISK_MAGIC;
 	/* We're ready to write a header immediately. */
 	a->archive.state = ARCHIVE_STATE_HEADER;
-	a->archive.vtable = archive_write_disk_vtable();
+	a->archive.vtable = &archive_write_disk_vtable;
 	a->start_time = time(NULL);
 	/* Query and restore the umask. */
 	umask(a->user_umask = umask(0));


### PR DESCRIPTION
Above all, hope the series isn't too long. I've opted for keeping the changes separate commits, instead of clumping it all up.

This MR covers the read filter/bidders code-base. The rest (read/write formats, write filters) are WIP, although I thought it's better to get feedback/review on this part first.

In a gist the series:
 - removes unused function pointers or dummy ones
 - promotes function pointers into `const struct foobar_vtable`

Ultimately, individual bidders' code gets simpler, bunch of code moves from text segment to rodata and binary is smaller.

As bonus point, this high-lights a few potential bugs in the existing code - bunch of bidders don't set the name... oops.

Happy to rename `vtable` and friends to something more suitable - suggestions welcome.
Looking forward to your input