### PR TITLE
Fix pathname overwrite in header_old_tar()

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1521,9 +1521,17 @@ header_old_tar(struct archive_read *a, struct tar *tar,
 	const struct archive_entry_header_ustar	*header;
 	int err = ARCHIVE_OK, err2;
 
-	/* Copy filename over (to ensure null termination). */
+	/*
+	 * Copy filename over (to ensure null termination).
+	 * Skip if pathname was already set e.g. by header_gnu_longname()
+	 */
 	header = (const struct archive_entry_header_ustar *)h;
-	if (archive_entry_copy_pathname_l(entry,
+
+	const char *existing_pathname = archive_entry_pathname(entry);
+	const wchar_t *existing_wcs_pathname = archive_entry_pathname_w(entry);
+	if ((existing_pathname == NULL || existing_pathname[0] == '\0')
+	    && (existing_wcs_pathname == NULL || existing_wcs_pathname[0] == '\0') &&
+	    archive_entry_copy_pathname_l(entry,
 	    header->name, sizeof(header->name), tar->sconv) != 0) {
 		err = set_conversion_failed_error(a, tar->sconv, "Pathname");
 		if (err == ARCHIVE_FATAL)


### PR DESCRIPTION
Fixes #2359 