### PR TITLE
tar: Warn when multiple --option values are specified

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -654,6 +654,11 @@ main(int argc, char **argv)
 			    ARCHIVE_READDISK_NO_TRAVERSE_MOUNTS;
 			break;
 		case OPTION_OPTIONS:
+			if (bsdtar->option_options != NULL) {
+				lafe_warnc(0,
+				    "Ignoring previous option '%s', separate multiple options with commas",
+				    bsdtar->option_options);
+			}
 			bsdtar->option_options = bsdtar->argument;
 			break;
 		case OPTION_OWNER: /* GNU tar */


### PR DESCRIPTION
The accepted way to specify multiple options is to list them all as one comma-separated parameter.  bsdtar would silently ignore all but the last value, which can be very confusing.  Print a warning in this scenario.