### PR TITLE
archive_write_open.3, archive_read_open.3: ends

### DIFF
--- a/libarchive/archive_write_open.3
+++ b/libarchive/archive_write_open.3
@@ -218,6 +218,7 @@ On failure, the callback should invoke
 .Fn archive_set_error
 to register an error code and message and
 return
+.Cm ARCHIVE_FATAL .
 .Bl -item -offset indent
 .It
 .Ft typedef int


### PR DESCRIPTION
If I am not mistaken, this fixes the return value in case of failure:

```
typedef int archive_close_callback(struct archive *, void *client_data)

The close callback is invoked by archive_close when the archive processing is complete. If the open callback fails, the close callback is not invoked.  The callback should return ARCHIVE_OK on success.  On failure, the callback should invoke archive_set_error() to register an error code and message and return ARCHIVE_FATAL.
```