### PR TITLE
win32: ensure that the MSVC build doesn't terminate when MinGW fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
   Windows:
     runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
         be: [mingw-gcc, msvc]
     steps:


### PR DESCRIPTION
For `matrix`-strategy builds, GitHub actions will terminate all related matrix legs when one of them fails.

Disabling `fail-fast` knocks this behavior off.