### PR TITLE
bsdcpio should exit with an error code if an entry can't be extracted

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -1032,6 +1032,7 @@ mode_in(struct cpio *cpio)
 			fprintf(stderr, "%s: %s\n",
 			    archive_entry_pathname(entry),
 			    archive_error_string(ext));
+			cpio->return_value = 1;
 		} else if (!archive_entry_size_is_set(entry)
 		    || archive_entry_size(entry) > 0) {
 			r = extract_data(a, ext);

--- a/cpio/test/test_extract_cpio_absolute_paths.c
+++ b/cpio/test/test_extract_cpio_absolute_paths.c
@@ -42,7 +42,7 @@ DEFINE_TEST(test_extract_cpio_absolute_paths)
 
 	// We should refuse to create the absolute path without --insecure.
 	r = systemf("%s -i < archive.cpio 2> stderr2.txt", testprog);
-	//assert(r != 0); // Should this command fail?
+	assert(r != 0);
 	assertFileNotExists(temp_absolute_file_name);
 	UNLINK(temp_absolute_file_name); // Cleanup just in case.
 

--- a/cpio/test/test_option_d.c
+++ b/cpio/test/test_option_d.c
@@ -44,7 +44,7 @@ DEFINE_TEST(test_option_d)
 	assertMakeDir("without-d", 0755);
 	assertChdir("without-d");
 	r = systemf("%s -i < ../archive.cpio >out 2>err", testprog);
-	assertEqualInt(r, 0);
+	assert(r != 0);
 	assertEmptyFile("out");
 	/* And the file should not be restored. */
 	assertFileNotExists("dir/file");


### PR DESCRIPTION
For example if --insecure is not specified, and one of the security checks fails.