### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ questions we are asked about libarchive:
   In case other thread calls the same function in parallel, it might
   get interrupted by it and cause the executable to use umask=0 for the
   remaining execution.
-  This will then lead to implicitely created directories to have 777
+  This will then lead to implicitly created directories to have 777
   permissions without sticky bit.
 
 * In particular, libarchive's modules to read or write a directory

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -895,7 +895,7 @@ __LA_DECL int archive_write_set_options(struct archive *_a,
 			    const char *opts);
 
 /*
- * Set a encryption passphrase.
+ * Set an encryption passphrase.
  */
 __LA_DECL int archive_write_set_passphrase(struct archive *_a, const char *p);
 __LA_DECL int archive_write_set_passphrase_callback(struct archive *,

--- a/libarchive/archive_entry_acl.3
+++ b/libarchive/archive_entry_acl.3
@@ -383,7 +383,7 @@ Prefix each default ACL entry with the word
 The mask and other ACLs don not contain a double colon.
 .El
 .Pp
-The following flags are effecive only on NFSv4 ACL:
+The following flags are effective only on NFSv4 ACL:
 .Bl -tag -offset indent -compact -width ARCHIV
 .It Dv ARCHIVE_ENTRY_ACL_STYLE_COMPACT
 Do not output minus characters for unset permissions and flags in NFSv4 ACL

--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -288,11 +288,11 @@ calls. If matched based on calls to
 .Tn archive_match_time_excluded ,
 or
 .Tn archive_match_owner_excluded ,
-then the callback function specified by the _excluded_func parameter will execute. This function will recieve data provided to the fourth parameter, void *_client_data.
+then the callback function specified by the _excluded_func parameter will execute. This function will receive data provided to the fourth parameter, void *_client_data.
 .It Fn archive_read_disk_set_metadata_filter_callback
 Allows the caller to set a callback function during calls to
 .Xr archive_read_header 3
-to filter out metadata for each entry. The callback function recieves the
+to filter out metadata for each entry. The callback function receives the
 .Tn struct archive
 object, void* custom filter data, and the 
 .Tn struct archive_entry .

--- a/libarchive/archive_read_support_format_all.c
+++ b/libarchive/archive_read_support_format_all.c
@@ -67,7 +67,7 @@ archive_read_support_format_all(struct archive *a)
 	 * increase the chance that a high bid from someone else will
 	 * make it unnecessary for these to do anything at all.
 	 */
-	/* These three have potentially large look-ahead. */
+	/* These have potentially large look-ahead. */
 	archive_read_support_format_7zip(a);
 	archive_read_support_format_cab(a);
 	archive_read_support_format_rar(a);

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -270,7 +270,7 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 		}
 		if (ar->strtab != NULL) {
 			archive_set_error(&a->archive, EINVAL,
-			    "More than one string tables exist");
+			    "More than one string table exists");
 			return (ARCHIVE_FATAL);
 		}
 
@@ -515,7 +515,7 @@ archive_read_format_ar_read_data(struct archive_read *a,
 		if (ar->entry_padding) {
 			if (skipped >= 0) {
 				archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-					"Truncated ar archive- failed consuming padding");
+					"Truncated ar archive - failed consuming padding");
 			}
 			return (ARCHIVE_FATAL);
 		}

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -1693,7 +1693,7 @@ archive_read_format_lha_cleanup(struct archive_read *a)
  * example.
  *   1. a symbolic-name is 'aaa/bb/cc'
  *   2. a filename is 'xxx/bbb'
- *  then a archived pathname is 'xxx/bbb|aaa/bb/cc'
+ *  then an archived pathname is 'xxx/bbb|aaa/bb/cc'
  */
 static int
 lha_parse_linkname(struct archive_wstring *linkname,
@@ -2385,7 +2385,7 @@ lzh_decode_blocks(struct lzh_stream *strm, int last)
 					return (100);
 				}
 
