### PR TITLE
Allow the ISO9660 root directory record to have length 68 as well as 34

### DIFF
--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -773,7 +773,7 @@ isSVD(struct iso9660 *iso9660, const unsigned char *h)
 
 	/* Read Root Directory Record in Volume Descriptor. */
 	p = h + SVD_root_directory_record_offset;
-	if (p[DR_length_offset] != 34)
+	if (p[DR_length_offset] != 34 && p[DR_length_offset] != 68)
 		return (0);
 
 	return (48);
@@ -851,7 +851,7 @@ isEVD(struct iso9660 *iso9660, const unsigned char *h)
 
 	/* Read Root Directory Record in Volume Descriptor. */
 	p = h + PVD_root_directory_record_offset;
-	if (p[DR_length_offset] != 34)
+	if (p[DR_length_offset] != 34 && p[DR_length_offset] != 68)
 		return (0);
 
 	return (48);
@@ -935,7 +935,7 @@ isPVD(struct iso9660 *iso9660, const unsigned char *h)
 
 	/* Read Root Directory Record in Volume Descriptor. */
 	p = h + PVD_root_directory_record_offset;
-	if (p[DR_length_offset] != 34)
+	if (p[DR_length_offset] != 34 && p[DR_length_offset] != 68)
 		return (0);
 
 	if (!iso9660->primary.location) {


### PR DESCRIPTION
This is found in CSRG ISOs (https://archive.org/details/The_CSRG_Archives_CD-ROM_1_August_1998_Marshall_Kirk_McKusick)

This blames to 2af7b5f12003509f6c0ca93066b9209ebcb67883 (Improve mixed Joliet and Rock Ridge extentions. [...] Fix reading the root directory; it did not read Rock Ridge extentions of the one.) which does
```diff
-       /* Store the root directory in the pending list. */
-       file = parse_file_info(iso9660, NULL, h + PVD_root_directory_record_offset);
-       add_entry(iso9660, file);
+       /* Read Root Directory Record in Volume Descriptor. */
+       p = h + PVD_root_directory_record_offset;
+       if (p[DR_length_offset] != 34)
+               return (0);
+       iso9660->primary.sector_number = archive_le32dec(p + DR_extent_offset);
+       iso9660->primary.block_size = archive_le32dec(p + DR_size_offset);
```
it's unclear to me where the 34 comes from. But I do know 68 is okay.

Closes #2232