### PR TITLE
Define INT_MAX via `#include <limits.h>`

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -43,6 +43,9 @@
 #ifdef HAVE_LANGINFO_H
 #include <langinfo.h>
 #endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
 #endif


### PR DESCRIPTION
#2110 added usages of INT_MAX here without adding the necessary header.

Resolves #2162 
