### PR TITLE
tar: Error on chdir error for trailing `-C`

### DIFF
--- a/tar/util.c
+++ b/tar/util.c
@@ -329,7 +329,7 @@ do_chdir(struct bsdtar *bsdtar)
 		return;
 
 	if (chdir(bsdtar->pending_chdir) != 0) {
-		lafe_errc(1, 0, "could not chdir to '%s'\n",
+		lafe_errc(1, 0, "could not chdir to '%s'",
 		    bsdtar->pending_chdir);
 	}
 	free(bsdtar->pending_chdir);

--- a/tar/write.c
+++ b/tar/write.c
@@ -519,6 +519,9 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 		bsdtar->argv++;
 	}
 
+	if (bsdtar->pending_chdir)
+		do_chdir(bsdtar);
+
 	archive_read_disk_set_matching(bsdtar->diskreader, NULL, NULL, NULL);
 	archive_read_disk_set_metadata_filter_callback(
 	    bsdtar->diskreader, NULL, NULL);


### PR DESCRIPTION
Call `do_chdir` one last time, even if there aren't any more files to add after it. This is so that a potential `chdir` failure doesn't go unnoticed.

Example:

```console
tar -cf example.tar file1 -C dir2
```

Here, even if `dir2` doesn't exit, `tar` won't fail. I think it makes sense that it should.
This emulates the behaviour of GNU tar:

```console
% tar -cf example.tar file1 -C dir2
tar: dir2: Cannot open: Not a directory
tar: Error is not recoverable: exiting now
```