### PR TITLE
xar: Fix another infinite loop and expat error handling

### DIFF
--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -2055,9 +2055,10 @@ xml_start(struct archive_read *a, const char *name, struct xmlattr_list *list)
 			    attr = attr->next) {
 				if (strcmp(attr->name, "link") != 0)
 					continue;
-				if (xar->file->hdnext != NULL || xar->file->link != 0) {
+				if (xar->file->hdnext != NULL || xar->file->link != 0 ||
+				    xar->file == xar->hdlink_orgs) {
 					archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-					    "File with multiple link targets");
+					    "File with multiple link attributes");
 					return (ARCHIVE_FATAL);
 				}
 				if (strcmp(attr->value, "original") == 0) {

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -3256,6 +3256,9 @@ expat_start_cb(void *userData, const XML_Char *name, const XML_Char **atts)
 	struct xmlattr_list list;
 	int r;
 
+	if (ud->state != ARCHIVE_OK)
+		return;
+
 	r = expat_xmlattr_setup(a, &list, atts);
 	if (r == ARCHIVE_OK)
 		r = xml_start(a, (const char *)name, &list);

--- a/libarchive/test/test_read_format_xar_doublelink.c
+++ b/libarchive/test/test_read_format_xar_doublelink.c
@@ -47,7 +47,7 @@ DEFINE_TEST(test_read_format_xar_doublelink)
 
 	assertA(ARCHIVE_FATAL == archive_read_next_header(a, &ae));
 	assertEqualString(archive_error_string(a),
-		"File with multiple link targets");
+		"File with multiple link attributes");
 	assert(archive_errno(a) != 0);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));


### PR DESCRIPTION
The expat code could override error conditions with success return values. Fixes https://github.com/libarchive/libarchive/issues/2146.

Since it made me curious why such incomplete failure check still leads to endless loops, I discovered another one which can be triggered by adding `link=original` multiple times. The already existing doublelink test file contains such condition as well.

Fixed both issues:
- expat code keeps track of error conditions
- Adding link=original multiple times is prohibited