### PR TITLE
Fixed issue #1743: Changed sprintf to safer snprintf

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -776,7 +776,7 @@ archive_read_format_7zip_read_header(struct archive_read *a,
 	}
 
 	/* Set up a more descriptive format name. */
-	sprintf(zip->format_name, "7-Zip");
+	snprintf(zip->format_name, sizeof(zip->format_name), "7-Zip");
 	a->archive.archive_format_name = zip->format_name;
 
 	return (ret);

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -996,7 +996,7 @@ archive_read_format_cab_read_header(struct archive_read *a,
 		cab->end_of_entry_cleanup = cab->end_of_entry = 1;
 
 	/* Set up a more descriptive format name. */
-	sprintf(cab->format_name, "CAB %d.%d (%s)",
+	snprintf(cab->format_name, sizeof(cab->format_name), "CAB %d.%d (%s)",
 	    hd->major, hd->minor, cab->entry_cffolder->compname);
 	a->archive.archive_format_name = cab->format_name;
 

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -739,7 +739,7 @@ archive_read_format_lha_read_header(struct archive_read *a,
 	if (lha->directory || lha->compsize == 0)
 		lha->end_of_entry = 1;
 
-	sprintf(lha->format_name, "lha -%c%c%c-",
+	snprintf(lha->format_name, sizeof(lha->format_name), "lha -%c%c%c-",
 	    lha->method[0], lha->method[1], lha->method[2]);
 	a->archive.archive_format_name = lha->format_name;
 

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1717,7 +1717,7 @@ build_pax_attribute_name(char *dest, const char *src)
 	 * to having clients override it.
 	 */
 #if HAVE_GETPID && 0  /* Disable this for now; see above comment. */
-	sprintf(buff, "PaxHeader.%d", getpid());
+	snprintf(buff, sizeof(buff), "PaxHeader.%d", getpid());
 #else
 	/* If the platform can't fetch the pid, don't include it. */
 	strcpy(buff, "PaxHeader");

--- a/libarchive/test/test_acl_platform_nfs4.c
+++ b/libarchive/test/test_acl_platform_nfs4.c
@@ -907,7 +907,7 @@ DEFINE_TEST(test_acl_platform_nfs4)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 
 	for (i = 0; i < acls_dir_cnt; ++i) {
-	  sprintf(buff, "dir%d", i);
+	  snprintf(buff, sizeof(buff), "dir%d", i);
 	  archive_entry_set_pathname(ae, buff);
 	  archive_entry_set_filetype(ae, AE_IFDIR);
 	  archive_entry_set_perm(ae, 0654);
@@ -960,7 +960,7 @@ DEFINE_TEST(test_acl_platform_nfs4)
 
 	/* Verify single-permission dirs on disk. */
 	for (i = 0; i < dircnt; ++i) {
-		sprintf(buff, "dir%d", i);
+		snprintf(buff, sizeof(buff), "dir%d", i);
 		assertEqualInt(0, stat(buff, &st));
 		assertEqualInt(st.st_mtime, 123456 + i);
 #if ARCHIVE_ACL_SUNOS_NFS4

--- a/libarchive/test/test_archive_api_feature.c
+++ b/libarchive/test/test_archive_api_feature.c
@@ -32,7 +32,7 @@ DEFINE_TEST(test_archive_api_feature)
 
 	/* This is the (hopefully) final versioning API. */
 	assertEqualInt(ARCHIVE_VERSION_NUMBER, archive_version_number());
-	sprintf(buff, "libarchive %d.%d.%d",
+	snprintf(buff, sizeof(buff), "libarchive %d.%d.%d",
 	    archive_version_number() / 1000000,
 	    (archive_version_number() / 1000) % 1000,
 	    archive_version_number() % 1000);

--- a/libarchive/test/test_read_truncated_filter.c
+++ b/libarchive/test/test_read_truncated_filter.c
@@ -81,7 +81,7 @@ test_truncation(const char *compression,
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "%s%d", compression, i);
+		snprintf(path, sizeof(path), "%s%d", compression, i);
 		archive_entry_copy_pathname(ae, path);
 		failure("%s", path);
 		if (!assertEqualIntA(a, ARCHIVE_OK,
@@ -123,7 +123,7 @@ test_truncation(const char *compression,
 			assert(NULL != archive_error_string(a));
 			break;
 		}
-		sprintf(path, "%s%d", compression, i);
+		snprintf(path, sizeof(path), "%s%d", compression, i);
 		assertEqualString(path, archive_entry_pathname(ae));
 		if (datasize != (size_t)archive_read_data(a, data, datasize)) {
 			failure("Should have non-NULL error message for %s",

--- a/libarchive/test/test_tar_large.c
+++ b/libarchive/test/test_tar_large.c
@@ -224,7 +224,7 @@ DEFINE_TEST(test_tar_large)
 	 */
 	for (i = 0; tests[i] != 0; i++) {
 		assert((ae = archive_entry_new()) != NULL);
-		sprintf(namebuff, "file_%d", i);
+		snprintf(namebuff, sizeof(namebuff), "file_%d", i);
 		archive_entry_copy_pathname(ae, namebuff);
 		archive_entry_set_mode(ae, S_IFREG | 0755);
 		filesize = tests[i];
@@ -271,7 +271,7 @@ DEFINE_TEST(test_tar_large)
 	 */
 	for (i = 0; tests[i] > 0; i++) {
 		assertEqualIntA(a, 0, archive_read_next_header(a, &ae));
-		sprintf(namebuff, "file_%d", i);
+		snprintf(namebuff, sizeof(namebuff), "file_%d", i);
 		assertEqualString(namebuff, archive_entry_pathname(ae));
 		assert(tests[i] == archive_entry_size(ae));
 	}

--- a/libarchive/test/test_write_disk_secure744.c
+++ b/libarchive/test/test_write_disk_secure744.c
@@ -75,7 +75,7 @@ DEFINE_TEST(test_write_disk_secure744)
 		archive_entry_free(ae);
 
 		*p++ = '/';
-		sprintf(p, "target%d", n);
+		snprintf(p, buff_size - (p - buff), "target%d", n);
 
 		/* Try to create a file through the symlink, should fail. */
 		assert((ae = archive_entry_new()) != NULL);

--- a/libarchive/test/test_write_filter_b64encode.c
+++ b/libarchive/test/test_write_filter_b64encode.c
@@ -64,7 +64,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_set_filetype(ae, AE_IFREG);
 		archive_entry_set_size(ae, datasize);
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -79,7 +79,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used1));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualIntA(a, 0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));
@@ -111,7 +111,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -128,7 +128,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used2));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));

--- a/libarchive/test/test_write_filter_bzip2.c
+++ b/libarchive/test/test_write_filter_bzip2.c
@@ -83,7 +83,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -99,7 +99,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used1));
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));
@@ -133,7 +133,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -160,7 +160,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used2));
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));
@@ -187,7 +187,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -212,7 +212,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used2));
 	for (i = 0; i < 999; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));

