### PR TITLE
Reorganize test code a bit

### DIFF
--- a/libarchive/test/test_read_data_large.c
+++ b/libarchive/test/test_read_data_large.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD: head/lib/libarchive/test/test_read_data_large.c 201247 2009-12-30 05:59:21Z kientzle $");
 
 /*

--- a/libarchive/test/test_read_extract.c
+++ b/libarchive/test/test_read_extract.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD: head/lib/libarchive/test/test_read_extract.c 201247 2009-12-30 05:59:21Z kientzle $");
 
 #define BUFF_SIZE 1000000

--- a/libarchive/test/test_read_large.c
+++ b/libarchive/test/test_read_large.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD: head/lib/libarchive/test/test_read_large.c 201247 2009-12-30 05:59:21Z kientzle $");
 
 static unsigned char testdata[10 * 1024 * 1024];

--- a/libarchive/test/test_read_pax_truncated.c
+++ b/libarchive/test/test_read_pax_truncated.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD: head/lib/libarchive/test/test_read_pax_truncated.c 189483 2009-03-07 03:34:34Z kientzle $");
 
 DEFINE_TEST(test_read_pax_truncated)

--- a/libarchive/test/test_read_truncated.c
+++ b/libarchive/test/test_read_truncated.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD: src/lib/libarchive/test/test_read_truncated.c,v 1.4 2008/09/01 05:38:33 kientzle Exp $");
 
 static char buff[1000000];

--- a/libarchive/test/test_read_truncated_filter.c
+++ b/libarchive/test/test_read_truncated_filter.c
@@ -25,7 +25,6 @@
  */
 
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD$");
 
 /*

--- a/libarchive/test/test_write_format_7zip_large.c
+++ b/libarchive/test/test_write_format_7zip_large.c
@@ -25,7 +25,6 @@
 
 
 #include "test.h"
-#include "test_utils.h"
 __FBSDID("$FreeBSD$");
 
 #define LARGE_SIZE	(16*1024*1024)

--- a/test_utils/test_common.h
+++ b/test_utils/test_common.h
@@ -471,4 +471,6 @@ void assertVersion(const char *prog, const char *base);
 #include <dmalloc.h>
 #endif
 
+#include "test_utils.h"
+
 #endif	/* TEST_COMMON_H */

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3462,6 +3462,12 @@ assertion_entry_compare_acls(const char *file, int line,
  *      DEFINE_TEST(test_function)
  * for each test.
  */
+struct test_list_t
+{
+  void (*func)(void);
+  const char *name;
+  int failures;
+};
 
 /* Use "list.h" to declare all of the test functions. */
 #undef DEFINE_TEST
@@ -3751,6 +3757,100 @@ success:
 	p = strdup(buff);
 	free(buff);
 	return p;
+}
+
+/* Filter tests against a glob pattern. Returns non-zero if test matches
+ * pattern, zero otherwise. A '^' at the beginning of the pattern negates
+ * the return values (i.e. returns zero for a match, non-zero otherwise.
+ */
+static int
+test_filter(const char *pattern, const char *test)
+{
+	int retval = 0;
+	int negate = 0;
+	const char *p = pattern;
+	const char *t = test;
+
+	if (p[0] == '^')
+	{
+		negate = 1;
+		p++;
+	}
+
+	while (1)
+	{
+		if (p[0] == '\\')
+			p++;
+		else if (p[0] == '*')
+		{
+			while (p[0] == '*')
+				p++;
+			if (p[0] == '\\')
+				p++;
+			if ((t = strchr(t, p[0])) == 0)
+				break;
+		}
+		if (p[0] != t[0])
+			break;
+		if (p[0] == '\0') {
+			retval = 1;
+			break;
+		}
+		p++;
+		t++;
+	}
+
+	return (negate) ? !retval : retval;
+}
+
+static int
+get_test_set(int *test_set, int limit, const char *test)
+{
+	int start, end;
+	int idx = 0;
+
+	if (test == NULL) {
+		/* Default: Run all tests. */
+		for (;idx < limit; idx++)
+			test_set[idx] = idx;
+		return (limit);
+	}
+	if (*test >= '0' && *test <= '9') {
+		const char *vp = test;
+		start = 0;
+		while (*vp >= '0' && *vp <= '9') {
+			start *= 10;
+			start += *vp - '0';
+			++vp;
+		}
+		if (*vp == '\0') {
+			end = start;
+		} else if (*vp == '-') {
+			++vp;
+			if (*vp == '\0') {
+				end = limit - 1;
+			} else {
+				end = 0;
+				while (*vp >= '0' && *vp <= '9') {
+					end *= 10;
+					end += *vp - '0';
+					++vp;
+				}
+			}
+		} else
+			return (-1);
+		if (start < 0 || end >= limit || start > end)
+			return (-1);
+		while (start <= end)
+			test_set[idx++] = start++;
+	} else {
+		for (start = 0; start < limit; ++start) {
+			const char *name = tests[start].name;
+			if (test_filter(test, name))
+				test_set[idx++] = start;
+		}
+	}
+	return ((idx == 0)?-1:idx);
 }
 
 int
