### PR TITLE
archive.h,archive_read_support_format_7zip.c: Add error code for encrypted headers

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -196,6 +196,7 @@ struct archive_entry;
 #define	ARCHIVE_FAILED	(-25)	/* Current operation cannot complete. */
 /* But if write_header is "fatal," then this archive is dead and useless. */
 #define	ARCHIVE_FATAL	(-30)	/* No more operations are possible. */
+#define	ARCHIVE_ENCRYPTED	(-50)	/* Archive header is encrypted. */
 
 /*
  * As far as possible, archive_errno returns standard platform errno codes.

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3090,7 +3090,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 		free_StreamsInfo(&(zip->si));
 		memset(&(zip->si), 0, sizeof(zip->si));
 		if (r < 0)
-			return (ARCHIVE_FATAL);
+			return (r);
 		zip->header_is_encoded = 1;
 		zip->header_crc32 = 0;
 		/* FALL THROUGH */
@@ -3543,7 +3543,7 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 					ARCHIVE_ERRNO_MISC,
 					"The %s is encrypted, "
 					"but currently not supported", cname);
-				return (ARCHIVE_FATAL);
+				return (ARCHIVE_ENCRYPTED);
 			}
 			case _7Z_X86_BCJ2: {
 				found_bcj2++;


### PR DESCRIPTION
Basic Information
  Version of libarchive: 3.8.0dev from 2024-09-21
  How you obtained it:  build from source
  Operating system and version: Linux
  What compiler and/or IDE you are using (include version): 14.2.0

Description of the problem you are seeing:
What did you do?
Read a 7z archive with encrypted header via `archive_read_next_header()`
What did you expect to happen?
Get a programmatical information that the header is encrypted.
What actually happened?
I get a generic error code ARCHIVE_FATAL so I'm not able to react e.g. by calling some other code/program to decrypt the header.

Motivation:

In case I encounter a 7z archive with encrypted header, I get an ARCHIVE_FATAL upon calling archive_read_next_header()
I would like to handle this separately, as FATAL may also be something completely different, e.g. a corrupt archive.
With ARCHIVE_ENCRYPTED it's possible to react accordingly, i.e. call an external program or other code to handle the encrypted header.