### PR TITLE
fix unused variable error if no zstd

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -451,6 +451,7 @@ archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_zstd_flush(struct archive_write_filter *f)
 {
+	(void)f; /* UNUSED */
 
 	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
Happens when no libzstd found.