### PR TITLE
cab: Cover all error cases in __archive_read_ahead

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1682,7 +1682,7 @@ cab_read_ahead_cfdata_lzx(struct archive_read *a, ssize_t *avail)
 		    cfdata->uncompressed_size - cab->xstrm.total_out;
 
 		d = __archive_read_ahead(a, 1, &bytes_avail);
-		if (bytes_avail <= 0) {
+		if (d == NULL) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated CAB file data");


### PR DESCRIPTION
If a short read is performed, fail with truncation error message as well.