### PR TITLE
read 64bit instead of 32bit integer in fallback code in archive_read_support_format_zip.c

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1561,7 +1561,7 @@ consume_end_of_file_marker(struct archive_read *a, struct zip *zip)
 	compressed32 = archive_le32dec(p);
 	uncompressed32 = archive_le32dec(p + 4);
 	compressed64 = archive_le64dec(p);
-	uncompressed64 = archive_le32dec(p + 8);
+	uncompressed64 = archive_le64dec(p + 8);
 
 	/* The earlier patterns may have failed because of CRC32
 	 * mismatch, so it's still possible that both sizes match.


### PR DESCRIPTION
Noticed this while surfing arround commits in the area of the XZ CVE Fallout.. Not sure if it can be exploited, but i doubt it..

I stumbled across this, as our "friend" commited to libarchive/test/test_write_format_zip_entry_size_unset.c in this commit: https://github.com/libarchive/libarchive/commit/fe81fefafec9ea22085f6a70f43054672cd272f9

Though it´s just a style fix of the file.. But it shows, he was interested in it.