### PR TITLE
xar: Avoid infinite link loop

### DIFF
--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -2055,6 +2055,11 @@ xml_start(struct archive_read *a, const char *name, struct xmlattr_list *list)
 			    attr = attr->next) {
 				if (strcmp(attr->name, "link") != 0)
 					continue;
+				if (xar->file->hdnext != NULL || xar->file->link != 0) {
+					archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+					    "File with multiple link targets");
+					return (ARCHIVE_FATAL);
+				}
 				if (strcmp(attr->value, "original") == 0) {
 					xar->file->hdnext = xar->hdlink_orgs;
 					xar->hdlink_orgs = xar->file;


### PR DESCRIPTION
A file may have only one link target at a time. Otherwise the internal link structure could loop. Besides, a hard link realistically can only link to one file, not multiple ones.

Consider such an archive invalid.

Proof of Concept:

1. Create archive which contains multiple files with multiple links
```
$ base64 -d > archive.xar << EOF
eGFyIQAcAAEAAAAAAAAB1gAAAAAAAAU8AAAAAXic7VTLcqMwELznKyjuRA9kLKdkcssXZC97E9KA
VeHhAtlF8vWRxMPrsr2pve+JmZ5Wa5jpkngdmzo6Qz+Yrt3H5BnHEbSq06at9vGv97eEx6/5kxhl
nz9FwnbKfSKhepDWnUisaSCnmLIEs4Tgd4pfNvxlwwS6poRDB1Afw6mJBvtZwz4eDpLEvhKJriwH
sDkWaI4COpgvLy5QCLwEWjRCVpoaIqNd27NMK91VHn22oxUopKFgP48Q1ab92MddbyrTyjrOD7LX
HhPIl/+RaNpOQ84Y54wLNGWhoOFsFLSda5ztBFrTUGw8DWfMzadZT5yMzgnG7j99NEED9LntCiMH
h/okwNXKrBZm1Xen40qdslBQ91dD2W83xWUnrqP7NEwcrbnQ5AO1raPJC01LK0MUiRrayh5ykgk0
hxM+L5he73peNr/s2kGLERfDyOOxNiq4Co1J9WWOMZqpslcHcwad3DcZ6LIgjDJebPSuTLMy1UBp
udvgXbpR2xKrIgVauF5vhJZeRttLZR/esC1hiznFgLkkUioMJaVM71SWySLLeEqUYrIgAt0qTbND
y/AE8ha+djj90+GLH//icvKjvR8w/vv61tfrQtyg/AMoUHgOvwGsBYwuAtBf07YHHCCVifUe8mGg
CXTEPed4nEvOzytJzSvhAgAO0QMGeJztVMtyozAQvOcrKO5ED2Qsp2Q=
EOF
```
2. Try to list content
```
$ bsdtar -tf archive.xar
```

An infinite loop is entered with 100 % CPU usage which will never complete (and neither fail due to memory constraints etc.).