### PR TITLE
[Windows] Ignore more directories generated by Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .deps/
 .libs/
 bin/
+out/
 .dirstamp
 Makefile
 Makefile.in
@@ -62,6 +63,7 @@ CMakeCache.txt
 CMakeFiles/
 DartConfiguration.tcl
 cmake.tmp/
+.vs/
 .vscode/
 
 doc/html/*.html


### PR DESCRIPTION
Compiling libarchive with Visual Studio (not Visual Studio Code) generates files in different directories.

Ignore these as well.