### PR TITLE
fix: OOB in rar delta filter

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3612,7 +3612,15 @@ execute_filter_delta(struct rar_filter *filter, struct rar_virtual_machine *vm)
   {
     uint8_t lastbyte = 0;
     for (idx = i; idx < length; idx += numchannels)
+    {
+      /*
+       * The src block should not overlap with the dst block.
+       * If so it would be better to consider this archive is broken.
+       */
+      if (src >= dst)
+        return 0;
       lastbyte = dst[idx] = lastbyte - *src++;
+    }
   }
 
   filter->filteredblockaddress = length;


### PR DESCRIPTION
This patch ensures that `src` won't move ahead of `dst`, so `src` will not OOB.

Since `dst` won't move in this function, and we only increasing `src` position, this check should be enough.

It should be safe to early return because this function does not allocate resources.