@@ -4049,7 +4149,7 @@ main(int argc, char **argv)
 		do {
 			int test_num;
 
-			test_num = get_test_set(test_set, limit, *argv, tests);
+			test_num = get_test_set(test_set, limit, *argv);
 			if (test_num < 0) {
 				printf("*** INVALID Test %s\n", *argv);
 				free(refdir_alloc);

--- a/test_utils/test_utils.c
+++ b/test_utils/test_utils.c
@@ -32,100 +32,6 @@
 #include <string.h>
 #include <assert.h>
 
-/* Filter tests against a glob pattern. Returns non-zero if test matches
- * pattern, zero otherwise. A '^' at the beginning of the pattern negates
- * the return values (i.e. returns zero for a match, non-zero otherwise.
- */
-static int
-test_filter(const char *pattern, const char *test)
-{
-	int retval = 0;
-	int negate = 0;
-	const char *p = pattern;
-	const char *t = test;
-
-	if (p[0] == '^')
-	{
-		negate = 1;
-		p++;
-	}
-
-	while (1)
-	{
-		if (p[0] == '\\')
-			p++;
-		else if (p[0] == '*')
-		{
-			while (p[0] == '*')
-				p++;
-			if (p[0] == '\\')
-				p++;
-			if ((t = strchr(t, p[0])) == 0)
-				break;
-		}
-		if (p[0] != t[0])
-			break;
-		if (p[0] == '\0') {
-			retval = 1;
-			break;
-		}
-		p++;
-		t++;
-	}
-
-	return (negate) ? !retval : retval;
-}
-
-int get_test_set(int *test_set, int limit, const char *test,
-	struct test_list_t *tests)
-{
-	int start, end;
-	int idx = 0;
-
-	if (test == NULL) {
-		/* Default: Run all tests. */
-		for (;idx < limit; idx++)
-			test_set[idx] = idx;
-		return (limit);
-	}
-	if (*test >= '0' && *test <= '9') {
-		const char *vp = test;
-		start = 0;
-		while (*vp >= '0' && *vp <= '9') {
-			start *= 10;
-			start += *vp - '0';
-			++vp;
-		}
-		if (*vp == '\0') {
-			end = start;
-		} else if (*vp == '-') {
-			++vp;
-			if (*vp == '\0') {
-				end = limit - 1;
-			} else {
-				end = 0;
-				while (*vp >= '0' && *vp <= '9') {
-					end *= 10;
-					end += *vp - '0';
-					++vp;
-				}
-			}
-		} else
-			return (-1);
-		if (start < 0 || end >= limit || start > end)
-			return (-1);
-		while (start <= end)
-			test_set[idx++] = start++;
-	} else {
-		for (start = 0; start < limit; ++start) {
-			const char *name = tests[start].name;
-			if (test_filter(test, name))
-				test_set[idx++] = start;
-		}
-	}
-	return ((idx == 0)?-1:idx);
-}
-
 static inline uint64_t
 xorshift64(uint64_t *state)
 {
@@ -146,7 +52,7 @@ xorshift64(uint64_t *state)
  * took ~22 seconds, whereas using a xorshift random number generator (that can
  * be inlined) reduces it to ~17 seconds on QEMU RISC-V.
  */
-void
+static void
 fill_with_pseudorandom_data_seed(uint64_t seed, void *buffer, size_t size)
 {
 	uint64_t *aligned_buffer;

--- a/test_utils/test_utils.h
+++ b/test_utils/test_utils.h
@@ -30,15 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct test_list_t
-{
-  void (*func)(void);
-  const char *name;
-  int failures;
-};
-
-int get_test_set(int *, int, const char *, struct test_list_t *);
+/* Fill a buffer with pseudorandom data */
 void fill_with_pseudorandom_data(void* buffer, size_t size);
-void fill_with_pseudorandom_data_seed(uint64_t seed, void* buffer, size_t size);
 
 #endif /* TEST_UTILS_H */


### PR DESCRIPTION
A few guiding principles:
* Each test source file includes ONLY "test.h" to make it easy
  to create new tests.
* Each test suite has a "test.h" that includes "test_util/test_common.h"
  to get access to all the common testing utility functions.

So "test_common.h" is then responsible for including
any smaller headers that declare specific pieces of
shared test functionality.

I've also pulled some test filtering logic that was _only_ used
in test_main.c into that file, and repurposed "test_utils.[ch]"
for common utility code.  (Eventually, a lot of the assertion
helpers currently in "test_main.c" should probably be organized
into one or more source files of their own.)