### PR TITLE
uu: Fix Visual Studio compiler warning

### DIFF
--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -506,7 +506,7 @@ read_more:
 		uudecode->in_cnt = 0;
 	}
 	for (;used < avail_in; d += llen, used += llen) {
-		int64_t l, body;
+		ssize_t l, body;
 
 		b = d;
 		len = get_line(b, avail_in - used, &nl);


### PR DESCRIPTION
Switch from int64_t to ssize_t for l and body, which is a no-op on 64 bit systems. On 32 bit systems, this change is okay because these variables interact with other ssize_t variables in this scope.

Fixes compiler warning regarding line 584 in which ssize_t and int64_t are mixed in calculations:

warning C4244: '=': conversion from 'int64_t' to 'long'