### PR TITLE
Fix FILETIME truncation on `archive_write_finish_entry()` on Windows

### DIFF
--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -2594,7 +2594,7 @@ set_times(struct archive_write_disk *a,
 {
 #define EPOC_TIME ARCHIVE_LITERAL_ULL(116444736000000000)
 #define WINTIME(sec, nsec) ((Int32x32To64(sec, 10000000) + EPOC_TIME)\
-	 + (((nsec)/1000)*10))
+	 + ((nsec)/100))
 
 	HANDLE hw = 0;
 	ULARGE_INTEGER wintm;


### PR DESCRIPTION
On Windows, `archive_write_finish_entry()` does not restore time correctly.
It truncates the last digit of original FILETIME which is stored in the archive.
This commit fixes this behavior.
See libarchive#2049 for detailed explanation on this issue.
