### PR TITLE
fix: OOB in rar audio filter

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3714,6 +3714,13 @@ execute_filter_audio(struct rar_filter *filter, struct rar_virtual_machine *vm)
     memset(&state, 0, sizeof(state));
     for (j = i; j < length; j += numchannels)
     {
+      /*
+       * The src block should not overlap with the dst block.
+       * If so it would be better to consider this archive is broken.
+       */
+      if (src >= dst)
+        return 0;
+
       int8_t delta = (int8_t)*src++;
       uint8_t predbyte, byte;
       int prederror;


### PR DESCRIPTION
This patch ensures that `src` won't move ahead of `dst`, so `src` will not OOB.

Since `dst` won't move in this function, and we only increasing `src` position, this check should be enough.

It should be safe to early return because this function does not allocate resources.