### PR TITLE
Including getopt.h if HAVE_GETOPT_OPTRESET is defined

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -78,6 +78,9 @@
 #include <sys/time.h>
 #endif
 #endif
+#ifdef HAVE_GETOPT_OPTRESET
+#include <getopt.h>
+#endif
 
 #include "bsdunzip.h"
 #include "passphrase.h"


### PR DESCRIPTION
On platforms that uses optreset we must also include getopt.h to have it defined