### PR TITLE
Replace `svfs.f_namelen` with `svfs.f_namemax`

### DIFF
--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1866,7 +1866,7 @@ setup_current_filesystem(struct archive_read_disk *a)
 #if defined(USE_READDIR_R)
 	/* Set maximum filename length. */
 #if defined(HAVE_STATVFS)
-	t->current_filesystem->name_max = svfs.f_namelen;
+	t->current_filesystem->name_max = svfs.f_namemax;
 #else
 	t->current_filesystem->name_max = sfs.f_namelen;
 #endif


### PR DESCRIPTION
When compile 3.7.0 with CentOS 7 coming with below error message:

    libarchive/archive_read_disk_posix.c:1869:40: error: 'struct statvfs' has no member named 'f_namelen'

The equivalent for `f_namelen` in struct statvfs is `f_namemax`.

See http://landley.net/mantis/mantis-346.html