### PR TITLE
7zip: Limit amount of properties

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2037,6 +2037,8 @@ read_Folder(struct archive_read *a, struct _7z_folder *f)
 			if (parse_7zip_uint64(
 			    a, &(f->coders[i].propertiesSize)) < 0)
 				return (-1);
+			if (UMAX_ENTRY < f->coders[i].propertiesSize)
+				return (-1);
 			if ((p = header_bytes(
 			    a, (size_t)f->coders[i].propertiesSize)) == NULL)
 				return (-1);


### PR DESCRIPTION
The uint64_t variable propertiesSize is eventually casted to size_t which, on 32 bit systems, can result in integer truncation.

In such a situation, it is possible that less than the minimum of 5 properties are parsed and processed, which will result in out of boundary reads in init_decompression because the error check `if (coder1->propertiesSize < 5)` still takes the uint64_t variable into account.