### PR TITLE
write_xar: move libxml2 behind an abstraction layer

### DIFF
--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -34,6 +34,9 @@
 #include <stdlib.h>
 #if HAVE_LIBXML_XMLWRITER_H
 #include <libxml/xmlwriter.h>
+#if defined(LIBXML_VERSION) && LIBXML_VERSION >= 20703
+#define XAR_WRITER_HAS_XML
+#endif /* LIBXML_VERSION */
 #endif
 #ifdef HAVE_BZLIB_H
 #include <bzlib.h>
@@ -70,8 +73,7 @@
  *
  */
 
-#if !(defined(HAVE_LIBXML_XMLWRITER_H) && defined(LIBXML_VERSION) &&\
-	LIBXML_VERSION >= 20703) ||\
+#if !defined(XAR_WRITER_HAS_XML) ||\
 	!defined(HAVE_ZLIB_H) || \
 	!defined(ARCHIVE_HAS_MD5) || !defined(ARCHIVE_HAS_SHA1)
 /*
@@ -94,9 +96,26 @@ archive_write_set_format_xar(struct archive *_a)
 
 #else	/* Support xar format */
 
-/*#define DEBUG_PRINT_TOC		1 */
+struct xml_writer;
+static int xml_writer_create(struct xml_writer **pctx);
+static int xml_writer_start_document(struct xml_writer *ctx);
+static int xml_writer_end_document(struct xml_writer *ctx);
+static int xml_writer_set_indent(struct xml_writer *ctx, unsigned int indent);
+static int xml_writer_start_element(struct xml_writer *ctx,
+    const char *localName);
+static int xml_writer_write_attribute(struct xml_writer *ctx, const char *key,
+    const char *value);
+static int xml_writer_write_attributef(struct xml_writer *ctx, const char *key,
+    const char *format, ...);
+static int xml_writer_write_string(struct xml_writer *ctx, const char *string);
+static int xml_writer_write_base64(struct xml_writer* ctx,
+    const char *data, size_t start, size_t len);
+static int xml_writer_end_element(struct xml_writer *ctx);
+static int xml_writer_get_final_content_and_length(struct xml_writer *ctx,
+    const char **out, size_t *size);
+static int xml_writer_destroy(struct xml_writer *ctx);
 
-#define BAD_CAST_CONST (const xmlChar *)
+/*#define DEBUG_PRINT_TOC		1 */
 
 #define HEADER_MAGIC	0x78617221
 #define HEADER_SIZE	28
@@ -807,50 +826,49 @@ xar_finish_entry(struct archive_write *a)
 }
 
 static int
-xmlwrite_string_attr(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_string_attr(struct archive_write *a, struct xml_writer *writer,
 	const char *key, const char *value,
 	const char *attrkey, const char *attrvalue)
 {
 	int r;
 
-	r = xmlTextWriterStartElement(writer, BAD_CAST_CONST(key));
+	r = xml_writer_start_element(writer, key);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterStartElement() failed: %d", r);
+		    "xml_writer_start_element() failed: %d", r);
 		return (ARCHIVE_FATAL);
 	}
 	if (attrkey != NULL && attrvalue != NULL) {
-		r = xmlTextWriterWriteAttribute(writer,
-		    BAD_CAST_CONST(attrkey), BAD_CAST_CONST(attrvalue));
+		r = xml_writer_write_attribute(writer, attrkey, attrvalue);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteAttribute() failed: %d", r);
+			    "xml_writer_write_attribute() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
 	if (value != NULL) {
-		r = xmlTextWriterWriteString(writer, BAD_CAST_CONST(value));
+		r = xml_writer_write_string(writer, value);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteString() failed: %d", r);
+			    "xml_writer_write_string() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
-	r = xmlTextWriterEndElement(writer);
+	r = xml_writer_end_element(writer);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterEndElement() failed: %d", r);
+		    "xml_writer_end_element() failed: %d", r);
 		return (ARCHIVE_FATAL);
 	}
 	return (ARCHIVE_OK);
 }
 
 static int
