### PR TITLE
7zip: Fix NULL pointer dereference on non-zlib builds

### DIFF
--- a/libarchive/archive_crc32.h
+++ b/libarchive/archive_crc32.h
@@ -30,6 +30,8 @@
 #error This header is only to be used internally to libarchive.
 #endif
 
+#include <stddef.h>
+
 /*
  * When zlib is unavailable, we should still be able to validate
  * uncompressed zip archives.  That requires us to be able to compute
@@ -45,6 +47,9 @@ crc32(unsigned long crc, const void *_p, size_t len)
 	const unsigned char *p = _p;
 	static volatile int crc_tbl_inited = 0;
 	static unsigned long crc_tbl[256];
+
+	if (_p == NULL)
+		return (0);
 
 	if (!crc_tbl_inited) {
 		for (b = 0; b < 256; ++b) {

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2414,6 +2414,8 @@ read_StreamsInfo(struct archive_read *a, struct _7z_stream_info *si)
 		packPos = si->pi.pos;
 		for (i = 0; i < si->pi.numPackStreams; i++) {
 			si->pi.positions[i] = packPos;
+			if (packPos > UINT64_MAX - si->pi.sizes[i])
+				return (-1);
 			packPos += si->pi.sizes[i];
 			if (packPos > zip->header_offset)
 				return (-1);

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3141,7 +3141,7 @@ get_uncompressed_data(struct archive_read *a, const void **buff, size_t size,
 		/* Copy mode. */
 
 		*buff = __archive_read_ahead(a, minimum, &bytes_avail);
-		if (bytes_avail <= 0) {
+		if (*buff == NULL) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated 7-Zip file data");

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2442,6 +2442,10 @@ read_StreamsInfo(struct archive_read *a, struct _7z_stream_info *si)
 		f = si->ci.folders;
 		for (i = 0; i < si->ci.numFolders; i++) {
 			f[i].packIndex = packIndex;
+			if (f[i].numPackedStreams > UINT32_MAX)
+				return (-1);
+			if (packIndex > UINT32_MAX - (uint32_t)f[i].numPackedStreams)
+				return (-1);
 			packIndex += (uint32_t)f[i].numPackedStreams;
 			if (packIndex > si->pi.numPackStreams)
 				return (-1);


### PR DESCRIPTION
If libarchive is built without zlib support, it is possible to trigger a NULL pointer dereference with specially crafted 7zip files.

It takes multiple conditions to be able to reach the issue in crc32 and all 7zip-specific ones are fixed with this PR.