### PR TITLE
fix detection of lzma_stream_encoder_mt with Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,7 +523,7 @@ IF(LIBLZMA_FOUND)
     "#include <lzma.h>\nint main() {return (int)lzma_version_number(); }"
     "WITHOUT_LZMA_API_STATIC;LZMA_API_STATIC")
   CHECK_C_SOURCE_COMPILES(
-    "#include <lzma.h>\n#if LZMA_VERSION < 50020000\n#error unsupported\n#endif\nint main(void){lzma_stream_encoder_mt(0, 0); return 0;}"
+    "#include <lzma.h>\n#if LZMA_VERSION < 50020000\n#error unsupported\n#endif\nint main(void){int ignored __attribute__((unused)); ignored = lzma_stream_encoder_mt(0, 0); return 0;}"
     HAVE_LZMA_STREAM_ENCODER_MT)
   IF(NOT WITHOUT_LZMA_API_STATIC AND LZMA_API_STATIC)
     ADD_DEFINITIONS(-DLZMA_API_STATIC)

--- a/configure.ac
+++ b/configure.ac
@@ -482,7 +482,7 @@ if test "x$with_lzma" != "xno"; then
                        [#if LZMA_VERSION < 50020000]
                        [#error unsupported]
                        [#endif]],
-                      [[lzma_stream_encoder_mt(0, 0);]])],
+                      [[int ignored __attribute__((unused)); ignored = lzma_stream_encoder_mt(0, 0);]])],
       [ac_cv_lzma_has_mt=yes], [ac_cv_lzma_has_mt=no])])
   if test "x$ac_cv_lzma_has_mt" != xno; then
 	  AC_DEFINE([HAVE_LZMA_STREAM_ENCODER_MT], [1], [Define to 1 if you have the `lzma_stream_encoder_mt' function.])


### PR DESCRIPTION
the function is marked as warn-unused-result, so by default in a Debug build with cmake, when Werror is set, this fails to detect. do the same for autotools.   


----

for reference:  
```
        libarchive/x/CMakeFiles/CMakeScratch/TryCompile-ohjfhf/src.c:5:16: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        int main(void){lzma_stream_encoder_mt(0, 0); return 0;}
                       ^~~~~~~~~~~~~~~~~~~~~~ ~~~~
        1 error generated.
```

i think a mere (void) cast works with clang, but afaik does not with gcc (ref https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425), this version should work with both..