### PR TITLE
Fix 'test_pax_filename_encoding_UTF16_win' by explicitly setting hdrcharset

### DIFF
--- a/libarchive/test/test_pax_filename_encoding.c
+++ b/libarchive/test/test_pax_filename_encoding.c
@@ -654,6 +654,7 @@ DEFINE_TEST(test_pax_filename_encoding_UTF16_win)
 	a = archive_read_new();
 	archive_read_support_format_all(a);
 	archive_read_support_filter_all(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_set_options(a, "hdrcharset=UTF-8"));
 	assertEqualInt(0, archive_read_open_memory(a, buff, used));
 
 	/* Read part 1: file */


### PR DESCRIPTION
It would seem as though #2127 conflicted with my change #2228.

I previously thought that the writer was putting info into the archive that strings were encoded in UTF-8, but I'm not so sure of that anymore... In any case, explicitly setting `hdrcharset` on the reader as well is a reasonable alternative and something we do already.