### PR TITLE
Enable LZMA support for FreeBSD

### DIFF
--- a/libarchive/config_freebsd.h
+++ b/libarchive/config_freebsd.h
@@ -236,6 +236,14 @@
 #define HAVE_ZLIB_H 1
 #define TIME_WITH_SYS_TIME 1
 
+#if __FreeBSD_version >= 800505
+#define HAVE_LIBLZMA 1
+#define HAVE_LZMA_H 1
+#if __FreeBSD_version >= 1002504
+#define HAVE_LZMA_STREAM_ENCODER_MT 1
+#endif
+#endif
+
 #if __FreeBSD_version >= 1100056
 #define HAVE_FUTIMENS 1
 #define HAVE_UTIMENSAT 1


### PR DESCRIPTION
All supported FreeBSD releases have LZMA by default.  This patch enables LZMA support including multi-threaded compression.