### PR TITLE
archive_read_set_options.3: document zip options

### DIFF
--- a/libarchive/archive_read_set_options.3
+++ b/libarchive/archive_read_set_options.3
@@ -255,6 +255,26 @@ have been concatenated together.
 Without this option, only the contents of
 the first concatenated archive would be read.
 .El
+.It Format zip
+.Bl -tag -compact -width indent
+.It Cm compat-2x
+Libarchive 2.x incorrectly encoded Unicode filenames on
+some platforms.
+This option mimics the libarchive 2.x filename handling
+so that such archives can be read correctly.
+.It Cm hdrcharset
+The value is used as a character set name that will be
+used when translating file names.
+.It Cm ignorecrc32
+Skip the CRC32 check.
+Mostly used for testing.
+.It Cm mac-ext
+Support Mac OS metadata extension that records data in special
+files beginning with a period and underscore.
+Defaults to enabled on Mac OS, disabled on other platforms.
+Use
+.Cm !mac-ext
+to disable.
 .El
 .\"
 .Sh ERRORS

--- a/libarchive/archive_read_set_options.3
+++ b/libarchive/archive_read_set_options.3
@@ -276,6 +276,7 @@ Use
 .Cm !mac-ext
 to disable.
 .El
+.El
 .\"
 .Sh ERRORS
 Detailed error codes and textual descriptions are available from the


### PR DESCRIPTION
We accept options in the source but are not documenting them. People are going to wonder whether they can open a Windows ZIP encoded in whatever code page without mojibake. That would also be important for #1873, because upstream unzip beta technically has an encoding option now.

The page is getting a bit repetitive, but what can I do?