### PR TITLE
Fix potential overflow warning in cpio test_option_t

### DIFF
--- a/cpio/test/test_option_t.c
+++ b/cpio/test/test_option_t.c
@@ -33,7 +33,7 @@ DEFINE_TEST(test_option_t)
 	char *p;
 	int r;
 	time_t mtime;
-	char date[32];
+	char date[48];
 	char date2[32];
 	struct tm *tmptr;
 #if defined(HAVE_LOCALTIME_R) || defined(HAVE_LOCALTIME_S)


### PR DESCRIPTION
Fixes an error from #2237.