### PR TITLE
Upgrade failing FreeBSD 12.3 (EOL) CI jobs to 12.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ FreeBSD_task:
     freebsd_instance:
       image_family: freebsd-13-1
     freebsd_instance:
-      image_family: freebsd-12-3
+      image_family: freebsd-12-4
   prepare_script:
   - ./build/ci/cirrus_ci/ci.sh prepare
   configure_script:


### PR DESCRIPTION
The freebsd-12-3 CI jobs seem to be failing on all PRs at the moment.

According to https://www.freebsd.org/releases/ 12.3 is EOL, so let's try updating these to 12.4 which is still supported.