### PR TITLE
Preserve the natural order in ISO9660 archives for linked files.

### DIFF
--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -3015,6 +3015,11 @@ heap_add_entry(struct archive_read *a, struct heap_queue *heap,
 	uint64_t file_key, parent_key;
 	int hole, parent;
 
+	/* Reserve 16 bits for possible key collisions (needed for linked items) */
+	/* For ISO files with more than 65535 entries, reordering will still occur */
+	key <<= 16;
+	key += heap->used & 0xFFFF;
+
 	/* Expand our pending files list as necessary. */
 	if (heap->used >= heap->allocated) {
 		struct file_info **new_pending_files;


### PR DESCRIPTION
When an ISO9660 archive contains hard links or sym links, the order of the files in the output of 'bsdtar -tf filename' is not the natural order.

With an extension to the key (while still supporting ISO files up to 2^48 bytes) the sorting order is guaranteed for ISO files that contain linked files for up to 2^16 files in total.