-xmlwrite_string(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_string(struct archive_write *a, struct xml_writer *writer,
 	const char *key, const char *value)
 {
 	int r;
@@ -858,34 +876,34 @@ xmlwrite_string(struct archive_write *a, xmlTextWriterPtr writer,
 	if (value == NULL)
 		return (ARCHIVE_OK);
 
-	r = xmlTextWriterStartElement(writer, BAD_CAST_CONST(key));
+	r = xml_writer_start_element(writer, key);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterStartElement() failed: %d", r);
+		    "xml_writer_start_element() failed: %d", r);
 		return (ARCHIVE_FATAL);
 	}
 	if (value != NULL) {
-		r = xmlTextWriterWriteString(writer, BAD_CAST_CONST(value));
+		r = xml_writer_write_string(writer, value);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteString() failed: %d", r);
+			    "xml_writer_write_string() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
-	r = xmlTextWriterEndElement(writer);
+	r = xml_writer_end_element(writer);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterEndElement() failed: %d", r);
+		    "xml_writer_end_element() failed: %d", r);
 		return (ARCHIVE_FATAL);
 	}
 	return (ARCHIVE_OK);
 }
 
 static int
-xmlwrite_fstring(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_fstring(struct archive_write *a, struct xml_writer *writer,
 	const char *key, const char *fmt, ...)
 {
 	struct xar *xar;
@@ -900,7 +918,7 @@ xmlwrite_fstring(struct archive_write *a, xmlTextWriterPtr writer,
 }
 
 static int
-xmlwrite_time(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_time(struct archive_write *a, struct xml_writer *writer,
 	const char *key, time_t t, int z)
 {
 	char timestr[100];
@@ -922,7 +940,7 @@ xmlwrite_time(struct archive_write *a, xmlTextWriterPtr writer,
 }
 
 static int
-xmlwrite_mode(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_mode(struct archive_write *a, struct xml_writer *writer,
 	const char *key, mode_t mode)
 {
 	char ms[5];
@@ -937,7 +955,7 @@ xmlwrite_mode(struct archive_write *a, xmlTextWriterPtr writer,
 }
 
 static int
-xmlwrite_sum(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_sum(struct archive_write *a, struct xml_writer *writer,
 	const char *key, struct chksumval *sum)
 {
 	const char *algname;
@@ -971,7 +989,7 @@ xmlwrite_sum(struct archive_write *a, xmlTextWriterPtr writer,
 }
 
 static int
-xmlwrite_heap(struct archive_write *a, xmlTextWriterPtr writer,
+xmlwrite_heap(struct archive_write *a, struct xml_writer *writer,
 	struct heap_data *heap)
 {
 	const char *encname;
@@ -1029,7 +1047,7 @@ xmlwrite_heap(struct archive_write *a, xmlTextWriterPtr writer,
  * Our implements records both <flags> and <ext2> if it's necessary.
  */
 static int
-make_fflags_entry(struct archive_write *a, xmlTextWriterPtr writer,
+make_fflags_entry(struct archive_write *a, struct xml_writer *writer,
     const char *element, const char *fflags_text)
 {
 	static const struct flagentry {
@@ -1119,11 +1137,11 @@ make_fflags_entry(struct archive_write *a, xmlTextWriterPtr writer,
 	} while (p != NULL);
 
 	if (n > 0) {
-		r = xmlTextWriterStartElement(writer, BAD_CAST_CONST(element));
+		r = xml_writer_start_element(writer, element);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 		for (i = 0; i < n; i++) {
@@ -1133,11 +1151,11 @@ make_fflags_entry(struct archive_write *a, xmlTextWriterPtr writer,
 				return (r);
 		}
 
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
@@ -1145,7 +1163,7 @@ make_fflags_entry(struct archive_write *a, xmlTextWriterPtr writer,
 }
 
 static int
-make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
+make_file_entry(struct archive_write *a, struct xml_writer *writer,
     struct file *file)
 {
 	struct xar *xar;
@@ -1173,34 +1191,34 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 	r = UTF8Toisolat1(tmp, &l, BAD_CAST(file->basename.s), &ll);
 	free(tmp);
 	if (r < 0) {
-		r = xmlTextWriterStartElement(writer, BAD_CAST("name"));
+		r = xml_writer_start_element(writer, "name");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
-		r = xmlTextWriterWriteAttribute(writer,
-		    BAD_CAST("enctype"), BAD_CAST("base64"));
+		r = xml_writer_write_attribute(writer,
+		    "enctype", "base64");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteAttribute() failed: %d", r);
+			    "xml_writer_write_attribute() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
-		r = xmlTextWriterWriteBase64(writer, file->basename.s,
+		r = xml_writer_write_base64(writer, file->basename.s,
 		    0, (int)archive_strlen(&(file->basename)));
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteBase64() failed: %d", r);
+			    "xml_writer_write_base64() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	} else {
@@ -1281,11 +1299,11 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 		break;
 	case AE_IFCHR:
 	case AE_IFBLK:
-		r = xmlTextWriterStartElement(writer, BAD_CAST("device"));
+		r = xml_writer_start_element(writer, "device");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 		r = xmlwrite_fstring(a, writer, "major",
@@ -1296,11 +1314,11 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 		    "%d", archive_entry_rdevminor(file->entry));
 		if (r < 0)
 			return (ARCHIVE_FATAL);
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 		break;
@@ -1436,19 +1454,19 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 
 		archive_entry_xattr_next(file->entry,
 		    &name, &value, &size);
-		r = xmlTextWriterStartElement(writer, BAD_CAST("ea"));
+		r = xml_writer_start_element(writer, "ea");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
-		r = xmlTextWriterWriteFormatAttribute(writer,
-		    BAD_CAST("id"), "%d", heap->id);
+		r = xml_writer_write_attributef(writer,
+		    "id", "%d", heap->id);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteAttribute() failed: %d", r);
+			    "xml_writer_write_attributef() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 		r = xmlwrite_heap(a, writer, heap);
@@ -1458,11 +1476,11 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
@@ -1471,11 +1489,11 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 	 * Make a file data entry, "<data>".
 	 */
 	if (file->data.length > 0) {
-		r = xmlTextWriterStartElement(writer, BAD_CAST("data"));
+		r = xml_writer_start_element(writer, "data");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 
@@ -1483,21 +1501,21 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
 
 	if (archive_strlen(&file->script) > 0) {
-		r = xmlTextWriterStartElement(writer, BAD_CAST("content"));
+		r = xml_writer_start_element(writer, "content");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 
@@ -1510,11 +1528,11 @@ make_file_entry(struct archive_write *a, xmlTextWriterPtr writer,
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			return (ARCHIVE_FATAL);
 		}
 	}
@@ -1530,8 +1548,9 @@ make_toc(struct archive_write *a)
 {
 	struct xar *xar;
 	struct file *np;
-	xmlBufferPtr bp;
-	xmlTextWriterPtr writer;
+	struct xml_writer *writer;
+	const char* content;
+	size_t use;
 	int algsize;
 	int r, ret;
 
@@ -1543,51 +1562,43 @@ make_toc(struct archive_write *a)
 	 * Initialize xml writer.
 	 */
 	writer = NULL;
-	bp = xmlBufferCreate();
-	if (bp == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "xmlBufferCreate() "
-		    "couldn't create xml buffer");
-		goto exit_toc;
-	}
-	writer = xmlNewTextWriterMemory(bp, 0);
-	if (writer == NULL) {
-		archive_set_error(&a->archive,
-		    ARCHIVE_ERRNO_MISC,
-		    "xmlNewTextWriterMemory() "
-		    "couldn't create xml writer");
-		goto exit_toc;
-	}
-	r = xmlTextWriterStartDocument(writer, "1.0", "UTF-8", NULL);
+	r = xml_writer_create(&writer);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterStartDocument() failed: %d", r);
+		    "xml_writer_create() failed: %d", r);
 		goto exit_toc;
 	}
-	r = xmlTextWriterSetIndent(writer, 4);
+	r = xml_writer_set_indent(writer, 4);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterSetIndent() failed: %d", r);
+		    "xml_writer_set_indent() failed: %d", r);
+		goto exit_toc;
+	}
+	r = xml_writer_start_document(writer);
+	if (r < 0) {
+		archive_set_error(&a->archive,
+		    ARCHIVE_ERRNO_MISC,
+		    "xml_writer_start_document() failed: %d", r);
 		goto exit_toc;
 	}
 
 	/*
 	 * Start recording TOC
 	 */
-	r = xmlTextWriterStartElement(writer, BAD_CAST("xar"));
+	r = xml_writer_start_element(writer, "xar");
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterStartElement() failed: %d", r);
+		    "xml_writer_start_element() failed: %d", r);
 		goto exit_toc;
 	}
-	r = xmlTextWriterStartElement(writer, BAD_CAST("toc"));
+	r = xml_writer_start_element(writer, "toc");
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterStartDocument() failed: %d", r);
+		    "xml_writer_start_element() failed: %d", r);
 		goto exit_toc;
 	}
 
@@ -1606,19 +1617,19 @@ make_toc(struct archive_write *a)
 		/*
 		 * Record TOC checksum
 		 */
-		r = xmlTextWriterStartElement(writer, BAD_CAST("checksum"));
+		r = xml_writer_start_element(writer, "checksum");
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterStartElement() failed: %d", r);
+			    "xml_writer_start_element() failed: %d", r);
 			goto exit_toc;
 		}
-		r = xmlTextWriterWriteAttribute(writer, BAD_CAST("style"),
-		    BAD_CAST_CONST(getalgname(xar->opt_toc_sumalg)));
+		r = xml_writer_write_attribute(writer, "style",
+		    getalgname(xar->opt_toc_sumalg));
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterWriteAttribute() failed: %d", r);
+			    "xml_writer_write_attribute() failed: %d", r);
 			goto exit_toc;
 		}
 
@@ -1636,11 +1647,11 @@ make_toc(struct archive_write *a)
 		if (r < 0)
 			goto exit_toc;
 
-		r = xmlTextWriterEndElement(writer);
+		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "xmlTextWriterEndElement() failed: %d", r);
+			    "xml_writer_end_element() failed: %d", r);
 			goto exit_toc;
 		}
 	}
@@ -1656,32 +1667,32 @@ make_toc(struct archive_write *a)
 		if (np->dir && np->children.first != NULL) {
 			/* Enter to sub directories. */
 			np = np->children.first;
-			r = xmlTextWriterStartElement(writer,
-			    BAD_CAST("file"));
+			r = xml_writer_start_element(writer,
+			    "file");
 			if (r < 0) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_MISC,
-				    "xmlTextWriterStartElement() "
+				    "xml_writer_start_element() "
 				    "failed: %d", r);
 				goto exit_toc;
 			}
-			r = xmlTextWriterWriteFormatAttribute(
-			    writer, BAD_CAST("id"), "%d", np->id);
+			r = xml_writer_write_attributef(
+			    writer, "id", "%d", np->id);
 			if (r < 0) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_MISC,
-				    "xmlTextWriterWriteAttribute() "
+				    "xml_writer_write_attributef() "
 				    "failed: %d", r);
 				goto exit_toc;
 			}
 			continue;
 		}
 		while (np != np->parent) {
-			r = xmlTextWriterEndElement(writer);
+			r = xml_writer_end_element(writer);
 			if (r < 0) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_MISC,
-				    "xmlTextWriterEndElement() "
+				    "xml_writer_end_element() "
 				    "failed: %d", r);
 				goto exit_toc;
 			}
