### PR TITLE
Update archive_entry_link_resolver to copy the "wide" pathname for hardlinks on Windows

### DIFF
--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -201,16 +201,26 @@ archive_entry_linkify(struct archive_entry_linkresolver *res,
 		le = find_entry(res, *e);
 		if (le != NULL) {
 			archive_entry_unset_size(*e);
+#if defined(_WIN32) && !defined(__CYGWIN__)
+			archive_entry_copy_hardlink_w(*e,
+			    archive_entry_pathname_w(le->canonical));
+#else
 			archive_entry_copy_hardlink(*e,
 			    archive_entry_pathname(le->canonical));
+#endif
 		} else
 			insert_entry(res, *e);
 		return;
 	case ARCHIVE_ENTRY_LINKIFY_LIKE_MTREE:
 		le = find_entry(res, *e);
 		if (le != NULL) {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+			archive_entry_copy_hardlink_w(*e,
+			    archive_entry_pathname_w(le->canonical));
+#else
 			archive_entry_copy_hardlink(*e,
 			    archive_entry_pathname(le->canonical));
+#endif
 		} else
 			insert_entry(res, *e);
 		return;
@@ -229,8 +239,13 @@ archive_entry_linkify(struct archive_entry_linkresolver *res,
 			le->entry = t;
 			/* Make the old entry into a hardlink. */
 			archive_entry_unset_size(*e);
+#if defined(_WIN32) && !defined(__CYGWIN__)
+			archive_entry_copy_hardlink_w(*e,
+			    archive_entry_pathname_w(le->canonical));
+#else
 			archive_entry_copy_hardlink(*e,
 			    archive_entry_pathname(le->canonical));
+#endif
 			/* If we ran out of links, return the
 			 * final entry as well. */
 			if (le->links == 0) {


### PR DESCRIPTION
On Windows, if you are using `archive_entry_link_resolver` and give it an entry that links to past entry whose pathname was set using a "wide" string that cannot be represented by the current locale (i.e. WCS -> MBS conversion fails), this code will crash due to a null pointer read. This updates to use the `_w` function instead on Windows.

Note: this is a partial cherry-pick from https://github.com/libarchive/libarchive/pull/2095, which I'm going to go through and break into smaller pieces in hopes of getting some things in while discussion of other things can continue.