### PR TITLE
zstd: use GetNativeSystemInfo() to get the number of threads

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -280,9 +280,9 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 #elif !defined(__CYGWIN__) && defined(_WIN32_WINNT) && \
     _WIN32_WINNT >= 0x0601 /* _WIN32_WINNT_WIN7 */
 		if (threads == 0) {
-			DWORD winCores = GetActiveProcessorCount(
-			    ALL_PROCESSOR_GROUPS);
-			threads = (intmax_t)winCores;
+			SYSTEM_INFO systemInfo;
+			GetNativeSystemInfo(&systemInfo);
+			threads = (intmax_t)systemInfo.dwNumberOfProcessors;
 		}
 #endif
 		if (threads < 0 || threads > INT_MAX) {


### PR DESCRIPTION
GetActiveProcessorCount() is not available in UWP [1] and it's not available before Windows 7.

SYSTEM_INFO::dwNumberOfProcessors gives the same information [2]

[1] https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getactiveprocessorcount
[2] https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info