@@ -1690,21 +1701,21 @@ make_toc(struct archive_write *a)
 				np = np->parent;
 			} else {
 				np = np->chnext;
-				r = xmlTextWriterStartElement(writer,
-				    BAD_CAST("file"));
+				r = xml_writer_start_element(writer,
+				    "file");
 				if (r < 0) {
 					archive_set_error(&a->archive,
 					    ARCHIVE_ERRNO_MISC,
-					    "xmlTextWriterStartElement() "
+					    "xml_writer_start_element() "
 					    "failed: %d", r);
 					goto exit_toc;
 				}
-				r = xmlTextWriterWriteFormatAttribute(
-				    writer, BAD_CAST("id"), "%d", np->id);
+				r = xml_writer_write_attributef(
+				    writer, "id", "%d", np->id);
 				if (r < 0) {
 					archive_set_error(&a->archive,
 					    ARCHIVE_ERRNO_MISC,
-					    "xmlTextWriterWriteAttribute() "
+					    "xml_writer_write_attributef() "
 					    "failed: %d", r);
 					goto exit_toc;
 				}
@@ -1713,31 +1724,40 @@ make_toc(struct archive_write *a)
 		}
 	} while (np != np->parent);
 
-	r = xmlTextWriterEndDocument(writer);
+	r = xml_writer_end_document(writer);
 	if (r < 0) {
 		archive_set_error(&a->archive,
 		    ARCHIVE_ERRNO_MISC,
-		    "xmlTextWriterEndDocument() failed: %d", r);
+		    "xml_writer_end_document() failed: %d", r);
 		goto exit_toc;
 	}
