### PR TITLE
Fix DONT_FAIL_ON_CRC_ERROR ifndef logic

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -447,8 +447,8 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	chsum = __archive_xxhash.XXH32(read_buf, (int)descriptor_bytes -1, 0);
 	chsum = (chsum >> 8) & 0xff;
 	chsum_verifier = read_buf[descriptor_bytes-1] & 0xff;
-	if (chsum != chsum_verifier)
 #ifndef DONT_FAIL_ON_CRC_ERROR
+	if (chsum != chsum_verifier)
 		goto malformed_error;
 #endif
 
@@ -520,8 +520,8 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 			read_buf + 4, (int)compressed_size, 0);
 		unsigned int chsum_block =
 		    archive_le32dec(read_buf + 4 + compressed_size);
-		if (chsum != chsum_block)
 #ifndef DONT_FAIL_ON_CRC_ERROR
+		if (chsum != chsum_block)
 			goto malformed_error;
 #endif
 	}

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -280,8 +280,8 @@ consume_header(struct archive_read_filter *self)
 		checksum = crc32(crc32(0, NULL, 0), p, len);
 	else
 		checksum = adler32(adler32(0, NULL, 0), p, len);
-	if (archive_be32dec(p + len) != checksum)
 #ifndef DONT_FAIL_ON_CRC_ERROR
+	if (archive_be32dec(p + len) != checksum)
 		goto corrupted;
 #endif
 	__archive_read_filter_consume(self->upstream, len + 4);

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3050,8 +3050,8 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 
 		/* Check the EncodedHeader CRC.*/
 		if (r == 0 && zip->header_crc32 != next_header_crc) {
-			archive_set_error(&a->archive, -1,
 #ifndef DONT_FAIL_ON_CRC_ERROR
+			archive_set_error(&a->archive, -1,
 			    "Damaged 7-Zip archive");
 			r = -1;
 #endif

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -622,8 +622,8 @@ read_toc(struct archive_read *a)
 			(size_t)xar->toc_chksum_size, NULL, 0);
 		__archive_read_consume(a, xar->toc_chksum_size);
 		xar->offset += xar->toc_chksum_size;
-		if (r != ARCHIVE_OK)
 #ifndef DONT_FAIL_ON_CRC_ERROR
+		if (r != ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
 #endif
 	}


### PR DESCRIPTION
An `if` without curly braces guards the following statement.

When `#ifndef` removes that statement, the `if` now guards whatever statement comes next.

I have not yet tested the changes.

Introduced in https://github.com/libarchive/libarchive/pull/1790. 
CC people from original PR: @jvoisin @mmatuska