--- a/libarchive/test/test_write_filter_compress.c
+++ b/libarchive/test/test_write_filter_compress.c
@@ -59,7 +59,7 @@ DEFINE_TEST(test_write_filter_compress)
 	    archive_write_open_memory(a, buff, buffsize, &used));
 
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -83,7 +83,7 @@ DEFINE_TEST(test_write_filter_compress)
 
 
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));

--- a/libarchive/test/test_write_filter_gzip.c
+++ b/libarchive/test/test_write_filter_gzip.c
@@ -85,7 +85,7 @@ DEFINE_TEST(test_write_filter_gzip)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -113,7 +113,7 @@ DEFINE_TEST(test_write_filter_gzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -148,7 +148,7 @@ DEFINE_TEST(test_write_filter_gzip)
 	    archive_write_set_options(a, "gzip:compression-level=9"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -187,7 +187,7 @@ DEFINE_TEST(test_write_filter_gzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -212,7 +212,7 @@ DEFINE_TEST(test_write_filter_gzip)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -249,7 +249,7 @@ DEFINE_TEST(test_write_filter_gzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_lrzip.c
+++ b/libarchive/test/test_write_filter_lrzip.c
@@ -68,7 +68,7 @@ DEFINE_TEST(test_write_filter_lrzip)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -84,7 +84,7 @@ DEFINE_TEST(test_write_filter_lrzip)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used1));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(ARCHIVE_OK,
 			archive_read_next_header(a, &ae)))
 			break;

--- a/libarchive/test/test_write_filter_lz4.c
+++ b/libarchive/test/test_write_filter_lz4.c
@@ -84,7 +84,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -107,7 +107,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used1));
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(ARCHIVE_OK,
 			archive_read_next_header(a, &ae)))
 			break;
