### PR TITLE
Fix the build with libressl-devel <2.7

### DIFF
--- a/libarchive/archive_openssl_evp_private.h
+++ b/libarchive/archive_openssl_evp_private.h
@@ -33,7 +33,8 @@
 #include <openssl/evp.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memset */
 static inline EVP_MD_CTX *EVP_MD_CTX_new(void)


### PR DESCRIPTION
This change is similar to what was done in
5da00ad75b09e262774ec3675bbe4d5a4502a852.

Co-authored by:	Greg Lewis <glewis@FreeBSD.org>
Co-authored by:	Piotr Kubaj <pkubaj@anongoth.pl>
Obtained from:	FreeBSD ports (9fcaa71e4675d12dc3c9a5895edd68610e03cbcd)
Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>