### PR TITLE
update BLAKE2_PACKED macro with a non-GCCism fallback

### DIFF
--- a/libarchive/archive_blake2.h
+++ b/libarchive/archive_blake2.h
@@ -21,8 +21,10 @@
 
 #if defined(_MSC_VER)
 #define BLAKE2_PACKED(x) __pragma(pack(push, 1)) x __pragma(pack(pop))
-#else
+#elif defined(__GNUC__)
 #define BLAKE2_PACKED(x) x __attribute__((packed))
+#else
+#define BLAKE2_PACKED(x) _Pragma("pack 1") x _Pragma("pack 0")
 #endif
 
 #if defined(__cplusplus)


### PR DESCRIPTION
in archive_blake2.h, two different ways of packing the blake2 structs are written in the BLAKE2_PACKED macro, both of which rely on vendor specific behavior - first checking for MSVC to use __pragma(), then defaulting to GCC specific __attribute__((packed)) otherwise.

this places the GCC behavior under its own check, and then adds a third fallback of _Pragma("pack X"). this is the method expected by the MIPSpro compilers, so fixes compilation errors on IRIX 6.5.22 when using them. this is also the correct way in C99 to use a pragma inside of a macro, so should work on any compiler supporting C99 and the "pack" pragma.