### PR TITLE
Various small fixes for Cygwin, Haiku, OpenIndiana

### DIFF
--- a/libarchive/archive_platform.h
+++ b/libarchive/archive_platform.h
@@ -61,6 +61,11 @@
 # endif
 #endif
 
+/* For cygwin, to avoid missing LONG, ULONG, PUCHAR, ... definitions */
+#ifdef __CYGWIN__
+#include <windef.h>
+#endif
+
 /* It should be possible to get rid of this by extending the feature-test
  * macros to cover Windows API functions, probably along with non-trivial
  * refactoring of code to find structures that sit more cleanly on top of

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -3605,7 +3605,7 @@ set_time_tru64(int fd, int mode, const char *name,
 	tstamp.atime.tv_sec = atime;
 	tstamp.mtime.tv_sec = mtime;
 	tstamp.ctime.tv_sec = ctime;
-#if defined (__hpux) && defined (__ia64)
+#if defined (__hpux) && ( defined (__ia64) || defined (__hppa) )
 	tstamp.atime.tv_nsec = atime_nsec;
 	tstamp.mtime.tv_nsec = mtime_nsec;
 	tstamp.ctime.tv_nsec = ctime_nsec;

--- a/libarchive_fe/passphrase.c
+++ b/libarchive_fe/passphrase.c
@@ -162,11 +162,7 @@ handler(int s)
 	signo[s] = 1;
 }
 
-#ifdef __HAIKU__
-char *
-#else
 static char *
-#endif
 readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
 {
 	ssize_t nr;

--- a/libarchive_fe/passphrase.c
+++ b/libarchive_fe/passphrase.c
@@ -162,7 +162,11 @@ handler(int s)
 	signo[s] = 1;
 }
 
+#ifdef __HAIKU__
+char *
+#else
 static char *
+#endif
 readpassphrase(const char *prompt, char *buf, size_t bufsiz, int flags)
 {
 	ssize_t nr;

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -25,6 +25,9 @@
 
 #include "bsdtar_platform.h"
 
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif


### PR DESCRIPTION
Basic Information
  Version of libarchive: 3.7.5 
  How you obtained it:  build from source
  Operating system and version: Linux, Cygwin et al.
  What compiler and/or IDE you are using (include version): gcc 14.2.0 (12.4.0 on Cygwin)

If you are using a pre-packaged binary
  Exact package name and version: Cygwin 3.5.4
  Repository you obtained it from: cygwin.com/setup

Especially for Cygwin (W11):
Using libarchive 3.7.5, 3.74 and Cygwin 3.5.4 (same applies for 3.5.3), I get a compile error as shown below after a simple ./configure and make. Adding <windef.h> solves the problem.
(not tested with 3.80dev but I assume that there will be the same error)

```
make  all-am
make[1]: Entering directory '/cygdrive/c/..../libarchive/libarchive-3.7.5'
  CC       tar/bsdtar-bsdtar.o
  CC       tar/bsdtar-cmdline.o
  CC       tar/bsdtar-creation_set.o
  CC       tar/bsdtar-read.o
  CC       tar/bsdtar-subst.o
  CC       tar/bsdtar-util.o
  CC       tar/bsdtar-write.o
  CC       libarchive/archive_acl.lo
  CC       libarchive/archive_check_magic.lo
  CC       libarchive/archive_cmdline.lo
  CC       libarchive/archive_cryptor.lo
  CC       libarchive/archive_digest.lo
In file included from libarchive/archive_digest_private.h:169,
                 from libarchive/archive_digest.c:31:
/usr/include/w32api/bcrypt.h:27:11: error: unknown type name ‘LONG’
   27 |   typedef LONG NTSTATUS,*PNTSTATUS;
      |           ^~~~
/usr/include/w32api/bcrypt.h:174:5: error: unknown type name ‘ULONG’
  174 |     ULONG dwMinLength;
      |     ^~~~~
/usr/include/w32api/bcrypt.h:175:5: error: unknown type name ‘ULONG’
  175 |     ULONG dwMaxLength;
      |     ^~~~~
/usr/include/w32api/bcrypt.h:176:5: error: unknown type name ‘ULONG’
  176 |     ULONG dwIncrement;
      |     ^~~~~
/usr/include/w32api/bcrypt.h:182:5: error: unknown type name ‘ULONG’
  182 |     ULONG cbOID;
      |     ^~~~~
/usr/include/w32api/bcrypt.h:183:5: error: unknown type name ‘PUCHAR’
  183 |     PUCHAR pbOID;
      |     ^~~~~~
/usr/include/w32api/bcrypt.h:187:5: error: unknown type name ‘ULONG’
  187 |     ULONG dwOIDCount;
      |     ^~~~~
/usr/include/w32api/bcrypt.h:192:5: error: unknown type name ‘LPCWSTR’
  192 |     LPCWSTR pszAlgId;
      |     ^~~~~~~
/usr/include/w32api/bcrypt.h:196:5: error: unknown type name ‘LPCWSTR’

...
[ more ]
```
