### PR TITLE
Fix various VS2019 compiler warnings

### DIFF
--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -230,7 +230,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 
 	/* Empty our output buffer. */
 	state->stream.next_out = state->out_block;
-	state->stream.avail_out = state->out_block_size;
+	state->stream.avail_out = (uint32_t)state->out_block_size;
 
 	/* Try to fill the output buffer. */
 	for (;;) {
@@ -288,7 +288,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 			return (ARCHIVE_FATAL);
 		}
 		state->stream.next_in = (char *)(uintptr_t)read_buf;
-		state->stream.avail_in = ret;
+		state->stream.avail_in = (uint32_t)ret;
 		/* There is no more data, return whatever we have. */
 		if (ret == 0) {
 			state->eof = 1;

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -584,7 +584,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 		    state->out_block + prefix64k, (int)compressed_size,
 		    state->flags.block_maximum_size,
 		    state->out_block,
-		    prefix64k);
+		    (int)prefix64k);
 #else
 		uncompressed_size = LZ4_decompress_safe_withPrefix64k(
 		    read_buf + 4,

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1477,9 +1477,9 @@ decompress(struct archive_read *a, struct _7zip *zip,
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	case _7Z_BZ2:
 		zip->bzstream.next_in = (char *)(uintptr_t)t_next_in;
-		zip->bzstream.avail_in = t_avail_in;
+		zip->bzstream.avail_in = (uint32_t)t_avail_in;
 		zip->bzstream.next_out = (char *)(uintptr_t)t_next_out;
-		zip->bzstream.avail_out = t_avail_out;
+		zip->bzstream.avail_out = (uint32_t)t_avail_out;
 		r = BZ2_bzDecompress(&(zip->bzstream));
 		switch (r) {
 		case BZ_STREAM_END: /* Found end of stream. */
@@ -3833,7 +3833,7 @@ arm_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 		}
 	}
 
-	zip->bcj_ip += i;
+	zip->bcj_ip += (uint32_t)i;
 
 	return i;
 }
@@ -3896,7 +3896,7 @@ arm64_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 		}
 	}
 
-	zip->bcj_ip += i;
+	zip->bcj_ip += (uint32_t)i;
 
 	return i;
 }

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1062,7 +1062,7 @@ archive_read_format_rar_read_header(struct archive_read *a,
 		      return (ARCHIVE_FATAL);
 	      }
 	      p = h;
-	      crc32_val = crc32(crc32_val, (const unsigned char *)p, to_read);
+	      crc32_val = crc32(crc32_val, (const unsigned char *)p, (unsigned int)to_read);
 	      __archive_read_consume(a, to_read);
 	      skip -= to_read;
       }
@@ -3437,7 +3437,7 @@ compile_program(const uint8_t *bytes, size_t length)
   prog = calloc(1, sizeof(*prog));
   if (!prog)
     return NULL;