@@ -142,7 +142,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -170,7 +170,7 @@ DEFINE_TEST(test_write_filter_lz4)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -195,7 +195,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -225,7 +225,7 @@ DEFINE_TEST(test_write_filter_lz4)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -330,7 +330,7 @@ test_options(const char *options)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -350,7 +350,7 @@ test_options(const char *options)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_lzip.c
+++ b/libarchive/test/test_write_filter_lzip.c
@@ -81,7 +81,7 @@ DEFINE_TEST(test_write_filter_lzip)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -103,7 +103,7 @@ DEFINE_TEST(test_write_filter_lzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -133,7 +133,7 @@ DEFINE_TEST(test_write_filter_lzip)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "9"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -157,7 +157,7 @@ DEFINE_TEST(test_write_filter_lzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			failure("Trying to read %s", path);
 			if (!assertEqualIntA(a, ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
@@ -181,7 +181,7 @@ DEFINE_TEST(test_write_filter_lzip)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "0"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -210,7 +210,7 @@ DEFINE_TEST(test_write_filter_lzip)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_lzma.c
+++ b/libarchive/test/test_write_filter_lzma.c
@@ -80,7 +80,7 @@ DEFINE_TEST(test_write_filter_lzma)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -102,7 +102,7 @@ DEFINE_TEST(test_write_filter_lzma)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -132,7 +132,7 @@ DEFINE_TEST(test_write_filter_lzma)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "9"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -156,7 +156,7 @@ DEFINE_TEST(test_write_filter_lzma)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			failure("Trying to read %s", path);
 			if (!assertEqualIntA(a, ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
@@ -180,7 +180,7 @@ DEFINE_TEST(test_write_filter_lzma)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "0"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -214,7 +214,7 @@ DEFINE_TEST(test_write_filter_lzma)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_lzop.c
+++ b/libarchive/test/test_write_filter_lzop.c
@@ -79,7 +79,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -99,7 +99,7 @@ DEFINE_TEST(test_write_filter_lzop)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -135,7 +135,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -163,7 +163,7 @@ DEFINE_TEST(test_write_filter_lzop)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -188,7 +188,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < filecount; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -218,7 +218,7 @@ DEFINE_TEST(test_write_filter_lzop)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < filecount; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_uuencode.c
+++ b/libarchive/test/test_write_filter_uuencode.c
@@ -64,7 +64,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_set_filetype(ae, AE_IFREG);
 		archive_entry_set_size(ae, datasize);
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -79,7 +79,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used1));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualIntA(a, 0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));
@@ -111,7 +111,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -128,7 +128,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used2));
 	for (i = 0; i < 99; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		if (!assertEqualInt(0, archive_read_next_header(a, &ae)))
 			break;
 		assertEqualString(path, archive_entry_pathname(ae));

--- a/libarchive/test/test_write_filter_xz.c
+++ b/libarchive/test/test_write_filter_xz.c
@@ -80,7 +80,7 @@ DEFINE_TEST(test_write_filter_xz)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -102,7 +102,7 @@ DEFINE_TEST(test_write_filter_xz)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -132,7 +132,7 @@ DEFINE_TEST(test_write_filter_xz)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "9"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -163,7 +163,7 @@ DEFINE_TEST(test_write_filter_xz)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			failure("Trying to read %s", path);
 			if (!assertEqualIntA(a, ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
@@ -187,7 +187,7 @@ DEFINE_TEST(test_write_filter_xz)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "0"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -220,7 +220,7 @@ DEFINE_TEST(test_write_filter_xz)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;

--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -74,7 +74,7 @@ DEFINE_TEST(test_write_filter_zstd)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize
@@ -96,7 +96,7 @@ DEFINE_TEST(test_write_filter_zstd)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used1));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			if (!assertEqualInt(ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
 				break;
@@ -135,7 +135,7 @@ DEFINE_TEST(test_write_filter_zstd)
 	    archive_write_set_filter_option(a, NULL, "threads", "4"));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_copy_pathname(ae, path);
 		archive_entry_set_size(ae, datasize);
@@ -158,7 +158,7 @@ DEFINE_TEST(test_write_filter_zstd)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used2));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			failure("Trying to read %s", path);
 			if (!assertEqualIntA(a, ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))
@@ -185,7 +185,7 @@ DEFINE_TEST(test_write_filter_zstd)
 	archive_entry_set_filetype(ae, AE_IFREG);
 	archive_entry_set_size(ae, datasize);
 	for (i = 0; i < 100; i++) {
-		sprintf(path, "file%03d", i);
+		snprintf(path, sizeof(path), "file%03d", i);
 		archive_entry_copy_pathname(ae, path);
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 		assertA(datasize == (size_t)archive_write_data(a, data, datasize));
@@ -205,7 +205,7 @@ DEFINE_TEST(test_write_filter_zstd)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_open_memory(a, buff, used3));
 		for (i = 0; i < 100; i++) {
-			sprintf(path, "file%03d", i);
+			snprintf(path, sizeof(path), "file%03d", i);
 			failure("Trying to read %s", path);
 			if (!assertEqualIntA(a, ARCHIVE_OK,
 				archive_read_next_header(a, &ae)))

--- a/libarchive/test/test_write_format_zip_large.c
+++ b/libarchive/test/test_write_format_zip_large.c
@@ -309,7 +309,7 @@ verify_large_zip(struct archive *a, struct fileblocks *fileblocks)
 	for (i = 0; test_sizes[i] > 0; i++) {
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_next_header(a, &ae));
-		sprintf(namebuff, "file_%d", i);
+		snprintf(namebuff, sizeof(namebuff), "file_%d", i);
 		assertEqualString(namebuff, archive_entry_pathname(ae));
 		assertEqualInt(test_sizes[i], archive_entry_size(ae));
 	}
@@ -359,7 +359,7 @@ DEFINE_TEST(test_write_format_zip_large)
 	 */
 	for (i = 0; test_sizes[i] != 0; i++) {
 		assert((ae = archive_entry_new()) != NULL);
-		sprintf(namebuff, "file_%d", i);
+		snprintf(namebuff, sizeof(namebuff), "file_%d", i);
 		archive_entry_copy_pathname(ae, namebuff);
 		archive_entry_set_mode(ae, S_IFREG | 0755);
 		filesize = test_sizes[i];

--- a/tar/test/test_copy.c
+++ b/tar/test/test_copy.c
@@ -160,21 +160,21 @@ create_tree(void)
 		failure("Internal sanity check failed: i = %d", i);
 		assert(filenames[i] != NULL);
 
-		sprintf(buff, "f/%s", filenames[i]);
+		snprintf(buff, sizeof(buff), "f/%s", filenames[i]);
 		assertMakeFile(buff, 0777, buff);
 
 		/* Create a link named "l/abcdef..." to the above. */
-		sprintf(buff2, "l/%s", filenames[i]);
+		snprintf(buff2, sizeof(buff2), "l/%s", filenames[i]);
 		assertMakeHardlink(buff2, buff);
 
 		/* Create a link named "m/abcdef..." to the above. */
-		sprintf(buff2, "m/%s", filenames[i]);
+		snprintf(buff2, sizeof(buff2), "m/%s", filenames[i]);
 		assertMakeHardlink(buff2, buff);
 
 		if (canSymlink()) {
 			/* Create a symlink named "s/abcdef..." to the above. */
-			sprintf(buff, "s/%s", filenames[i]);
-			sprintf(buff2, "../f/%s", filenames[i]);
+			snprintf(buff, sizeof(buff), "s/%s", filenames[i]);
+			snprintf(buff2, sizeof(buff2), "../f/%s", filenames[i]);
 			failure("buff=\"%s\" buff2=\"%s\"", buff, buff2);
 			assertMakeSymlink(buff, buff2, 0);
 		}
@@ -202,13 +202,13 @@ verify_tree(size_t limit)
 	/* Generate the names we know should be there and verify them. */
 	for (i = 1; i < LOOP_MAX; i++) {
 		/* Verify a file named "f/abcdef..." */
-		sprintf(name1, "f/%s", filenames[i]);
+		snprintf(name1, sizeof(name1), "f/%s", filenames[i]);
 		if (i <= limit) {
 			assertFileExists(name1);
 			assertFileContents(name1, (int)strlen(name1), name1);
 		}
 
-		sprintf(name2, "l/%s", filenames[i]);
+		snprintf(name2, sizeof(name2), "l/%s", filenames[i]);
 		if (i + 2 <= limit) {
 			/* Verify hardlink "l/abcdef..." */
 			assertIsHardlink(name1, name2);
@@ -219,14 +219,14 @@ verify_tree(size_t limit)
 
 		if (canSymlink()) {
 			/* Verify symlink "s/abcdef..." */
-			sprintf(name1, "s/%s", filenames[i]);
-			sprintf(name2, "../f/%s", filenames[i]);
+			snprintf(name1, sizeof(name1), "s/%s", filenames[i]);
+			snprintf(name2, sizeof(name2), "../f/%s", filenames[i]);
 			if (strlen(name2) <= limit)
 				assertIsSymlink(name1, name2, 0);
 		}
 
 		/* Verify dir "d/abcdef...". */
-		sprintf(name1, "d/%s", filenames[i]);
+		snprintf(name1, sizeof(name1), "d/%s", filenames[i]);
 		if (i + 1 <= limit) { /* +1 for trailing slash */
 			if (assertIsDir(name1, -1)) {
 				/* TODO: opendir/readdir this

--- a/tar/util.c
+++ b/tar/util.c
@@ -63,7 +63,7 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/util.c,v 1.23 2008/12/15 06:00:25 kientzle E
 #include "err.h"
 #include "passphrase.h"
 
-static size_t	bsdtar_expand_char(char *, size_t, char);
+static size_t	bsdtar_expand_char(char *, size_t, size_t, char);
 static const char *strip_components(const char *path, int elements);
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -173,12 +173,12 @@ safe_fprintf(FILE *f, const char *fmt, ...)
 				/* Not printable, format the bytes. */
 				while (n-- > 0)
 					i += (unsigned)bsdtar_expand_char(
-					    outbuff, i, *p++);
+					    outbuff, sizeof(outbuff), i, *p++);
 			}
 		} else {
 			/* After any conversion failure, don't bother
 			 * trying to convert the rest. */
-			i += (unsigned)bsdtar_expand_char(outbuff, i, *p++);
+			i += (unsigned)bsdtar_expand_char(outbuff, sizeof(outbuff), i, *p++);
 			try_wc = 0;
 		}
 
@@ -200,7 +200,7 @@ safe_fprintf(FILE *f, const char *fmt, ...)
  * Render an arbitrary sequence of bytes into printable ASCII characters.
  */
 static size_t
-bsdtar_expand_char(char *buff, size_t offset, char c)
+bsdtar_expand_char(char *buff, size_t buffsize, size_t offset, char c)
 {
 	size_t i = offset;
 
@@ -221,7 +221,7 @@ bsdtar_expand_char(char *buff, size_t offset, char c)
 		case '\v': buff[i++] = 'v'; break;
 		case '\\': buff[i++] = '\\'; break;
 		default:
-			sprintf(buff + i, "%03o", 0xFF & (int)c);
+			snprintf(buff + i, buffsize - i, "%03o", 0xFF & (int)c);
 			i += 3;
 		}
 	}
@@ -309,11 +309,12 @@ set_chdir(struct bsdtar *bsdtar, const char *newdir)
 		/* The -C /foo -C bar case; concatenate */
 		char *old_pending = bsdtar->pending_chdir;
 		size_t old_len = strlen(old_pending);
-		bsdtar->pending_chdir = malloc(old_len + strlen(newdir) + 2);
+        size_t new_len = old_len + strlen(newdir) + 2;
+		bsdtar->pending_chdir = malloc(new_len);
 		if (old_pending[old_len - 1] == '/')
 			old_pending[old_len - 1] = '\0';
 		if (bsdtar->pending_chdir != NULL)
-			sprintf(bsdtar->pending_chdir, "%s/%s",
+			snprintf(bsdtar->pending_chdir, new_len, "%s/%s",
 			    old_pending, newdir);
 		free(old_pending);
 	}
@@ -695,7 +696,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	/* Use uname if it's present, else uid. */
 	p = archive_entry_uname(entry);
 	if ((p == NULL) || (*p == '\0')) {
-		sprintf(tmp, "%lu ",
+		snprintf(tmp, sizeof(tmp), "%lu ",
 		    (unsigned long)archive_entry_uid(entry));
 		p = tmp;
 	}
@@ -710,7 +711,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 		fprintf(out, "%s", p);
 		w = strlen(p);
 	} else {
-		sprintf(tmp, "%lu",
+		snprintf(tmp, sizeof(tmp), "%lu",
 		    (unsigned long)archive_entry_gid(entry));
 		w = strlen(tmp);
 		fprintf(out, "%s", tmp);
@@ -723,7 +724,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	 */
 	if (archive_entry_filetype(entry) == AE_IFCHR
 	    || archive_entry_filetype(entry) == AE_IFBLK) {
-		sprintf(tmp, "%lu,%lu",
+		snprintf(tmp, sizeof(tmp), "%lu,%lu",
 		    (unsigned long)archive_entry_rdevmajor(entry),
 		    (unsigned long)archive_entry_rdevminor(entry));
 	} else {

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -426,7 +426,7 @@ failure(const char *fmt, ...)
 		nextmsg = NULL;
 	} else {
 		va_start(ap, fmt);
-		vsprintf(msgbuff, fmt, ap);
+		vsnprintf(msgbuff, sizeof(msgbuff), fmt, ap);
 		va_end(ap);
 		nextmsg = msgbuff;
 	}
@@ -551,7 +551,7 @@ test_skipping(const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	vsprintf(buff, fmt, ap);
+	vsnprintf(buff, sizeof(buff), fmt, ap);
 	va_end(ap);
 	/* Use failure() message if set. */
 	msg = nextmsg;
@@ -3065,7 +3065,7 @@ systemf(const char *fmt, ...)
 	int r;
 
 	va_start(ap, fmt);
-	vsprintf(buff, fmt, ap);
+	vsnprintf(buff, sizeof(buff), fmt, ap);
 	if (verbosity > VERBOSITY_FULL)
 		logprintf("Cmd: %s\n", buff);
 	r = system(buff);
@@ -3090,7 +3090,7 @@ slurpfile(size_t * sizep, const char *fmt, ...)
 	int r;
 
 	va_start(ap, fmt);
-	vsprintf(filename, fmt, ap);
+	vsnprintf(filename, sizeof(filename), fmt, ap);
 	va_end(ap);
 
 	f = fopen(filename, "rb");
@@ -3157,7 +3157,7 @@ extract_reference_file(const char *name)
 	char buff[1024];
 	FILE *in, *out;
 
-	sprintf(buff, "%s/%s.uu", refdir, name);
+	snprintf(buff, sizeof(buff), "%s/%s.uu", refdir, name);
 	in = fopen(buff, "r");
 	failure("Couldn't open reference file %s", buff);
 	assert(in != NULL);
@@ -3218,7 +3218,7 @@ copy_reference_file(const char *name)
 	FILE *in, *out;
 	size_t rbytes;
 
-	sprintf(buff, "%s/%s", refdir, name);
+	snprintf(buff, sizeof(buff), "%s/%s", refdir, name);
 	in = fopen(buff, "rb");
 	failure("Couldn't open reference file %s", buff);
 	assert(in != NULL);
@@ -3545,7 +3545,7 @@ test_run(int i, const char *tmpdir)
 		exit(1);
 	}
 	/* Create a log file for this test. */
-	sprintf(logfilename, "%s.log", tests[i].name);
+	snprintf(logfilename, sizeof(logfilename), "%s.log", tests[i].name);
 	logfile = fopen(logfilename, "w");
 	fprintf(logfile, "%s\n\n", tests[i].name);
 	/* Chdir() to a work dir for this specific test. */


### PR DESCRIPTION
Also few vsprintf to vsnprintf.

Most cases were trivial, one private function was changed to take the buffer length.