### PR TITLE
Perform "dead stripping" on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,6 @@ IF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
   # either of the following two, yet neither is supported as of 3.0.2
   # - check_linker_flag - does not exist
   # - try_compile - does not support linker flags
-  #
-  # The CI fails with this on MacOS
   IF(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
     # Place the functions and data into separate sections, allowing the linker
     # to garbage collect the unused ones.
@@ -135,6 +133,9 @@ IF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
     # Printing the discarded section is "too much", so enable on demand.
     #SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -Wl,--print-gc-sections")
     #SET(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -Wl,--print-gc-sections")
+  ELSE()
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-dead_strip")
   ENDIF(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
 ENDIF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
        CMAKE_C_COMPILER_ID MATCHES "^Clang$")

--- a/Makefile.am
+++ b/Makefile.am
@@ -289,7 +289,7 @@ endif
 
 # -no-undefined marks that libarchive doesn't rely on symbols
 # defined in the application.  This is mandatory for cygwin.
-libarchive_la_LDFLAGS= -no-undefined -version-info $(ARCHIVE_LIBTOOL_VERSION) $(GC_SECTIONS)
+libarchive_la_LDFLAGS= -no-undefined -version-info $(ARCHIVE_LIBTOOL_VERSION) $(DEAD_CODE_REMOVAL)
 libarchive_la_LIBADD= $(LTLIBICONV)
 
 # Manpages to install
@@ -1050,7 +1050,7 @@ endif
 
 bsdtar_LDADD= libarchive.la libarchive_fe.la $(LTLIBICONV)
 bsdtar_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdtar_ccstatic) $(PLATFORMCPPFLAGS)
-bsdtar_LDFLAGS= $(bsdtar_ldstatic) $(GC_SECTIONS)
+bsdtar_LDFLAGS= $(bsdtar_ldstatic) $(DEAD_CODE_REMOVAL)
 
 bsdtar_EXTRA_DIST= \
 	tar/bsdtar.1 \
@@ -1216,7 +1216,7 @@ endif
 
 bsdcpio_LDADD= libarchive_fe.la libarchive.la $(LTLIBICONV)
 bsdcpio_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdcpio_ccstatic) $(PLATFORMCPPFLAGS)
-bsdcpio_LDFLAGS= $(bsdcpio_ldstatic) $(GC_SECTIONS)
+bsdcpio_LDFLAGS= $(bsdcpio_ldstatic) $(DEAD_CODE_REMOVAL)
 
 bsdcpio_EXTRA_DIST= \
 	cpio/bsdcpio.1 \
@@ -1370,7 +1370,7 @@ endif
 
 bsdcat_LDADD= libarchive_fe.la libarchive.la $(LTLIBICONV)
 bsdcat_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdcat_ccstatic) $(PLATFORMCPPFLAGS)
-bsdcat_LDFLAGS= $(bsdcat_ldstatic) $(GC_SECTIONS)
+bsdcat_LDFLAGS= $(bsdcat_ldstatic) $(DEAD_CODE_REMOVAL)
 
 bsdcat_EXTRA_DIST= \
 	cat/bsdcat.1 \
@@ -1478,7 +1478,7 @@ endif
 
 bsdunzip_LDADD= libarchive_fe.la libarchive.la $(LTLIBICONV)
 bsdunzip_CPPFLAGS= -I$(top_srcdir)/libarchive -I$(top_srcdir)/libarchive_fe $(bsdunzip_ccstatic) $(PLATFORMCPPFLAGS)
-bsdunzip_LDFLAGS= $(bsdunzip_ldstatic) $(GC_SECTIONS)
+bsdunzip_LDFLAGS= $(bsdunzip_ldstatic) $(DEAD_CODE_REMOVAL)
 
 bsdunzip_EXTRA_DIST= \
 	unzip/bsdunzip.1 \

--- a/configure.ac
+++ b/configure.ac
@@ -614,21 +614,35 @@ fi
 # Checks for supported compiler flags
 AX_APPEND_COMPILE_FLAGS([-Wall -Wformat -Wformat-security])
 
-# Place the functions and data into separate sections, allowing the linker
-# to garbage collect the unused ones.
+# Place the functions and data into separate sections, allowing GNU style
+# linkers to garbage collect the unused ones.
 save_LDFLAGS=$LDFLAGS
 LDFLAGS="$LDFLAGS -Wl,--gc-sections"
 AC_MSG_CHECKING([whether ld supports --gc-sections])
 AC_LINK_IFELSE(
     [AC_LANG_SOURCE([static char UnusedFunc() { return 5; } int main() { return 0;}])],
     [AC_MSG_RESULT([yes])
-        GC_SECTIONS="-Wl,--gc-sections";
+        DEAD_CODE_REMOVAL="-Wl,--gc-sections";
         AX_APPEND_COMPILE_FLAGS([-ffunction-sections -fdata-sections])],
     [AC_MSG_RESULT([no])
-        GC_SECTIONS="";])
+        DEAD_CODE_REMOVAL="";])
 LDFLAGS=$save_LDFLAGS
 
-AC_SUBST(GC_SECTIONS)
+if test "$DEAD_CODE_REMOVAL" == ""; then
+    # Macos linkers have a -dead_strip flag, which is similar to --gc-sections.
+    save_LDFLAGS=$LDFLAGS
+    LDFLAGS="$LDFLAGS -Wl,-dead_strip"
+    AC_MSG_CHECKING([whether ld supports -dead_strip])
+    AC_LINK_IFELSE(
+        [AC_LANG_SOURCE([static char UnusedFunc() { return 5; } int main() { return 0;}])],
+        [AC_MSG_RESULT([yes])
+            DEAD_CODE_REMOVAL="-Wl,-dead_strip";],
+        [AC_MSG_RESULT([no])
+            DEAD_CODE_REMOVAL="";])
+    LDFLAGS=$save_LDFLAGS
+fi
+
+AC_SUBST(DEAD_CODE_REMOVAL)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST


### PR DESCRIPTION
Since Xcode 1.5, macos ld has a -dead_strip flag which is roughly equivalent to --gc-sections in GNU style linkers, let's use it.

Reference: https://opensource.apple.com/source/cctools/cctools-622.5.1/RelNotes/CompilerTools.html

Results from running the following command, before and after this change, formatted for easy comparison (the actual values will vary with toolchain and library versions used):
```
size bsdtar bsdcpio bsdunzip bsdcat .libs/libarchive.13.dylib

__TEXT __DATA __OBJC others     dec        hex

655360 16384  0      4295196672 4295868416 1000dc000 bsdtar # before
638976 16384  0      4295180288 4295835648 1000d4000 bsdtar # after

638976 32768  0      4295196672 4295868416 1000dc000 bsdcpio # before
606208 32768  0      4295163904 4295802880 1000cc000 bsdcpio # after

147456 16384  0      4295065600 4295229440 100040000 bsdunzip # before
114688 16384  0      4295032832 4295163904 100030000 bsdunzip # after

131072 16384  0      4295065600 4295213056 10003c000 bsdcat # before
 49152 16384  0      4295016448 4295081984 10001c000 bsdcat # after

638976 16384  0          229376     884736     d8000 .libs/libarchive.13.dylib # before
622592 16384  0          229376     868352     d4000 .libs/libarchive.13.dylib # after
```