### PR TITLE
Prevent usage of uninitialized variable in `__archive_mkstemp`

### DIFF
--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -255,10 +255,9 @@ __archive_mktempx(const char *tmpdir, wchar_t *template)
 #endif
 	fd = -1;
 	ws = NULL;
+	archive_string_init(&temp_name);
 
 	if (template == NULL) {
-		archive_string_init(&temp_name);
-
 		/* Get a temporary directory. */
 		if (tmpdir == NULL) {
 			size_t l;


### PR DESCRIPTION
Calling `__archive_mkstemp` can lead to access of an uninitialized variable in `__archive_mktempx`, because `temp_name` is only initialized if supplied `template` argument is `NULL`.

If `template` is not `NULL`, it is eventually compared with `temp_name.s` anyway.

The fix is simple: Always initialize `temp_name`, which merely sets values in the struct. No memory allocation occurs and the check leads to the expected result.

How to reproduce:

1. Compile libarchive with Visual Studio 2022 and CMake's Debug profile
2. Run test `bsdtar_test_option_safe_writes`
3. A popup (Microsoft Visual C++ Runtime Library) appears, stating that variable temp_name is being used without being initialized 