### PR TITLE
fix for tar auto-compress using ISO files

### DIFF
--- a/tar/creation_set.c
+++ b/tar/creation_set.c
@@ -95,7 +95,7 @@ get_format_code(const char *suffix)
 		{ ".7z",	"7zip" },
 		{ ".ar",	"arbsd" },
 		{ ".cpio",	"cpio" },
-		{ ".iso",	"iso9960" },
+		{ ".iso",	"iso" },
 		{ ".mtree",	"mtree" },
 		{ ".shar",	"shar" },
 		{ ".tar",	"paxr" },


### PR DESCRIPTION
Currently "tar acvf myfile.iso mypath" fails with:
Can't use format iso9960: No such format 'iso9960'