### PR TITLE
warc: Check realloc return value

### DIFF
--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -215,6 +215,7 @@ _warc_rdhdr(struct archive_read *a, struct archive_entry *entry)
 	const char *buf;
 	ssize_t nrd;
 	const char *eoh;
+	char *tmp;
 	/* for the file name, saves some strndup()'ing */
 	warc_string_t fnam;
 	/* warc record type, not that we really use it a lot */
@@ -321,7 +322,14 @@ start_over:
 		 * malloc()+free() roundtrip */
 		if (fnam.len + 1U > w->pool.len) {
 			w->pool.len = ((fnam.len + 64U) / 64U) * 64U;
-			w->pool.str = realloc(w->pool.str, w->pool.len);
+			tmp = realloc(w->pool.str, w->pool.len);
+			if (tmp == NULL) {
+				archive_set_error(
+					&a->archive, ENOMEM,
+					"Out of memory");
+				return (ARCHIVE_FATAL);
+			}
+			w->pool.str = tmp;
 		}
 		memcpy(w->pool.str, fnam.str, fnam.len);
 		w->pool.str[fnam.len] = '\0';


### PR DESCRIPTION
Since realloc could fail, check its return value and set a proper error message.