### PR TITLE
[RAR4] Avoid overwriting data at "end" of circular window buffer

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2176,6 +2176,19 @@ read_data_compressed(struct archive_read *a, const void **buff, size_t *size,
     {
       start = rar->offset;
       end = start + rar->dictionary_size;
+
+      /* We don't want to overflow the window and overwrite data that we write
+       * at 'start'. Therefore, reduce the end length by the maximum match size,
+       * which is 260 bytes. You can compute this maximum by looking at the
+       * definition of 'expand', in particular when 'symbol >= 271'. */
+      /* NOTE: It's possible for 'dictionary_size' to be less than this 260
+       * value, however that will only be the case when 'unp_size' is small,
+       * which should only happen when the entry size is small and there's no
+       * risk of overflowing the buffer */
+      if (rar->dictionary_size > 260) {
+        end -= 260;
+      }
+
       if (rar->filters.filterstart < end) {
         end = rar->filters.filterstart;
       }


### PR DESCRIPTION
We have data that suggests that one of the most common sources of failures for extracting archives is "File CRC Error". I was able to track down one archive that gives this error, which is available here: https://simplaza.org/fs2crew-fenix-a320-edition-v1-2-234/. In this case, 5 bytes differed in the file `FS2Crew - Fenix A320 Edition v1.2.234\FS2Crew Fenix A320 for MSFS.exe` written to disk (which is a 334 MB executable file). These byte changes are:

Address|Expected|Incorrect
---------|----------|---------
06C37100|DE|AA
06C37101|A8|FF
06C37102|F6|CF
06C37103|BD|7E
0E437100|26|09

This effectively boils down to two sequences of bytes: a 4 byte sequence starting at `06C37100` and a 1 byte sequence starting at `0E437100`. When debugging, you can see that both of these ranges where incorrect memory is written are at the "start" offsets when `expand` is called. It turns out that if you look at the final expected file at these offsets advanced `0x400000` bytes (the default dictionary size - and therefore the default window size), you'll see the exact same byte(s) written to those memory location(s), suggesting that this window buffer is getting "overflown" and bytes at the end of the range of data uncompressed are writing over the bytes at the beginning of that range.

I contemplated two solutions here: (1) detect when overflow would happen and then not write data in such situations, and (2) decrease `end` by some amount that would ensure no overflow would happen. I've opted for solution (2) here because the code in this area is quite complex and attempting to "roll back" or save progress looked very difficult to accomplish and would increase the complexity even more. If you look at the definition of the `expand` function, you'll see that the maximum match length is 260 bytes: 224 (from the `lengthbases` array) plus 3 plus 31 (5 bit maximum from the `lengthbits` array) plus an additional 2 from two increments later on in the `else` statement. The solution I've therefore implemented here is to pass an `end` offset that's effectively equal to `start + dictionary_size - 260`.