### PR TITLE
fixed: No libarchiveConfig.cmake file after build and install with th…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2089,6 +2089,12 @@ IF(ENABLE_TEST)
   ADD_CUSTOM_TARGET(run_all_tests)
 ENDIF(ENABLE_TEST)
 
+IF(ENABLE_INSTALL)
+  INSTALL(EXPORT libarchive_target
+          FILE libarchiveConfig.cmake
+          DESTINATION share/cmake/Libarchive)
+ENDIF(ENABLE_INSTALL)
+
 add_subdirectory(libarchive)
 add_subdirectory(cat)
 add_subdirectory(tar)

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -244,7 +244,7 @@ ENDIF()
 
 # Libarchive is a shared library
 ADD_LIBRARY(archive SHARED ${libarchive_SOURCES} ${include_HEADERS})
-TARGET_INCLUDE_DIRECTORIES(archive PUBLIC .)
+TARGET_INCLUDE_DIRECTORIES(archive PRIVATE .)
 TARGET_LINK_LIBRARIES(archive ${ADDITIONAL_LIBS})
 SET_TARGET_PROPERTIES(archive PROPERTIES SOVERSION ${SOVERSION})
 
@@ -264,6 +264,8 @@ IF(ENABLE_INSTALL)
           RUNTIME DESTINATION bin
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib)
+  INSTALL(TARGETS archive archive_static
+          EXPORT libarchive_target)
   INSTALL_MAN(${libarchive_MANS})
   INSTALL(FILES ${include_HEADERS} DESTINATION include)
 ENDIF()


### PR DESCRIPTION
using cmake to build and install, No libarchiveConfig.cmake file is in prefix directory.
Fixed: libarchiveConfig.cmake Will be in ${PREFIX}/share/cmake/Libarchive/ directory