-				/* lzh_br_read_ahead() always try to fill the
+				/* lzh_br_read_ahead() always tries to fill the
 				 * cache buffer up. In specific situation we
 				 * are close to the end of the data, the cache
 				 * buffer will not be full and thus we have to

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -416,8 +416,8 @@ next_line(struct archive_read *a,
 }
 
 /*
- * Compare characters with a mtree keyword.
- * Returns the length of a mtree keyword if matched.
+ * Compare characters with an mtree keyword.
+ * Returns the length of an mtree keyword if matched.
  * Returns 0 if not matched.
  */
 static int
@@ -515,7 +515,7 @@ bid_keyword(const char *p,  ssize_t len)
 
 /*
  * Test whether there is a set of mtree keywords.
- * Returns the number of keyword.
+ * Returns the number of keywords.
  * Returns -1 if we got incorrect sequence.
  * This function expects a set of "<space characters>keyword=value".
  * When "unset" is specified, expects a set of "<space characters>keyword".
@@ -760,7 +760,7 @@ detect_form(struct archive_read *a, int *is_form_d)
 					multiline = 1;
 				else {
 					/* We've got plenty of correct lines
-					 * to assume that this file is a mtree
+					 * to assume that this file is an mtree
 					 * format. */
 					if (++entry_cnt >= MAX_BID_ENTRY)
 						break;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1393,7 +1393,7 @@ check_authentication_code(struct archive_read *a, const void *_p)
  *  [CRC32] [compressed low] [compressed high] [uncompressed low] [uncompressed high] [other PK marker]
  * ```
  * Since the 32-bit and 64-bit compressed sizes both match, the
- * actualy size must fit in 32 bits, which implies the high-order
+ * actual size must fit in 32 bits, which implies the high-order
  * word of the compressed size is zero.  So we know the uncompressed
  * low word is zero, which again implies that if we accept the shorter
  * format, there will not be a valid PK marker following it.

--- a/libarchive/archive_write_private.h
+++ b/libarchive/archive_write_private.h
@@ -158,7 +158,7 @@ int	__archive_write_program_write(struct archive_write_filter *,
 	    struct archive_write_program_data *, const void *, size_t);
 
 /*
- * Get a encryption passphrase.
+ * Get an encryption passphrase.
  */
 const char * __archive_write_get_passphrase(struct archive_write *a);
 #endif

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -387,7 +387,7 @@ archive_write_gnutar_header(struct archive_write *a,
 	if (r != 0) {
 		if (errno == ENOMEM) {
 			archive_set_error(&a->archive, ENOMEM,
-			    "Can't allocate memory for Pathame");
+			    "Can't allocate memory for pathname");
 			ret = ARCHIVE_FATAL;
 			goto exit_write_header;
 		}

--- a/libarchive/libarchive_internals.3
+++ b/libarchive/libarchive_internals.3
@@ -124,7 +124,7 @@ to read the entire file into memory at once and return the
 entire file to libarchive as a single block;
 other clients may begin asynchronous I/O operations for the
 next block on each request.
-.Ss Decompresssion Layer
+.Ss Decompression Layer
 The decompression layer not only handles decompression,
 it also buffers data so that the format handlers see a
 much nicer I/O model.

--- a/libarchive/test/test_read_format_xar_doublelink.xar.uu
+++ b/libarchive/test/test_read_format_xar_doublelink.xar.uu
@@ -1,4 +1,4 @@
-begin 664 test_read_foxmat_xar_doublelink.xar
+begin 664 test_read_format_xar_doublelink.xar
 M>&%R(0`<``$````````!0`````````/7`````7B<[9/!<L(@%$7W?@7#/H60
 MU'0R!'?]`KOICDF>D3&``]'1?GT!-1U;;:=[5[G<=WB0=P>^..@![<%Y94V#
 M\R>*$9C6=LKT#7Y;OF8O>"%F_""=F"$^VC9\$&\=R#'LR$:E03#*RHR6&2N6


### PR DESCRIPTION
Fix typos in comments, documentation, and error messages.