### PR TITLE
archive_write: validate header before arguments

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -129,13 +129,14 @@ archive_write_new(void)
 int
 archive_write_set_bytes_per_block(struct archive *_a, int bytes_per_block)
 {
+	struct archive_write *a = (struct archive_write *)_a;
+	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	    ARCHIVE_STATE_NEW, "archive_write_set_bytes_per_block");
+
 	if (bytes_per_block < 0) {
 		// Do nothing if the bytes_per_block is negative
 		return 0;
 	}
-	struct archive_write *a = (struct archive_write *)_a;
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_write_set_bytes_per_block");
 	a->bytes_per_block = bytes_per_block;
 	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
Fixes: 575e2eab ("Fix handling a negative bytes_per_block values (#2206)")