### PR TITLE
Fix a handful of clang-tidy warnings

### DIFF
--- a/libarchive/archive_blake2_impl.h
+++ b/libarchive/archive_blake2_impl.h
@@ -85,7 +85,7 @@ static BLAKE2_INLINE void store16( void *dst, uint16_t w )
 #else
   uint8_t *p = ( uint8_t * )dst;
   *p++ = ( uint8_t )w; w >>= 8;
-  *p++ = ( uint8_t )w;
+  *p   = ( uint8_t )w;
 #endif
 }
 

--- a/libarchive/archive_disk_acl_darwin.c
+++ b/libarchive/archive_disk_acl_darwin.c
@@ -76,8 +76,8 @@ static const acl_perm_map_t acl_nfs4_perm_map[] = {
 #endif
 };
 
-static const int acl_nfs4_perm_map_size =
-    (int)(sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
+static const size_t acl_nfs4_perm_map_size =
+	(sizeof(acl_nfs4_perm_map) / sizeof(acl_nfs4_perm_map[0]));
 
 static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_INHERITED, ACL_ENTRY_INHERITED},
@@ -87,8 +87,8 @@ static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_INHERIT_ONLY, ACL_ENTRY_ONLY_INHERIT}
 };
 
-static const int acl_nfs4_flag_map_size =
-    (int)(sizeof(acl_nfs4_flag_map)/sizeof(acl_nfs4_flag_map[0]));
+static const size_t acl_nfs4_flag_map_size =
+	(sizeof(acl_nfs4_flag_map) / sizeof(acl_nfs4_flag_map[0]));
 
 static int translate_guid(struct archive *a, acl_entry_t acl_entry,
     int *ae_id, int *ae_tag, const char **ae_name)
