### PR TITLE
Raise the lzip max dictionary size to 512MB.

### DIFF
--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -293,8 +293,8 @@ lzma_bidder_bid(struct archive_read_filter_bidder *self,
 	/* Second through fifth bytes are dictionary size, stored in
 	 * little-endian order. The minimum dictionary size is
 	 * 1 << 12(4KiB) which the lzma of LZMA SDK uses with option
-	 * -d12 and the maximum dictionary size is 1 << 27(128MiB)
-	 * which the one uses with option -d27.
+	 * -d12 and the maximum dictionary size is 1 << 29(512MiB)
+	 * which the one uses with option -d29.
 	 * NOTE: A comment of LZMA SDK source code says this dictionary
 	 * range is from 1 << 12 to 1 << 30. */
 	dicsize = archive_le32dec(buffer+1);
@@ -377,7 +377,7 @@ lzip_has_member(struct archive_read_filter *filter)
 
 	/* Dictionary size. */
 	log2dic = buffer[5] & 0x1f;
-	if (log2dic < 12 || log2dic > 27)
+	if (log2dic < 12 || log2dic > 29)
 		return (0);
 	bits_checked += 8;
 
@@ -562,7 +562,7 @@ lzip_init(struct archive_read_filter *self)
 
 	/* Get dictionary size. */
 	log2dic = h[5] & 0x1f;
-	if (log2dic < 12 || log2dic > 27)
+	if (log2dic < 12 || log2dic > 29)
 		return (ARCHIVE_FATAL);
 	dicsize = 1U << log2dic;
 	if (log2dic > 12)

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -251,13 +251,13 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 		int ds, log2dic, wedges;
 
 		/* Calculate a coded dictionary size */
-		if (dict_size < (1 << 12) || dict_size > (1 << 27)) {
+		if (dict_size < (1 << 12) || dict_size > (1 << 29)) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "Unacceptable dictionary size for lzip: %d",
 			    dict_size);
 			return (ARCHIVE_FATAL);
 		}
-		for (log2dic = 27; log2dic >= 12; log2dic--) {
+		for (log2dic = 29; log2dic >= 12; log2dic--) {
 			if (dict_size & (1 << log2dic))
 				break;
 		}


### PR DESCRIPTION
Hi,

Thanks a lot for writing and maintaining libarchive, and apologies for my somewhat slacking efforts of bringing it into Debian!

What do you think about this change that allows libarchive to read and write lzip archives with a dictionary as large as the lzip tool supports? Its documentation - https://www.nongnu.org/lzip/manual/lzip_manual.html#File-format - states that "Bits 4-0 contain the base 2 logarithm of the base size (12 to 29)" and also "alid values for dictionary size range from 4 KiB to 512 MiB".

I saw the comment referencing another source code comment about the max value being 30, but what do you think about at least raising it to 29, which is what a currently used tool is known to support?

Thanks in advance for looking at this, and keep up the great work!

G'luck,
Peter
