### PR TITLE
7zip writer: support multithreaded zstandard compression

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -324,7 +324,21 @@ static int	make_header(struct archive_write *, uint64_t, uint64_t,
 		    uint64_t, int, struct coder *);
 static int	make_streamsInfo(struct archive_write *, uint64_t, uint64_t,
 		    	uint64_t, int, struct coder *, int, uint32_t);
-static int string_to_number(const char *, intmax_t *);
+
+static int
+string_to_number(const char *string, intmax_t *numberp)
+{
+	char *end;
+
+	if (string == NULL || *string == '\0')
+		return (ARCHIVE_WARN);
+	*numberp = strtoimax(string, &end, 10);
+	if (end == string || *end != '\0' || errno == EOVERFLOW) {
+		*numberp = 0;
+		return (ARCHIVE_WARN);
+	}
+	return (ARCHIVE_OK);
+}
 
 int
 archive_write_set_format_7zip(struct archive *_a)
@@ -2578,21 +2592,6 @@ compression_end(struct archive *a, struct la_zstream *lastrm)
 		free(lastrm->props);
 		lastrm->props = NULL;
 		return (lastrm->end(a, lastrm));
-	}
-	return (ARCHIVE_OK);
-}
-
-static int
-string_to_number(const char *string, intmax_t *numberp)
-{
-	char *end;
-
-	if (string == NULL || *string == '\0')
-		return (ARCHIVE_WARN);
-	*numberp = strtoimax(string, &end, 10);
-	if (end == string || *end != '\0' || errno == EOVERFLOW) {
-		*numberp = 0;
-		return (ARCHIVE_WARN);
 	}
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -295,6 +295,11 @@ support negative values depending on the library version and
 commonly used values 1 through 22.
 The interpretation of the compression level depends on the chosen
 compression method.
+.It Cm threads
+The value is interpreted as a decimal integer specifying the
+number of threads for multi-threaded compression (for compressors
+like zstd that support it). If set to 0, an attempt will be made
+to discover the number of CPU cores.
 .El
 .It Format bin
 .Bl -tag -compact -width indent


### PR DESCRIPTION
To test this manually:
bsdtar -cavf /tmp/foo.7z --options='compression=zstd,threads=4' *