### PR TITLE
Reenable CI tests for MSVC

### DIFF
--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -138,10 +138,8 @@ IF "%1"=="deplibs" (
     SET SKIP_TEST_SPARSE=1
     mingw32-make test VERBOSE=1 || EXIT /b 1
   ) ELSE IF "%BE%"=="msvc" (
-    ECHO "Skipping tests on this platform"
-    EXIT /b 0
-    REM CD build_ci\cmake
-    REM cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
+    CD build_ci\cmake
+    cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
   )
 ) ELSE IF "%1%"=="install" (
   IF "%BE%"=="mingw-gcc" (

--- a/tar/test/test_option_ignore_zeros.c
+++ b/tar/test/test_option_ignore_zeros.c
@@ -89,6 +89,14 @@ DEFINE_TEST(test_option_ignore_zeros_mode_x)
 
 DEFINE_TEST(test_option_ignore_zeros_mode_c)
 {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	// The first command run by systemf below prints this to stderr:
+	// bsdtar.exe: a: Can't translate uname '(null)' to UTF-8
+	// bsdtar.exe: b: Can't translate uname '(null)' to UTF-8
+	skipping("TODO: figure out why this test fails on github workflows with MSVC");
+	return;
+#endif
+
 	if (make_files())
 		return;
 


### PR DESCRIPTION
These were disabled when migrating from Cirrus CI. Let's enable them for github workflows, disable any failing tests on this configuration and leave TODO notes to fix them.

This was the only failure that I found:
```
  684/764 Test #684: bsdtar_test_option_ignore_zeros_mode_c ...................................***Failed    0.10 sec
  
  If tests fail or crash, details will be in:
     C:\Users\RUNNER~1\AppData\Local\Temp/bsdtar_test.exe.2024-09-29T11.42.13-000
  
  Reference files will be read from: D:/a/libarchive/libarchive/tar/test
  Running tests on: "D:\a\libarchive\libarchive\build_ci\cmake\bin\Release\bsdtar.exe"
  Exercising: bsdtar 3.8.0 - libarchive 3.8.0dev zlib/1.3 liblzma/5.4.4 bz2lib/1.1.0 libzstd/1.5.5 
  
   39: test_option_ignore_zeros_mode_c
  D:\a\libarchive\libarchive\tar\test\test_option_ignore_zeros.c(99): File should be empty: test-c.err
      File size: 112
      Contents:
  0000 62 73 64 74 61 72 2e 65 78 65 3a 20 61 3a 20 43 bsdtar.exe: a: C
  0010 61 6e 27 74 20 74 72 61 6e 73 6c 61 74 65 20 75 an't translate u
  0020 6e 61 6d 65 20 27 28 6e 75 6c 6c 29 27 20 74 6f name '(null)' to
  0030 20 55 54 46 2d 38 0d 0a 62 73 64 74 61 72 2e 65  UTF-8..bsdtar.e
  0040 78 65 3a 20 62 3a 20 43 61 6e 27 74 20 74 72 61 xe: b: Can't tra
  0050 6e 73 6c 61 74 65 20 75 6e 61 6d 65 20 27 28 6e nslate uname '(n
  0060 75 6c 6c 29 27 20 74 6f 20 55 54 46 2d 38 0d 0a ull)' to UTF-8..
  
  Totals:
    Tests run:                1
    Tests failed:             1
    Assertions checked:      21
    Assertions failed:        1
    Skips reported:           0
```