### PR TITLE
Make zstd:threads=0 option work as documented

### DIFF
--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -177,4 +177,6 @@ void __archive_reset_read_data(struct archive *);
 # define	ARCHIVE_LITERAL_ULL(x)	x##ull
 #endif
 
+int __archive_num_physical_cores(void);
+
 #endif

--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -177,6 +177,6 @@ void __archive_reset_read_data(struct archive *);
 # define	ARCHIVE_LITERAL_ULL(x)	x##ull
 #endif
 
-int __archive_num_physical_cores(void);
+int __archive_num_logical_cores(void);
 
 #endif

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -29,17 +29,26 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
 #ifdef HAVE_STRING_H
 #include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
 #endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #if defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
@@ -66,6 +75,10 @@
 #endif
 #ifdef HAVE_LZ4_H
 #include <lz4.h>
+#endif
+
+#if defined(_WIN32)
+#include <sysinfoapi.h>
 #endif
 
 #include "archive.h"
@@ -700,4 +713,137 @@ archive_utility_string_sort(char **strings)
 	  while (strings[size] != NULL)
 		size++;
 	  return archive_utility_string_sort_helper(strings, size);
+}
+
+// This should be enough to find "cpu cores<whitespace>:<space><number>" at the start of a line in /proc/cpuinfo
+#define PROC_CPUINFO_BUF_SIZE 80
+
+int
+__archive_num_physical_cores()
+{
+	static int cores = 0;
+	if (cores > 0) return cores;
+
+#if defined(__FreeBSD__)
+	int sysctlbynameCores = 0;
+	size_t size = sizeof(sysctlbynameCores);
+	if (sysctlbyname("kern.smp.cores", &sysctlbynameCores, &size, NULL, 0) != 0)
+		goto unixfallback;
+
+	if (sysctlbynameCores <= 0) goto unixfallback;
+	cores = sysctlbynameCores;
+	return cores;
+#endif
+
+#ifdef __APPLE__
+	int32_t sysctlbynameCores = 0;
+	size_t size = sizeof(sysctlbynameCores);
+	if (sysctlbyname("hw.physicalcpu", &sysctlbynameCores, &size, NULL, 0) != 0)
+		goto unixfallback;
+
+	if (sysctlbynameCores <= 0) goto unixfallback;
+	cores = sysctlbynameCores;
+	return cores;
+#endif // __APPLE__
+
+#if defined(__linux__)
+	// Look in /proc/cpuinfo for a line like "cpu cores       : <num>"
+
+	FILE *fp = fopen("/proc/cpuinfo", "r");
+	if (fp == NULL) goto unixfallback;
+
+	char buf[PROC_CPUINFO_BUF_SIZE];
+
+	for (;;) {
+		if (fgets(buf, PROC_CPUINFO_BUF_SIZE, fp) == NULL) {
+			// Reached EOF without finding the value.
+			fclose(fp);
+			goto unixfallback;
+		}
+
+		if (strncmp(buf, "cpu cores", 9) == 0) {
+			// Found the right line. We don't need to read any more.
+			fclose(fp);
+
+			const char *colon = strchr(buf, ':');
+			if (colon == NULL || *colon == '\0') {
+				// Unable to parse the line.
+				goto unixfallback;
+			}
+
+			int cpuinfoCores = atoi(colon + 1);
+			if (cpuinfoCores <= 0) goto unixfallback;
+			cores = cpuinfoCores;
+			return cores;
+		}
+
+		// Skip the rest of the line.
+
+		for (;;) {
+			if (strchr(buf, '\n') != NULL) {
+				break; // Found the end of the line.
+			}
+
+			if (fgets(buf, PROC_CPUINFO_BUF_SIZE, fp) == NULL) {
+				// No data left to read.
+				fclose(fp);
+				goto unixfallback;
+			}
+		}
+	}
+#endif // __linux__
+
+goto unixfallback; // Avoid -Wunused-label warnings.
+unixfallback:
+
+#if defined(HAVE_UNISTD_H) && defined(_SC_NPROCESSORS_ONLN)
+
+	// Fall back to sysconf on unix, if none of the more platform-specific
+	// methods worked. This might return logical cores instead of physical
+	// cores, but maybe that's better than returning 1?
+
+	{
+		int sysconfCores = 0;
+		sysconfCores = (int)sysconf(_SC_NPROCESSORS_ONLN);
+		if (sysconfCores <= 0) goto failure;
+		cores = sysconfCores;
+		return cores;
+	}
+#endif // HAVE_UNISTD_H && _SC_NPROCESSORS_ONLN
+
+#if _WIN32_WINNT >= 0x0601 /* _WIN32_WINNT_WIN7 */
+	DWORD len = 0;
+
+	if (GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len)) goto windowsfallback;
+	if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) goto windowsfallback;
+
+	BOOL should_free_buffer = 0;
+	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)malloc(len);
+	if (buffer == NULL) goto windowsfallback;
+	should_free_buffer = 1;
+
+	if (!GetLogicalProcessorInformationEx(RelationProcessorCore, buffer, &len)) goto windowsfallback;
+
+	cores = len / buffer->Size;
+	free(buffer);
+	should_free_buffer = 0;
+
+	if (cores > 0) return cores;
+
+windowsfallback:
+	if (should_free_buffer)
+		free(buffer);
+
+	SYSTEM_INFO sysinfo;
+	GetSystemInfo(&sysinfo);
+	if (sysinfo.dwNumberOfProcessors > 0) { // Logical processors.
+		cores = sysinfo.dwNumberOfProcessors;
+		return cores;
+	}
+#endif // _WIN32_WINNT >= 0x0601
+
+goto failure; // Avoid -Wunused-label warnings.
+failure:
+	if (cores <= 0) cores = 1;
+	return cores;
 }

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -29,9 +29,6 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#include <sys/sysctl.h>
-#endif
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
@@ -81,7 +78,7 @@
 #endif
 
 #if defined(_WIN32)
