### PR TITLE
archive_entry_perms.3: clarify that you don't need to strdup() [gu]name

### DIFF
--- a/libarchive/archive_entry_perms.3
+++ b/libarchive/archive_entry_perms.3
@@ -150,6 +150,7 @@ character strings at the same time.
 .Fn archive_entry_set_XXX
 is an alias for
 .Fn archive_entry_copy_XXX .
+The strings are copied, and don't need to outlive the call.
 .Ss File Flags
 File flags are transparently converted between a bitmap
 representation and a textual format.


### PR DESCRIPTION
Currently updating archivemount which does
```c
	pwd = getpwuid(st.st_uid);
	if(pwd) 
		archive_entry_set_uname(node->entry, strdup(pwd->pw_name));
	grp = getgrgid(st.st_gid);
	if(grp) 
		archive_entry_set_gname(node->entry, strdup(grp->gr_name));
```
and I'm assuming the strdups are actually leaks? The manual is silent on this.