### PR TITLE
Use calloc arguments that correspond with the variable's true purpose

### DIFF
--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -192,7 +192,7 @@ bzip2_reader_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_BZIP2;
 	self->name = "bzip2";
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	out_block = (unsigned char *)malloc(out_block_size);
 	if (state == NULL || out_block == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -218,7 +218,7 @@ compress_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_COMPRESS;
 	self->name = "compress (.Z)";
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	out_block = malloc(out_block_size);
 	if (state == NULL || out_block == NULL) {
 		free(out_block);

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -310,7 +310,7 @@ gzip_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_GZIP;
 	self->name = "gzip";
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	out_block = (unsigned char *)malloc(out_block_size);
 	if (state == NULL || out_block == NULL) {
 		free(out_block);

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -225,7 +225,7 @@ lz4_reader_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_LZ4;
 	self->name = "lz4";
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	if (state == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for lz4 decompression");

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -187,7 +187,7 @@ lzop_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_LZOP;
 	self->name = "lzop";
 
-	state = (struct read_lzop *)calloc(sizeof(*state), 1);
+	state = (struct read_lzop *)calloc(1, sizeof(*state));
 	if (state == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for lzop decompression");

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -141,7 +141,7 @@ rpm_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_RPM;
 	self->name = "rpm";
 
-	rpm = (struct rpm *)calloc(sizeof(*rpm), 1);
+	rpm = (struct rpm *)calloc(1, sizeof(*rpm));
 	if (rpm == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for rpm");

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -374,7 +374,7 @@ uudecode_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_UU;
 	self->name = "uu";
 
-	uudecode = (struct uudecode *)calloc(sizeof(*uudecode), 1);
+	uudecode = (struct uudecode *)calloc(1, sizeof(*uudecode));
 	out_buff = malloc(OUT_BUFF_SIZE);
 	in_buff = malloc(IN_BUFF_SIZE);
 	if (uudecode == NULL || out_buff == NULL || in_buff == NULL) {

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -478,7 +478,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	struct private_data *state;
 	int ret;
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	out_block = (unsigned char *)malloc(out_block_size);
 	if (state == NULL || out_block == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -177,7 +177,7 @@ zstd_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_ZSTD;
 	self->name = "zstd";
 
-	state = (struct private_data *)calloc(sizeof(*state), 1);
+	state = (struct private_data *)calloc(1, sizeof(*state));
 	out_block = (unsigned char *)malloc(out_block_size);
 	dstream = ZSTD_createDStream();
 

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -734,7 +734,7 @@ archive_read_support_format_rar(struct archive *_a)
   archive_check_magic(_a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_NEW,
                       "archive_read_support_format_rar");
 
-  rar = (struct rar *)calloc(sizeof(*rar), 1);
+  rar = (struct rar *)calloc(1, sizeof(*rar));
   if (rar == NULL)
   {
     archive_set_error(&a->archive, ENOMEM, "Can't allocate rar data");

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -115,7 +115,7 @@ archive_write_new(void)
 
 	/* Initialize a block of nulls for padding purposes. */
 	a->null_length = 1024;
-	nulls = (unsigned char *)calloc(1, a->null_length);
+	nulls = (unsigned char *)calloc(a->null_length, sizeof(unsigned char));
 	if (nulls == NULL) {
 		free(a);
 		return (NULL);

--- a/libarchive/test/test_archive_read_multiple_data_objects.c
+++ b/libarchive/test/test_archive_read_multiple_data_objects.c
@@ -185,7 +185,7 @@ file_open(struct archive *a, void *data)
     mydata->fd = open(mydata->filename, O_RDONLY | O_BINARY);
     if (mydata->fd >= 0)
     {
-      if ((mydata->buffer = (void*)calloc(1, BLOCK_SIZE)) == NULL)
+      if ((mydata->buffer = (void*)calloc(BLOCK_SIZE, 1)) == NULL)
         return (ARCHIVE_FAILED);
     }
   }
@@ -287,7 +287,7 @@ test_customized_multiple_data_objects(void)
       return;
     }
     assert((mydata->filename =
-      (char *)calloc(1, strlen(filename) + 1)) != NULL);
+      (char *)calloc(strlen(filename) + 1, sizeof(char))) != NULL);
     if (mydata->filename == NULL) {
       free(mydata);
       assertEqualInt(ARCHIVE_OK, archive_read_free(a));

--- a/libarchive/test/test_archive_string.c
+++ b/libarchive/test/test_archive_string.c
@@ -406,7 +406,7 @@ DEFINE_TEST(test_archive_string_sort)
 
   srand((unsigned int)time(NULL));
   size = sizeof(strings) / sizeof(char *);
-  assert((test_strings = (char **)calloc(1, sizeof(strings))) != NULL);
+  assert((test_strings = (char **)calloc(size, sizeof(char *))) != NULL);
   for (i = 0; i < (size - 1); i++)
     assert((test_strings[i] = strdup(strings[i])) != NULL);
 

--- a/libarchive/test/test_archive_write_add_filter_by_name.c
+++ b/libarchive/test/test_archive_write_add_filter_by_name.c
@@ -38,7 +38,7 @@ test_filter_by_name(const char *filter_name, int filter_code,
 	char *buff;
 	int r;
 
-	assert((buff = calloc(1, buffsize)) != NULL);
+	assert((buff = calloc(buffsize, sizeof(char))) != NULL);
 	if (buff == NULL)
 		return;
 

--- a/libarchive/test/test_read_format_zip_nested.c
+++ b/libarchive/test/test_read_format_zip_nested.c
@@ -50,7 +50,7 @@ DEFINE_TEST(test_read_format_zip_nested)
 
 	/* Save contents of inner Zip. */
 	innerLength = (size_t)archive_entry_size(ae);
-	inner = calloc(innerLength, 1);
+	inner = calloc(innerLength, sizeof(char));
 	assertEqualInt(innerLength, archive_read_data(a, inner, innerLength));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));

--- a/libarchive/test/test_write_filter_lz4.c
+++ b/libarchive/test/test_write_filter_lz4.c
@@ -62,7 +62,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	assert(NULL != (buff = (char *)malloc(buffsize)));
 
 	datasize = 10000;
-	assert(NULL != (data = (char *)calloc(1, datasize)));
+	assert(NULL != (data = (char *)calloc(datasize, 1)));
 	filecount = 10;
 
 	/*
@@ -306,7 +306,7 @@ test_options(const char *options)
 	assert(NULL != (buff = (char *)malloc(buffsize)));
 
 	datasize = 10000;
-	assert(NULL != (data = (char *)calloc(1, datasize)));
+	assert(NULL != (data = (char *)calloc(datasize, 1)));
 	filecount = 10;
 
 	/*

--- a/libarchive/test/test_write_filter_lzop.c
+++ b/libarchive/test/test_write_filter_lzop.c
@@ -57,7 +57,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	assert(NULL != (buff = (char *)malloc(buffsize)));
 
 	datasize = 10000;
-	assert(NULL != (data = (char *)calloc(1, datasize)));
+	assert(NULL != (data = (char *)calloc(datasize, 1)));
 	filecount = 10;
 
 	/*

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -1245,7 +1245,7 @@ assertion_file_contains_lines_any_order(const char *file, int line,
 		c = *p;
 	}
 	if (actual_count) {
-		actual = calloc(sizeof(char *), actual_count);
+		actual = calloc(actual_count, sizeof(char *));
 		if (actual == NULL) {
 			failure_start(pathname, line, "Can't allocate memory");
 			failure_finish(NULL);


### PR DESCRIPTION
First argument is number of times to allocate a region of the second size, which is the size of the element being allocated.