### PR TITLE
bsdtar(1): Document threads options for zstd and xz

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -638,10 +638,20 @@ a compression dictionary to improve compression ratio.
 .It Cm zstd:compression-level
 A decimal integer specifying the zstd compression level. Supported values depend
 on the library version, common values are from 1 to 22.
+.It Cm zstd:threads
+Specify the number of worker threads to use.
+Setting threads to a special value 0 makes
+.Xr zstd 1
+use as many threads as there are CPU cores on the system.
 .It Cm lzop:compression-level
 A decimal integer from 1 to 9 specifying the lzop compression level.
 .It Cm xz:compression-level
 A decimal integer from 0 to 9 specifying the xz compression level.
+.It Cm xz:threads
+Specify the number of worker threads to use.
+Setting threads to a special value 0 makes
+.Xr xz 1
+use as many threads as there are CPU cores on the system.
 .It Cm mtree: Ns Ar keyword
 The mtree writer module allows you to specify which mtree keywords
 will be included in the output.


### PR DESCRIPTION
Originally, it was written by Felix Johnson <felix.the.red@gmail.com> for xz.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=233543#c10

I just copied it for zstd.