### PR TITLE
Include android_lf.h only for libarchive sources

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -97,7 +97,7 @@ typedef ssize_t la_ssize_t;
 #endif
 
 /* Large file support for Android */
-#ifdef __ANDROID__
+#if defined(__LIBARCHIVE_BUILD) && defined(__ANDROID__)
 #include "android_lf.h"
 #endif
 

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -99,7 +99,7 @@ typedef ssize_t la_ssize_t;
 #endif
 
 /* Large file support for Android */
-#ifdef __ANDROID__
+#if defined(__LIBARCHIVE_BUILD) && defined(__ANDROID__)
 #include "android_lf.h"
 #endif
 


### PR DESCRIPTION
Header that contains redefinitions open common names such as `open` should only be included when library is being built to avoid breaking builds of files that include `archive.h` and use `open` as e.g. variable name.