### PR TITLE
Fix syntax error of DONT_FAIL_ON_CRC_ERROR in archive_read_support_fo…

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3050,8 +3050,8 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 
 		/* Check the EncodedHeader CRC.*/
 		if (r == 0 && zip->header_crc32 != next_header_crc) {
-			archive_set_error(&a->archive, -1,
 #ifndef DONT_FAIL_ON_CRC_ERROR
+			archive_set_error(&a->archive, -1,
 			    "Damaged 7-Zip archive");
 			r = -1;
 #endif


### PR DESCRIPTION
Following code snippet in `libarchive/archive_read_support_format_7zip.c` causing a build fail while enable the `DONT_FAIL_ON_CRC_ERROR`

```
/* Check the EncodedHeader CRC.*/
		if (r == 0 && zip->header_crc32 != next_header_crc) {
			archive_set_error(&a->archive, -1,
#ifndef DONT_FAIL_ON_CRC_ERROR
			    "Damaged 7-Zip archive");
			r = -1;
#endif
```

I fix it like this:

```
/* Check the EncodedHeader CRC.*/
		if (r == 0 && zip->header_crc32 != next_header_crc) {
#ifndef DONT_FAIL_ON_CRC_ERROR
			archive_set_error(&a->archive, -1,
			    "Damaged 7-Zip archive");
			r = -1;
#endif
```