### PR TITLE
zip size entry of -1 should be treated the same as 0

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1144,7 +1144,8 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 			    (intmax_t)zip_entry->compressed_size);
 			ret = ARCHIVE_WARN;
 		}
-		if (zip_entry->uncompressed_size == 0) {
+		if (zip_entry->uncompressed_size == 0 ||
+			zip_entry->uncompressed_size == 0xffffffff) {
 			zip_entry->uncompressed_size
 			    = zip_entry_central_dir.uncompressed_size;
 		} else if (zip_entry->uncompressed_size


### PR DESCRIPTION
there are zip files in the wild that have a -1 size in the local header, but correct size in central directory. There was a case for 0 that just needs to also include -1
This 1 line diff allows these archives to be listed and read correctly w/o warnings - the same as infozip does