### PR TITLE
autotools: do not add iconv for Requires.private

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,6 @@ if test "x$with_iconv" != "xno"; then
     AC_CHECK_HEADERS([localcharset.h])
     am_save_LIBS="$LIBS"
     LIBS="${LIBS} ${LIBICONV}"
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
     AC_CHECK_FUNCS([locale_charset])
     LIBS="${am_save_LIBS}"
     if test "x$ac_cv_func_locale_charset" != "xyes"; then


### PR DESCRIPTION
There is no pkgconfig file for iconv, thus things break with this change. Let's drop iconv from Requires.private.

Fixes: a83f3d32 ("autotools: Fix static linking when openssl is enabled in windows")