### PR TITLE
Always close open file handle in archive_write_finish_entry

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1747,9 +1747,10 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		 * to see what happened.
 		 */
 		a->pst = NULL;
-		if ((ret = lazy_stat(a)) != ARCHIVE_OK)
-			close_file_descriptor(a);
-			return (ret);
+        if ((ret = lazy_stat(a)) != ARCHIVE_OK) {
+            close_file_descriptor(a);
+            return (ret);
+        }
 		/* We can use lseek()/write() to extend the file if
 		 * ftruncate didn't work or isn't available. */
 		if (a->st.st_size < a->filesize) {

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1727,7 +1727,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 				r = hfs_write_data_block(
 				    a, null_d, a->file_remaining_bytes);
 			if (r < 0)
-                close_file_descriptor(a);
+				close_file_descriptor(a);
 				return ((int)r);
 		}
 #endif
@@ -1737,7 +1737,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		    a->filesize == 0) {
 			archive_set_error(&a->archive, errno,
 			    "File size could not be restored");
-            close_file_descriptor(a);
+			close_file_descriptor(a);
 			return (ARCHIVE_FAILED);
 		}
 #endif
@@ -1748,7 +1748,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		 */
 		a->pst = NULL;
 		if ((ret = lazy_stat(a)) != ARCHIVE_OK)
-            close_file_descriptor(a);
+			close_file_descriptor(a);
 			return (ret);
 		/* We can use lseek()/write() to extend the file if
 		 * ftruncate didn't work or isn't available. */
@@ -1757,13 +1757,13 @@ _archive_write_disk_finish_entry(struct archive *_a)
 			if (lseek(a->fd, a->filesize - 1, SEEK_SET) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Seek failed");
-                close_file_descriptor(a);
+				close_file_descriptor(a);
 				return (ARCHIVE_FATAL);
 			}
 			if (write(a->fd, &nul, 1) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Write to restore size failed");
-                close_file_descriptor(a);
+				close_file_descriptor(a);
 				return (ARCHIVE_FATAL);
 			}
 			a->pst = NULL;
@@ -4718,10 +4718,10 @@ archive_write_disk_set_acls(struct archive *a, int fd, const char *name,
  */
 static void close_file_descriptor(struct archive_write_disk* a)
 {
-    if (a->fd >= 0) {
-        close(a->fd);
-        a->fd = -1;
-    }
+	if (a->fd >= 0) {
+		close(a->fd);
+		a->fd = -1;
+	}
 }
 
 

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1727,7 +1727,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 				r = hfs_write_data_block(
 				    a, null_d, a->file_remaining_bytes);
 			if (r < 0)
-                close_file_descriptor(a->fd);
+                close_file_descriptor(a);
 				return ((int)r);
 		}
 #endif
@@ -1737,7 +1737,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		    a->filesize == 0) {
 			archive_set_error(&a->archive, errno,
 			    "File size could not be restored");
-            close_file_descriptor(a->fd);
+            close_file_descriptor(a);
 			return (ARCHIVE_FAILED);
 		}
 #endif
@@ -1748,7 +1748,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		 */
 		a->pst = NULL;
 		if ((ret = lazy_stat(a)) != ARCHIVE_OK)
-            close_file_descriptor(a->fd);
+            close_file_descriptor(a);
 			return (ret);
 		/* We can use lseek()/write() to extend the file if
 		 * ftruncate didn't work or isn't available. */
@@ -1757,13 +1757,13 @@ _archive_write_disk_finish_entry(struct archive *_a)
 			if (lseek(a->fd, a->filesize - 1, SEEK_SET) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Seek failed");
-                close_file_descriptor(a->fd);
+                close_file_descriptor(a);
 				return (ARCHIVE_FATAL);
 			}
 			if (write(a->fd, &nul, 1) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Write to restore size failed");
-                close_file_descriptor(a->fd);
+                close_file_descriptor(a);
 				return (ARCHIVE_FATAL);
 			}
 			a->pst = NULL;

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -397,6 +397,7 @@ static int	set_times_from_entry(struct archive_write_disk *);
 static struct fixup_entry *sort_dir_list(struct fixup_entry *p);
 static ssize_t	write_data_block(struct archive_write_disk *,
 		    const char *, size_t);
