### PR TITLE
tar: fix memory leaks when processing symlinks or parsing pax headers

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -296,6 +296,7 @@ archive_read_format_tar_cleanup(struct archive_read *a)
 	archive_string_free(&tar->entry_pathname_override);
 	archive_string_free(&tar->entry_uname);
 	archive_string_free(&tar->entry_gname);
+	archive_string_free(&tar->entry_linkpath);
 	archive_string_free(&tar->line);
 	archive_string_free(&tar->pax_global);
 	archive_string_free(&tar->longname);
@@ -1935,6 +1936,7 @@ header_pax_extension(struct archive_read *a, struct tar *tar,
 		*unconsumed += 1;
 		tar_flush_unconsumed(a, unconsumed);
 	}
+	archive_string_free(&attr_name);
 	*unconsumed += ext_size + ext_padding;
 
 	/*


### PR DESCRIPTION
Fix memory leaks introduced by #2127:

* `struct tar` member `entry_linkpath` was moved at the same time as
   other members were removed, but its cleanup was accidentally removed
   with the others.

* `header_pax_extension` local variable `attr_name` was not cleaned up.

Resolves #2336