+
+	r = xml_writer_get_final_content_and_length(writer, &content, &use);
+	if (r < 0) {
+		archive_set_error(&a->archive,
+		    ARCHIVE_ERRNO_MISC,
+		    "xml_writer_get_final_content_and_length() failed: %d", r);
+		goto exit_toc;
+	}
+
 #if DEBUG_PRINT_TOC
 	fprintf(stderr, "\n---TOC-- %d bytes --\n%s\n",
-	    strlen((const char *)bp->content), bp->content);
+	    (int)strlen(content), content);
 #endif
 
 	/*
 	 * Compress the TOC and calculate the sum of the TOC.
 	 */
 	xar->toc.temp_offset = xar->temp_offset;
-	xar->toc.size = bp->use;
+	xar->toc.size = (uint64_t)use;
 	checksum_init(&(xar->a_sumwrk), xar->opt_toc_sumalg);
 
 	r = compression_init_encoder_gzip(&(a->archive),
 	    &(xar->stream), 6, 1);
 	if (r != ARCHIVE_OK)
 		goto exit_toc;
-	xar->stream.next_in = bp->content;
-	xar->stream.avail_in = bp->use;
+	xar->stream.next_in = (const unsigned char *)content;
+	xar->stream.avail_in = use;
 	xar->stream.total_in = 0;
 	xar->stream.next_out = xar->wbuff;
 	xar->stream.avail_out = sizeof(xar->wbuff);
