### PR TITLE
Set read-only workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   MacOS:
     runs-on: macos-13

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master", "3.5" ]
@@ -14,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       security-events: write
 
     strategy:


### PR DESCRIPTION
Fixes #1957.

This PR ensures all workflows run with minimal permissions, instead of with `write-all` permissions. This will protect the project from supply-chain attacks.

The change to codeql.yml is for consistency and future-proofing. Should another job eventually be added to the workflow, it will run with just `contents: read`.