### PR TITLE
cmake: do not require zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ IF(ENABLE_ZLIB)
   # Require zlib >= 1.2.1, see: https://github.com/libarchive/libarchive/issues/615
   # zlib 1.2.0 should also work, but it is difficult to test for. Let's require
   # zlib >= 1.2.1 for consistency with the autoconf build.
-  FIND_PACKAGE(ZLIB 1.2.1 REQUIRED)
+  FIND_PACKAGE(ZLIB 1.2.1)
 ELSE()
   SET(ZLIB_FOUND FALSE) # Override cached value
 ENDIF()


### PR DESCRIPTION
Followup to #2318 which accidentally made zlib required.

Tested locally by increasing the version in CMakeLists.txt to 1.4.1 (which does not exist yet), and confirming that the build reports that a suitable version of zlib was not found, while the build continued.

Sorry about the mistake.