### PR TITLE
Update ustar creation sanity check to use WCS path on Windows

### DIFF
--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -254,7 +254,11 @@ archive_write_ustar_header(struct archive_write *a, struct archive_entry *entry)
 		sconv = ustar->opt_sconv;
 
 	/* Sanity check. */
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	if (archive_entry_pathname_w(entry) == NULL) {
+#else
 	if (archive_entry_pathname(entry) == NULL) {
+#endif
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 		    "Can't record entry in tar file without pathname");
 		return (ARCHIVE_FAILED);


### PR DESCRIPTION
On Windows, the MBS pathname might be null if the string was set with a WCS that can't be represented by the current locale. This is handled properly by the rest of the code, but there's a sanity check that does not make the proper distinction.

Note: this is a partial cherry-pick from https://github.com/libarchive/libarchive/pull/2095, which I'm going to go through and break into smaller pieces in hopes of getting some things in while discussion of other things can continue.