+static void close_file_descriptor(struct archive_write_disk *);
 
 static int	_archive_write_disk_close(struct archive *);
 static int	_archive_write_disk_free(struct archive *);
@@ -1726,6 +1727,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 				r = hfs_write_data_block(
 				    a, null_d, a->file_remaining_bytes);
 			if (r < 0)
+                close_file_descriptor(a->fd);
 				return ((int)r);
 		}
 #endif
@@ -1735,6 +1737,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		    a->filesize == 0) {
 			archive_set_error(&a->archive, errno,
 			    "File size could not be restored");
+            close_file_descriptor(a->fd);
 			return (ARCHIVE_FAILED);
 		}
 #endif
@@ -1745,6 +1748,7 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		 */
 		a->pst = NULL;
 		if ((ret = lazy_stat(a)) != ARCHIVE_OK)
+            close_file_descriptor(a->fd);
 			return (ret);
 		/* We can use lseek()/write() to extend the file if
 		 * ftruncate didn't work or isn't available. */
@@ -1753,11 +1757,13 @@ _archive_write_disk_finish_entry(struct archive *_a)
 			if (lseek(a->fd, a->filesize - 1, SEEK_SET) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Seek failed");
+                close_file_descriptor(a->fd);
 				return (ARCHIVE_FATAL);
 			}
 			if (write(a->fd, &nul, 1) < 0) {
 				archive_set_error(&a->archive, errno,
 				    "Write to restore size failed");
+                close_file_descriptor(a->fd);
 				return (ARCHIVE_FATAL);
 			}
 			a->pst = NULL;
@@ -4706,6 +4712,18 @@ archive_write_disk_set_acls(struct archive *a, int fd, const char *name,
 	return (ARCHIVE_OK);
 }
 #endif
+
+/*
+ * Close the file descriptor if one is open.
+ */
+static void close_file_descriptor(struct archive_write_disk* a)
+{
+    if (a->fd >= 0) {
+        close(a->fd);
+        a->fd = -1;
+    }
+}
+
 
 #endif /* !_WIN32 || __CYGWIN__ */
 

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1185,8 +1185,8 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		if (la_ftruncate(a->fh, a->filesize) == -1) {
 			archive_set_error(&a->archive, errno,
 			    "File size could not be restored");
-            CloseHandle(a->fh);
-            a->fh = INVALID_HANDLE_VALUE;
+			CloseHandle(a->fh);
+			a->fh = INVALID_HANDLE_VALUE;
 			return (ARCHIVE_FAILED);
 		}
 	}

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1185,6 +1185,8 @@ _archive_write_disk_finish_entry(struct archive *_a)
 		if (la_ftruncate(a->fh, a->filesize) == -1) {
 			archive_set_error(&a->archive, errno,
 			    "File size could not be restored");
+            CloseHandle(a->fh);
+            a->fh = INVALID_HANDLE_VALUE;
 			return (ARCHIVE_FAILED);
 		}
 	}


### PR DESCRIPTION
### Summary
This pull requests fixes the issue described in #1852. Now, `archive_write_finish_entry` always closes open file handles even if one of its operations fails.

### Description
Prior to this pull request, `archive_write_finish_entry` would not close open file if it ran into an error. For example, if `archive_write_finish_entry` could not pad the entry due to insufficient disk space, `archive_write_finish_entry` would return without closing the file handle. On Windows, this made it impossible to delete the file until the program finished running. Please refer to the description in #1852 for a detailed example.

### Solution
Now, `archive_write_finish_entry` always closes the file handle no matter what. 

**NOTE:** I made this change to both the posix and windows implementations `archive_write_finish_entry`. While posix does not have the same limitation as windows (i.e. you can delete files with open file handles), I still think it is a bug to leave the file handles open before returning. 

### Testing
I was unable to write an automated test case for this change because the error only occurs when there is not enough disk space. However, I did manually confirm the issue is fixed on Windows using the same reproduction steps described in #1852.

### Legal Disclaimer
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY.



 