### PR TITLE
[Windows] Fix test compilation warnings with Visual Studio

### DIFF
--- a/cpio/test/test_option_c.c
+++ b/cpio/test/test_option_c.c
@@ -119,9 +119,9 @@ DEFINE_TEST(test_option_c)
 	assert(is_octal(e, 76)); /* Entire header is octal digits. */
 	assertEqualMem(e + 0, "070707", 6); /* Magic */
 	assert(is_octal(e + 6, 6)); /* dev */
-	dev = from_octal(e + 6, 6);
+	dev = (int)from_octal(e + 6, 6);
 	assert(is_octal(e + 12, 6)); /* ino */
-	ino = from_octal(e + 12, 6);
+	ino = (int)from_octal(e + 12, 6);
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	/* Group members bits and others bits do not work. */
 	assertEqualMem(e + 18, "100666", 6); /* Mode */
@@ -129,10 +129,10 @@ DEFINE_TEST(test_option_c)
 	assertEqualMem(e + 18, "100644", 6); /* Mode */
 #endif
 	if (uid < 0)
-		uid = from_octal(e + 24, 6);
+		uid = (int)from_octal(e + 24, 6);
 	assertEqualInt(from_octal(e + 24, 6), uid); /* uid */
 	assert(is_octal(e + 30, 6)); /* gid */
-	gid = from_octal(e + 30, 6);
+	gid = (int)from_octal(e + 30, 6);
 	assertEqualMem(e + 36, "000001", 6); /* nlink */
 	failure("file entries should not have rdev set (dev field was 0%o)",
 	    dev);

--- a/libarchive/test/test_archive_match_time.c
+++ b/libarchive/test/test_archive_match_time.c
@@ -316,14 +316,13 @@ test_newer_mtime_than_file_mbs(void)
 static void
 test_newer_ctime_than_file_mbs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -373,6 +372,7 @@ test_newer_ctime_than_file_mbs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void
@@ -435,14 +435,13 @@ test_newer_mtime_than_file_wcs(void)
 static void
 test_newer_ctime_than_file_wcs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -493,6 +492,7 @@ test_newer_ctime_than_file_wcs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void
@@ -787,14 +787,13 @@ test_older_mtime_than_file_mbs(void)
 static void
 test_older_ctime_than_file_mbs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -845,6 +844,7 @@ test_older_ctime_than_file_mbs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void
@@ -907,14 +907,13 @@ test_older_mtime_than_file_wcs(void)
 static void
 test_older_ctime_than_file_wcs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -965,6 +964,7 @@ test_older_ctime_than_file_wcs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void
@@ -1088,14 +1088,13 @@ test_mtime_between_files_wcs(void)
 static void
 test_ctime_between_files_mbs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -1147,19 +1146,19 @@ test_ctime_between_files_mbs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void
 test_ctime_between_files_wcs(void)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	skipping("Can't set ctime on Windows");
+	return;
+#else
 	struct archive *a;
 	struct archive_entry *ae;
 	struct archive *m;
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-        skipping("Can't set ctime on Windows");
-        return;
-#endif
 
 	if (!assert((m = archive_match_new()) != NULL))
 		return;
@@ -1211,6 +1210,7 @@ test_ctime_between_files_wcs(void)
 	archive_read_free(a);
 	archive_entry_free(ae);
 	archive_match_free(m);
+#endif
 }
 
 static void

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -932,19 +932,22 @@ DEFINE_TEST(test_read_format_rar5_symlink)
 	assertEqualInt(AE_IFLNK, archive_entry_filetype(ae));
 	assertEqualString("file.txt", archive_entry_symlink(ae));
 	assertEqualInt(AE_SYMLINK_TYPE_FILE, archive_entry_symlink_type(ae));
-	assertA(0 == archive_read_data(a, NULL, archive_entry_size(ae)));
+	assertEqualInt(0, archive_entry_size(ae));
+	assertA(0 == archive_read_data(a, NULL, (size_t)archive_entry_size(ae)));
 
 	assertA(0 == archive_read_next_header(a, &ae));
 	assertEqualString("dirlink", archive_entry_pathname(ae));
 	assertEqualInt(AE_IFLNK, archive_entry_filetype(ae));
 	assertEqualString("dir", archive_entry_symlink(ae));
 	assertEqualInt(AE_SYMLINK_TYPE_DIRECTORY, archive_entry_symlink_type(ae));
-	assertA(0 == archive_read_data(a, NULL, archive_entry_size(ae)));
+	assertEqualInt(0, archive_entry_size(ae));
+	assertA(0 == archive_read_data(a, NULL, (size_t)archive_entry_size(ae)));
 
 	assertA(0 == archive_read_next_header(a, &ae));
 	assertEqualString("dir", archive_entry_pathname(ae));
 	assertEqualInt(AE_IFDIR, archive_entry_filetype(ae));
-	assertA(0 == archive_read_data(a, NULL, archive_entry_size(ae)));
+	assertEqualInt(0, archive_entry_size(ae));
+	assertA(0 == archive_read_data(a, NULL, (size_t)archive_entry_size(ae)));
 
 	assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
 
@@ -969,7 +972,8 @@ DEFINE_TEST(test_read_format_rar5_hardlink)
 	assertEqualString("hardlink.txt", archive_entry_pathname(ae));
 	assertEqualInt(AE_IFREG, archive_entry_filetype(ae));
 	assertEqualString("file.txt", archive_entry_hardlink(ae));
-	assertA(0 == archive_read_data(a, NULL, archive_entry_size(ae)));
+	assertEqualInt(0, archive_entry_size(ae));
+	assertA(0 == archive_read_data(a, NULL, (size_t)archive_entry_size(ae)));
 
 	assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
 

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -121,6 +121,8 @@
 #define access _access
 #undef chdir
 #define chdir _chdir
+#undef chmod
+#define chmod _chmod
 #endif
 #ifndef fileno
 #define fileno _fileno


### PR DESCRIPTION
Fixes all test-related compiler warnings with Visual Studio 2022 on Windows 11.

Contains some changes from https://github.com/libarchive/libarchive/pull/2095.

CC: @dunhor