### PR TITLE
Fix Visual Studio compiler warnings (64 bit)

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -843,7 +843,7 @@ DEFINE_TEST(test_read_format_rar5_block_by_block)
 	struct archive_entry *ae;
 	struct archive *a;
 	uint8_t buf[173];
-	int bytes_read;
+	ssize_t bytes_read;
 	uint32_t computed_crc = 0;
 
 	extract_reference_file("test_read_format_rar5_compressed.rar");

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -219,7 +219,8 @@ my_CreateSymbolicLinkA(const char *linkname, const char *target,
 	static BOOLEAN (WINAPI *f)(LPCSTR, LPCSTR, DWORD);
 	DWORD attrs;
 	static int set;
-	int ret, tmpflags, llen, tlen;
+	int ret, tmpflags;
+	size_t llen, tlen;
 	int flags = 0;
 	char *src, *tgt, *p;
 	if (!set) {
@@ -3879,9 +3880,9 @@ main(int argc, char **argv)
 	static const int limit = sizeof(tests) / sizeof(tests[0]);
 	int test_set[sizeof(tests) / sizeof(tests[0])];
 	int i = 0, j = 0, tests_run = 0, tests_failed = 0, option;
-	int testprogdir_len;
+	size_t testprogdir_len;
 #ifdef PROGRAM
-	int tmp2_len;
+	size_t tmp2_len;
 #endif
 	time_t now;
 	struct tm *tmptr;
@@ -4085,7 +4086,7 @@ main(int argc, char **argv)
 
 	{
 		char *testprg;
-		int testprg_len;
+		size_t testprg_len;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 		/* Command.com sometimes rejects '/' separators. */
 		testprg = strdup(testprogfile);


### PR DESCRIPTION
Some warnings are specific to 64 bit systems. Compiled with Visual Studio 2022 on Windows 11 x64.