### PR TITLE
b64encode: Fix typo in error message

### DIFF
--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -83,7 +83,7 @@ archive_write_add_filter_b64encode(struct archive *_a)
 	struct private_b64encode *state;
 
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uu");
+	    ARCHIVE_STATE_NEW, "archive_write_add_filter_b64encode");
 
 	state = (struct private_b64encode *)calloc(1, sizeof(*state));
 	if (state == NULL) {


### PR DESCRIPTION
If this function fails, log b64encode instead of uu.