### PR TITLE
zip: Fix out of boundary access

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -4089,7 +4089,7 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
 				 * as the actual resource fork doesn't end with '/'.
 				 */
 				size_t tmp_length = filename_length;
-				if (name[tmp_length - 1] == '/') {
+				if (tmp_length > 0 && name[tmp_length - 1] == '/') {
 					tmp_length--;
 					r = rsrc_basename(name, tmp_length);
 				}


### PR DESCRIPTION
If a ZIP file contains a file with an empty name and mac-ext option is set, then a check accesses memory out of bound of `name`.