### PR TITLE
Fix typo in libarchive/archive_read_support_filter_lzop.c

### DIFF
--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -173,7 +173,7 @@ lzop_bidder_init(struct archive_read_filter *self)
 static const struct archive_read_filter_vtable
 lzop_reader_vtable = {
 	.read = lzop_filter_read,
-	.close = lzop_filter_close.
+	.close = lzop_filter_close
 };
 
 /*


### PR DESCRIPTION
Extra "dot" in line 176 of libarchive/archive_read_support_filter_lzop.c