### PR TITLE
zip: Improve bid for huge EOCDs

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3680,7 +3680,7 @@ read_eocd(struct zip *zip, const char *p, int64_t current_offset)
 	if (archive_le16dec(p + 10) != archive_le16dec(p + 8))
 		return 0;
 	/* Central directory can't extend beyond start of EOCD record. */
-	if (cd_offset + cd_size > current_offset)
+	if ((int64_t)cd_offset + cd_size > current_offset)
 		return 0;
 
 	/* Save the central directory location for later use. */


### PR DESCRIPTION
Cast any of cd_offset or cd_size to int64_t to avoid truncation of result because both variables are of type uint32_t.

The calculation happens before comparison with current_offset, so it is not automatically expanded to int64_t during calculation.