### PR TITLE
Fix EOF handling of __archive_read_ahead

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -380,6 +380,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_match_path.c \
 	libarchive/test/test_archive_match_time.c \
 	libarchive/test/test_archive_pathmatch.c \
+	libarchive/test/test_archive_read.c \
 	libarchive/test/test_archive_read_add_passphrase.c \
 	libarchive/test/test_archive_read_close_twice.c \
 	libarchive/test/test_archive_read_close_twice_open_fd.c \

--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -27,7 +27,9 @@
 #define ARCHIVE_PRIVATE_H_INCLUDED
 
 #ifndef __LIBARCHIVE_BUILD
+#ifndef __LIBARCHIVE_TEST
 #error This header is only to be used internally to libarchive.
+#endif
 #endif
 
 #if HAVE_ICONV_H

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1382,7 +1382,7 @@ __archive_read_filter_ahead(struct archive_read_filter *filter,
 		if (filter->client_avail <= 0) {
 			if (filter->end_of_file) {
 				if (avail != NULL)
-					*avail = 0;
+					*avail = filter->avail;
 				return (NULL);
 			}
 			bytes_read = (filter->vtable->read)(filter,

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -24,6 +24,7 @@ IF(ENABLE_TEST)
     test_archive_match_path.c
     test_archive_match_time.c
     test_archive_pathmatch.c
+    test_archive_read.c
     test_archive_read_add_passphrase.c
     test_archive_read_close_twice.c
     test_archive_read_close_twice_open_fd.c

--- a/libarchive/test/test_archive_read.c
+++ b/libarchive/test/test_archive_read.c
@@ -1,0 +1,63 @@
+/*-
+ * Copyright (c) 2024 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#define __LIBARCHIVE_TEST
+#include "archive_read_private.h"
+
+static char buf[1024];
+
+DEFINE_TEST(test_archive_read_ahead_eof)
+{
+	struct archive *a;
+	struct archive_read *ar;
+	ssize_t avail;
+
+	/* prepare a reader of raw in-memory data */
+	assert((a = archive_read_new()) != NULL);
+	ar = (struct archive_read *)a;
+
+	assertA(0 == archive_read_support_format_raw(a));
+	assertA(0 == archive_read_open_memory(a, buf, sizeof(buf)));
+
+	/* perform a read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, sizeof(buf) - 1, &avail));
+	assertEqualInt(sizeof(buf), avail);
+
+	/* perform a read which cannot be fulfilled due to EOF */
+	assert(NULL == __archive_read_ahead(ar, sizeof(buf) + 1, &avail));
+	assertEqualInt(sizeof(buf), avail);
+
+	/* perform the same read again */
+	assert(NULL == __archive_read_ahead(ar, sizeof(buf) + 1, &avail));
+	assertEqualInt(sizeof(buf), avail);
+
+	/* perform another read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, sizeof(buf), &avail));
+	assertEqualInt(sizeof(buf), avail);
+
+	assert(0 == archive_read_free(a));
+}


### PR DESCRIPTION
Reaching EOF for first time sets the correct amount of available bytes, but each subsequent call returns 0.

Do not forget that the copy buffer can already contain data and return the amount of bytes left in there.

See added test case.