### PR TITLE
Reintroduce size_t cast to clarify the use of a u32 shift on a u64 arg

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2803,7 +2803,7 @@ make_table(struct archive_read *a, struct huffman_code *code)
   else
     code->tablesize = code->maxlength;
 
-  code->table = calloc(1U << code->tablesize, sizeof(*code->table));
+  code->table = calloc(((size_t)1U) << code->tablesize, sizeof(*code->table));
 
   return make_table_recurse(a, code, 0, code->table, 0, code->tablesize);
 }


### PR DESCRIPTION
Building for 64-bit Windows with MSVC generates warning `C4334`, `'<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)`

The clearest way to signal to the compiler that we intend this to fit in a `size_t` is to cast it.

This should be safe and clear on all supported platforms.

We could also use a 64-bit shift with a 64-bit operand (e.g. `1ULL`, which will be 64-bit on all platforms), but that will generate narrowing warnings on 32-bit `size_t` platforms.

Regressed in #2285 