### PR TITLE
Fix .pc file referencing non-existing iconv.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,11 +376,8 @@ if test "x$with_iconv" != "xno"; then
   AC_CHECK_HEADERS([iconv.h],[],[],[#include <stdlib.h>])
   if test "x$am_cv_func_iconv" = "xyes"; then
     AC_CHECK_HEADERS([localcharset.h])
-    am_save_LIBS="$LIBS"
     LIBS="${LIBS} ${LIBICONV}"
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
     AC_CHECK_FUNCS([locale_charset])
-    LIBS="${am_save_LIBS}"
     if test "x$ac_cv_func_locale_charset" != "xyes"; then
       # If locale_charset() is not in libiconv, we have to find libcharset.
       AC_CHECK_LIB(charset,locale_charset)


### PR DESCRIPTION
This was added in #1723 but missed that the platform it was tested with patches libiconv to provide a pkg-config file, while that's not the case on other platforms.

Instead of adding iconv to Requires.private add the linker flags to Libs.private by not reverting the "LIBS" assignment.