### PR TITLE
document supported formats for `--mac-metadata` - see #2041

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -401,6 +401,8 @@ This is the reverse of
 and the default behavior in c, r, and u modes or if
 .Nm
 is run in x mode as root.
+Currently supported only for pax formats
+(including "pax restricted", the default tar format for bsdtar.)
 .It Fl n , Fl Fl norecurse , Fl Fl no-recursion
 Do not operate recursively on the content of directories.
 .It Fl Fl newer Ar date


### PR DESCRIPTION
Doc fix to clarify that `--mac-metadata` is only supported for certain formats. Hopefully just a short-term fix until support is added for other formats. (See discussion on #2041)