### PR TITLE
Ignore checksum mismatches when fuzzing tar archives

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1005,7 +1005,12 @@ checksum(struct archive_read *a, const void *h)
 	if (sum == check)
 		return (1);
 
+#if DONT_FAIL_ON_CRC_ERROR
+	/* Speed up fuzzing by pretending the checksum is always right. */
+	return (1);
+#else
 	return (0);
+#endif
 }
 
 /*


### PR DESCRIPTION
This should speed up fuzzing just a bit, so we
can find more bugs!