### PR TITLE
further cleanup _localtime64_s

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -1154,10 +1154,6 @@ list_item_verbose(struct cpio *cpio, struct archive_entry *entry)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm		tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t			terr;
-	__time64_t		tmptime;
-#endif
 
 	if (!now)
 		time(&now);
@@ -1206,12 +1202,7 @@ list_item_verbose(struct cpio *cpio, struct archive_entry *entry)
 		fmt = cpio->day_first ? "%e %b %H:%M" : "%b %e %H:%M";
 #endif
 #if defined(HAVE__LOCALTIME64_S)
-	tmptime = mtime;
-	terr = _localtime64_s(&tmbuf, &tmptime);
-	if (terr)
-		ltime = NULL;
-	else
-		ltime = &tmbuf;
+	ltime = _localtime64_s(&tmbuf, &mtime) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 	ltime = localtime_r(&mtime, &tmbuf);
 #else

--- a/cpio/test/test_option_t.c
+++ b/cpio/test/test_option_t.c
@@ -40,10 +40,6 @@ DEFINE_TEST(test_option_t)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t terr;
-	__time64_t tmptime;
-#endif
 
 	/* List reference archive, make sure the TOC is correct. */
 	extract_reference_file("test_option_t.cpio");
@@ -96,12 +92,7 @@ DEFINE_TEST(test_option_t)
 	setlocale(LC_ALL, "");
 #endif
 #if defined(HAVE__LOCALTIME64_S)
-        tmptime = mtime;
-        terr = _localtime64_s(&tmbuf, &tmptime);
-        if (terr)
-                tmptr = NULL;
-        else
-                tmptr = &tmbuf;
+        tmptr = _localtime64_s(&tmbuf, &mtime) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
         tmptr = localtime_r(&mtime, &tmbuf);
 #else

--- a/libarchive/test/test_write_format_zip_compression_store.c
+++ b/libarchive/test/test_write_format_zip_compression_store.c
@@ -132,21 +132,12 @@ static void verify_uncompressed_contents(const char *buff, size_t used)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t terr;
-	 __time64_t tmptime;
-#endif
 	/* p is the pointer to walk over the central directory,
 	 * q walks over the local headers, the data and the data descriptors. */
 	const char *p, *q, *local_header, *extra_start;
 
 #if defined(HAVE__LOCALTIME64_S)
-	tmptime = now;
-	terr = _localtime64_s(&tmbuf, &tmptime);
-	if (terr)
-		tm = NULL;
-	else
-		tm = &tmbuf;
+	tm = _localtime64_s(&tmbuf, &now) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 	tm = localtime_r(&now, &tmbuf);
 #else

--- a/libarchive/test/test_write_format_zip_file.c
+++ b/libarchive/test/test_write_format_zip_file.c
@@ -77,10 +77,6 @@ DEFINE_TEST(test_write_format_zip_file)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t terr;
-	__time64_t tmptime;
-#endif
 	size_t used, buffsize = 1000000;
 	unsigned long crc;
 	int file_perm = 00644;
@@ -99,12 +95,7 @@ DEFINE_TEST(test_write_format_zip_file)
 #endif
 
 #if defined(HAVE__LOCALTIME64_S)
-	tmptime = t;
-	terr = _localtime64_s(&tmbuf, &tmptime);
-	if (terr)
-		tm = NULL;
-	else
-		tm = &tmbuf;
+	tm = _localtime64_s(&tmbuf, &t) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 	tm = localtime_r(&t, &tmbuf);
 #else

--- a/libarchive/test/test_write_format_zip_file_zip64.c
+++ b/libarchive/test/test_write_format_zip_file_zip64.c
@@ -79,10 +79,6 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t terr;
-	__time64_t tmptime;
-#endif
 	size_t used, buffsize = 1000000;
 	unsigned long crc;
 	int file_perm = 00644;
@@ -100,12 +96,7 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 #endif
 
 #if defined(HAVE__LOCALTIME64_S)
-	tmptime = t;
-	terr = _localtime64_s(&tmbuf, &tmptime);
-	if (terr)
-		tm = NULL;
-	else
-		tm = &tmbuf;
+	tm = _localtime64_s(&tmbuf, &t) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 	tm = localtime_r(&t, &tmbuf);
 #else

--- a/tar/util.c
+++ b/tar/util.c
@@ -671,10 +671,6 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm		tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t			terr;
-	__time64_t		tmptime;
-#endif
 
 	/*
 	 * We avoid collecting the entire list in memory at once by
@@ -747,12 +743,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	else
 		fmt = bsdtar->day_first ? DAY_FMT " %b %H:%M" : "%b " DAY_FMT " %H:%M";
 #if defined(HAVE__LOCALTIME64_S)
-	tmptime = tim;
-	terr = _localtime64_s(&tmbuf, &tmptime);
-	if (terr)
-		ltime = NULL;
-	else
-		ltime = &tmbuf;
+	ltime = _localtime64_s(&tmbuf, &tim) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 	ltime = localtime_r(&tim, &tmbuf);
 #else

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3871,10 +3871,6 @@ main(int argc, char **argv)
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE__LOCALTIME64_S)
 	struct tm tmbuf;
 #endif
-#if defined(HAVE__LOCALTIME64_S)
-	errno_t	terr;
-	__time64_t tmptime;
-#endif
 	char *refdir_alloc = NULL;
 	const char *progname;
 	char **saved_argv;
@@ -4110,12 +4106,7 @@ main(int argc, char **argv)
 	now = time(NULL);
 	for (i = 0; ; i++) {
 #if defined(HAVE__LOCALTIME64_S)
-		tmptime = now;
-		terr = _localtime64_s(&tmbuf, &tmptime);
-		if (terr)
-			tmptr = NULL;
-		else
-			tmptr = &tmbuf;
+		tmptr = _localtime64_s(&tmbuf, &now) ? NULL : &tmbuf;
 #elif defined(HAVE_LOCALTIME_R)
 		tmptr = localtime_r(&now, &tmbuf);
 #else


### PR DESCRIPTION
These were missing from 2d329073435d36065ce30bfd29428f6a45e41016

Signed-off-by: Rosen Penev <rosenp@gmail.com>