### PR TITLE
Fixed size attribute in pax header

### DIFF
--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1028,10 +1028,8 @@ archive_write_pax_header(struct archive_write *a,
 	archive_string_init(&entry_name);
 	archive_strcpy(&entry_name, archive_entry_pathname(entry_main));
 
-	/* If file size is too large, add 'size' to pax extended attrs. */
+	/* If file size is too large, we need pax extended attrs. */
 	if (archive_entry_size(entry_main) >= (((int64_t)1) << 33)) {
-		add_pax_attr_int(&(pax->pax_header), "size",
-		    archive_entry_size(entry_main));
 		need_extension = 1;
 	}
 
@@ -1345,6 +1343,12 @@ archive_write_pax_header(struct archive_write *a,
 		pax->sparse_map_padding = 0x1ff & (-(ssize_t)mapsize);
 		archive_entry_set_size(entry_main,
 		    mapsize + pax->sparse_map_padding + sparse_total);
+	}
+
+	/* If file size is too large, add 'size' to pax extended attrs. */
+	if (archive_entry_size(entry_main) >= (((int64_t)1) << 33)) {
+		add_pax_attr_int(&(pax->pax_header), "size",
+		    archive_entry_size(entry_main));
 	}
 
 	/* Format 'ustar' header for main entry.


### PR DESCRIPTION
Check for need of size attribute in pax header is done prematurely [1]. Data size may still change in case of sparse files etc. Check should be done after all size adjustments [2] otherwise size value may be wrong. This causes error by tar when extracting archive containing sparse file >= 8G created by bsdtar (for more details see: [3]).

I tried to run "make check" with this change, which passed. Also with this change I was now able to extract archive created by bsdtar containing both sparse and non sparse files >=8G by both bsdtar and tar.

[1] https://github.com/libarchive/libarchive/blob/7ef089ec204a279ef87ebd19fbedef42ec418d05/libarchive/archive_write_set_format_pax.c#L1031
[2] https://github.com/libarchive/libarchive/blob/7ef089ec204a279ef87ebd19fbedef42ec418d05/libarchive/archive_write_set_format_pax.c#L1346
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2037839