### PR TITLE
CI: update FreeBSD versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,11 +10,9 @@ FreeBSD_task:
       BS: cmake
   matrix:
     freebsd_instance:
-      image_family: freebsd-13-0
+      image_family: freebsd-13-1
     freebsd_instance:
-      image_family: freebsd-12-2
-    freebsd_instance:
-      image_family: freebsd-11-4
+      image_family: freebsd-12-3
   prepare_script:
   - ./build/ci/cirrus_ci/ci.sh prepare
   configure_script:


### PR DESCRIPTION
Update to latest released versions (12.3 and 13.1), and drop now-EOL 11.4.