### PR TITLE
cmake: Set CMP0075 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ endif()
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW) #3.12.0 `find_package()`` uses ``<PackageName>_ROOT`` variables.
 endif()
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW) #3.12.0 `check_include_file()`` and friends use ``CMAKE_REQUIRED_LIBRARIES``.
+endif()
 #
 PROJECT(libarchive C)
 #


### PR DESCRIPTION
The new behavior of this policy makes check_include_file() and friends use the CMAKE_REQUIRED_LIBRARIES variable before checking for headers. This is used to check for cryptography algorithms provided by OpenSSL. This change addresses the following warning:

  CMake Warning (dev) at /usr/share/cmake-3.25/Modules/CheckIncludeFiles.cmake:121 (message):
    Policy CMP0075 is not set: Include file check macros honor
    CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
    details.  Use the cmake_policy command to set the policy and suppress this
    warning.

    CMAKE_REQUIRED_LIBRARIES is set to:

      /usr/lib/x86_64-linux-gnu/libcrypto.so

    For compatibility with CMake 3.11 and below this check is ignoring it.
  Call Stack (most recent call first):
    CMakeLists.txt:676 (CHECK_INCLUDE_FILES)
    CMakeLists.txt:841 (LA_CHECK_INCLUDE_FILE)
  This warning is for project developers.  Use -Wno-dev to suppress it.