@@ -1768,9 +1788,7 @@ make_toc(struct archive_write *a)
 	ret = ARCHIVE_OK;
 exit_toc:
 	if (writer)
-		xmlFreeTextWriter(writer);
-	if (bp)
-		xmlBufferFree(bp);
+		xml_writer_destroy(writer);
 
 	return (ret);
 }
@@ -3250,5 +3268,134 @@ getalgname(enum sumalg sumalg)
 		return (MD5_NAME);
 	}
 }
+
+#if HAVE_LIBXML_XMLWRITER_H
+
+#define BAD_CAST_CONST (const xmlChar *)
+
+struct xml_writer {
+	xmlTextWriterPtr writer;
+	xmlBufferPtr bp;
+	unsigned int indent;
+};
+
+static int
+xml_writer_create(struct xml_writer **pctx)
+{
+	struct xml_writer *ctx = calloc(1, sizeof(struct xml_writer));
+	if (ctx == NULL) {
+		return (-1);
+	}
+
+	ctx->bp = xmlBufferCreate();
+	if (ctx->bp == NULL) {
+		free(ctx);
+		return (-1);
+	}
+
+	ctx->writer = xmlNewTextWriterMemory(ctx->bp, 0);
+	if (ctx->writer == NULL) {
+		xmlBufferFree(ctx->bp);
+		free(ctx);
+		return (-1);
+	}
+
+	*pctx = ctx;
+	return (0);
+}
+
+static int
+xml_writer_destroy(struct xml_writer *ctx)
+{
+	xmlFreeTextWriter(ctx->writer);
+	xmlBufferFree(ctx->bp);
+	free(ctx);
+	return (0);
+}
+
+static int
+xml_writer_start_document(struct xml_writer *ctx)
+{
+	int r;
+	r = xmlTextWriterStartDocument(ctx->writer, "1.0", "UTF-8", NULL);
+	if (r < 0) {
+		return (r);
+	}
+
+	r = xmlTextWriterSetIndent(ctx->writer, (int)ctx->indent);
+	return (r);
+}
+
+static int
+xml_writer_end_document(struct xml_writer *ctx)
+{
+	return (xmlTextWriterEndDocument(ctx->writer));
+}
+
+static int
+xml_writer_set_indent(struct xml_writer *ctx, unsigned int indent)
+{
+	/* libxml2 only lets you set the indent after starting the document */
+	ctx->indent = indent;
+	return (0);
+}
+
+static int
+xml_writer_start_element(struct xml_writer *ctx, const char *localName)
+{
+	return (xmlTextWriterStartElement(ctx->writer,
+	    BAD_CAST_CONST(localName)));
+}
+
+static int
+xml_writer_write_attribute(struct xml_writer *ctx,
+    const char *key, const char *value)
+{
+	return (xmlTextWriterWriteAttribute(ctx->writer,
+	    BAD_CAST_CONST(key), BAD_CAST_CONST(value)));
+}
+
+static int
+xml_writer_write_attributef(struct xml_writer *ctx,
+    const char *key, const char *format, ...)
+{
+	va_list ap;
+	int ret;
+	va_start(ap, format);
+	ret = xmlTextWriterWriteVFormatAttribute(ctx->writer,
+	    BAD_CAST_CONST(key), format, ap);
+	va_end(ap);
+	return (ret);
+}
+
+static int
+xml_writer_write_string(struct xml_writer *ctx, const char *string)
+{
+	return (xmlTextWriterWriteString(ctx->writer, BAD_CAST_CONST(string)));
+}
+
+static int
+xml_writer_write_base64(struct xml_writer* ctx,
+    const char *data, size_t start, size_t len)
+{
+	return (xmlTextWriterWriteBase64(ctx->writer, data,
+	    (int)start, (int)len));
+}
+
+static int
+xml_writer_end_element(struct xml_writer *ctx)
+{
+	return (xmlTextWriterEndElement(ctx->writer));
+}
+
+static int
+xml_writer_get_final_content_and_length(struct xml_writer *ctx,
+    const char **out, size_t *size)
+{
+	*out = (const char*)ctx->bp->content;
+	*size = (size_t)ctx->bp->use;
+	return (0);
+}
+#endif /* HAVE_LIBXML_XMLWRITER_H */
 
 #endif /* Support xar format */


### PR DESCRIPTION
This commit prepares the XAR writer for another XML writing backend.

Almost everything in this changeset leaves the code identical to how
it started, except for a new layer of indirection between the xar writer
and the XML writer.

The things that are not one-to-one renames include:

- The removal of `UTF8Toisolat1` for the purposes of validating UTF-8
  - The writer code made a copy of every filename for the purposes of checking
    whether it was Latin-1 stored as UTF-8. In xar, Non-Latin-1 gets stored
    Base64-encoded.
  - I've replaced this use because (1) it was inefficient and (2) `UTF8Toisolat1`
    is a `libxml2` export.
  - The new function has slightly different results than the one it is replacing
    for invalid UTF-8. Namely, it treats illegal UTF-8 "overlong" encodings of
    Latin-1 codepoints as _invalid_. It operates on the principle that we can
    determine whether something is Latin-1 based entirely on how long the sequence
    is expected to be.
- The move of `SetIndent` to before `StartDocument`, which the abstraction layer
  immediately undoes. This is to accommodate XML writers that require indent to be
  set _before_ the document starts.