### PR TITLE
Rename the test to match the filename, and avoid test failures on cas…

### DIFF
--- a/unzip/test/test_P_encryption.c
+++ b/unzip/test/test_P_encryption.c
@@ -26,7 +26,7 @@
 #include "test.h"
 
 /* Test P arg - password protected */
-DEFINE_TEST(test_P)
+DEFINE_TEST(test_P_encryption)
 {
 	const char *reffile = "test_encrypted.zip";
 	int r;


### PR DESCRIPTION
…e-insensitive filesystems

Resolves #2164 