### PR TITLE
Fix CI build

### DIFF
--- a/build/ci/cirrus_ci/Dockerfile.mingw
+++ b/build/ci/cirrus_ci/Dockerfile.mingw
@@ -4,5 +4,5 @@ RUN choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=User' cmake
 RUN choco install -y --no-progress mingw
 RUN curl -o zlib-1.2.11.tar.gz https://www.zlib.net/zlib-1.2.11.tar.gz
 RUN tar -x -f zlib-1.2.11.tar.gz
-RUN cd zlib-1.2.11 && cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . && mingw32-make && mingw32-make install
+RUN cd zlib-1.2.11 && cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" . && mingw32-make && mingw32-make install
 RUN del /f /q /s zlib-1.2.11 zlib-1.2.11.tar.gz

--- a/build/ci/cirrus_ci/ci.cmd
+++ b/build/ci/cirrus_ci/ci.cmd
@@ -41,10 +41,11 @@ IF "%1%"=="prepare" (
   IF NOT EXIST zlib-%ZLIB_VERSION% (
     tar -x -z -f zlib-%ZLIB_VERSION%.tar.gz
   )
-  SET PATH=%PATH%;C:\Program Files\cmake\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin
+  SET PATH=%PATH%;C:\Program Files\cmake\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\cmake\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin
+
   CD zlib-%ZLIB_VERSION%
   IF "%BE%"=="mingw-gcc" (
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
     mingw32-make || EXIT /b 1
     mingw32-make test || EXIT /b 1
     mingw32-make install || EXIT /b 1

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -55,7 +55,7 @@ IF "%1"=="deplibs" (
   CD zlib-%ZLIB_VERSION%
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
     mingw32-make || EXIT /b 1
     mingw32-make test || EXIT /b 1
     mingw32-make install || EXIT /b 1
@@ -69,7 +69,7 @@ IF "%1"=="deplibs" (
   CD bzip2-%BZIP2_VERSION%
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
     mingw32-make || EXIT /b 1
     REM mingw32-make test || EXIT /b 1
     mingw32-make install || EXIT /b 1
@@ -83,7 +83,7 @@ IF "%1"=="deplibs" (
   CD xz-%XZ_VERSION%
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
     mingw32-make || EXIT /b 1
     mingw32-make install || EXIT /b 1
   ) ELSE IF "%BE%"=="msvc" (
@@ -95,7 +95,7 @@ IF "%1"=="deplibs" (
   CD zstd-%ZSTD_VERSION%\build\cmake
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
     mingw32-make || EXIT /b 1
     mingw32-make install || EXIT /b 1
   ) ELSE IF "%BE%"=="msvc" (
@@ -108,7 +108,7 @@ IF "%1"=="deplibs" (
     SET PATH=%MINGWPATH%
     MKDIR build_ci\cmake
     CD build_ci\cmake
-    cmake -G "MinGW Makefiles" -D ZLIB_LIBRARY="C:/Program Files (x86)/zlib/lib/libzlibstatic.a" -D ZLIB_INCLUDE_DIR="C:/Program Files (x86)/zlib/include" -D BZIP2_LIBRARIES="C:/Program Files (x86)/bzip2/lib/libbz2_static.a" -D BZIP2_INCLUDE_DIR="C:/Program Files (x86)/bzip2/include" -D LIBLZMA_LIBRARY="C:/Program Files (x86)/xz/lib/liblzma.a" -D LIBLZMA_INCLUDE_DIR="C:/Program Files (x86)/xz/include" -D ZSTD_LIBRARY="C:/Program Files (x86)/zstd/lib/libzstd.a" -D ZSTD_INCLUDE_DIR="C:/Program Files (x86)/zstd/include" ..\.. || EXIT /b 1
+    cmake -G "MinGW Makefiles" -D CMAKE_MAKE_PROGRAM="mingw32-make" -D CMAKE_C_COMPILER="${CC}" -D ZLIB_LIBRARY="C:/Program Files (x86)/zlib/lib/libzlibstatic.a" -D ZLIB_INCLUDE_DIR="C:/Program Files (x86)/zlib/include" -D BZIP2_LIBRARIES="C:/Program Files (x86)/bzip2/lib/libbz2_static.a" -D BZIP2_INCLUDE_DIR="C:/Program Files (x86)/bzip2/include" -D LIBLZMA_LIBRARY="C:/Program Files (x86)/xz/lib/liblzma.a" -D LIBLZMA_INCLUDE_DIR="C:/Program Files (x86)/xz/include" -D ZSTD_LIBRARY="C:/Program Files (x86)/zstd/lib/libzstd.a" -D ZSTD_INCLUDE_DIR="C:/Program Files (x86)/zstd/include" ..\.. || EXIT /b 1
   ) ELSE IF "%BE%"=="msvc" (
     MKDIR build_ci\cmake
     CD build_ci\cmake


### PR DESCRIPTION
-D CMAKE_MAKE_PROGRAM="mingw32-make" is required in some cases so lets always specify that when using MinGW Makefiles just to be safe.