### PR TITLE
tools: Fix stack overflow with many arguments

### DIFF
--- a/cat/cmdline.c
+++ b/cat/cmdline.c
@@ -114,12 +114,18 @@ bsdcat_getopt(struct bsdcat *bsdcat)
 	enum { state_start = 0, state_old_tar, state_next_word,
 	       state_short, state_long };
 
-	const struct bsdcat_option *popt, *match = NULL, *match2 = NULL;
-	const char *p, *long_prefix = "--";
+	const struct bsdcat_option *popt, *match, *match2;
+	const char *p, *long_prefix;
 	size_t optlength;
-	int opt = '?';
-	int required = 0;
+	int opt;
+	int required;
 
+again:
+	match = NULL;
+	match2 = NULL;
+	long_prefix = "--";
+	opt = '?';
+	required = 0;
 	bsdcat->argument = NULL;
 
 	/* First time through, initialize everything. */
@@ -172,7 +178,7 @@ bsdcat_getopt(struct bsdcat *bsdcat)
 		if (opt == '\0') {
 			/* End of this group; recurse to get next option. */
 			bsdcat->getopt_state = state_next_word;
-			return bsdcat_getopt(bsdcat);
+			goto again;
 		}
 
 		/* Does this option take an argument? */

--- a/cpio/cmdline.c
+++ b/cpio/cmdline.c
@@ -114,12 +114,18 @@ cpio_getopt(struct cpio *cpio)
 	static int state = state_start;
 	static char *opt_word;
 
-	const struct option *popt, *match = NULL, *match2 = NULL;
-	const char *p, *long_prefix = "--";
+	const struct option *popt, *match, *match2;
+	const char *p, *long_prefix;
 	size_t optlength;
-	int opt = '?';
-	int required = 0;
+	int opt;
+	int required;
 
+again:
+	match = NULL;
+	match2 = NULL;
+	long_prefix = "--";
+	opt = '?';
+	required = 0;
 	cpio->argument = NULL;
 
 	/* First time through, initialize everything. */
@@ -169,7 +175,7 @@ cpio_getopt(struct cpio *cpio)
 		if (opt == '\0') {
 			/* End of this group; recurse to get next option. */
 			state = state_next_word;
-			return cpio_getopt(cpio);
+			goto again;
 		}
 
 		/* Does this option take an argument? */

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -218,12 +218,18 @@ bsdtar_getopt(struct bsdtar *bsdtar)
 	enum { state_start = 0, state_old_tar, state_next_word,
 	       state_short, state_long };
 
-	const struct bsdtar_option *popt, *match = NULL, *match2 = NULL;
-	const char *p, *long_prefix = "--";
+	const struct bsdtar_option *popt, *match, *match2;
+	const char *p, *long_prefix;
 	size_t optlength;
-	int opt = '?';
-	int required = 0;
+	int opt;
+	int required;
 
+again:
+	match = NULL;
+	match2 = NULL;
+	long_prefix = "--";
+	opt = '?';
+	required = 0;
 	bsdtar->argument = NULL;
 
 	/* First time through, initialize everything. */
@@ -310,7 +316,7 @@ bsdtar_getopt(struct bsdtar *bsdtar)
 		if (opt == '\0') {
 			/* End of this group; recurse to get next option. */
 			bsdtar->getopt_state = state_next_word;
-			return bsdtar_getopt(bsdtar);
+			goto again;
 		}
 
 		/* Does this option take an argument? */

--- a/unzip/cmdline.c
+++ b/unzip/cmdline.c
@@ -81,12 +81,18 @@ bsdunzip_getopt(struct bsdunzip *bsdunzip)
 {
 	enum { state_start = 0, state_next_word, state_short, state_long };
 
-	const struct bsdunzip_option *popt, *match = NULL, *match2 = NULL;
-	const char *p, *long_prefix = "--";
+	const struct bsdunzip_option *popt, *match, *match2;
+	const char *p, *long_prefix;
 	size_t optlength;
-	int opt = OPTION_NONE;
-	int required = 0;
+	int opt;
+	int required;
 
+again:
+	match = NULL;
+	match2 = NULL;
+	long_prefix = "--";
+	opt = OPTION_NONE;
+	required = 0;
 	bsdunzip->argument = NULL;
 
 	/* First time through, initialize everything. */
@@ -140,7 +146,7 @@ bsdunzip_getopt(struct bsdunzip *bsdunzip)
 		if (opt == '\0') {
 			/* End of this group; recurse to get next option. */
 			bsdunzip->getopt_state = state_next_word;
-			return bsdunzip_getopt(bsdunzip);
+			goto again;
 		}
 
 		/* Does this option take an argument? */


### PR DESCRIPTION
Supplying a lot of "-" arguments to tools can lead to stack overflow due to recursive *_getopt function calls.

Proof of Concept:

1. Compile libarchive with Visual Studio 2022
2. Call bsdtar with insane amount of arguments
```
PS> bsdtar.exe ("- "*10000).split(" ")
```
The event log shows that bsdtar.exe failed with `0xc00000fd` (stack overflow).

If compiled with gcc, this does not happen by default because the code is internally optimized to use this suggested loop instead. You have to compile with CFLAGS="-O0" to provoke it with gcc as well.