### PR TITLE
tests: redirect stdout in one call in test_extract_tar_absolute_paths

### DIFF
--- a/tar/test/test_option_P.c
+++ b/tar/test/test_option_P.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_extract_tar_absolute_paths)
 	UNLINK(temp_absolute_file_name);
 
 	// Extracting the archive without -P / --absolute-paths should strip leading drive letter or slash
-	r = systemf("%s -xf test.tar", testprog);
+	r = systemf("%s -xf test.tar 2>test.err", testprog);
 	assertEqualInt(r, 0);
 	assertFileNotExists(temp_absolute_file_name);
 


### PR DESCRIPTION
This redirects the message "Removing leading '/' from member names"
from stderr to a file in one case.