### PR TITLE
Remove redundant operations

### DIFF
--- a/cat/bsdcat.c
+++ b/cat/bsdcat.c
@@ -128,7 +128,7 @@ main(int argc, char **argv)
 	bsdcat->argv = argv;
 	bsdcat->argc = argc;
 
-	while ((c = bsdcat_getopt(bsdcat)) != -1) {
+	if ((c = bsdcat_getopt(bsdcat)) != -1) {
 		switch (c) {
 		case 'h':
 			usage(stdout, 0);

--- a/libarchive/archive_cmdline.c
+++ b/libarchive/archive_cmdline.c
@@ -71,7 +71,7 @@ get_argument(struct archive_string *as, const char *p)
 	archive_string_empty(as);
 
 	/* Skip beginning space characters. */
-	while (*s != '\0' && *s == ' ')
+	while (*s == ' ')
 		s++;
 	/* Copy non-space characters. */
 	while (*s != '\0' && *s != ' ') {

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -4630,7 +4630,7 @@ set_xattrs(struct archive_write_disk *a)
 				e = extattr_set_fd(a->fd, namespace, name,
 				    value, size);
 				if (e == 0 && errno == 0) {
-					e = size;
+					e = (int)size;
 				}
 			} else {
 				e = extattr_set_link(

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -296,7 +296,7 @@ archive_write_gnutar_header(struct archive_write *a,
 	/* Only regular files (not hardlinks) have data. */
 	if (archive_entry_hardlink(entry) != NULL ||
 	    archive_entry_symlink(entry) != NULL ||
-	    !(archive_entry_filetype(entry) == AE_IFREG))
+	    archive_entry_filetype(entry) != AE_IFREG)
 		archive_entry_set_size(entry, 0);
 
 	if (AE_IFDIR == archive_entry_filetype(entry)) {

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -267,7 +267,7 @@ archive_write_ustar_header(struct archive_write *a, struct archive_entry *entry)
 	/* Only regular files (not hardlinks) have data. */
 	if (archive_entry_hardlink(entry) != NULL ||
 	    archive_entry_symlink(entry) != NULL ||
-	    !(archive_entry_filetype(entry) == AE_IFREG))
+	    archive_entry_filetype(entry) != AE_IFREG)
 		archive_entry_set_size(entry, 0);
 
 	if (AE_IFDIR == archive_entry_filetype(entry)) {

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -241,7 +241,7 @@ archive_write_v7tar_header(struct archive_write *a, struct archive_entry *entry)
 	/* Only regular files (not hardlinks) have data. */
 	if (archive_entry_hardlink(entry) != NULL ||
 	    archive_entry_symlink(entry) != NULL ||
-	    !(archive_entry_filetype(entry) == AE_IFREG))
+	    archive_entry_filetype(entry) != AE_IFREG)
 		archive_entry_set_size(entry, 0);
 
 	if (AE_IFDIR == archive_entry_filetype(entry)) {


### PR DESCRIPTION
Some operations, like assigning to 0, or breaking after a non-returning function, are redundant and can be removed.