### PR TITLE
Add setting for GNU compatibility and use it to change default archive file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,10 @@ AM_CFLAGS=$(DEV_CFLAGS)
 PLATFORMCPPFLAGS = @PLATFORMCPPFLAGS@
 AM_CPPFLAGS=$(PLATFORMCPPFLAGS)
 
+if GNU_COMPATIBILITY
+gnu_compatibility= -DGNU_COMPATIBILITY
+endif
+
 #
 # What to include in the distribution
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -1026,7 +1026,7 @@ bsdtar_ccstatic=
 endif
 
 bsdtar_LDADD= libarchive.la libarchive_fe.la $(LTLIBICONV)
-bsdtar_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdtar_ccstatic) $(PLATFORMCPPFLAGS)
+bsdtar_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdtar_ccstatic) $(PLATFORMCPPFLAGS) $(gnu_compatibility)
 bsdtar_LDFLAGS= $(bsdtar_ldstatic)
 
 bsdtar_EXTRA_DIST= \

--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,25 @@ AC_PROG_LIBTOOL
 AC_CHECK_TOOL([STRIP],[strip])
 AC_PROG_MKDIR_P
 
+AC_ARG_ENABLE([gnu-compatibility],
+	[AS_HELP_STRING([--enable-gnu-compatibility], [enable GNU comptatibility])
+AS_HELP_STRING([--disable-gnu-compatibility], [disable GNU compatibility (default)])],
+	[], [enable_gnu_compatibility=no])
+
+case "$enable_gnu_compatibility" in
+yes)
+	gnu_compatibility=yes
+	;;
+no)
+	gnu_compatibility=no
+	;;
+*)
+	AC_MSG_FAILURE([Unsupported value for --enable-gnu-compatibility])
+	;;
+esac
+
+AM_CONDITIONAL([GNU_COMPATIBILITY], [ test "$gnu_compatibility" = yes ])
+
 #
 # Options for building bsdtar.
 #

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -75,10 +75,18 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/bsdtar.c,v 1.93 2008/11/08 04:43:24 kientzle
  * the default tape device for the system.  Pick something reasonable here.
  */
 #ifdef __linux
+#ifndef GNU_COMPATIBILITY
 #define	_PATH_DEFTAPE "/dev/st0"
+#else
+#define	_PATH_DEFTAPE "-"
+#endif
 #endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
+#ifndef GNU_COMPATIBILITY
 #define	_PATH_DEFTAPE "\\\\.\\tape0"
+#else
+#define	_PATH_DEFTAPE "-"
+#endif
 #endif
 #if defined(__APPLE__)
 #undef _PATH_DEFTAPE


### PR DESCRIPTION
Since in several scenarios GNU compatibility is desired add an option to
enable it. In this way libarchive can be configured to mimic GNU
utilities and make the transition easier.

Also use this new feature to change the default archive file in libarchive tar.