### PR TITLE
[MSVC] cast to unsigned int to fix compiler error - archive_read_support_format_rar.c

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3142,7 +3142,7 @@ copy_from_lzss_window_to_unp(struct archive_read *a, const void **buffer,
   } else {
       goto fatal;
   }
-  rar->unp_offset += length;
+  rar->unp_offset += (unsigned int) length;
   if (rar->unp_offset >= rar->unp_buffer_size)
     *buffer = rar->unp_buffer;
   else


### PR DESCRIPTION
Fixes error `C4267: '+=': conversion from 'size_t' to 'unsigned int'. Possible loss of data.` which stops compiling with MSVC.

From looking at the code it goes from int64_t of rar->bytes_uncopied which is then casted to size_t and saved to bs already by the code.
Could this pontentially create issues with hws where size_t is 64 bits and not 32? Still, it is used for an addition with an `unsigned int` result so this casting could have no major issues.