### PR TITLE
Disable program call with stdin/stdout usage on UWP builds

### DIFF
--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -31,6 +31,7 @@
 
 #include "filter_fork.h"
 
+#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 /* There are some editions of Windows ("nano server," for example) that
  * do not host user32.dll. If we want to keep running on those editions,
  * we need to delay-load WaitForInputIdle. */
@@ -224,6 +225,14 @@ fail:
 	__archive_cmdline_free(acmd);
 	return ARCHIVE_FAILED;
 }
+#else /* !WINAPI_PARTITION_DESKTOP */
+int
+__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout, HANDLE *out_child)
+{
+	(void)cmd; (void)child_stdin; (void) child_stdout; (void) out_child;
+	return ARCHIVE_FAILED;
+}
+#endif /* !WINAPI_PARTITION_DESKTOP */
 
 void
 __archive_check_child(int in, int out)


### PR DESCRIPTION
Some calls are not allowed:
* WaitForInputIdle [1]
* SetHandleInformation [2]
* STARTF_XXX flags for CreateProcess are not allowed

[1] https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-waitforinputidle#requirements
[2] https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-sethandleinformation#requirements