### PR TITLE
Remove two unnecessary strings from the tar state

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -123,8 +123,6 @@ struct tar {
 	struct archive_string	 entry_uname;
 	struct archive_string	 entry_gname;
 	struct archive_string	 entry_linkpath;
-	struct archive_string	 longname;
-	struct archive_string	 pax_global;
 	struct archive_string	 line;
 	int			 pax_hdrcharset_utf8;
 	int64_t			 entry_bytes_remaining;
@@ -298,8 +296,6 @@ archive_read_format_tar_cleanup(struct archive_read *a)
 	archive_string_free(&tar->entry_gname);
 	archive_string_free(&tar->entry_linkpath);
 	archive_string_free(&tar->line);
-	archive_string_free(&tar->pax_global);
-	archive_string_free(&tar->longname);
 	archive_string_free(&tar->localname);
 	free(tar);
 	(a->format->data) = NULL;
@@ -1177,13 +1173,16 @@ header_gnu_longname(struct archive_read *a, struct tar *tar,
     struct archive_entry *entry, const void *h, size_t *unconsumed)
 {
 	int err;
+	struct archive_string longname;
 
-	err = read_body_to_string(a, tar, &(tar->longname), h, unconsumed);
-	if (err != ARCHIVE_OK)
-		return (err);
-	if (archive_entry_copy_pathname_l(entry, tar->longname.s,
-	    archive_strlen(&(tar->longname)), tar->sconv) != 0)
-		err = set_conversion_failed_error(a, tar->sconv, "Pathname");
+	archive_string_init(&longname);
+	err = read_body_to_string(a, tar, &longname, h, unconsumed);
+	if (err == ARCHIVE_OK) {
+		if (archive_entry_copy_pathname_l(entry, longname.s,
+		    archive_strlen(&longname), tar->sconv) != 0)
+			err = set_conversion_failed_error(a, tar->sconv, "Pathname");
+	}
+	archive_string_free(&longname);
 	return (err);
 }
 


### PR DESCRIPTION
`pax_global` is not used at all and can be removed.

`longname` is only used locally within one function, so convert it to a local variable there.