### PR TITLE
Ensure filter programs inherit the correct environment

### DIFF
--- a/libarchive/filter_fork_posix.c
+++ b/libarchive/filter_fork_posix.c
@@ -65,6 +65,10 @@
 #  include <unistd.h>
 #endif
 
+#if defined(HAVE_POSIX_SPAWNP)
+extern char *const environ[];
+#endif
+
 #include "archive.h"
 #include "archive_cmdline_private.h"
 
@@ -137,7 +141,7 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
 			goto actions_inited;
 	}
 	r = posix_spawnp(&child, cmdline->path, &actions, NULL,
-		cmdline->argv, NULL);
+		cmdline->argv, environ);
 	if (r != 0)
 		goto actions_inited;
 	posix_spawn_file_actions_destroy(&actions);


### PR DESCRIPTION
A soon-to-be landed change in HardenedBSD will make it so that consumers
of the posix_spawn(3) API will need to explicitly state their intentions
with regards to the environment. If a NULL environment variable pointer
is passed, then the spawned process will enherit an empty environment.

This change ensures that the filter programs inherit the process'
environment variables.