### PR TITLE
Check archive_read_support_format_raw return value

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -605,7 +605,8 @@ add_pattern_from_file(struct archive_match *a, struct match_list *mlist,
 		return (ARCHIVE_FATAL);
 	}
 	r = archive_read_support_format_raw(ar);
-	r = archive_read_support_format_empty(ar);
+	if (r == ARCHIVE_OK)
+		r = archive_read_support_format_empty(ar);
 	if (r != ARCHIVE_OK) {
 		archive_copy_error(&(a->archive), ar);
 		archive_read_free(ar);


### PR DESCRIPTION
If call of archive_read_support_format_raw fails, do not override the error return value with the return value of
archive_read_support_format_empty. Instead, return error code as expected.