### PR TITLE
Fix RIPEMD-160 test for OpenSSL 3.0

### DIFF
--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -433,7 +433,9 @@ static int
 __archive_ripemd160init(archive_rmd160_ctx *ctx)
 {
   if ((*ctx = EVP_MD_CTX_new()) == NULL)
-	return (ARCHIVE_FAILED);
+    return (ARCHIVE_FAILED);
+  if ((OSSL_PROVIDER_load(NULL, "legacy")) == NULL)
+    return (ARCHIVE_FAILED);
   EVP_DigestInit(*ctx, EVP_ripemd160());
   return (ARCHIVE_OK);
 }


### PR DESCRIPTION
In OpenSSL 3.0, RIPEMD-160 is only available as part of the legacy
provider, so in order to run this test properly, it needs to first load
that provider.

Fixes: https://github.com/libarchive/libarchive/issues/1549

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>