### PR TITLE
tar/write.h: Support `sys/xattr.h`

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -32,7 +32,9 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
-#ifdef HAVE_ATTR_XATTR_H
+#if HAVE_SYS_XATTR_H
+#include <sys/xattr.h>
+#elif HAVE_ATTR_XATTR_H
 #include <attr/xattr.h>
 #endif
 #ifdef HAVE_ERRNO_H


### PR DESCRIPTION
Synchronize the last use of `attr/xattr.h` to support using `sys/xattr.h` instead.  The former header is deprecated on GNU/Linux, and this replacement makes it possible to build libarchive without the `attr` package.