### PR TITLE
Fix tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ CMakeCache.txt
 CMakeFiles/
 DartConfiguration.tcl
 cmake.tmp/
+.vscode/
 
 doc/html/*.html
 doc/man/*.1
@@ -74,3 +75,5 @@ test-suite.log
 
 .sw?
 .*.sw?
+
+*.pdb

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -2438,6 +2438,7 @@ archive_read_disk_entry_from_file(struct archive *_a,
 		return (ARCHIVE_OK);
 	}
 
+	r = ARCHIVE_OK;
 	if ((a->flags & ARCHIVE_READDISK_NO_SPARSE) == 0) {
 		r = setup_sparse_from_disk(a, entry, h);
 		if (fd < 0)

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -552,6 +552,8 @@ archive_wstring_append_from_mbs_in_codepage(struct archive_wstring *dest,
 		} else
 			mbflag = MB_PRECOMPOSED;
 
+		mbflag |= MB_ERR_INVALID_CHARS;
+
 		buffsize = dest->length + length + 1;
 		do {
 			/* Allocate memory for WCS. */
@@ -1526,7 +1528,7 @@ get_current_codepage(void)
 	p = strrchr(locale, '.');
 	if (p == NULL)
 		return (GetACP());
-	if (strcmp(p+1, "utf8") == 0)
+	if ((strcmp(p+1, "utf8") == 0) || (strcmp(p+1, "UTF-8") == 0))
 		return CP_UTF8;
 	cp = my_atoi(p+1);
 	if ((int)cp <= 0)

--- a/libarchive/test/test_read_format_cpio_filename.c
+++ b/libarchive/test/test_read_format_cpio_filename.c
@@ -136,6 +136,11 @@ cleanup:
 
 DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_jp)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	/* Since we explicitly DON'T set hdrcharset=UTF-8 below */
+	skipping("Windows defaults to OEMCP, not UTF-8");
+	return;
+#else
 	const char *refname = "test_read_format_cpio_filename_utf8_jp.cpio";
 	struct archive *a;
 	struct archive_entry *ae;
@@ -179,6 +184,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_jp)
 	/* Close the archive. */
 	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
 }
 
 DEFINE_TEST(test_read_format_cpio_filename_CP866_KOI8R)
@@ -499,6 +505,11 @@ cleanup:
 
 DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_ru)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	/* Since we explicitly DON'T set hdrcharset=UTF-8 below */
+	skipping("Windows defaults to OEMCP, not UTF-8");
+	return;
+#else
 	const char *refname = "test_read_format_cpio_filename_utf8_ru.cpio";
 	struct archive *a;
 	struct archive_entry *ae;
@@ -541,6 +552,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_ru)
 	/* Close the archive. */
 	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
 }
 
 DEFINE_TEST(test_read_format_cpio_filename_eucJP_CP932)

--- a/libarchive/test/test_read_format_rar.c
+++ b/libarchive/test/test_read_format_rar.c
@@ -214,6 +214,14 @@ DEFINE_TEST(test_read_format_rar_unicode_UTF8)
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_support_filter_all(a));
   assertA(0 == archive_read_support_format_all(a));
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  /* Windows will use OEMCP as default, but the file is UTF-8. */
+  if (ARCHIVE_OK != archive_read_set_options(a, "rar:hdrcharset=UTF-8")) {
+	skipping("This system cannot read input as UTF-8.");
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	return;
+  }
+#endif
   assertA(0 == archive_read_open_filename(a, reffile, 10240));
 
   /* First header. */

--- a/libarchive/test/test_read_format_zip_filename.c
+++ b/libarchive/test/test_read_format_zip_filename.c
@@ -1178,6 +1178,11 @@ next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
+	 * By default, Windows will create an sconv_default object, which will
+	 * interpret filenames as OEMCP
+	 */
+#if !defined(_WIN32) || defined(__CYGWIN__)
+	/*
 	 * Read filename in en_US.UTF-8 without "hdrcharset=KOI8-R" option.
 	 * The filename we can properly read is only second file.
 	 */
@@ -1220,4 +1225,5 @@ next_test:
 	/* Close the archive. */
 	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
 }

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -120,7 +120,7 @@ create_sparse_file(const char *path, const struct sparse *s)
 	memset(buff, ' ', sizeof(buff));
 
 	handle = CreateFileA(path, GENERIC_WRITE, 0,
-	    NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL,
+	    NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
 	    NULL);
 	assert(handle != INVALID_HANDLE_VALUE);
 	assert(DeviceIoControl(handle, FSCTL_SET_SPARSE, NULL, 0,

--- a/libarchive/test/test_zip_filename_encoding.c
+++ b/libarchive/test/test_zip_filename_encoding.c
@@ -70,7 +70,9 @@ DEFINE_TEST(test_zip_filename_encoding_UTF8)
 	/*
 	 * Verify that UTF-8 filenames are correctly stored without
 	 * hdrcharset=UTF-8 option.
+	 * Skip on Windows where we default to OEMCP
 	 */
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	a = archive_write_new();
 	assertEqualInt(ARCHIVE_OK, archive_write_set_format_zip(a));
 	assertEqualInt(ARCHIVE_OK,
@@ -89,6 +91,7 @@ DEFINE_TEST(test_zip_filename_encoding_UTF8)
 	 * which indicates the filename charset is UTF-8. */
 	assertEqualInt(0x08, buff[7]);
 	assertEqualMem(buff + 30, "\xD0\xBF\xD1\x80\xD0\xB8", 6);
+#endif
 
 	/*
 	 * Verify that A bit 11 of general purpose flag is not set


### PR DESCRIPTION
I'll comment in the code for locations that seem like they may need additional explanation/discussion. For the most part, a good number of failing tests are failing because they make the assumption that archive contents are read as utf-8 by default, which is not true for Windows, which assumes OEM code page by default.