### PR TITLE
Only add "iconv" to the .pc file if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,9 @@ if test "x$with_iconv" != "xno"; then
     AC_CHECK_HEADERS([localcharset.h])
     am_save_LIBS="$LIBS"
     LIBS="${LIBS} ${LIBICONV}"
-    LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
+    if test -n "$LIBICONV"; then
+      LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
+    fi
     AC_CHECK_FUNCS([locale_charset])
     LIBS="${am_save_LIBS}"
     if test "x$ac_cv_func_locale_charset" != "xyes"; then


### PR DESCRIPTION
Hi,

Thanks for writing and maintaining libarchive!

What do you think about this trivial change that does not add "iconv" to the pkg-config file's list of required packages unless it is actually needed? On at least Debian GNU/Linux systems, the iconv(3) function is part of the system C library and there is no Debian package that installs an iconv.pc file, so I had to make this change to the Debian package of libarchive.

Thanks again, and keep up the great work!

G'luck,
Peter