### PR TITLE
Fix the archive_write_disk.3 man page

### DIFF
--- a/libarchive/archive_write_disk.3
+++ b/libarchive/archive_write_disk.3
@@ -163,14 +163,14 @@ caused by archives that (deliberately or otherwise) extract
 files outside of the current directory.
 The default is not to perform this check.
 If
-.It Cm ARCHIVE_EXTRACT_SPARSE
-Scan data for blocks of NUL bytes and try to recreate them with holes.
-This results in sparse files, independent of whether the archive format
-supports or uses them.
 .Cm ARCHIVE_EXTRACT_UNLINK
 is specified together with this option, the library will
 remove any intermediate symlinks it finds and return an
 error only if such symlink could not be removed.
+.It Cm ARCHIVE_EXTRACT_SPARSE
+Scan data for blocks of NUL bytes and try to recreate them with holes.
+This results in sparse files, independent of whether the archive format
+supports or uses them.
 .It Cm ARCHIVE_EXTRACT_TIME
 The timestamps (mtime, ctime, and atime) should be restored.
 By default, they are ignored.


### PR DESCRIPTION
Some of the text was reordered incorrectly in a14fe904e2c63fefb99446980226a1bec4a95c5c, so the end of the description of the `ARCHIVE_EXTRACT_SECURE_SYMLINKS` flag ended up at the end of the description of `ARCHIVE_EXTRACT_SPARSE`.