### PR TITLE
tests: reduce zstd long option to 23

### DIFF
--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -230,12 +230,8 @@ DEFINE_TEST(test_write_filter_zstd)
 	    archive_write_set_filter_option(a, NULL, "max-frame-out", "1GB"));
 #endif
 #if ZSTD_VERSION_NUMBER >= MINVER_LONG
-	if ((int)(sizeof(size_t) == 4))
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_write_set_filter_option(a, NULL, "long", "26"));
-	else
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_write_set_filter_option(a, NULL, "long", "27"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_filter_option(a, NULL, "long", "23"));
 	assertEqualIntA(a, ARCHIVE_FAILED,
 	    archive_write_set_filter_option(a, NULL, "long", "-1")); /* negative */
 #endif


### PR DESCRIPTION
With 26 and 27, the sub-test is pushing 2G and 4G memory respectively.

There is no particular reason why we need to push for higher limits here, so let's pick 23 with weights around 0.25G. The test suite overall is in the 0.25 - 0.5G range and this fits perfectly.

Closes: https://github.com/libarchive/libarchive/issues/2080