### PR TITLE
Fix archive_write_set_format_option for 7zip format

### DIFF
--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -282,7 +282,8 @@ and other special entries.
 .It Cm compression-level
 The value is interpreted as a decimal integer specifying the
 compression level.
-Values between 0 and 9 are supported.
+Values between 0 and 9 are supported, with the exception of bzip2
+which only supports values between 1 and 9.
 The interpretation of the compression level depends on the chosen
 compression method.
 .El

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -270,6 +270,7 @@ of physical CPU cores.
 .It Cm compression
 The value is one of
 .Dq store ,
+.Dq copy ,
 .Dq deflate ,
 .Dq bzip2 ,
 .Dq lzma1 ,
@@ -277,6 +278,11 @@ The value is one of
 or
 .Dq ppmd
 to indicate how the following entries should be compressed.
+The values
+.Dq store
+and
+.Dq copy
+are synonyms.
 Note that this setting is ignored for directories, symbolic links,
 and other special entries.
 .It Cm compression-level


### PR DESCRIPTION
A couple of small fixes to the documentation of the `archive_write_set_format_option` for the 7zip format. See commits for details.