### PR TITLE
Revert "Use proper Create OS value on Windows to fix archive charset detection (#2240)

### DIFF
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -798,17 +798,6 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	struct archive_string_conv *sconv = get_sconv(a, zip);
 	int ret, ret2 = ARCHIVE_OK;
 	mode_t type;
-#if defined(_WIN32)
-	/* On Windows use MS-DOS value as internal Windows zip archiver does
-	 * Fixes charset problems like https://sourceforge.net/p/sevenzip/bugs/2463/
-	 * Full set of possible create os values:
-	 * https://pkwaredownloads.blob.core.windows.net/pem/APPNOTE-6.3.10.txt
-	 * See "4.4.2 version made by (2 bytes)" */
-	int create_os = 0;
-#else
-	// Use UNIX value in all other cases
-	int create_os = 3;
-#endif
 	int version_needed = 10;
 #define MIN_VERSION_NEEDED(x) do { if (version_needed < x) { version_needed = x; } } while (0)
 
@@ -1158,8 +1147,8 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	++zip->central_directory_entries;
 	memset(zip->file_header, 0, 46);
 	memcpy(zip->file_header, "PK\001\002", 4);
-	/* "Made by PKZip 2.0 on Unix or MS-DOS." */
-	archive_le16enc(zip->file_header + 4, create_os * 256 + version_needed);
+	/* "Made by PKZip 2.0 on Unix." */
+	archive_le16enc(zip->file_header + 4, 3 * 256 + version_needed);
 	archive_le16enc(zip->file_header + 6, version_needed);
 	archive_le16enc(zip->file_header + 8, zip->entry_flags);
 	if (zip->entry_encryption == ENCRYPTION_WINZIP_AES128
@@ -1292,7 +1281,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 		e += 1;
 		if (included & 1) {
 			archive_le16enc(e, /* "Version created by" */
-			    create_os * 256 + version_needed);
+			    3 * 256 + version_needed);
 			e += 2;
 		}
 		if (included & 2) {


### PR DESCRIPTION
Two problems are prompting this revert:

* In order to change the Create OS value to "Windows", we would need to record other data (such as `external_attributes`) in Windows format as well.

* Changing the Create OS value doesn't actually fix the filename-encoding issue that originally motivated this PR

This reverts commit 755af84301adc4262722a4c88671a8d0a1c83fae.