### PR TITLE
Check the programmer error when in archive_write_get_bytes_per_block

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -354,6 +354,10 @@ archive_write_client_open(struct archive_write_filter *f)
 	int ret;
 
 	f->bytes_per_block = archive_write_get_bytes_per_block(f->archive);
+	if (f->bytes_per_block < 0){
+                // The `__archive_check_magic` function already set an error
+        	return (ARCHIVE_FATAL);
+        }
 	f->bytes_in_last_block =
 	    archive_write_get_bytes_in_last_block(f->archive);
 	buffer_size = f->bytes_per_block;

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -146,12 +146,17 @@ static int
 archive_filter_b64encode_open(struct archive_write_filter *f)
 {
 	struct private_b64encode *state = (struct private_b64encode *)f->data;
-	size_t bs = 65536, bpb;
+	ssize_t bpb;
+	size_t bs = 65536;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 		/* Buffer size should be a multiple number of the bytes
 		 * per block for performance. */
 		bpb = archive_write_get_bytes_per_block(f->archive);
+		if (bpb < 0){
+	                // The `__archive_check_magic` function already set an error
+                	return (ARCHIVE_FATAL);
+      		}
 		if (bpb > bs)
 			bs = bpb;
 		else if (bpb != 0)

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -166,11 +166,16 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 	int ret;
 
 	if (data->compressed == NULL) {
-		size_t bs = 65536, bpb;
+		ssize_t bpb;
+		size_t bs = 65536;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of the bytes
 			 * per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
+			if (bpb < 0){
+		                // The `__archive_check_magic` function already set an error
+                		return (ARCHIVE_FATAL);
+			}
 			if (bpb > bs)
 				bs = bpb;
 			else if (bpb != 0)

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -145,7 +145,8 @@ static int
 archive_compressor_compress_open(struct archive_write_filter *f)
 {
 	struct private_data *state;
-	size_t bs = 65536, bpb;
+	ssize_t bpb;
+	size_t bs = 65536;
 
 	f->code = ARCHIVE_FILTER_COMPRESS;
 	f->name = "compress";
@@ -161,6 +162,10 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 		/* Buffer size should be a multiple number of the bytes
 		 * per block for performance. */
 		bpb = archive_write_get_bytes_per_block(f->archive);
+		if (bpb < 0){
+                	// The `__archive_check_magic` function already set an error
+        	        return (ARCHIVE_FATAL);
+	        }
 		if (bpb > bs)
 			bs = bpb;
 		else if (bpb != 0)

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -183,11 +183,16 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	int ret;
 
 	if (data->compressed == NULL) {
-		size_t bs = 65536, bpb;
+		ssize_t bpb;
+		size_t bs = 65536;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
 			 * the of bytes per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
+			if (bpb < 0){
+		                // The `__archive_check_magic` function already set an error
+                		return (ARCHIVE_FATAL);
+            		}
 			if (bpb > bs)
 				bs = bpb;
 			else if (bpb != 0)

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -233,12 +233,17 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 
 	required_size = 4 + 15 + 4 + data->block_size + 4 + 4;
 	if (data->out_buffer_size < required_size) {
-		size_t bs = required_size, bpb;
+		ssize_t bpb;
+		size_t bs = required_size;
 		free(data->out_buffer);
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
 			 * the of bytes per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
+			if (bpb < 0){
+                		// The `__archive_check_magic` function already set an error
+		                return (ARCHIVE_FATAL);
+            		}
 			if (bpb > bs)
 				bs = bpb;
 			else if (bpb != 0) {

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -308,11 +308,16 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 	int ret;
 
 	if (data->compressed == NULL) {
-		size_t bs = 65536, bpb;
+		ssize_t bpb;
+		size_t bs = 65536;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of the bytes
 			 * per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
+			if (bpb < 0){
+                		// The `__archive_check_magic` function already set an error
+		                return (ARCHIVE_FATAL);
+            		}
 			if (bpb > bs)
 				bs = bpb;
 			else if (bpb != 0)

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -360,11 +360,16 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 	struct private_data *data = (struct private_data *)f->data;
 
 	if (data->out.dst == NULL) {
-		size_t bs = ZSTD_CStreamOutSize(), bpb;
+		ssize_t bpb;
+		size_t bs = ZSTD_CStreamOutSize();
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
 			 * the of bytes per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
+			if (bpb < 0){
+				// The `__archive_check_magic` function already set an error
+				return (ARCHIVE_FATAL);
+			}
 			if (bpb > bs)
 				bs = bpb;
 			else if (bpb != 0)


### PR DESCRIPTION
The `archive_write_get_bytes_per_block` can return a negative value when the `archive_check_magic` function detects a programmer error. This is not handled properly as the program only displays an error but doesn't terminate.

Reported issue: https://github.com/libarchive/libarchive/issues/2185