### PR TITLE
Increase archive limits to allow archives with more PAX Extended Attributes

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -230,7 +230,7 @@ static void	tar_flush_unconsumed(struct archive_read *, size_t *);
  * need to be high enough for any correct value.  These
  * will likely need some adjustment as we get more experience. */
 static const size_t guname_limit = 65536; /* Longest uname or gname: 64kiB */
-static const size_t pathname_limit = 1048576; /* Longest path name: 1MiB */
+static const size_t pathname_limit = 4194304; /* Longest path name: 4MiB */
 static const size_t sparse_map_limit = 8 * 1048576; /* Longest sparse map: 8MiB */
 static const size_t xattr_limit = 16 * 1048576; /* Longest xattr: 16MiB */
 static const size_t fflags_limit = 512; /* Longest fflags */


### PR DESCRIPTION
Increase allowed pax extended attribute size. Fixes: https://github.com/libarchive/libarchive/issues/1987

As suggested here: https://github.com/libarchive/libarchive/issues/1987#issuecomment-1759925054