### PR TITLE
unescape when extracting link

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1675,6 +1675,7 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 		break;
 	case 'l':
 		if (strcmp(key, "link") == 0) {
+			parse_escapes(val, NULL);
 			archive_entry_copy_symlink(entry, val);
 			return (ARCHIVE_OK);
 		}


### PR DESCRIPTION
The file name is escaped when archiving, so it needs to be unescaped
when extracting.