### PR TITLE
Fix cpio test in 2038

### DIFF
--- a/cpio/test/test_option_c.c
+++ b/cpio/test/test_option_c.c
@@ -37,10 +37,10 @@ is_octal(const char *p, size_t l)
 	return (1);
 }
 
-static int
+static long long int
 from_octal(const char *p, size_t l)
 {
-	int r = 0;
+	long long int r = 0;
 
 	while (l > 0) {
 		r *= 8;
@@ -161,7 +161,7 @@ DEFINE_TEST(test_option_c)
 		assertEqualInt(from_octal(e + 24, 6), uid); /* uid */
 		assertEqualInt(gid, from_octal(e + 30, 6)); /* gid */
 		assertEqualMem(e + 36, "000001", 6); /* nlink */
-		failure("file entries should have rdev == 0 (dev was 0%o)",
+		failure("file entries should have rdev == 0 (dev was 0%llo)",
 		    from_octal(e + 6, 6));
 		assertEqualMem(e + 42, "000000", 6); /* rdev */
 		t = from_octal(e + 48, 11); /* mtime */


### PR DESCRIPTION
Without this patch, `bsdcpio_test_option_c` failed after 2038-01-19 with

```
 .../libarchive-3.6.2/cpio/test/test_option_c.c:143: Assertion failed: t >= now - 2
 .../libarchive-3.6.2/cpio/test/test_option_c.c:169: Assertion failed: t >= now - 2
 .../libarchive-3.6.2/cpio/test/test_option_c.c:205: Assertion failed: t >= now - 2
```

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.