@@ -124,7 +124,7 @@ static void
 add_trivial_nfs4_acl(struct archive_entry *entry)
 {
 	mode_t mode;
-	int i;
+	size_t i;
 	const int rperm = ARCHIVE_ENTRY_ACL_READ_DATA;
 	const int wperm = ARCHIVE_ENTRY_ACL_WRITE_DATA |
 	    ARCHIVE_ENTRY_ACL_APPEND_DATA;
@@ -214,8 +214,9 @@ translate_acl(struct archive_read_disk *a,
 	acl_flagset_t	 acl_flagset;
 	acl_entry_t	 acl_entry;
 	acl_permset_t	 acl_permset;
-	int		 i, entry_acl_type;
+	int		 entry_acl_type;
 	int		 r, s, ae_id, ae_tag, ae_perm;
+	size_t		 i;
 	const char	*ae_name;
 
 	s = acl_get_entry(acl, ACL_FIRST_ENTRY, &acl_entry);
@@ -333,7 +334,7 @@ set_acl(struct archive *a, int fd, const char *name,
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i;
+	size_t		 i;
 
 	ret = ARCHIVE_OK;
 	entries = archive_acl_reset(abstract_acl, ae_requested_type);

--- a/libarchive/archive_disk_acl_freebsd.c
+++ b/libarchive/archive_disk_acl_freebsd.c
@@ -59,8 +59,8 @@ static const acl_perm_map_t acl_posix_perm_map[] = {
 	{ARCHIVE_ENTRY_ACL_READ, ACL_READ},
 };
 
-static const int acl_posix_perm_map_size =
-    (int)(sizeof(acl_posix_perm_map)/sizeof(acl_posix_perm_map[0]));
+static const size_t acl_posix_perm_map_size =
+    (sizeof(acl_posix_perm_map) / sizeof(acl_posix_perm_map[0]));
 
 #if ARCHIVE_ACL_FREEBSD_NFS4
 static const acl_perm_map_t acl_nfs4_perm_map[] = {
@@ -83,8 +83,8 @@ static const acl_perm_map_t acl_nfs4_perm_map[] = {
 	{ARCHIVE_ENTRY_ACL_SYNCHRONIZE, ACL_SYNCHRONIZE}
 };
 
-static const int acl_nfs4_perm_map_size =
-    (int)(sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
+static const size_t acl_nfs4_perm_map_size =
+	(sizeof(acl_nfs4_perm_map) / sizeof(acl_nfs4_perm_map[0]));
 
 static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_FILE_INHERIT, ACL_ENTRY_FILE_INHERIT},
@@ -98,8 +98,8 @@ static const acl_perm_map_t acl_nfs4_flag_map[] = {
 #endif
 };
 
-static const int acl_nfs4_flag_map_size =
-    (int)(sizeof(acl_nfs4_flag_map)/sizeof(acl_nfs4_flag_map[0]));
+static const size_t acl_nfs4_flag_map_size =
+	(sizeof(acl_nfs4_flag_map) / sizeof(acl_nfs4_flag_map[0]));
 #endif /* ARCHIVE_ACL_FREEBSD_NFS4 */
 
 static int
@@ -114,8 +114,9 @@ translate_acl(struct archive_read_disk *a,
 	acl_tag_t	 acl_tag;
 	acl_entry_t	 acl_entry;
 	acl_permset_t	 acl_permset;
-	int		 i, entry_acl_type, perm_map_size;
+	int		 entry_acl_type;
 	const acl_perm_map_t	*perm_map;
+	size_t	 i, perm_map_size;
 	int		 r, s, ae_id, ae_tag, ae_perm;
 	void		*q;
 	const char	*ae_name;
@@ -332,13 +333,12 @@ set_acl(struct archive *a, int fd, const char *name,
 #endif
 	int		 ret;
 	int		 ae_type, ae_permset, ae_tag, ae_id;
-	int		 perm_map_size;
+	size_t		 i, perm_map_size;
 	const acl_perm_map_t	*perm_map;
 	uid_t		 ae_uid;
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i;
 
 	ret = ARCHIVE_OK;
 	entries = archive_acl_reset(abstract_acl, ae_requested_type);

--- a/libarchive/archive_disk_acl_linux.c
+++ b/libarchive/archive_disk_acl_linux.c
@@ -62,8 +62,8 @@ static const acl_perm_map_t acl_posix_perm_map[] = {
 	{ARCHIVE_ENTRY_ACL_READ, ACL_READ},
 };
 
-static const int acl_posix_perm_map_size =
-    (int)(sizeof(acl_posix_perm_map)/sizeof(acl_posix_perm_map[0]));
+static const size_t acl_posix_perm_map_size =
+	(sizeof(acl_posix_perm_map) / sizeof(acl_posix_perm_map[0]));
 #endif /* ARCHIVE_ACL_LIBACL */
 
 #if ARCHIVE_ACL_LIBRICHACL
@@ -87,8 +87,8 @@ static const acl_perm_map_t acl_nfs4_perm_map[] = {
 	{ARCHIVE_ENTRY_ACL_SYNCHRONIZE, RICHACE_SYNCHRONIZE}
 };
 
-static const int acl_nfs4_perm_map_size =
-    (int)(sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
+static const size_t acl_nfs4_perm_map_size =
+    (sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
 
 static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_FILE_INHERIT, RICHACE_FILE_INHERIT_ACE},
@@ -98,8 +98,8 @@ static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_INHERITED, RICHACE_INHERITED_ACE}
 };
 
-static const int acl_nfs4_flag_map_size =
-    (int)(sizeof(acl_nfs4_flag_map)/sizeof(acl_nfs4_flag_map[0]));
+static const size_t acl_nfs4_flag_map_size =
+	(sizeof(acl_nfs4_flag_map) / sizeof(acl_nfs4_flag_map[0]));
 #endif /* ARCHIVE_ACL_LIBRICHACL */
 
 #if ARCHIVE_ACL_LIBACL
@@ -113,8 +113,9 @@ translate_acl(struct archive_read_disk *a,
 	acl_tag_t	 acl_tag;
 	acl_entry_t	 acl_entry;
 	acl_permset_t	 acl_permset;
-	int		 i, entry_acl_type;
+	int		 entry_acl_type;
 	int		 r, s, ae_id, ae_tag, ae_perm;
+	size_t		 i;
 	void		*q;
 	const char	*ae_name;
 
@@ -219,7 +220,8 @@ translate_richacl(struct archive_read_disk *a, struct archive_entry *entry,
     struct richacl *richacl)
 {
 	int ae_id, ae_tag, ae_perm;
-	int entry_acl_type, i;
+	int entry_acl_type;
+	size_t i;
 	const char *ae_name;
 
 	struct richace *richace;
@@ -326,7 +328,7 @@ set_richacl(struct archive *a, int fd, const char *name,
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i;
+	size_t		 i;
 	int		 ret;
 	int		 e = 0;
 	struct richacl  *richacl = NULL;
@@ -469,7 +471,7 @@ set_acl(struct archive *a, int fd, const char *name,
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i;
+	size_t		 i;
 	int		 ret;
 	acl_t		 acl = NULL;
 	acl_entry_t	 acl_entry;

--- a/libarchive/archive_disk_acl_sunos.c
+++ b/libarchive/archive_disk_acl_sunos.c
@@ -81,8 +81,8 @@ static const acl_perm_map_t acl_nfs4_perm_map[] = {
 	{ARCHIVE_ENTRY_ACL_SYNCHRONIZE, ACE_SYNCHRONIZE}
 };
 
-static const int acl_nfs4_perm_map_size =
-    (int)(sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
+static const size_t acl_nfs4_perm_map_size =
+    (sizeof(acl_nfs4_perm_map)/sizeof(acl_nfs4_perm_map[0]));
 
 static const acl_perm_map_t acl_nfs4_flag_map[] = {
 	{ARCHIVE_ENTRY_ACL_ENTRY_FILE_INHERIT, ACE_FILE_INHERIT_ACE},
@@ -96,8 +96,8 @@ static const acl_perm_map_t acl_nfs4_flag_map[] = {
 #endif
 };
 
-const int acl_nfs4_flag_map_size =
-    (int)(sizeof(acl_nfs4_flag_map)/sizeof(acl_nfs4_flag_map[0]));
+const size_t acl_nfs4_flag_map_size =
+	(sizeof(acl_nfs4_flag_map) / sizeof(acl_nfs4_flag_map[0]));
 
 #endif /* ARCHIVE_ACL_SUNOS_NFS4 */
 
@@ -164,7 +164,7 @@ sun_acl_is_trivial(void *aclp, int aclcnt, mode_t mode, int is_nfs4,
     int is_dir, int *trivialp)
 {
 #if ARCHIVE_ACL_SUNOS_NFS4
-	int i, p;
+	size_t i, p;
 	const uint32_t rperm = ACE_READ_DATA;
 	const uint32_t wperm = ACE_WRITE_DATA | ACE_APPEND_DATA;
 	const uint32_t eperm = ACE_EXECUTE;
@@ -316,10 +316,11 @@ translate_acl(struct archive_read_disk *a,
     struct archive_entry *entry, void *aclp, int aclcnt,
     int default_entry_acl_type)
 {
-	int e, i;
+	int e;
 	int ae_id, ae_tag, ae_perm;
 	int entry_acl_type;
 	const char *ae_name;
+	size_t i;
 	aclent_t *aclent;
 #if ARCHIVE_ACL_SUNOS_NFS4
 	ace_t *ace;
@@ -454,13 +455,12 @@ set_acl(struct archive *a, int fd, const char *name,
 	void		 *aclp;
 	int		 ret;
 	int		 ae_type, ae_permset, ae_tag, ae_id;
-	int		 perm_map_size;
+	size_t		 i, perm_map_size;
 	const acl_perm_map_t	*perm_map;
 	uid_t		 ae_uid;
 	gid_t		 ae_gid;
 	const char	*ae_name;
 	int		 entries;
-	int		 i;
 
 	ret = ARCHIVE_OK;
 	entries = archive_acl_reset(abstract_acl, ae_requested_type);

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -894,7 +894,8 @@ setup_sparse_fiemap(struct archive_read_disk *a,
 	do_fiemap = 1;
 	size = archive_entry_size(entry);
 	for (iters = 0; ; ++iters) {
-		int i, r;
+		size_t i;
+		int r;
 
 		r = ioctl(*fd, FS_IOC_FIEMAP, fm); 
 		if (r < 0) {
@@ -911,7 +912,7 @@ setup_sparse_fiemap(struct archive_read_disk *a,
 			break;
 		}
 		fe = fm->fm_extents;
-		for (i = 0; i < (int)fm->fm_mapped_extents; i++, fe++) {
+		for (i = 0; i < fm->fm_mapped_extents; i++, fe++) {
 			if (!(fe->fe_flags & FIEMAP_EXTENT_UNWRITTEN)) {
 				/* The fe_length of the last block does not
 				 * adjust itself to its size files. */

--- a/libarchive/archive_read_open_fd.c
+++ b/libarchive/archive_read_open_fd.c
@@ -135,13 +135,13 @@ file_skip(struct archive *a, void *client_data, int64_t request)
 	struct read_fd_data *mine = (struct read_fd_data *)client_data;
 	off_t skip = (off_t)request;
 	int64_t old_offset, new_offset;
-	int skip_bits = sizeof(skip) * 8 - 1;  /* off_t is a signed type. */
 
 	if (!mine->use_lseek)
 		return (0);
 
 	/* Reduce a request that would overflow the 'skip' variable. */
 	if (sizeof(request) > sizeof(skip)) {
+		int skip_bits = sizeof(skip) * 8 - 1;  /* off_t is a signed type. */
 		const int64_t max_skip =
 		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
 		if (request > max_skip)

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -133,7 +133,6 @@ FILE_skip(struct archive *a, void *client_data, int64_t request)
 	long skip = (long)request;
 #endif
 	int64_t old_offset, new_offset;
-	int skip_bits = sizeof(skip) * 8 - 1;
 
 	(void)a; /* UNUSED */
 
@@ -148,6 +147,7 @@ FILE_skip(struct archive *a, void *client_data, int64_t request)
 
 	/* If request is too big for a long or an off_t, reduce it. */
 	if (sizeof(request) > sizeof(skip)) {
+		int skip_bits = sizeof(skip) * 8 - 1;
 		const int64_t max_skip =
 		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
 		if (request > max_skip)

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -38,9 +38,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 #ifdef HAVE_LZO_LZOCONF_H
 #include <lzo/lzoconf.h>
 #endif

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -28,10 +28,6 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
-
-#ifdef HAVE_ERRNO_H
-#include <errno.h>
-#endif
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -511,10 +511,10 @@ rar_br_fillup(struct archive_read *a, struct rar_br *br)
             ((uint64_t)br->next_in[1]) << 48 |
             ((uint64_t)br->next_in[2]) << 40 |
             ((uint64_t)br->next_in[3]) << 32 |
-            ((uint32_t)br->next_in[4]) << 24 |
-            ((uint32_t)br->next_in[5]) << 16 |
-            ((uint32_t)br->next_in[6]) << 8 |
-             (uint32_t)br->next_in[7];
+            ((uint64_t)br->next_in[4]) << 24 |
+            ((uint64_t)br->next_in[5]) << 16 |
+            ((uint64_t)br->next_in[6]) << 8 |
+             (uint64_t)br->next_in[7];
         br->next_in += 8;
         br->avail_in -= 8;
         br->cache_avail += 8 * 8;
@@ -530,10 +530,10 @@ rar_br_fillup(struct archive_read *a, struct rar_br *br)
             ((uint64_t)br->next_in[0]) << 48 |
             ((uint64_t)br->next_in[1]) << 40 |
             ((uint64_t)br->next_in[2]) << 32 |
-            ((uint32_t)br->next_in[3]) << 24 |
-            ((uint32_t)br->next_in[4]) << 16 |
-            ((uint32_t)br->next_in[5]) << 8 |
-             (uint32_t)br->next_in[6];
+            ((uint64_t)br->next_in[3]) << 24 |
+            ((uint64_t)br->next_in[4]) << 16 |
+            ((uint64_t)br->next_in[5]) << 8 |
+             (uint64_t)br->next_in[6];
         br->next_in += 7;
         br->avail_in -= 7;
         br->cache_avail += 7 * 8;
@@ -548,10 +548,10 @@ rar_br_fillup(struct archive_read *a, struct rar_br *br)
            (br->cache_buffer << 48) |
             ((uint64_t)br->next_in[0]) << 40 |
             ((uint64_t)br->next_in[1]) << 32 |
-            ((uint32_t)br->next_in[2]) << 24 |
-            ((uint32_t)br->next_in[3]) << 16 |
-            ((uint32_t)br->next_in[4]) << 8 |
-             (uint32_t)br->next_in[5];
+            ((uint64_t)br->next_in[2]) << 24 |
+            ((uint64_t)br->next_in[3]) << 16 |
+            ((uint64_t)br->next_in[4]) << 8 |
+             (uint64_t)br->next_in[5];
         br->next_in += 6;
         br->avail_in -= 6;
         br->cache_avail += 6 * 8;

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -1142,7 +1142,7 @@ canonical_charset_name(const char *charset)
 			c -= 'a' - 'A';
 		*p++ = c;
 	}
-	*p++ = '\0';
+	*p = '\0';
 
 	if (strcmp(cs, "UTF-8") == 0 ||
 	    strcmp(cs, "UTF8") == 0)

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -4576,7 +4576,7 @@ set_xattrs(struct archive_write_disk *a)
 	struct archive_string errlist;
 	int ret = ARCHIVE_OK;
 	int i = archive_entry_xattr_reset(entry);
-	short fail = 0;
+	int fail = 0;
 
 	archive_string_init(&errlist);
 
@@ -4633,7 +4633,7 @@ set_xattrs(struct archive_write_disk *a)
 				e = extattr_set_fd(a->fd, namespace, name,
 				    value, size);
 				if (e == 0 && errno == 0) {
-					e = size;
+					e = (int)size;
 				}
 			} else {
 				e = extattr_set_link(

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -60,7 +60,7 @@ static int	write_header(struct archive_write *, struct archive_entry *);
 
 struct cpio {
 	uint64_t	  entry_bytes_remaining;
-	int		  padding;
+	size_t		  padding;
 
 	struct archive_string_conv *opt_sconv;
 	struct archive_string_conv *sconv_default;
@@ -98,7 +98,7 @@ struct cpio {
 #define	c_header_size 110
 
 /* Logic trick: difference between 'n' and next multiple of 4 */
-#define PAD4(n)	(3 & (1 + ~(n)))
+#define PAD4(n)	(3U & (1U + ~(n)))
 
 /*
  * Set output format to 'cpio' format.
@@ -219,12 +219,11 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	int64_t ino;
 	struct cpio *cpio;
 	const char *p, *path;
-	int pathlength, ret, ret_final;
+	int ret, ret_final;
 	char h[c_header_size];
 	struct archive_string_conv *sconv;
 	struct archive_entry *entry_main;
-	size_t len;
-	int pad;
+	size_t len, pad, pathlength;
 
 	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
@@ -261,7 +260,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		    archive_string_conversion_charset_name(sconv));
 		ret_final = ARCHIVE_WARN;
 	}
-	pathlength = (int)len + 1; /* Include trailing null. */
+	pathlength = len + 1; /* Include trailing null. */
 
 	memset(h, 0, c_header_size);
 	format_hex(0x070701, h + c_magic_offset, c_magic_size);
@@ -349,7 +348,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	}
 
 	cpio->entry_bytes_remaining = archive_entry_size(entry);
-	cpio->padding = (int)PAD4(cpio->entry_bytes_remaining);
+	cpio->padding = (size_t)PAD4(cpio->entry_bytes_remaining);
 
 	/* Write the symlink now. */
 	if (p != NULL  &&  *p != '\0') {

--- a/libarchive/test/test_acl_platform_nfs4.c
+++ b/libarchive/test/test_acl_platform_nfs4.c
@@ -561,7 +561,6 @@ acl_match(acl_entry_t aclent, struct myacl_t *myacl)
 	if (perms != myacl->permset)
 		return (0);
 
-	r = 0;
 	switch (tag_type) {
 	case ACL_EXTENDED_ALLOW:
 		if (myacl->type != ARCHIVE_ENTRY_ACL_TYPE_ALLOW)

--- a/libarchive/test/test_fuzz.c
+++ b/libarchive/test/test_fuzz.c
@@ -160,7 +160,7 @@ test_fuzz(const struct files *filesets)
 			q = (int)size / 100;
 			if (q < 4)
 				q = 4;
-			numbytes = (int)(rand() % q);
+			numbytes = rand() % q;
 			for (j = 0; j < numbytes; ++j)
 				image[rand() % size] = (char)rand();
 

--- a/libarchive/xxhash.c
+++ b/libarchive/xxhash.c
@@ -393,7 +393,7 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (void* state_in, const void* inpu
             state->v1 += XXH_readLE32(p32, endian) * PRIME32_2; state->v1 = XXH_rotl32(state->v1, 13); state->v1 *= PRIME32_1; p32++;
             state->v2 += XXH_readLE32(p32, endian) * PRIME32_2; state->v2 = XXH_rotl32(state->v2, 13); state->v2 *= PRIME32_1; p32++;
             state->v3 += XXH_readLE32(p32, endian) * PRIME32_2; state->v3 = XXH_rotl32(state->v3, 13); state->v3 *= PRIME32_1; p32++;
-            state->v4 += XXH_readLE32(p32, endian) * PRIME32_2; state->v4 = XXH_rotl32(state->v4, 13); state->v4 *= PRIME32_1; p32++;
+            state->v4 += XXH_readLE32(p32, endian) * PRIME32_2; state->v4 = XXH_rotl32(state->v4, 13); state->v4 *= PRIME32_1;
         }
         p += 16-state->memsize;
         state->memsize = 0;

--- a/tar/subst.c
+++ b/tar/subst.c
@@ -273,7 +273,7 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result,
 				case '8':
 				case '9':
 					realloc_strncat(result, rule->result + j, i - j - 1);
-					if ((size_t)(c - '0') > (size_t)(rule->re.re_nsub)) {
+					if ((size_t)(c - '0') > rule->re.re_nsub) {
 						free(buffer);
 						free(*result);
 						*result = NULL;

--- a/tar/write.c
+++ b/tar/write.c
@@ -302,7 +302,7 @@ tar_mode_r(struct bsdtar *bsdtar)
 		    cset_get_format(bsdtar->cset));
 		/* ... complain if it's not compatible. */
 		format &= ARCHIVE_FORMAT_BASE_MASK;
-		if (format != (int)(archive_format(a) & ARCHIVE_FORMAT_BASE_MASK)
+		if (format != (archive_format(a) & ARCHIVE_FORMAT_BASE_MASK)
 		    && format != ARCHIVE_FORMAT_EMPTY) {
 			lafe_errc(1, 0,
 			    "Format %s is incompatible with the archive %s.",


### PR DESCRIPTION
This fixes a couple of warnings raised by clang-tidy.

Addendum: When I wrote this, I was under the impression that clang-tidy warnings were compiler warnings.

I now know that this isn't necessarily true. Clang-tidy is part of LLVM but technically separate from clang.