### PR TITLE
Remove unnecessary OpenSSL compat ifdef.

### DIFF
--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -401,14 +401,6 @@ aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
 	memcpy(ctx->key, key, key_len);
 	memset(ctx->nonce, 0, sizeof(ctx->nonce));
 	ctx->encr_pos = AES_BLOCK_SIZE;
-#if OPENSSL_VERSION_NUMBER  >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
-	if (!EVP_CIPHER_CTX_reset(ctx->ctx)) {
-		EVP_CIPHER_CTX_free(ctx->ctx);
-		ctx->ctx = NULL;
-	}
-#else
-	EVP_CIPHER_CTX_init(ctx->ctx);
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
EVP_CIPHER_CTX_new() is effectively a calloc(). On a freshly allocated
EVP_CIPHER_CTX *, EVP_CIPHER_CTX_reset() is nothing but a memset() to 0.
In particular, it can't fail. If it could fail, the code would carry on
and would later result in a NULL deref since the failure is not reported
to the caller. Similarly, EVP_CIPHER_CTX_init() is just a memset() to 0.
This is true for all flavors of OpenSSL this was written for.