### PR TITLE
Fix MSVC warnings on x64

### DIFF
--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -110,7 +110,7 @@ win_crypto_Update(Digest_CTX *ctx, const unsigned char *buf, size_t len)
 #if defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
 	BCryptHashData(ctx->hHash,
 		      (PUCHAR)(uintptr_t)buf,
-		      len, 0);
+		      (ULONG)len, 0);
 #else
 	CryptHashData(ctx->hash,
 		      (unsigned char *)(uintptr_t)buf,

--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -93,7 +93,7 @@ archive_random(void *buf, size_t nbytes)
 	status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RNG_ALGORITHM, NULL, 0);
 	if (!BCRYPT_SUCCESS(status))
 		return ARCHIVE_FAILED;
-	status = BCryptGenRandom(hAlg, buf, nbytes, 0);
+	status = BCryptGenRandom(hAlg, buf, (ULONG)nbytes, 0);
 	BCryptCloseAlgorithmProvider(hAlg, 0);
 	if (!BCRYPT_SUCCESS(status))
 		return ARCHIVE_FAILED;


### PR DESCRIPTION
On Windows x64, `long` & `ulong` are 4 bytes instead of 8 bytes like everywhere else

The arguments to these functions expect a `ULONG` instead of a size_t for some reason
