### PR TITLE
rar: Fix Visual Studio compiler warning

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3365,7 +3365,7 @@ run_filters(struct archive_read *a)
   if (filters == NULL || filter == NULL)
     return (0);
 
-  start = filters->filterstart;
+  start = (size_t)filters->filterstart;
   end = start + filter->blocklength;
 
   filters->filterstart = INT64_MAX;
@@ -3405,7 +3405,7 @@ run_filters(struct archive_read *a)
   ret = copy_from_lzss_window(a, filters->vm->memory, start, filter->blocklength);
   if (ret != ARCHIVE_OK)
     return 0;
-  if (!execute_filter(a, filter, filters->vm, rar->offset))
+  if (!execute_filter(a, filter, filters->vm, (size_t)rar->offset))
     return 0;
 
   lastfilteraddress = filter->filteredblockaddress;
@@ -3417,7 +3417,7 @@ run_filters(struct archive_read *a)
   while ((filter = filters->stack) != NULL && (int64_t)filter->blockstartpos == filters->filterstart && filter->blocklength == lastfilterlength)
   {
     memmove(&filters->vm->memory[0], &filters->vm->memory[lastfilteraddress], lastfilterlength);
-    if (!execute_filter(a, filter, filters->vm, rar->offset))
+    if (!execute_filter(a, filter, filters->vm, (size_t)rar->offset))
       return 0;
 
     lastfilteraddress = filter->filteredblockaddress;


### PR DESCRIPTION
Fixes the following warning:

warning C4244: '=': conversion from 'int64_t' to 'size_t', possible loss of data