### PR TITLE
tar: demote -xa from error to a warning

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -804,8 +804,14 @@ main(int argc, char **argv)
 		    "Must specify one of -c, -r, -t, -u, -x");
 
 	/* Check boolean options only permitted in certain modes. */
-	if (bsdtar->flags & OPTFLAG_AUTO_COMPRESS)
-		only_mode(bsdtar, "-a", "c");
+	if (bsdtar->flags & OPTFLAG_AUTO_COMPRESS) {
+		only_mode(bsdtar, "-a", "cx");
+		if (bsdtar->mode == 'x') {
+			bsdtar->flags &= ~OPTFLAG_AUTO_COMPRESS;
+			lafe_warnc(0,
+			    "Ignoring option -a in mode -x");
+		}
+	}
 	if (bsdtar->readdisk_flags & ARCHIVE_READDISK_NO_TRAVERSE_MOUNTS)
 		only_mode(bsdtar, "--one-file-system", "cru");
 	if (bsdtar->flags & OPTFLAG_FAST_READ)


### PR DESCRIPTION
It's fairly common for people to use caf and xaf on Linux. The former in
itself being GNU tar specific - libarchive tar does not allow xa.

While it makes little sense to use xaf with libarchive tar, that is
implementation detail which gets in the way when trying to write trivial
tooling/scripts.

For the sake of compatibility, reduce the error to a warning and augment
the message itself. Making it clear that the option makes little sense.
