### PR TITLE
windows: include archive_platform.h first in blake2s sources

### DIFF
--- a/libarchive/archive_blake2s_ref.c
+++ b/libarchive/archive_blake2s_ref.c
@@ -13,11 +13,12 @@
    https://blake2.net.
 */
 
+#include "archive_platform.h"
+
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 
-#include "archive_platform.h"
 #include "archive_blake2.h"
 #include "archive_blake2_impl.h"
 

--- a/libarchive/archive_blake2sp_ref.c
+++ b/libarchive/archive_blake2sp_ref.c
@@ -13,6 +13,8 @@
    https://blake2.net.
 */
 
+#include "archive_platform.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -21,7 +23,6 @@
 #include <omp.h>
 #endif
 
-#include "archive_platform.h"
 #include "archive_blake2.h"
 #include "archive_blake2_impl.h"
 


### PR DESCRIPTION
Move the inclusion added by #1623 to be first.  This is our convention in all other `.c` sources.  It ensures that our configured `_WIN32_WINNT` value is defined before including any system headers.