### PR TITLE
Never allow empty passwords

### DIFF
--- a/libarchive/archive_write_set_passphrase.c
+++ b/libarchive/archive_write_set_passphrase.c
@@ -30,14 +30,9 @@
 #endif
 #include "archive_write_private.h"
 
-int
-archive_write_set_passphrase(struct archive *_a, const char *p)
+static int
+set_passphrase(struct archive_write *a, const char *p)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC, ARCHIVE_STATE_NEW,
-		"archive_write_set_passphrase");
-
 	if (p == NULL || p[0] == '\0') {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 		    "Empty passphrase is unacceptable");
@@ -51,6 +46,18 @@ archive_write_set_passphrase(struct archive *_a, const char *p)
 		return (ARCHIVE_FATAL);
 	}
 	return (ARCHIVE_OK);
+}
+
+
+int
+archive_write_set_passphrase(struct archive *_a, const char *p)
+{
+	struct archive_write *a = (struct archive_write *)_a;
+
+	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC, ARCHIVE_STATE_NEW,
+		"archive_write_set_passphrase");
+
+	return (set_passphrase(a, p));
 }
 
 
@@ -80,15 +87,9 @@ __archive_write_get_passphrase(struct archive_write *a)
 		const char *p;
 		p = a->passphrase_callback(&a->archive,
 		    a->passphrase_client_data);
-		if (p != NULL) {
-			a->passphrase = strdup(p);
-			if (a->passphrase == NULL) {
-				archive_set_error(&a->archive, ENOMEM,
-				    "Can't allocate data for passphrase");
-				return (NULL);
-			}
-			return (a->passphrase);
-		}
+		set_passphrase(a, p);
+		a->passphrase_callback = NULL;
+		a->passphrase_client_data = NULL;
 	}
-	return (NULL);
+	return (a->passphrase);
 }


### PR DESCRIPTION
Passwords for encryption must not be empty. Neither through command line option nor through interactive input.

With this PR applied:
```
$ bsdtar --format zip --options zip:encryption -cf archive.zip input.txt
Enter passphrase: <press enter>
bsdtar: Encryption needs passphrase
```

Output with command line argument (unaffected by this PR):
```
$ bsdtar --format zip --options zip:encryption --passphrase '' -cf archive.zip input.txt
bsdtar: Empty passphrase is unacceptable
```

The outputs differ due to internal difference in handling the results.

It is still possible to supply a passphrase through command line argument which cannot be entered interactively, i.e. $'\r\n'. See https://github.com/libarchive/libarchive/pull/2115 for more details.