### PR TITLE
fix: set tree::current for initial tree walking

### DIFF
--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1955,6 +1955,8 @@ tree_dir_next_windows(struct tree *t, const wchar_t *pattern)
 				t->visit_type = r != 0 ? r : TREE_ERROR_DIR;
 				return (t->visit_type);
 			}
+			/* Top stack item needs a regular visit. */
+			t->current = t->stack;
 			t->findData = &t->_findData;
 			pattern = NULL;
 		} else if (!FindNextFileW(t->d, &t->_findData)) {

--- a/tar/test/test_option_H_upper.c
+++ b/tar/test/test_option_H_upper.c
@@ -78,8 +78,22 @@ DEFINE_TEST(test_option_H_upper)
 	/* Test 3: With -H, some symlinks on command line. */
 	assertMakeDir("test3", 0755);
 	assertEqualInt(0,
-	    systemf("%s -cf test3/archive.tar -H -C in ld1 d1 link2 linkY >test2/c.out 2>test2/c.err", testprog));
+	    systemf("%s -cf test3/archive.tar -H -C in ld1 d1 link2 linkY >test3/c.out 2>test3/c.err", testprog));
 	assertChdir("test3");
+	assertEqualInt(0,
+	    systemf("%s -xf archive.tar >c.out 2>c.err", testprog));
+	assertIsDir("ld1", umasked(0755));
+	assertIsSymlink("d1/linkX", "fileX", 0);
+	assertIsSymlink("d1/link1", "file1", 0);
+	assertIsReg("link2", umasked(0644));
+	assertIsSymlink("linkY", "d1/fileY", 0);
+	assertChdir("..");
+
+	/* Test 4: With -H, using wildcards with some symlinks on command line. */
+	assertMakeDir("test4", 0755);
+	assertEqualInt(0,
+	    systemf("%s -cf test4/archive.tar -H -C in * >test4/c.out 2>test4/c.err", testprog));
+	assertChdir("test4");
 	assertEqualInt(0,
 	    systemf("%s -xf archive.tar >c.out 2>c.err", testprog));
 	assertIsDir("ld1", umasked(0755));

--- a/tar/test/test_option_H_upper.c
+++ b/tar/test/test_option_H_upper.c
@@ -89,7 +89,8 @@ DEFINE_TEST(test_option_H_upper)
 	assertIsSymlink("linkY", "d1/fileY", 0);
 	assertChdir("..");
 
-	/* Test 4: With -H, using wildcards with some symlinks on command line. */
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	/* Test 4: With -H, using wildcards with some symlinks on command line. (wildcards are supported only in Windows) */
 	assertMakeDir("test4", 0755);
 	assertEqualInt(0,
 	    systemf("%s -cf test4/archive.tar -H -C in * >test4/c.out 2>test4/c.err", testprog));
@@ -102,4 +103,5 @@ DEFINE_TEST(test_option_H_upper)
 	assertIsReg("link2", umasked(0644));
 	assertIsSymlink("linkY", "d1/fileY", 0);
 	assertChdir("..");
+#endif
 }

--- a/tar/test/test_option_L_upper.c
+++ b/tar/test/test_option_L_upper.c
@@ -78,8 +78,22 @@ DEFINE_TEST(test_option_L_upper)
 	/* Test 3: With -L, some symlinks on command line. */
 	assertMakeDir("test3", 0755);
 	assertEqualInt(0,
-	    systemf("%s -cf test3/archive.tar -L -C in ld1 d1 link2 linkY >test2/c.out 2>test2/c.err", testprog));
+	    systemf("%s -cf test3/archive.tar -L -C in ld1 d1 link2 linkY >test3/c.out 2>test3/c.err", testprog));
 	assertChdir("test3");
+	assertEqualInt(0,
+	    systemf("%s -xf archive.tar >c.out 2>c.err", testprog));
+	assertIsDir("ld1", umasked(0755));
+	assertIsReg("d1/link1", umasked(0644));
+	assertIsSymlink("d1/linkX", "fileX", 0);
+	assertIsReg("link2", umasked(0644));
+	assertIsSymlink("linkY", "d1/fileY", 0);
+	assertChdir("..");
+
+	/* Test 4: With -L, using wildcards with some symlinks on command line. */
+	assertMakeDir("test4", 0755);
+	assertEqualInt(0,
+	    systemf("%s -cf test4/archive.tar -L -C in * >test4/c.out 2>test4/c.err", testprog));
+	assertChdir("test4");
 	assertEqualInt(0,
 	    systemf("%s -xf archive.tar >c.out 2>c.err", testprog));
 	assertIsDir("ld1", umasked(0755));

--- a/tar/test/test_option_L_upper.c
+++ b/tar/test/test_option_L_upper.c
@@ -89,7 +89,8 @@ DEFINE_TEST(test_option_L_upper)
 	assertIsSymlink("linkY", "d1/fileY", 0);
 	assertChdir("..");
 
-	/* Test 4: With -L, using wildcards with some symlinks on command line. */
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	/* Test 4: With -L, using wildcards with some symlinks on command line. (wildcards are supported only in Windows) */
 	assertMakeDir("test4", 0755);
 	assertEqualInt(0,
 	    systemf("%s -cf test4/archive.tar -L -C in * >test4/c.out 2>test4/c.err", testprog));
@@ -102,4 +103,5 @@ DEFINE_TEST(test_option_L_upper)
 	assertIsReg("link2", umasked(0644));
 	assertIsSymlink("linkY", "d1/fileY", 0);
 	assertChdir("..");
+#endif
 }


### PR DESCRIPTION
- Fixes #2211 

On tree walking with wildcards, initializes `tree::current` (i.e. `t->current`) with `t->stack` to refrain from accessing null pointer.