### PR TITLE
Fix error message printing

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -984,12 +984,11 @@ write_entry(struct bsdtar *bsdtar, struct archive *a,
 			safe_fprintf(stderr, "a ");
 			list_item_verbose(bsdtar, stderr, entry);
 			lafe_warnc(0, ": %s", archive_error_string(a));
-		} else if (bsdtar->verbose > 0) {
+		} else {
 			lafe_warnc(0, "%s: %s",
 			    archive_entry_pathname(entry),
 			    archive_error_string(a));
-		} else
-			fprintf(stderr, ": %s", archive_error_string(a));
+		}
 	}
 
 	if (e == ARCHIVE_FATAL)


### PR DESCRIPTION
We always print the error message with or without -v, but for some reason, we were omitting the path being processed. Simplify so that we always print the full error including context.