### PR TITLE
fix Bl -width

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -953,7 +953,7 @@ archives.
 .Sh ENVIRONMENT
 The following environment variables affect the execution of
 .Nm :
-.Bl -tag -width ".Ev BLOCKSIZE"
+.Bl -tag -width indent
 .It Ev TAR_READER_OPTIONS
 The default options for format readers and compression readers.
 The


### PR DESCRIPTION
In `bsdtar.1`, every `.Bl` list uses `-width indent` -- except this one,
which uses `-width ".Ev BLOCKSIZE"` which does nit even appear in the list.
Make it `indent` like every other list.