### PR TITLE
Add header file path configuration for libarchive_static in cmake

### DIFF
--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -251,6 +251,7 @@ SET_TARGET_PROPERTIES(archive PROPERTIES SOVERSION ${SOVERSION})
 # archive_static is a static library
 ADD_LIBRARY(archive_static STATIC ${libarchive_SOURCES} ${include_HEADERS})
 TARGET_LINK_LIBRARIES(archive_static ${ADDITIONAL_LIBS})
+TARGET_INCLUDE_DIRECTORIES(archive_static  PUBLIC .)
 SET_TARGET_PROPERTIES(archive_static PROPERTIES COMPILE_DEFINITIONS
   LIBARCHIVE_STATIC)
 # On Posix systems, libarchive.so and libarchive.a can co-exist.

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -451,7 +451,8 @@ archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_zstd_flush(struct archive_write_filter *f)
 {
-
+        // Silence unused-parameter compiler warnings.
+        (void)f;
 	return (ARCHIVE_OK);
 }
 


### PR DESCRIPTION
The dynamic library of libarchive has the path configuration of the header file, and the static library also needs to have it.
In this way, when the external library uses target_link_library(xxx archive_static), it can indirectly include the header file