### PR TITLE
7zip: Fix DONT_FAIL_ON_CRC_ERROR check

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3010,7 +3010,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	/* CRC check. */
 	if (crc32(0, (const unsigned char *)p + 12, 20)
 	    != archive_le32dec(p + 8)) {
-#ifdef DONT_FAIL_ON_CRC_ERROR
+#ifndef DONT_FAIL_ON_CRC_ERROR
 		archive_set_error(&a->archive, -1, "Header CRC error");
 		return (ARCHIVE_FATAL);
 #endif


### PR DESCRIPTION
This actually disabled CRC checks on regular builds and enabled it if CRC checks were supposed to be disabled.

All other occurrences properly use ifndef instead of ifdef.