### PR TITLE
Fix for version 4.0

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -1080,7 +1080,11 @@ extract_data(struct archive *ar, struct archive *aw)
 			exit(1);
 		}
 		r = (int)archive_write_data_block(aw, block, size, offset);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 		if (r != ARCHIVE_OK) {
+#else
+		if (r != size) {
+#endif
 			lafe_warnc(archive_errno(aw),
 			    "%s", archive_error_string(aw));
 			return (r);

--- a/examples/minitar/minitar.c
+++ b/examples/minitar/minitar.c
@@ -421,7 +421,11 @@ copy_data(struct archive *ar, struct archive *aw)
 			return (r);
 		}
 		r = archive_write_data_block(aw, buff, size, offset);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 		if (r != ARCHIVE_OK) {
+#else
+		if (r != size) {
+#endif
 			errmsg(archive_error_string(ar));
 			return (r);
 		}

--- a/examples/untar.c
+++ b/examples/untar.c
@@ -215,7 +215,11 @@ copy_data(struct archive *ar, struct archive *aw)
 		if (r != ARCHIVE_OK)
 			return (r);
 		r = archive_write_data_block(aw, buff, size, offset);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 		if (r != ARCHIVE_OK) {
+#else
+		if (r != size) {
+#endif
 			warn("archive_write_data_block()",
 			    archive_error_string(aw));
 			return (r);

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1235,7 +1235,7 @@ _archive_entry_copy_link_l(struct archive_entry *entry,
 }
 
 void
-archive_entry_set_mode(struct archive_entry *entry, mode_t m)
+archive_entry_set_mode(struct archive_entry *entry, __LA_MODE_T m)
 {
 	entry->stat_valid = 0;
 	entry->acl.mode = m;
@@ -1310,7 +1310,7 @@ _archive_entry_copy_pathname_l(struct archive_entry *entry,
 }
 
 void
-archive_entry_set_perm(struct archive_entry *entry, mode_t p)
+archive_entry_set_perm(struct archive_entry *entry, __LA_MODE_T p)
 {
 	entry->stat_valid = 0;
 	entry->acl.mode &= AE_IFMT;

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -142,7 +142,11 @@ copy_data(struct archive *ar, struct archive *aw)
 		r = (int)archive_write_data_block(aw, buff, size, offset);
 		if (r < ARCHIVE_WARN)
 			r = ARCHIVE_WARN;
+#if ARCHIVE_VERSION_NUMBER < 4000000
 		if (r < ARCHIVE_OK) {
+#else
+		if (r != size) {
+#endif
 			archive_set_error(ar, archive_errno(aw),
 			    "%s", archive_error_string(aw));
 			return (r);

--- a/libarchive/archive_write_data.3
+++ b/libarchive/archive_write_data.3
@@ -49,7 +49,8 @@ except that it performs a seek on the file being
 written to the specified offset before writing the data.
 This is useful when restoring sparse files from archive
 formats that support sparse files.
-Returns number of bytes written or -1 on error.
+Returns number of bytes written or a negative error
+code on error.
 (Note: This is currently not supported for
 .Tn archive_write
 handles, only for

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1675,7 +1675,7 @@ _archive_write_disk_data_block(struct archive *_a,
 		    (uintmax_t)a->filesize);
 		return (ARCHIVE_WARN);
 	}
-#if ARCHIVE_VERSION_NUMBER < 3999000
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	return (ARCHIVE_OK);
 #else
 	return (size);

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1173,7 +1173,7 @@ _archive_write_disk_data_block(struct archive *_a,
 		    "Write request too large");
 		return (ARCHIVE_WARN);
 	}
-#if ARCHIVE_VERSION_NUMBER < 3999000
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	return (ARCHIVE_OK);
 #else
 	return (size);

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -143,7 +143,7 @@ DEFINE_TEST(test_read_append_filter)
       archive_read_open_memory(a, archive, sizeof(archive)));
   assertEqualInt(ARCHIVE_OK, archive_read_next_header(a, &ae));
   assertEqualInt(1, archive_file_count(a));
-  assertEqualInt(archive_filter_code(a, 0), ARCHIVE_COMPRESSION_GZIP);
+  assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_GZIP);
   assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
   assertEqualInt(ARCHIVE_OK, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));

--- a/libarchive/test/test_write_disk.c
+++ b/libarchive/test/test_write_disk.c
@@ -123,8 +123,13 @@ static void create_reg_file2(struct archive_entry *ae, const char *msg)
 	archive_entry_set_size(ae, datasize);
 	assertEqualIntA(ad, 0, archive_write_header(ad, ae));
 	for (i = 0; i < datasize - 999; i += 1000) {
+#if ARCHIVE_VERSION_NUMBER < 4000000
 		assertEqualIntA(ad, ARCHIVE_OK,
 		    archive_write_data_block(ad, data + i, 1000, i));
+#else
+		assertEqualIntA(ad, 1000,
+		    archive_write_data_block(ad, data + i, 1000, i));
+#endif
 	}
 	assertEqualIntA(ad, 0, archive_write_finish_entry(ad));
 	assertEqualInt(0, archive_write_free(ad));
@@ -173,8 +178,13 @@ static void create_reg_file4(struct archive_entry *ae, const char *msg)
 	assert((ad = archive_write_disk_new()) != NULL);
 	/* Leave the size unset.  The data should not be truncated. */
 	assertEqualIntA(ad, 0, archive_write_header(ad, ae));
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	assertEqualInt(ARCHIVE_OK,
 	    archive_write_data_block(ad, data, sizeof(data), 0));
+#else
+	assertEqualInt(sizeof(data),
+	    archive_write_data_block(ad, data, sizeof(data), 0));
+#endif
 	assertEqualIntA(ad, 0, archive_write_finish_entry(ad));
 	assertEqualInt(0, archive_write_free(ad));
 

--- a/libarchive/test/test_write_disk_sparse.c
+++ b/libarchive/test/test_write_disk_sparse.c
@@ -157,22 +157,37 @@ verify_write_data_block(struct archive *a, int sparse)
 	memset(buff, 0, buff_size);
 	memcpy(buff, data, sizeof(data));
 	failure("%s", msg);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	assertEqualInt(ARCHIVE_OK,
 	    archive_write_data_block(a, buff, buff_size, 100));
+#else
+	assertEqualInt(buff_size,
+	    archive_write_data_block(a, buff, buff_size, 100));
+#endif
 
 	/* Second has non-null data in the middle. */
 	memset(buff, 0, buff_size);
 	memcpy(buff + buff_size / 2 - 3, data, sizeof(data));
 	failure("%s", msg);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	assertEqualInt(ARCHIVE_OK,
 	    archive_write_data_block(a, buff, buff_size, buff_size + 200));
+#else
+	assertEqualInt(buff_size,
+	    archive_write_data_block(a, buff, buff_size, buff_size + 200));
+#endif
 
 	/* Third has non-null data at the end. */
 	memset(buff, 0, buff_size);
 	memcpy(buff + buff_size - sizeof(data), data, sizeof(data));
 	failure("%s", msg);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 	assertEqualInt(ARCHIVE_OK,
 	    archive_write_data_block(a, buff, buff_size, buff_size * 2 + 300));
+#else
+	assertEqualInt(buff_size,
+	    archive_write_data_block(a, buff, buff_size, buff_size * 2 + 300));
+#endif
 
 	failure("%s", msg);
 	assertEqualIntA(a, 0, archive_write_finish_entry(a));


### PR DESCRIPTION
Fixes for various issues related to the 4.0 transition such as missing __LA_MODE_T uses, incorrect documentation, and wrong archive_write_data_block return value checks.

Follow-up from #2392.