### PR TITLE
configure.ac,CMakeLists.txt: Add libbsd on Haiku for readpassphrase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -881,6 +881,14 @@ IF(NOT OPENSSL_FOUND)
   ENDIF(LIBMD_FOUND)
 ENDIF(NOT OPENSSL_FOUND)
 
+# libbsd for readpassphrase on Haiku
+IF("${CMAKE_SYSTEM_NAME}" MATCHES "Haiku")
+  MESSAGE(STATUS "Adding libbsd for Haiku")
+  SET(CMAKE_REQUIRED_LIBRARIES "bsd")
+  FIND_LIBRARY(LIBBSD_LIBRARY NAMES bsd)
+  LIST(APPEND ADDITIONAL_LIBS ${LIBBSD_LIBRARY})
+ENDIF("${CMAKE_SYSTEM_NAME}" MATCHES "Haiku")
+
 #
 # How to prove that CRYPTO functions, which have several names on various
 # platforms, just see if archive_digest.c can compile and link against

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,11 @@ case "$host_os" in
 esac
 AC_SUBST(PLATFORMCPPFLAGS)
 
+dnl Linking on Haiku needs libbsd because of readpassphrase
+case "$host_os" in
+  haiku*) LIBS="-lbsd $LIBS" ;;
+esac
+
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O


### PR DESCRIPTION
Followup from #2346 

Add libbsd to make/cmake configuration for linking readpassphrase on Haiku.
Maybe there is a better way to do this for cmake, I'm not that familiar with it.