### PR TITLE
Moved negative check for input byte count to after min calculation

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1736,13 +1736,15 @@ zip_read_data_zipx_xz(struct archive_read *a, const void **buff,
 	}
 
 	compressed_buf = __archive_read_ahead(a, 1, &bytes_avail);
-	if (bytes_avail < 0) {
+
+	in_bytes = zipmin(zip->entry_bytes_remaining, bytes_avail);
+
+	if (in_bytes < 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Truncated xz file body");
 		return (ARCHIVE_FATAL);
 	}
 
-	in_bytes = zipmin(zip->entry_bytes_remaining, bytes_avail);
 	zip->zipx_lzma_stream.next_in = compressed_buf;
 	zip->zipx_lzma_stream.avail_in = in_bytes;
 	zip->zipx_lzma_stream.total_in = 0;
@@ -1829,15 +1831,16 @@ zip_read_data_zipx_lzma_alone(struct archive_read *a, const void **buff,
 	 * data.
 	 */
 	compressed_buf = __archive_read_ahead(a, 1, &bytes_avail);
-	if (bytes_avail < 0) {
+
+	in_bytes = zipmin(zip->entry_bytes_remaining, bytes_avail);
+
+	if (in_bytes < 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Truncated lzma file body");
 		return (ARCHIVE_FATAL);
 	}
 
 	/* Set decompressor parameters. */
-	in_bytes = zipmin(zip->entry_bytes_remaining, bytes_avail);
-
 	zip->zipx_lzma_stream.next_in = compressed_buf;
 	zip->zipx_lzma_stream.avail_in = in_bytes;
 	zip->zipx_lzma_stream.total_in = 0;


### PR DESCRIPTION
Based on the investigation done by Lasse Collin, the bug in #1672 is caused by the in_bytes variable being set to a negative number because zip->entry_bytes_remaining was negative. The LZMA avail_in value is unsigned, so it was treating the available in as a large positive number and trying to continue reading input. This resulted in the invalid read segmentation fault.  

This is a quick fix to the issue. I tested it on the file provided by [icycityone](https://github.com/icycityone) and it no longer segmentation faults. I am not sure if a deeper fix is needed to prevent zip->entry_bytes_remaining from being negative, but this will at least solve the problem in the short term. 

Thank you to [icycityone](https://github.com/icycityone) for discovering and reporting this bug and thank you to Lasse Collin for discovering the source of the problem. 

fixes #1672 