### PR TITLE
archive: Add 'ARCHIVE_ ZERO 'macro and conditional statement

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -198,6 +198,7 @@ struct archive_entry;
 #define	ARCHIVE_FAILED	(-25)	/* Current operation cannot complete. */
 /* But if write_header is "fatal," then this archive is dead and useless. */
 #define	ARCHIVE_FATAL	(-30)	/* No more operations are possible. */
+#define	ARCHIVE_ZERO	(-35)	/* Target data filling 'zero' failed. */
 
 /*
  * As far as possible, archive_errno returns standard platform errno codes.

--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -102,6 +102,11 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	    ARCHIVE_OK) {
 		const char *p = buff;
 		if (target_offset > actual_offset) {
+			if (!nulls) {
+				r = ARCHIVE_ZERO;
+				goto leave;
+			}
+
 			r = pad_to(a, fd, can_lseek, nulls_size, nulls,
 			    target_offset, actual_offset);
 			if (r != ARCHIVE_OK)
@@ -125,6 +130,11 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	}
 
 	if (r == ARCHIVE_EOF && target_offset > actual_offset) {
+		if (!nulls) {
+			r = ARCHIVE_ZERO;
+			goto leave;
+		}
+
 		r2 = pad_to(a, fd, can_lseek, nulls_size, nulls,
 		    target_offset, actual_offset);
 		if (r2 != ARCHIVE_OK)
@@ -133,6 +143,7 @@ archive_read_data_into_fd(struct archive *a, int fd)
 
 cleanup:
 	free(nulls);
+leave:
 	if (r != ARCHIVE_EOF)
 		return (r);
 	return (ARCHIVE_OK);


### PR DESCRIPTION
In archive_read_data_into_fd function, the 'nulls' pointer allocation failure may cause the program to crash, increase the pointer check condition and 'ARCHIVE_ ZERO 'macro can increase program robustness and express' zero' filling type.
Add 'ARCHIVE_ ZERO 'macro, used to indicate errors related to' zero 'filling memory bytes.