### PR TITLE
Optimize bit handling in archive_compressor_xz_init_stream

### DIFF
--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -106,7 +106,7 @@ write_all_states(char *buff, unsigned int states)
 	*buff = '\0';
 
 	/* A trick for computing the lowest set bit. */
-	while ((lowbit = states & (1 + ~states)) != 0) {
+	while ((lowbit = states & (1U + ~states)) != 0) {
 		states &= ~lowbit;		/* Clear the low bit. */
 		strcat(buff, state_name(lowbit));
 		if (states != 0)

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3277,7 +3277,7 @@ parse_filter(struct archive_read *a, const uint8_t *bytes, uint16_t length, uint
   {
     uint8_t mask = (uint8_t)membr_bits(&br, 7);
     for (i = 0; i < 7; i++)
-      if ((mask & (1 << i)))
+      if ((mask & (1U << i)))
         registers[i] = membr_next_rarvm_number(&br);
   }
 

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -70,6 +70,7 @@
 #endif
 #define NOCRYPT
 #include <windows.h>
+#include <intrin.h>
 //#define	EFTYPE 7
 
 #if defined(__BORLANDC__)

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -245,27 +245,40 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 	} else if (f->code == ARCHIVE_FILTER_LZMA) {
 		ret = lzma_alone_encoder(&(data->stream), &data->lzma_opt);
 	} else {	/* ARCHIVE_FILTER_LZIP */
-		int dict_size = data->lzma_opt.dict_size;
-		int ds, log2dic, wedges;
+		uint32_t dict_size = data->lzma_opt.dict_size;
+		uint32_t wedges;
+		unsigned char ds;
 
 		/* Calculate a coded dictionary size */
-		if (dict_size < (1 << 12) || dict_size > (1 << 29)) {
+		if (dict_size < (1U << 12) || dict_size > (1U << 29)) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "Unacceptable dictionary size for lzip: %d",
 			    dict_size);
 			return (ARCHIVE_FATAL);
 		}
-		for (log2dic = 29; log2dic >= 12; log2dic--) {
-			if (dict_size & (1 << log2dic))
-				break;
+
+		{
+#if __has_builtin(__builtin_clz)
+			int log2dic = 31 - __builtin_clz(dict_size);
+#elif defined(_MSC_VER)
+			unsigned long log2dic;
+			// No need to check return value when dict_size is proven to have at least 1 bit by this point
+			_BitScanReverse(&log2dic, dict_size);
+#else
+			unsigned int log2dic;
+			for (log2dic = 29U; log2dic >= 12U; log2dic--) {
+				if (dict_size & (1U << log2dic))
+					break;
+			}
+#endif
+			if (dict_size > (1U << log2dic)) {
+				log2dic++;
+				wedges = ((1U << log2dic) - dict_size) >> (log2dic - 4);
+			}
+			else
+				wedges = 0;
+			ds = (((wedges << 5) & 0xe0) | (log2dic & 0x1f));
 		}
-		if (dict_size > (1 << log2dic)) {
-			log2dic++;
-			wedges =
-			    ((1 << log2dic) - dict_size) / (1 << (log2dic - 4));
-		} else
-			wedges = 0;
-		ds = ((wedges << 5) & 0xe0) | (log2dic & 0x1f);
 
 		data->crc32 = 0;
 		/* Make a header */
@@ -274,7 +287,7 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 		data->compressed[2] = 0x49;
 		data->compressed[3] = 0x50;
 		data->compressed[4] = 1;/* Version */
-		data->compressed[5] = (unsigned char)ds;
+		data->compressed[5] = ds;
 		data->stream.next_out += 6;
 		data->stream.avail_out -= 6;
 


### PR DESCRIPTION
Add intrin.h for _BitScanReverse. This makes the operations being done much clearer and also faster as well.