### PR TITLE
Don't specify visibility attributes for static libraries

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -118,10 +118,13 @@ typedef ssize_t la_ssize_t;
 #   define __LA_DECL	__declspec(dllimport)
 #  endif
 # endif
-#elif defined __LIBARCHIVE_ENABLE_VISIBILITY
+#elif defined __LIBARCHIVE_ENABLE_VISIBILITY && (!defined LIBARCHIVE_STATIC)
 #  define __LA_DECL __attribute__((visibility("default")))
 #else
-/* Static libraries or non-Windows needs no special declaration. */
+/*
+ * Static libraries on all platforms and shared libraries on non-Windows
+ * platforms that don't support visibility annotations.
+ */
 # define __LA_DECL
 #endif
 

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -120,10 +120,13 @@ typedef ssize_t la_ssize_t;
 #   define __LA_DECL	__declspec(dllimport)
 #  endif
 # endif
-#elif defined __LIBARCHIVE_ENABLE_VISIBILITY
+#elif defined __LIBARCHIVE_ENABLE_VISIBILITY && (!defined LIBARCHIVE_STATIC)
 #  define __LA_DECL __attribute__((visibility("default")))
 #else
-/* Static libraries on all platforms and shared libraries on non-Windows. */
+/*
+ * Static libraries on all platforms and shared libraries on non-Windows
+ * platforms that don't support visibility annotations.
+ */
 # define __LA_DECL
 #endif
 


### PR DESCRIPTION
This was introduced in #1751 and will cause those symbols get exported when static libarchive is linked to a shared library.