### PR TITLE
xar: guard against file entries containing multiple name elements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -937,6 +937,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_ustar_filename_koi8r.tar.Z.uu \
 	libarchive/test/test_read_format_warc.warc.uu \
 	libarchive/test/test_read_format_xar_doublelink.xar.uu \
+	libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu \
 	libarchive/test/test_read_format_zip.zip.uu \
 	libarchive/test/test_read_format_zip_7075_utf8_paths.zip.uu \
 	libarchive/test/test_read_format_zip_7z_deflate.zip.uu \

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -2707,6 +2707,9 @@ xml_data(void *userData, const char *s, size_t len)
 
 	switch (xar->xmlsts) {
 	case FILE_NAME:
+		if (xar->file->has & HAS_PATHNAME)
+			break;
+
 		if (xar->file->parent != NULL) {
 			archive_string_concat(&(xar->file->pathname),
 			    &(xar->file->parent->pathname));

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -860,3 +860,34 @@ DEFINE_TEST(test_read_format_xar)
         verify(archive12, sizeof(archive12), verify12, NULL, GZIP);
 	verifyB(archive13, sizeof(archive13));
 }
+
+DEFINE_TEST(test_read_format_xar_duplicate_filename_node)
+{
+	static const char *reffiles[] =
+	{
+		"test_read_format_xar_duplicate_filename_node.xar",
+		NULL
+	};
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+
+	extract_reference_files(reffiles);
+	assert((a = archive_read_new()) != NULL);
+	assertA(0 == archive_read_support_filter_all(a));
+
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+
+	assertA(0 == archive_read_open_filenames(a, reffiles, 10240));
+
+	assertA(0 == archive_read_next_header(a, &ae));
+	assertEqualString("File", archive_entry_pathname(ae));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu
+++ b/libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu
@@ -1,0 +1,14 @@
+begin 644 test_read_format_xar_duplicate_filename_node.xar
+M>&%R(0`<``$````````!EP````````.]`````7B<A5-);H,P%-U7ZAT0>VIC
+MC('((;N<H-UT][$-L<H0@1,E.7T-`0H=TI6?__OSP'>7JG3.JNUT4V]=_P6[
+MCJI%(W5=;-VWU[T7N[OT^8E?H+6/XW#3B`%8*%H%QMIY1E<J)9A0#S//IZ\$
+M;PC=^(RCM<ID=U#BHSM53F>NI=JZW0%\=R0MW>1YITR*.1K1S'3ZUL?A:`"C
+M-S2YFP2Y+I6CI:UFX;0&&W]O&8X&^#]AKD>5Y@,QP)G0=2-M&E'"DIBC^V\F
+MI3IKH>HF]0-&68!]PM$LF[6JW@8S9CM4K<Q/6O:%]\\L*^ZR8BD3O[<<)^^V
+M'XM>][$>J%9K57B@"FM5"0;FG_V7JB[,(?5MHB-<D.,<R<^1SD-=S7203VLX
+M;0D<CZ46PS:ABU?<]-%UT-(`6G'09R6]W_<KIG$LJ9\%"6!)"&80R#`)<"!R
+M'(DL)T`CH2384K\[6J5U,2T(\V>8#&+(0L`DQED2!@!)1(,PS^.$,I&)+"-1
+M&`*)./KIZ:N]:-%?COHMO%\?NI\?1_T]?@(L`P/8\;44V2:R;"\D48GC?CRL
+C(UAG)C5XG./E`@``)@`8>)R%4TEN@S`4W5?J'1![:F.,@<@`
+`
+end


### PR DESCRIPTION
It appears that there are xar archives (in the form of Apple .pkg files) that contain TOCs with duplicated name elements:

```xml
<file id="25">
  <data> ... </data>
  <type>file</type>
  <name>PackageInfo</name>
  <name>PackageInfo</name>
  <name>PackageInfo</name>
</file>
```

When libarchive encounters one such file, it will produce an archive_entry named PackageInfoPackageInfoPackageInfo.

To produce a test archive, the XAR writer was modified to emit two name elements.