### PR TITLE
Change CMAKE_BUILD_TYPE comparison to be case-insensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,14 @@ IF("${cached_type}" STREQUAL "UNINITIALIZED")
   SET(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING "Build Type" FORCE)
 ENDIF("${cached_type}" STREQUAL "UNINITIALIZED")
 # Check the Build Type.
-IF(NOT "${CMAKE_BUILD_TYPE}"
-       MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel|None)\$")
+# Convert the CMAKE_BUILD_TYPE to uppercase to perform a case-insensitive comparison.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+IF(NOT "${CMAKE_BUILD_TYPE_UPPER}"
+       MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL|NONE)\$")
   MESSAGE(FATAL_ERROR
           "Unknown keyword for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}\n"
-          "Acceptable keywords: Debug,Release,RelWithDebInfo,MinSizeRel,None")
-ENDIF(NOT "${CMAKE_BUILD_TYPE}"
-          MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel|None)\$")
+          "Acceptable keywords: Debug, Release, RelWithDebInfo, MinSizeRel, None")
+ENDIF()
 
 # On MacOS, prefer MacPorts libraries to system libraries.
 # I haven't come up with a compelling argument for this to be conditional.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ IF(NOT "${CMAKE_BUILD_TYPE_UPPER}"
   MESSAGE(FATAL_ERROR
           "Unknown keyword for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}\n"
           "Acceptable keywords: Debug, Release, RelWithDebInfo, MinSizeRel, None")
-ENDIF()
+ENDIF(NOT "${CMAKE_BUILD_TYPE_UPPER}"
+       MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL|NONE)\$")
 
 # On MacOS, prefer MacPorts libraries to system libraries.
 # I haven't come up with a compelling argument for this to be conditional.


### PR DESCRIPTION
Currently the `CMAKE_BUILD_TYPE` is being compared in a case-sensitive way. It seems current CMake documentation [suggests treating this in a case-insensitive manner now-a-days](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#case-sensitivity).

This being case-sensitive creates needless complexities in other projects if they compile their own project with `cmake -DCMAKE_BUILD_TYPE=release ..`, etc. In this specific case, libarchive has a fatal error due to the lowercase `release`.

I'd honestly like to remove these comparisons entirely; as I'm not sure if they're really needed or not if `libarchive` is only using the Makefile or Ninja generators with CMake.

This PR changes the `CMAKE_BUILD_TYPE` comparison to be case-insensitive, and leaves the rest alone.

This should also fix the following issue(s):
* https://github.com/libarchive/libarchive/issues/1792