### PR TITLE
Update archive_private to avoid template keyword

### DIFF
--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -160,9 +160,9 @@ __LA_NORETURN void	__archive_errx(int retvalue, const char *msg);
 void	__archive_ensure_cloexec_flag(int fd);
 int	__archive_mktemp(const char *tmpdir);
 #if defined(_WIN32) && !defined(__CYGWIN__)
-int	__archive_mkstemp(wchar_t *template);
+int	__archive_mkstemp(wchar_t *templates);
 #else
-int	__archive_mkstemp(char *template);
+int	__archive_mkstemp(char *templates);
 #endif
 
 int	__archive_clean(struct archive *);


### PR DESCRIPTION
We get compiler errors due to template being a keyword in C++. So I just added an s.

e.g. on Windows:
<img width="740" alt="Screenshot 2024-09-20 at 14 26 54" src="https://github.com/user-attachments/assets/a545b1f6-4c22-4304-a561-94ff53316a10">

same for clang on macOS:

```
.../libarchive/archive_private.h:165:33: error: expected ',' or '...' before 'template'
  165 | int     __archive_mkstemp(char *template);
      |                                 ^~~~~~~~

```

I would appreciate if this change could be included. Of course it's fine to use a different name change.