### PR TITLE
configure.ac: fix bashism in dead code removal check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -662,7 +662,7 @@ AC_LINK_IFELSE(
         DEAD_CODE_REMOVAL="";])
 LDFLAGS=$save_LDFLAGS
 
-if test "$DEAD_CODE_REMOVAL" == ""; then
+if test "$DEAD_CODE_REMOVAL" = ""; then
     # Macos linkers have a -dead_strip flag, which is similar to --gc-sections.
     save_LDFLAGS=$LDFLAGS
     LDFLAGS="$LDFLAGS -Wl,-dead_strip"


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.