### PR TITLE
cmake: look for zlib >= 1.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,10 @@ SET(ADDITIONAL_LIBS "")
 # Find ZLIB
 #
 IF(ENABLE_ZLIB)
-  FIND_PACKAGE(ZLIB)
+  # Require zlib >= 1.2.1, see: https://github.com/libarchive/libarchive/issues/615
+  # zlib 1.2.0 should also work, but it is difficult to test for. Let's require
+  # zlib >= 1.2.1 for consistency with the autoconf build.
+  FIND_PACKAGE(ZLIB 1.2.1 REQUIRED)
 ELSE()
   SET(ZLIB_FOUND FALSE) # Override cached value
 ENDIF()

--- a/configure.ac
+++ b/configure.ac
@@ -380,8 +380,23 @@ AC_ARG_WITH([zlib],
   AS_HELP_STRING([--without-zlib], [Don't build support for gzip through zlib]))
 
 if test "x$with_zlib" != "xno"; then
-  AC_CHECK_HEADERS([zlib.h])
-  AC_CHECK_LIB(z,inflate)
+  old_LIBS="$LIBS"
+  LIBS="$LIBS -lz"
+  AC_LINK_IFELSE([AC_LANG_SOURCE([[
+      #include <zlib.h>
+      #if !defined(ZLIB_VERNUM)
+      // zlib 1.2.0 should work too, but it's difficult to test for.
+      // zlib 1.2.1 onwards have ZLIB_VERNUM, which is easy to check.
+      #error zlib >= 1.2.1 is required.
+      #endif
+      // Check that there's an inflate function.
+      int main(int argc, char **argv) { inflate(NULL, 0); return 0; }
+    ]])],
+    [AC_DEFINE([HAVE_ZLIB_H], [1], [Define to 1 if you have zlib >= 1.2.1])
+      AC_MSG_RESULT([found a suitable version of zlib (>= 1.2.1)])
+    ],
+    [AC_MSG_RESULT([could not find a suitable version of zlib (>= 1.2.1)])
+      LIBS="$old_LIBS"])
 fi
 
 AC_ARG_WITH([bz2lib],


### PR DESCRIPTION
zlib 1.2.0 added this improvement for inflate:
"Raw inflate no longer needs an extra dummy byte at end"

libarchive does not feed zlib extra data beyond end of stream, so it does not work with zlib < 1.2.0.

https://github.com/libarchive/libarchive/issues/615

This check is easy with cmake, `BS=cmake ./build/ci/build.sh -a configure` shows this locally:
```
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found suitable version "1.3", minimum required is "1.2.0")  
```

Is it worth adding an autoconf check for this? Alternatively, we could add a compile time check, though it is difficult to check zlib version numbers before 1.2.1:
```
// We could put this in libarchive/archive_version_details.c for example:
#ifdef HAVE_ZLIB_H
#include <zlib.h>

#if !defined(ZLIB_VERNUM)
// We don't support zlib < 1.2.0. The ZLIB_VERNUM macro was only added in zlib 1.2.1,
// so that is much easier to check for.
// https://github.com/libarchive/libarchive/issues/615
#error zlib version is too old, 1.2.1 or later is required
#endif

#endif
```