### PR TITLE
Fix Y2038 check

### DIFF
--- a/libarchive/archive_getdate.c
+++ b/libarchive/archive_getdate.c
@@ -714,7 +714,7 @@ Convert(time_t Month, time_t Day, time_t Year,
 	    ? 29 : 28;
 	/* Checking for 2038 bogusly assumes that time_t is 32 bits.  But
 	   I'm too lazy to try to check for time_t overflow in another way.  */
-	if (Year < EPOCH || Year > 2038
+	if (Year < EPOCH || Year >= 2038
 	    || Month < 1 || Month > 12
 	    /* Lint fluff:  "conversion from long may lose accuracy" */
 	    || Day < 1 || Day > DaysInMonth[(int)--Month]


### PR DESCRIPTION
If time_t is a signed 32-bit integer, then we cannot represent times after 03:14:07 on 2038-01-19.  Indicating an error if (Year > 2038) is not sufficient; for safety, we need to bail if (Year >= 2038).

As the comment above this line notes, it would be better to check if time_t is 32 bits first.  And even if we didn't check for that, we could use a much more complicated check:

    ((Year > 2038) || ((Year == 2038) && (Month > 1)) ||
    ((Year == 2038) && (Month == 1) && (Day >= 19)))

But I don't think the additional complexity is worth it; rejecting any dates in 2038 eliminates fewer than 3 weeks of potentially-valid dates.