### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ used before a patch is released.
 
 You may submit the report in the following ways:
 
-- send an email to ???@???; and/or
+- send an email to security@libarchive.de; and/or
 - send us a [private vulnerability report](https://github.com/libarchive/libarchive/security/advisories/new)
 
 Please provide the following information in your report:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/libarchive/libarchive/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such, we ask
+that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #1865.

This PR defines a security policy for the project. See the linked issue for further details.

I couldn't find a relevant email or website, so I've left a placeholder for now. Let me know what you want to use or if you'd rather only use one mode of reporting (only GitHub private reporting or only email, it's your call!).

I've also left a 90-day remediation timeline, which is pretty standard. But let me know if you'd rather change this or anything else!