### PR TITLE
Add threads write option for zstd to man pages

### DIFF
--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -257,6 +257,11 @@ If supported, the default value is read from
 The value is interpreted as a decimal integer specifying the
 compression level. Supported values depend on the library version,
 common values are from 1 to 22.
+.It Cm threads
+The value is interpreted as a decimal integer specifying the
+number of threads for multi-threaded zstd compression.
+If set to 0, zstd will attempt to detect and use the number
+of physical CPU cores.
 .El
 .It Format 7zip
 .Bl -tag -compact -width indent


### PR DESCRIPTION
The threads option of zstd is supported by libarchive, but it is missing in the man pages.
Fixes #1951 