### PR TITLE
Checks for null references

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1063,6 +1063,9 @@ ppmd_read(void *p)
 		ssize_t bytes_avail = 0;
 		const uint8_t* data = __archive_read_ahead(a,
 		    (size_t)zip->ppstream.stream_in+1, &bytes_avail);
+		if(data == NULL) {
+			return (0);
+		}
 		if(bytes_avail < zip->ppstream.stream_in+1) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1063,10 +1063,7 @@ ppmd_read(void *p)
 		ssize_t bytes_avail = 0;
 		const uint8_t* data = __archive_read_ahead(a,
 		    (size_t)zip->ppstream.stream_in+1, &bytes_avail);
-		if(data == NULL) {
-			return (0);
-		}
-		if(bytes_avail < zip->ppstream.stream_in+1) {
+		if(data == NULL || bytes_avail < zip->ppstream.stream_in+1) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated 7z file data");

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -577,6 +577,9 @@ archive_write_binary_close(struct archive_write *a)
 	struct archive_entry *trailer;
 
 	trailer = archive_entry_new2(NULL);
+	if (trailer == NULL) {
+		return ARCHIVE_FATAL;
+	}
 	/* nlink = 1 here for GNU cpio compat. */
 	archive_entry_set_nlink(trailer, 1);
 	archive_entry_set_size(trailer, 0);

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -467,6 +467,9 @@ archive_write_odc_close(struct archive_write *a)
 	struct archive_entry *trailer;
 
 	trailer = archive_entry_new2(NULL);
+	if (trailer == NULL) {
+		return ARCHIVE_FATAL;
+	}
 	/* nlink = 1 here for GNU cpio compat. */
 	archive_entry_set_nlink(trailer, 1);
 	archive_entry_set_size(trailer, 0);


### PR DESCRIPTION
Microsoft's static analysis tool found some vulnerabilities from unguarded null references that I changed in [microsoft/cmake](https://github.com/microsoft/cmake). Pushing these changes upstream so they can be added to [kitware/cmake](https://github.com/Kitware/CMake).