### PR TITLE
Fix sanitizer complaint about unsigned underflow in header_newc

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -637,7 +637,7 @@ header_newc(struct archive_read *a, struct cpio *cpio,
 	archive_entry_set_mtime(entry, atol16(header + newc_mtime_offset, newc_mtime_size), 0);
 	*namelength = (size_t)atol16(header + newc_namesize_offset, newc_namesize_size);
 	/* Pad name to 2 more than a multiple of 4. */
-	*name_pad = (2 - *namelength) & 3;
+	*name_pad = 6 - (*namelength & 3);
 
 	/* Make sure that the padded name length fits into size_t. */
 	if (*name_pad > SIZE_MAX - *namelength) {


### PR DESCRIPTION
The integer sanitizer on clang was complaining about *name_pad = (2 - *namelength) & 3;

Replace with the equivalent 6 - (*namelength & 3), derived from  2 + 4 - (*namelength & 3).