### PR TITLE
Increase the hole size for this test to 32MiB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   MacOS:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         bs: [autotools, cmake]

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -71,8 +71,11 @@ static void create_sparse_file(const char *, const struct sparse *);
  * does support sparse files is certain to store a gap this big
  * as a hole. */
 /* A few data points:
- * ZFS on FreeBSD needs this to be at least 200kB */
-/* macOS APFS needs this to be at 4096x4097 bytes */
+ * = ZFS on FreeBSD needs this to be at least 200kB
+ * = macOS APFS needs this to be at least 4096x4097 bytes
+ *
+ * 32MiB here is bigger than either of the above.
+ */
 #define MIN_HOLE (32 * 1024UL * 1024UL)
 
 #if defined(_WIN32) && !defined(__CYGWIN__)

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -67,13 +67,13 @@ struct sparse {
 
 static void create_sparse_file(const char *, const struct sparse *);
 
-#if defined(__APPLE__)
-/* On APFS holes need to be at least 4096x4097 bytes */
-#define MIN_HOLE 16781312
-#else
-/* Elsewhere we work with 4096*10 bytes */
-#define MIN_HOLE 409600
-#endif
+/* This should be large enough that any OS/filesystem that
+ * does support sparse files is certain to store a gap this big
+ * as a hole. */
+/* A few data points:
+ * ZFS on FreeBSD needs this to be at least 200kB */
+/* macOS APFS needs this to be at 4096x4097 bytes */
+#define MIN_HOLE (32 * 1024UL * 1024UL)
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <winioctl.h>


### PR DESCRIPTION
APFS on macOS 15 seems to have a higher threshold for creating sparse files.