### PR TITLE
tar: respect --strip-components and -s patterns in c r & u modes when reading archives

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -694,6 +694,8 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina)
 	while (ARCHIVE_OK == (e = archive_read_next_header(ina, &in_entry))) {
 		if (archive_match_excluded(bsdtar->matching, in_entry))
 			continue;
+		if(edit_pathname(bsdtar, in_entry))
+			continue;
 		if ((bsdtar->flags & OPTFLAG_INTERACTIVE) &&
 		    !yes("copy '%s'", archive_entry_pathname(in_entry)))
 			continue;


### PR DESCRIPTION
I see that support for these flags was improved previously by @toofishes in #271 (3d5c70ee05eead5697fc96b29fee8758990612d0) but I noticed they were ignored when appending archives, for example `tar -cf - --strip-components 1 @some-archive` will not strip anything, nor will `-s` pattern replacements be applied. I found this a bit surprising as the documentation makes no mention of any limitations with respect to these flags.

This change was a bit _too_ easy so it wouldn't surprise me if I was missing something. Tests pass and if this change is not controversial, I'd be glad to add some new tests to cover the relevant scenarios.