### PR TITLE
win32: specify the calling convention for functions that interact with libc

### DIFF
--- a/libarchive/archive_blake2_impl.h
+++ b/libarchive/archive_blake2_impl.h
@@ -154,7 +154,7 @@ static BLAKE2_INLINE uint64_t rotr64( const uint64_t w, const unsigned c )
 /* prevents compiler optimizing out memset() */
 static BLAKE2_INLINE void secure_zero_memory(void *v, size_t n)
 {
-  static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
+  static void *(__LA_LIBC_CC *const volatile memset_v)(void *, int, size_t) = &memset;
   memset_v(v, 0, n);
 }
 

--- a/libarchive/archive_blake2s_ref.c
+++ b/libarchive/archive_blake2s_ref.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "archive_platform.h"
 #include "archive_blake2.h"
 #include "archive_blake2_impl.h"
 

--- a/libarchive/archive_blake2sp_ref.c
+++ b/libarchive/archive_blake2sp_ref.c
@@ -21,6 +21,7 @@
 #include <omp.h>
 #endif
 
+#include "archive_platform.h"
 #include "archive_blake2.h"
 #include "archive_blake2_impl.h"
 

--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -77,7 +77,7 @@ static	pack_t	pack_12_20;
 static	pack_t	pack_14_18;
 static	pack_t	pack_8_24;
 static	pack_t	pack_bsdos;
-static	int	compare_format(const void *, const void *);
+static	int	__LA_LIBC_CC compare_format(const void *, const void *);
 
 static const char iMajorError[] = "invalid major number";
 static const char iMinorError[] = "invalid minor number";
@@ -310,6 +310,7 @@ static const struct format {
 };
 
 static int
+__LA_LIBC_CC
 compare_format(const void *key, const void *element)
 {
 	const char		*name;

--- a/libarchive/archive_platform.h
+++ b/libarchive/archive_platform.h
@@ -69,8 +69,16 @@
  * either Windows or Posix APIs. */
 #if (defined(__WIN32__) || defined(_WIN32) || defined(__WIN32)) && !defined(__CYGWIN__)
 #include "archive_windows.h"
+/* The C library on Windows specifies a calling convention for callback
+ * functions and exports; when we interact with them (capture pointers,
+ * call and pass function pointers) we need to match their calling
+ * convention.
+ * This only matters when libarchive is built with /Gr, /Gz or /Gv
+ * (which change the default calling convention.) */
+#define __LA_LIBC_CC __cdecl
 #else
 #define la_stat(path,stref)		stat(path,stref)
+#define __LA_LIBC_CC
 #endif
 
 /*

--- a/libarchive/archive_write_set_format_cpio.c
+++ b/libarchive/archive_write_set_format_cpio.c
@@ -1,3 +1,4 @@
+#include "archive_platform.h"
 #include "archive.h"
 
 /*

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -6802,6 +6802,7 @@ isoent_rr_move(struct archive_write *a)
  * This comparing rule is according to ISO9660 Standard 6.9.1
  */
 static int
+__LA_LIBC_CC
 _compare_path_table(const void *v1, const void *v2)
 {
 	const struct isoent *p1, *p2;
@@ -6844,6 +6845,7 @@ _compare_path_table(const void *v1, const void *v2)
 }
 
 static int
+__LA_LIBC_CC
 _compare_path_table_joliet(const void *v1, const void *v2)
 {
 	const struct isoent *p1, *p2;


### PR DESCRIPTION
The C library on Windows specifies a calling convention for callback
functions and exports; when we interact with them (capture pointers,
call and pass function pointers) we need to match their calling
convention.

On x86, the default calling convention is `__cdecl`. However, it can be
changed with the compiler flags `/Gr`, `/Gz` and `/Gv`. When it's
changed, code that was relying on the implicit calling convention to
match libc's calling convention will fail to compile.

On x64 and ARM64, this doesn't really matter -- the only(*) calling
convention is documented by the MS platform guidelines and the compiler
ignores any other calling convention decorations (so: libc specifies
`__cdecl`, but is compiled as per platform defaults).

This only matters when libarchive is built with `/Gr`, `/Gz` or `/Gv`.

(*) for C code.