### PR TITLE
Fix check for tape device

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -216,9 +216,9 @@ main(int argc, char **argv)
 #if defined(_PATH_DEFTAPE)
 	if (bsdtar->filename == NULL) {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-		int tapeExists = _access(_PATH_DEFTAPE, 0);
+		int tapeExists = !_access(_PATH_DEFTAPE, 0);
 #else
-		int tapeExists = access(_PATH_DEFTAPE, F_OK);
+		int tapeExists = !access(_PATH_DEFTAPE, F_OK);
 #endif
 		if (tapeExists) {
 			bsdtar->filename = _PATH_DEFTAPE;


### PR DESCRIPTION
In b6b423f0 a fallback in tar to stdio was implemented. However, the check
for the tape device didn't interpret the correct value returned from
access(). Fix the check to implement the fallback properly.

Signed-off-by: Walter Lozano <walter.lozano@collabora.com>