### PR TITLE
Remove the write_all_states() return type

### DIFF
--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -98,13 +98,12 @@ archive_handle_type_name(unsigned m)
 	}
 }
 
-
-static char *
+static void
 write_all_states(char *buff, unsigned int states)
 {
 	unsigned int lowbit;
 
-	buff[0] = '\0';
+	*buff = '\0';
 
 	/* A trick for computing the lowest set bit. */
 	while ((lowbit = states & (1 + ~states)) != 0) {
@@ -113,7 +112,6 @@ write_all_states(char *buff, unsigned int states)
 		if (states != 0)
 			strcat(buff, "/");
 	}
-	return buff;
 }
 
 /*
@@ -159,16 +157,19 @@ __archive_check_magic(struct archive *a, unsigned int magic,
 
 	if ((a->state & state) == 0) {
 		/* If we're already FATAL, don't overwrite the error. */
-		if (a->state != ARCHIVE_STATE_FATAL)
+		if (a->state != ARCHIVE_STATE_FATAL) {
+			write_all_states(states1, a->state);
+			write_all_states(states2, state);
 			archive_set_error(a, -1,
 			    "INTERNAL ERROR: Function '%s' invoked with"
 			    " archive structure in state '%s',"
 			    " should be in state '%s'",
 			    function,
-			    write_all_states(states1, a->state),
-			    write_all_states(states2, state));
+			    states1,
+			    states2);
+		}
 		a->state = ARCHIVE_STATE_FATAL;
 		return (ARCHIVE_FATAL);
 	}
-	return ARCHIVE_OK;
+	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
The return value is never used, so let's change it to void.