### PR TITLE
Fix some test failures when building --without-zlib

### DIFF
--- a/libarchive/test/test_read_format_zip_winzip_aes.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes.c
@@ -115,7 +115,7 @@ test_winzip_aes(const char *refname, int need_libz)
 	} else {
 		assertEqualInt(ARCHIVE_FAILED, archive_read_data(a, buff, 19));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	

--- a/libarchive/test/test_read_format_zip_winzip_aes_large.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes_large.c
@@ -143,7 +143,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 		assertEqualInt(ARCHIVE_FAILED,
 			archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 
@@ -161,7 +161,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 		assertEqualInt(ARCHIVE_FAILED,
 			archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 
@@ -179,7 +179,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 		assertEqualInt(ARCHIVE_FAILED,
 			archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 
@@ -197,7 +197,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 		assertEqualInt(ARCHIVE_FAILED,
 			archive_read_data(a, buff, sizeof(buff)));
 		assertEqualString(archive_error_string(a),
-		    "Unsupported ZIP compression method (deflation)");
+		    "Unsupported ZIP compression method (8: deflation)");
 		assert(archive_errno(a) != 0);
 	}
 	


### PR DESCRIPTION
This PR fixes a few test failures that occur when libarchive is compiled `--without-zlib` — these that seemed to have obvious solutions. I can report the remaining issues later or all of them, if you prefer.