### PR TITLE
Fix compilation when using Clang in "MSVC mode"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ endif ()
 # aggressive about diagnosing build problems; this can get
 # relaxed somewhat in final shipping versions.
 IF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
-    CMAKE_C_COMPILER_ID MATCHES "^Clang$")
+    CMAKE_C_COMPILER_ID MATCHES "^Clang$" AND NOT MSVC)
   SET(CMAKE_REQUIRED_FLAGS "-Wall -Wformat -Wformat-security")
   #################################################################
   # Set compile flags for all build types.
@@ -144,7 +144,7 @@ IF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
     SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-dead_strip")
   ENDIF(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
 ENDIF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
-       CMAKE_C_COMPILER_ID MATCHES "^Clang$")
+       CMAKE_C_COMPILER_ID MATCHES "^Clang$" AND NOT MSVC)
 IF (CMAKE_C_COMPILER_ID MATCHES "^XL$")
   SET(CMAKE_C_COMPILER "xlc_r")
   SET(CMAKE_REQUIRED_FLAGS "-qflag=e:e -qformat=sec")


### PR DESCRIPTION
When using Clang in "MSVC mode" (i.e. clang-cl), command line arguments are interpreted as MSVC would interpret them, at least when there are conflicts. This means that `-Wall` - potentially among other switches - is interpreted _dramatically_ differently by clang-cl compared to "normal" Clang.

In CMake, this can be detected by testing for `if (MSVC)` in addition to compiler id test, which is what I do here.

Note: this is a partial cherry-pick from #2095, which I'm going to go through and break into smaller pieces in hopes of getting some things in while discussion of other things can continue.