### PR TITLE
Fixes for running tests on Windows (or Wine)

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1251,7 +1251,10 @@ parse_file(struct archive_read *a, struct archive_entry *entry,
 			mtree->fd = open(path, O_RDONLY | O_BINARY | O_CLOEXEC);
 			__archive_ensure_cloexec_flag(mtree->fd);
 			if (mtree->fd == -1 &&
-				(errno != ENOENT ||
+                            /* On Windows, attempting to open a file with an invalid name
+                             * result in EINVAL (Error 22)
+                             */
+				((errno != ENOENT && errno != EINVAL) ||
 				 archive_strlen(&mtree->contents_name) > 0)) {
 				archive_set_error(&a->archive, errno,
 						"Can't open %s", path);

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1250,12 +1250,17 @@ parse_file(struct archive_read *a, struct archive_entry *entry,
 				archive_entry_filetype(entry) == AE_IFDIR) {
 			mtree->fd = open(path, O_RDONLY | O_BINARY | O_CLOEXEC);
 			__archive_ensure_cloexec_flag(mtree->fd);
-			if (mtree->fd == -1 &&
-                            /* On Windows, attempting to open a file with an invalid name
-                             * result in EINVAL (Error 22)
-                             */
-				((errno != ENOENT && errno != EINVAL) ||
-				 archive_strlen(&mtree->contents_name) > 0)) {
+			if (mtree->fd == -1 && (
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        /*
+         * On Windows, attempting to open a file with an
+         * invalid name result in EINVAL (Error 22)
+         */
+				(errno != ENOENT && errno != EINVAL)
+#else
+				errno != ENOENT
+#endif
+        || archive_strlen(&mtree->contents_name) > 0)) {
 				archive_set_error(&a->archive, errno,
 						"Can't open %s", path);
 				r = ARCHIVE_WARN;

--- a/libarchive/test/test_archive_match_time.c
+++ b/libarchive/test/test_archive_match_time.c
@@ -321,6 +321,11 @@ test_newer_ctime_than_file_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -434,6 +439,11 @@ test_newer_ctime_than_file_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -782,6 +792,11 @@ test_older_ctime_than_file_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -896,6 +911,11 @@ test_older_ctime_than_file_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -1073,6 +1093,11 @@ test_ctime_between_files_mbs(void)
 	struct archive_entry *ae;
 	struct archive *m;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
+
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
 	if (!assert((ae = archive_entry_new()) != NULL)) {
@@ -1131,6 +1156,11 @@ test_ctime_between_files_wcs(void)
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+        skipping("Can't set ctime on Windows");
+        return;
+#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;


### PR DESCRIPTION
This PR contains two commits which fix problems with running the tests on Windows:

* `open()` sets `EINVAL` for files with invalid names, instead of `ENOENT`; one of the tests triggers this with a filename that's invalid on Windows.
* You can't set the `ctime` on Windows, so we skip the tests which depend on doing that.