### PR TITLE
lzop: Prevent integer overflow

### DIFF
--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -291,7 +291,8 @@ consume_header(struct archive_read_filter *self)
 		if (p == NULL)
 			goto truncated;
 		len = archive_be32dec(p);
-		__archive_read_filter_consume(self->upstream, len + 4 + 4);
+		__archive_read_filter_consume(self->upstream,
+		    (int64_t)len + 4 + 4);
 	}
 	state->flags = flags;
 	state->in_stream = 1;


### PR DESCRIPTION
Cast to int64_t to cover all unsigned 32 bit values without running into issues with C standard.