### PR TITLE
bsdcat_getopt only gets called once due to noreturn, so turn while into if

### DIFF
--- a/cat/bsdcat.c
+++ b/cat/bsdcat.c
@@ -128,7 +128,7 @@ main(int argc, char **argv)
 	bsdcat->argv = argv;
 	bsdcat->argc = argc;
 
-	while ((c = bsdcat_getopt(bsdcat)) != -1) {
+	if ((c = bsdcat_getopt(bsdcat)) != -1) {
 		switch (c) {
 		case 'h':
 			usage(stdout, 0);


### PR DESCRIPTION
While implies to both compiler and programmer that bsdcat_getopt will be called multiple times. However, it will only be called once, because it either gets called and the result is -1, or if it is not, version or usage is called, and the program is terminated anyway.