### PR TITLE
Fix max path-length metadata writing

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -4360,8 +4360,7 @@ set_mac_metadata(struct archive_write_disk *a, const char *pathname,
 	 * silly dance of writing the data to disk just so that
 	 * copyfile() can read it back in again. */
 	archive_string_init(&tmp);
-	archive_strcpy(&tmp, pathname);
-	archive_strcat(&tmp, ".XXXXXX");
+	archive_strcpy(&tmp, "tar.mmd.XXXXXX");
 	fd = mkstemp(tmp.s);
 
 	if (fd < 0) {


### PR DESCRIPTION
Previous code added `.XXXXXX` to the end of the filename to write the mac metadata.  This is a problem if the filename is at or near the filesystem max path length.  This reuses the same code used by create_tempdatafork to ensure that the filename is not too long.