### PR TITLE
Improved control over frame size in zstd filter.

### DIFF
--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -136,28 +136,98 @@ DEFINE_TEST(test_write_filter_zstd)
 	/* frame-per-file: boolean */
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_set_filter_option(a, NULL, "frame-per-file", ""));
-	/* min-frame-size: >= 0 */
+	/* min-frame-in: >= 0 */
 	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "min-frame-size", ""));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", ""));
 	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "min-frame-size", "-1"));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "-1"));
 	assertEqualIntA(a, ARCHIVE_OK,
-	    archive_write_set_filter_option(a, NULL, "min-frame-size", "0"));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "0"));
 	assertEqualIntA(a, ARCHIVE_OK,
-	    archive_write_set_filter_option(a, NULL, "min-frame-size", "1048576"));
-	/* max-frame-size: >= 1024 */
-	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", ""));
-	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", "-1"));
-	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", "0"));
-	assertEqualIntA(a, ARCHIVE_FAILED,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", "1023"));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1048576"));
 	assertEqualIntA(a, ARCHIVE_OK,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", "1024"));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1k"));
 	assertEqualIntA(a, ARCHIVE_OK,
-	    archive_write_set_filter_option(a, NULL, "max-frame-size", "1048576"));
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1kB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1M"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1MB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1G"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-out", "1GB"));
+	/* min-frame-out: >= 0 */
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", ""));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "-1"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "0"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1048576"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1k"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1kB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1M"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1MB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1G"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "min-frame-in", "1GB"));
+	/* max-frame-in: >= 1024 */
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", ""));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "-1"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "0"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1023"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1024"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1048576"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1k"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1kB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1M"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1MB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1G"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-in", "1GB"));
+	/* max-frame-out: >= 1024 */
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", ""));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "-1"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "0"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1023"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1024"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1048576"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1k"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1kB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1M"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1MB"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1G"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1GB"));
 #endif
 #if ZSTD_VERSION_NUMBER >= MINVER_LONG
 	if ((int)(sizeof(size_t) == 4))

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 10, 2023
+.Dd March 1, 2024
 .Dt TAR 1
 .Os
 .Sh NAME
@@ -655,16 +655,56 @@ use as many threads as there are CPU cores on the system.
 .It Cm zstd:frame-per-file
 Start a new compression frame at the beginning of each file in the
 archive.
-.It Cm zstd:min-frame-size Ns = Ns Ar N
+.It Cm zstd:min-frame-in Ns = Ns Ar N
 In combination with
 .Cm zstd:frame-per-file ,
-do not start a new compression frame unless the current frame is at least
+do not start a new compression frame unless the uncompressed size of
+the current frame is at least
 .Ar N
 bytes.
-.It Cm zstd:max-frame-size Ns = Ns Ar N
-Start a new compression frame as soon as the current frame exceeds
+The number may be followed by
+.Li k / Li kB ,
+.Li M / Li MB ,
+or
+.Li G / Li GB
+to indicate kilobytes, megabytes or gigabytes respectively.
+.It Cm zstd:min-frame-out Ns = Ns Ar N , Cm zstd:min-frame-size Ns = Ns Ar N
+In combination with
+.Cm zstd:frame-per-file ,
+do not start a new compression frame unless the compressed size of the
+current frame is at least
 .Ar N
 bytes.
+The number may be followed by
+.Li k / Li kB ,
+.Li M / Li MB ,
+or
+.Li G / Li GB
+to indicate kilobytes, megabytes or gigabytes respectively.
+.It Cm zstd:max-frame-in Ns = Ns Ar N , Cm zstd:max-frame-size Ns = Ns Ar N
+Start a new compression frame as soon as possible after the
+uncompressed size of the current frame exceeds
+.Ar N
+bytes.
+The number may be followed by
+.Li k / Li kB ,
+.Li M / Li MB ,
+or
+.Li G / Li GB
+to indicate kilobytes, megabytes or gigabytes respectively.
+Values less than 1,024 will be rejected.
+.It Cm zstd:max-frame-out Ns = Ns Ar N
+Start a new compression frame as soon as possible after the compressed
+size of the current frame exceeds
+.Ar N
+bytes.
+The number may be followed by
+.Li k / Li kB ,
+.Li M / Li MB ,
+or
+.Li G / Li GB
+to indicate kilobytes, megabytes or gigabytes respectively.
+Values less than 1,024 will be rejected.
 .It Cm lzop:compression-level
 A decimal integer from 1 to 9 specifying the lzop compression level.
 .It Cm xz:compression-level


### PR DESCRIPTION
Instead of just `min-frame-size` and `max-frame-size`, we now have four separate options:

* `min-frame-in` delays the creation of a new frame on flush until the uncompressed size of the current frame passes a certain threshold.

* `min-frame-out` delays the creation of a new frame on flush until the compressed size of the current frame passes a certain threshold.

* `max-frame-in` forces the creation of a new frame as soon as possible after the uncompressed size of the current frame reaches a certain limit.

* `max-frame-out` forces the creation of a new frame as soon as possible after the compressed size of the current frame reaches a certain limit.

We now also support `k`, `kB`, `M`, `MB`, `G` and `GB` suffixes for all four options.

The old options are retained as aliases for the corresponding new options.