### PR TITLE
Produce meaningful I/O error message

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -997,8 +997,13 @@ write_entry(struct bsdtar *bsdtar, struct archive *a,
 	 * that case, just skip the write.
 	 */
 	if (e >= ARCHIVE_WARN && archive_entry_size(entry) > 0) {
-		if (copy_file_data_block(bsdtar, a, bsdtar->diskreader, entry))
-			exit(1);
+		if (copy_file_data_block(bsdtar, a, bsdtar->diskreader, entry)) {
+			if (errno == EIO) {
+				lafe_errc(1, errno, "failed to read input file");
+			} else {
+				exit(1);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Description:

When I was backing up a file which is corrupt and opening it causes EIO I just get a meaningless message: bsdtar: (null)

This patch introduces a better error message.

You can probably improve on this but it illustrates the issue.

====================

Expected:

```
[liveuser@localhost-live libarchive-3.6.1]$ LD_LIBRARY_PATH=.libs ./bsdtar -cf /dev/null /mnt/@home/ambie/'Freetown Farm is cultivating veggies — and nurturing communities.mp4'
bsdtar: Removing leading '/' from member names
bsdtar: failed to read input file: Input/output error
[liveuser@localhost-live libarchive-3.6.1]$ 
```

Actual:

```
[liveuser@localhost-live libarchive-3.6.1]$ LD_LIBRARY_PATH=.libs ./bsdtar -cf /dev/null /mnt/@home/ambie/'Freetown Farm is cultivating veggies — and nurturing communities.mp4'
bsdtar: Removing leading '/' from member names
bsdtar: (null)
[liveuser@localhost-live libarchive-3.6.1]$ 
```

Additional info:

#1  0x000000000040df42 in write_entry (bsdtar=0x7fffffffdd80, a=0x5015e0, entry=0x51bf90) at tar/write.c:1001 (gdb) l
996              * to inform us that the archive body won't get stored.  In
997              * that case, just skip the write.
998              */
999             if (e >= ARCHIVE_WARN && archive_entry_size(entry) > 0) {
1000                    if (copy_file_data_block(bsdtar, a, bsdtar->diskreader, entry))
1001                            exit(1);
1002            }
1003    }
1004    
1005    static void
(gdb) print errno
$1 = 5