-#include <sysinfoapi.h>
+#include <winbase.h>
 #endif
 
 #include "archive.h"

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -29,6 +29,9 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
@@ -267,7 +270,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		if (threads == 0) {
 			threads = __archive_num_logical_cores();
 		}
-		if (threads < 0) {
+		if (threads < 0 || threads > INT_MAX) {
 			return (ARCHIVE_WARN);
 		}
 		data->threads = (int)threads;

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -265,7 +265,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 			return (ARCHIVE_WARN);
 		}
 		if (threads == 0) {
-			threads = __archive_num_physical_cores();
+			threads = __archive_num_logical_cores();
 		}
 		if (threads < 0) {
 			return (ARCHIVE_WARN);

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -264,6 +264,9 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		if (string_to_number(value, &threads) != ARCHIVE_OK) {
 			return (ARCHIVE_WARN);
 		}
+		if (threads == 0) {
+			threads = __archive_num_physical_cores();
+		}
 		if (threads < 0) {
 			return (ARCHIVE_WARN);
 		}

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -649,8 +649,8 @@ A decimal integer specifying the zstd compression level.
 Supported values depend
 on the library version, common values are from 1 to 22.
 .It Cm zstd:threads Ns = Ns Ar N
-Specify the number of worker threads to use, or 0 to use as many
-threads as there are CPU cores in the system.
+Specify the number of worker threads to use, or 0 to attempt to use as many
+threads as there are logical CPU cores in the system.
 .It Cm zstd:frame-per-file
 Start a new compression frame at the beginning of each file in the
 archive.

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd March 1, 2024
+.Dd April 1, 2024
 .Dt TAR 1
 .Os
 .Sh NAME
@@ -644,14 +644,13 @@ A decimal integer from 4 to 7 specifying the lz4 compression block size
 .It Cm lz4:block-dependence
 Use the previous block of the block being compressed for
 a compression dictionary to improve compression ratio.
-.It Cm zstd:compression-level
-A decimal integer specifying the zstd compression level. Supported values depend
+.It Cm zstd:compression-level Ns = Ns Ar N
+A decimal integer specifying the zstd compression level.
+Supported values depend
 on the library version, common values are from 1 to 22.
-.It Cm zstd:threads
-Specify the number of worker threads to use.
-Setting threads to a special value 0 makes
-.Xr zstd 1
-use as many threads as there are CPU cores on the system.
+.It Cm zstd:threads Ns = Ns Ar N
+Specify the number of worker threads to use, or 0 to use as many
+threads as there are CPU cores in the system.
 .It Cm zstd:frame-per-file
 Start a new compression frame at the beginning of each file in the
 archive.


### PR DESCRIPTION
Attempt to detect and use the number of logical CPU cores (unlike zstd, which counts physical cores by default).

Fixes #2057.