-  prog->fingerprint = crc32(0, bytes, length) | ((uint64_t)length << 32);
+  prog->fingerprint = crc32(0, bytes, (unsigned int)length) | ((uint64_t)length << 32);
 
   if (membr_bits(&br, 1))
   {

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2475,7 +2475,7 @@ static void update_crc(struct rar5* rar, const uint8_t* p, size_t to_read) {
 		 * `stored_crc32` info filled in. */
 		if(rar->file.stored_crc32 > 0) {
 			rar->file.calculated_crc32 =
-				crc32(rar->file.calculated_crc32, p, to_read);
+				crc32(rar->file.calculated_crc32, p, (unsigned int)to_read);
 		}
 
 		/* Check if the file uses an optional BLAKE2sp checksum

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -2186,11 +2186,11 @@ zip_read_data_zipx_bzip2(struct archive_read *a, const void **buff,
 
 	/* Setup buffer boundaries. */
 	zip->bzstream.next_in = (char*)(uintptr_t) compressed_buff;
-	zip->bzstream.avail_in = in_bytes;
+	zip->bzstream.avail_in = (uint32_t)in_bytes;
 	zip->bzstream.total_in_hi32 = 0;
 	zip->bzstream.total_in_lo32 = 0;
 	zip->bzstream.next_out = (char*) zip->uncompressed_buffer;
-	zip->bzstream.avail_out = zip->uncompressed_buffer_size;
+	zip->bzstream.avail_out = (uint32_t)zip->uncompressed_buffer_size;
 	zip->bzstream.total_out_hi32 = 0;
 	zip->bzstream.total_out_lo32 = 0;
 

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -190,7 +190,7 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 
 	memset(&data->stream, 0, sizeof(data->stream));
 	data->stream.next_out = data->compressed;
-	data->stream.avail_out = data->compressed_buffer_size;
+	data->stream.avail_out = (uint32_t)data->compressed_buffer_size;
 	f->write = archive_compressor_bzip2_write;
 
 	/* Initialize compression library */
@@ -244,7 +244,7 @@ archive_compressor_bzip2_write(struct archive_write_filter *f,
 
 	/* Compress input data to output buffer */
 	SET_NEXT_IN(data, buff);
-	data->stream.avail_in = length;
+	data->stream.avail_in = (uint32_t)length;
 	if (drive_compressor(f, data, 0))
 		return (ARCHIVE_FATAL);
 	return (ARCHIVE_OK);
@@ -313,7 +313,7 @@ drive_compressor(struct archive_write_filter *f,
 				return (ARCHIVE_FATAL);
 			}
 			data->stream.next_out = data->compressed;
-			data->stream.avail_out = data->compressed_buffer_size;
+			data->stream.avail_out = (uint32_t)data->compressed_buffer_size;
 		}
 
 		/* If there's nothing to do, we're done. */

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -518,10 +518,10 @@ drive_compressor_independence(struct archive_write_filter *f, const char *p,
 	} else {
 		/* The buffer is not compressed. The compressed size was
 		 * bigger than its uncompressed size. */
-		archive_le32enc(data->out, length | 0x80000000);
+		archive_le32enc(data->out, (uint32_t)(length | 0x80000000));
 		data->out += 4;
 		memcpy(data->out, p, length);
-		outsize = length;
+		outsize = (uint32_t)length;
 	}
 	data->out += outsize;
 	if (data->block_checksum) {
@@ -603,10 +603,10 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 	} else {
 		/* The buffer is not compressed. The compressed size was
 		 * bigger than its uncompressed size. */
-		archive_le32enc(data->out, length | 0x80000000);
+		archive_le32enc(data->out, (uint32_t)(length | 0x80000000));
 		data->out += 4;
 		memcpy(data->out, p, length);
-		outsize = length;
+		outsize = (uint32_t)length;
 	}
 	data->out += outsize;
 	if (data->block_checksum) {

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -214,7 +214,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		if (level < minimum || level > maximum) {
 			return (ARCHIVE_WARN);
 		}
-		data->compression_level = level;
+		data->compression_level = (int)level;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "threads") == 0) {
 		intmax_t threads;
@@ -224,7 +224,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		if (threads < 0) {
 			return (ARCHIVE_WARN);
 		}
-		data->threads = threads;
+		data->threads = (int)threads;
 		return (ARCHIVE_OK);
 #if HAVE_ZSTD_H && HAVE_LIBZSTD_COMPRESSOR
 	} else if (strcmp(key, "frame-per-file") == 0) {

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1809,11 +1809,11 @@ compression_init_encoder_bzip2(struct archive *a,
 	 * of ugly hackery to convert a const * pointer to
 	 * a non-const pointer. */
 	strm->next_in = (char *)(uintptr_t)(const void *)lastrm->next_in;
-	strm->avail_in = lastrm->avail_in;
+	strm->avail_in = (uint32_t)lastrm->avail_in;
 	strm->total_in_lo32 = (uint32_t)(lastrm->total_in & 0xffffffff);
 	strm->total_in_hi32 = (uint32_t)(lastrm->total_in >> 32);
 	strm->next_out = (char *)lastrm->next_out;
-	strm->avail_out = lastrm->avail_out;
+	strm->avail_out = (uint32_t)lastrm->avail_out;
 	strm->total_out_lo32 = (uint32_t)(lastrm->total_out & 0xffffffff);
 	strm->total_out_hi32 = (uint32_t)(lastrm->total_out >> 32);
 	if (BZ2_bzCompressInit(strm, level, 0, 30) != BZ_OK) {
@@ -1842,11 +1842,11 @@ compression_code_bzip2(struct archive *a,
 	 * of ugly hackery to convert a const * pointer to
 	 * a non-const pointer. */
 	strm->next_in = (char *)(uintptr_t)(const void *)lastrm->next_in;
-	strm->avail_in = lastrm->avail_in;
+	strm->avail_in = (uint32_t)lastrm->avail_in;
 	strm->total_in_lo32 = (uint32_t)(lastrm->total_in & 0xffffffff);
 	strm->total_in_hi32 = (uint32_t)(lastrm->total_in >> 32);
 	strm->next_out = (char *)lastrm->next_out;
-	strm->avail_out = lastrm->avail_out;
+	strm->avail_out = (uint32_t)lastrm->avail_out;
 	strm->total_out_lo32 = (uint32_t)(lastrm->total_out & 0xffffffff);
 	strm->total_out_hi32 = (uint32_t)(lastrm->total_out >> 32);
 	r = BZ2_bzCompress(strm,


### PR DESCRIPTION
This PR fixes a bunch of warnings I saw while building with VS2019. I also included some lz4 warning fixes, where I lost track of the warning messages (the changes look ok to me, but I can drop them from the PR if you prefer).

```
libarchive\archive_digest.c(113,12): warning C4267: 'function': conversion from 'size_t' to 'ULONG', possible loss of data
libarchive\archive_random.c(96,44): warning C4267: 'function': conversion from 'size_t' to 'ULONG', possible loss of data
libarchive\archive_read_support_filter_bzip2.c(233,49): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_read_support_filter_bzip2.c(291,31): warning C4244: '=': conversion from 'int64_t' to 'unsigned int', possible loss of data
libarchive\archive_read_support_format_7zip.c(1480,38): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_read_support_format_7zip.c(1482,40): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
okken\Desktop\libarchive-fake7za\libarchive\archive_read_support_format_7zip.c(3899,18): warning C4267: '+=': conversion from 'size_t' to 'uint32_t', possible loss of data
libarchive\archive_read_support_format_rar.c(1065,70): warning C4267: 'function': conversion from 'size_t' to 'uInt', possible loss of data
libarchive\archive_read_support_format_rar.c(3440,45): warning C4267: 'function': conversion from 'size_t' to 'uInt', possible loss of data
libarchive\archive_read_support_format_rar5.c(2478,49): warning C4267: 'function': conversion from 'size_t' to 'uInt', possible loss of data
libarchive\archive_read_support_format_zip.c(2189,35): warning C4244: '=': conversion from 'int64_t' to 'unsigned int', possible loss of data
libarchive\archive_read_support_format_zip.c(2193,57): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_add_filter_bzip2.c(193,55): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_add_filter_bzip2.c(247,32): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_add_filter_bzip2.c(316,57): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_add_filter_zstd.c(217,34): warning C4244: '=': conversion from 'intmax_t' to 'int', possible loss of data
libarchive\archive_write_add_filter_zstd.c(227,26): warning C4244: '=': conversion from 'intmax_t' to 'int', possible loss of data
libarchive\archive_write_set_format_7zip.c(1812,35): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_set_format_7zip.c(1816,37): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_set_format_7zip.c(1845,35): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
libarchive\archive_write_set_format_7zip.c(1849,37): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
```