### PR TITLE
zip: Fix test failure

### DIFF
--- a/libarchive/test/test_write_format_zip_stream.c
+++ b/libarchive/test/test_write_format_zip_stream.c
@@ -82,6 +82,7 @@ DEFINE_TEST(test_write_format_zip_stream)
 	const char *file_name = "file";
 
 #ifndef HAVE_ZLIB_H
+	zip_version = 10;
 	zip_compression = 0;
 #endif
 


### PR DESCRIPTION
Fix `test_write_format_zip_stream` failure when `HAVE_ZLIB_H` is not defined.

If `libz` is present, `zip` archives would be compressed by default, which requires `zip_version=20`. Otherwise, the archive is not compressed and only requires `zip_version=10`. I'm building libarchive on a machine not intended for developing, so basicly there's no optional dependencies like `libz` available, guess that's why nobody else has reported this issue.