### PR TITLE
Fix FreeBSD builds with WARNS=6

### DIFF
--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -231,15 +231,20 @@ static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-	OSSL_PARAM params[2];
+	EVP_MAC *mac;
 
-	EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+	char sha1[] = "SHA1";
+	OSSL_PARAM params[] = {
+		OSSL_PARAM_utf8_string("digest", sha1, sizeof(sha1) - 1),
+		OSSL_PARAM_END
+	};
+
+	mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
 	*ctx = EVP_MAC_CTX_new(mac);
+	EVP_MAC_free(mac);
 	if (*ctx == NULL)
 		return -1;
-	EVP_MAC_free(mac);
-	params[0] = OSSL_PARAM_construct_utf8_string("digest", "SHA1", 0);
-	params[1] = OSSL_PARAM_construct_end();
+
 	EVP_MAC_init(*ctx, key, key_len, params);
 #else
 	*ctx = HMAC_CTX_new();

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -77,6 +77,8 @@ typedef	struct hmac_sha1_ctx archive_hmac_sha1_ctx;
 #include <openssl/opensslv.h>
 #include <openssl/hmac.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/params.h>
+
 typedef EVP_MAC_CTX *archive_hmac_sha1_ctx;
 
 #else


### PR DESCRIPTION
WARNS=6 on FreeBSD passes several CFLAGS that causes the previous code to fail with `-Wincompatible-pointer-types-discards-qualifiers` when compiled with clang.

This particular change adjusts the code to be
`-Wincompatible-pointer-types-discards-qualifiers` clean. This change changes the calls to use OSSL_PARAM macro abbreviated calls, instead of calling more verbose (and less documented) callers.

While here, also address a `mac` object leak if `ctx` cannot be allocated cleanly by always free'ing `mac` after it's been attached to `ctx`.

Co-authored-by: Pierre Pronchery <pierre@freebsdfoundation.org>
Sponsored by:	The FreeBSD Foundation
Signed-off-by:	Enji Cooper <yaneurabeya@gmail.com>