### PR TITLE
Moving the tests' integer reading functions to test_utils.

### DIFF
--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -28,7 +28,6 @@
  * help. */
 #define __LIBARCHIVE_BUILD
 #include <archive_crc32.h>
-#include <archive_endian.h>
 
 #define PROLOGUE(reffile) \
 	struct archive_entry *ae; \
@@ -82,7 +81,7 @@ int verify_data(const uint8_t* data_ptr, int magic, int size) {
 		/* *lptr is a value inside unpacked test file, val is the
 		 * value that should be in the unpacked test file. */
 
-		if(archive_le32dec(lptr) != (uint32_t) val)
+		if(i4le(lptr) != (uint32_t) val)
 			return 0;
 	}
 

--- a/libarchive/test/test_write_format_zip64_stream.c
+++ b/libarchive/test/test_write_format_zip64_stream.c
@@ -59,12 +59,6 @@ bitcrc32(unsigned long c, void *_p, size_t s)
 	return (c);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned i2(const unsigned char *p) { return ((p[0] & 0xff) | ((p[1] & 0xff) << 8)); }
-static unsigned i4(const unsigned char *p) { return (i2(p) | (i2(p + 2) << 16)); }
-/* We're only working with small values here; ignore the 4 high bytes. */
-static unsigned i8(const unsigned char *p) { return (i4(p)); }
-
 DEFINE_TEST(test_write_format_zip64_stream)
 {
 	struct archive *a;
@@ -119,54 +113,54 @@ DEFINE_TEST(test_write_format_zip64_stream)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
-	eocd = buff + i4(p + 12) + i4(p + 16);
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
+	eocd = buff + i4le(p + 12) + i4le(p + 16);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	central_header = p = buff + i4(buffend - 6);
+	central_header = p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + zip_version); /* Version made by */
-	assertEqualInt(i2(p + 6), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 12), 0); /* File time */
-	assertEqualInt(i2(p + 14), 33); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + zip_version); /* Version made by */
+	assertEqualInt(i2le(p + 6), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 12), 0); /* File time */
+	assertEqualInt(i2le(p + 14), 33); /* File date */
 	crc = bitcrc32(0, file_data, sizeof(file_data));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	compressed_size = i4(p + 20);  /* Compressed size */
-	assertEqualInt(i4(p + 24), sizeof(file_data)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	/* assertEqualInt(i2(p + 30), 28); */ /* Extra field length: See below */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	compressed_size = i4le(p + 20);  /* Compressed size */
+	assertEqualInt(i4le(p + 24), sizeof(file_data)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	/* assertEqualInt(i2le(p + 30), 28); */ /* Extra field length: See below */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = central_header + 46 + strlen(file_name);
-	extension_end = extension_start + i2(central_header + 30);
+	extension_end = extension_start + i2le(central_header + 30);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	/* TODO: verify 'ux' contents */
-	p += 4 + i2(p + 2);
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), 0); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), 0); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
 	/* Note: We don't expect to see zip64 extension in the central
 	 * directory, since the writer knows the actual full size by
@@ -176,9 +170,9 @@ DEFINE_TEST(test_write_format_zip64_stream)
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -188,21 +182,21 @@ DEFINE_TEST(test_write_format_zip64_stream)
 
 	/* After Central dir, we find Zip64 eocd and Zip64 eocd locator. */
 	assertEqualMem(p, "PK\006\006", 4); /* Zip64 eocd */
-	assertEqualInt(i8(p + 4), 44); /* We're using v1 Zip64 eocd */
-	assertEqualInt(i2(p + 12), 45); /* Written by Version 4.5 */
-	assertEqualInt(i2(p + 14), 45); /* Needs version 4.5 to extract */
-	assertEqualInt(i4(p + 16), 0); /* This is disk #0 */
-	assertEqualInt(i4(p + 20), 0); /* Dir starts on disk #0 */
-	assertEqualInt(i8(p + 24), 1); /* 1 entry on this disk */
-	assertEqualInt(i8(p + 32), 1); /* 1 entry total */
-	assertEqualInt(i8(p + 40), eocd - central_header); /* size of cd */
-	assertEqualInt(i8(p + 48), central_header - buff); /* start of cd */
-	p += 12 + i8(p + 4);
+	assertEqualInt(i8le(p + 4), 44); /* We're using v1 Zip64 eocd */
+	assertEqualInt(i2le(p + 12), 45); /* Written by Version 4.5 */
+	assertEqualInt(i2le(p + 14), 45); /* Needs version 4.5 to extract */
+	assertEqualInt(i4le(p + 16), 0); /* This is disk #0 */
+	assertEqualInt(i4le(p + 20), 0); /* Dir starts on disk #0 */
+	assertEqualInt(i8le(p + 24), 1); /* 1 entry on this disk */
+	assertEqualInt(i8le(p + 32), 1); /* 1 entry total */
+	assertEqualInt(i8le(p + 40), eocd - central_header); /* size of cd */
+	assertEqualInt(i8le(p + 48), central_header - buff); /* start of cd */
+	p += 12 + i8le(p + 4);
 
 	assertEqualMem(p, "PK\006\007", 4); /* Zip64 eocd locator */
-	assertEqualInt(i4(p + 4), 0); /* Zip64 eocd is on disk #0 */
-	assertEqualInt(i8(p + 8), eocd - buff); /* Offset of Zip64 eocd */
-	assertEqualInt(i4(p + 16), 1); /* 1 disk */
+	assertEqualInt(i4le(p + 4), 0); /* Zip64 eocd is on disk #0 */
+	assertEqualInt(i8le(p + 8), eocd - buff); /* Offset of Zip64 eocd */
+	assertEqualInt(i4le(p + 16), 1); /* 1 disk */
 	p += 20;
 
 	/* Regular EOCD immediately follows Zip64 records. */
@@ -211,48 +205,48 @@ DEFINE_TEST(test_write_format_zip64_stream)
 	/* Verify local header of file entry. */
 	p = local_header = buff;
 	assertEqualMem(p, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(p + 4), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 6), 8); /* Flags: bit 3 = length-at-end */
-	assertEqualInt(i2(p + 8), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 10), 0); /* File time */
-	assertEqualInt(i2(p + 12), 33); /* File date */
-	assertEqualInt(i4(p + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(p + 18), 0); /* Compressed size must be zero for length-at-end */
-	assertEqualInt(i4(p + 22), 0); /* Uncompressed size must be zero for length-at-end */
-	assertEqualInt(i2(p + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 28), 37); /* Extra field length */
+	assertEqualInt(i2le(p + 4), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 6), 8); /* Flags: bit 3 = length-at-end */
+	assertEqualInt(i2le(p + 8), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 10), 0); /* File time */
+	assertEqualInt(i2le(p + 12), 33); /* File date */
+	assertEqualInt(i4le(p + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(p + 18), 0); /* Compressed size must be zero for length-at-end */
+	assertEqualInt(i4le(p + 22), 0); /* Uncompressed size must be zero for length-at-end */
+	assertEqualInt(i2le(p + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 28), 37); /* Extra field length */
 	assertEqualMem(p + 30, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = local_header + 30 + strlen(file_name);
-	extension_end = extension_start + i2(local_header + 28);
+	extension_end = extension_start + i2le(local_header + 28);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(p + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), file_gid); /* 'Ux' GID */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), file_gid); /* 'Ux' GID */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), 0); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), 0); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(p + 2), 9); /* size */
+	assertEqualInt(i2le(p), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(p + 2), 9); /* size */
 	assertEqualInt(p[4], 7); /* bitmap of included fields */
-	assertEqualInt(i2(p + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(p + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i2le(p + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(p + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	p += 4 + i2le(p + 2);
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -265,9 +259,9 @@ DEFINE_TEST(test_write_format_zip64_stream)
 	data_end = p;
 	assertEqualInt(data_end - data_start, compressed_size);
 	assertEqualMem(p, "PK\007\010", 4);
-	assertEqualInt(i4(p + 4), crc); /* CRC-32 */
-	assertEqualInt(i8(p + 8), compressed_size); /* compressed size */
-	assertEqualInt(i8(p + 16), sizeof(file_data)); /* uncompressed size */
+	assertEqualInt(i4le(p + 4), crc); /* CRC-32 */
+	assertEqualInt(i8le(p + 8), compressed_size); /* compressed size */
+	assertEqualInt(i8le(p + 16), sizeof(file_data)); /* uncompressed size */
 
 	/* Central directory should immediately follow the only entry. */
 	assertEqualAddress(p + 24, central_header);

--- a/libarchive/test/test_write_format_zip_compression_bzip2.c
+++ b/libarchive/test/test_write_format_zip_compression_bzip2.c
@@ -85,21 +85,6 @@ static void verify_write_bzip2(struct archive *a)
 	archive_entry_free(entry);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned int
-i2(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (p[0] | (p[1] << 8));
-}
-
-static unsigned int
-i4(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (i2(p) | (i2(p + 2) << 16));
-}
-
 static void verify_bzip2_contents(const char *buff, size_t used)
 {
 	const char *buffend;
@@ -140,98 +125,98 @@ static void verify_bzip2_contents(const char *buff, size_t used)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
 	failure("CD start (%d) + CD length (%d) should == archive size - 22",
-	    i4(p + 12), i4(p + 16));
-	assertEqualInt(i4(p + 12) + i4(p + 16), used - 22);
+	    i4le(p + 12), i4le(p + 16));
+	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	p = buff + i4(buffend - 6);
+	p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory, except compressed size (offset 20). */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 46); /* Version made by */
-	assertEqualInt(i2(p + 6), 46); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), 12); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 46); /* Version made by */
+	assertEqualInt(i2le(p + 6), 46); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), 12); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = bitcrc32(0, file_data1, sizeof(file_data1));
 	crc = bitcrc32(crc, file_data2, sizeof(file_data2));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = p + 46 + strlen(file_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 /* TODO */
-	p = p + 4 + i2(p + 2);
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of file entry. */
 	local_header = q = buff;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 46); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 8); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) */
-	assertEqualInt(i2(q + 8), 12); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
-	assertEqualInt(i2(q + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 46); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 8); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) */
+	assertEqualInt(i2le(q + 8), 12); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
+	assertEqualInt(i2le(q + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, file_name, strlen(file_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(file_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(q + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), file_gid); /* 'Ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), file_gid); /* 'Ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 3); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 3); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 3); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* Bitmap of fields included. */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* Verify data of file entry, using our own zip reader to test. */
 	assertEqualIntA(zip_archive, ARCHIVE_OK, archive_read_next_header(zip_archive, &ae));
@@ -251,89 +236,89 @@ static void verify_bzip2_contents(const char *buff, size_t used)
 
 	/* Verify data descriptor of file entry, except compressed size (offset 8). */
 	assertEqualMem(q, "PK\007\010", 4); /* Signature */
-	assertEqualInt(i4(q + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i4le(q + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
 	q = q + 16;
 
 	/* Verify folder entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 20); /* Version made by */
-	assertEqualInt(i2(p + 6), 20); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 0); /* Flags */
-	assertEqualInt(i2(p + 10), 0); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 20); /* Version made by */
+	assertEqualInt(i2le(p + 6), 20); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 0); /* Flags */
+	assertEqualInt(i2le(p + 10), 0); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = 0;
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 20), 0); /* Compressed size */
-	assertEqualInt(i4(p + 24), 0); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), q - buff); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 20), 0); /* Compressed size */
+	assertEqualInt(i4le(p + 24), 0); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), q - buff); /* Offset of local header */
 	assertEqualMem(p + 46, folder_name, strlen(folder_name)); /* Pathname */
 	p = p + 46 + strlen(folder_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(p + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), folder_gid); /* 'ux' GID */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), folder_gid); /* 'ux' GID */
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of folder entry. */
 	local_header = q;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 20); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 0); /* Flags */
-	assertEqualInt(i2(q + 8), 0); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size */
-	assertEqualInt(i2(q + 26), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 20); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 0); /* Flags */
+	assertEqualInt(i2le(q + 8), 0); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size */
+	assertEqualInt(i2le(q + 26), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, folder_name, strlen(folder_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(folder_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(q + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), folder_gid); /* 'ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), folder_gid); /* 'ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 5); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 5); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 5); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* bitmap of fields */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* There should not be any data in the folder entry,
 	 * so the first central directory entry should be next: */

--- a/libarchive/test/test_write_format_zip_compression_lzmaxz.c
+++ b/libarchive/test/test_write_format_zip_compression_lzmaxz.c
@@ -59,21 +59,6 @@ static void verify_write_lzma(struct archive *a)
 	archive_entry_free(entry);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned int
-i2(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (p[0] | (p[1] << 8));
-}
-
-static unsigned int
-i4(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (i2(p) | (i2(p + 2) << 16));
-}
-
 static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 	uint16_t flags)
 {
@@ -115,98 +100,98 @@ static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
 	failure("CD start (%d) + CD length (%d) should == archive size - 22",
-	    i4(p + 12), i4(p + 16));
-	assertEqualInt(i4(p + 12) + i4(p + 16), used - 22);
+	    i4le(p + 12), i4le(p + 16));
+	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	p = buff + i4(buffend - 6);
+	p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory, except compressed size (offset 20). */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 63); /* Version made by */
-	assertEqualInt(i2(p + 6), 63); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), flags); /* Flags */
-	assertEqualInt(i2(p + 10), id); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 63); /* Version made by */
+	assertEqualInt(i2le(p + 6), 63); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), flags); /* Flags */
+	assertEqualInt(i2le(p + 10), id); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = lzma_crc32(file_data1, sizeof(file_data1), 0);
 	crc = lzma_crc32(file_data2, sizeof(file_data2), crc);
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = p + 46 + strlen(file_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 /* TODO */
-	p = p + 4 + i2(p + 2);
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of file entry. */
 	local_header = q = buff;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 63); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), flags); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) and bit 1 = EOPM (because we always write it) */
-	assertEqualInt(i2(q + 8), id); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
-	assertEqualInt(i2(q + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 63); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), flags); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) and bit 1 = EOPM (because we always write it) */
+	assertEqualInt(i2le(q + 8), id); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
+	assertEqualInt(i2le(q + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, file_name, strlen(file_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(file_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(q + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), file_gid); /* 'Ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), file_gid); /* 'Ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 3); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 3); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 3); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* Bitmap of fields included. */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* Verify data of file entry, using our own zip reader to test. */
 	assertEqualIntA(zip_archive, ARCHIVE_OK, archive_read_next_header(zip_archive, &ae));
@@ -226,89 +211,89 @@ static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 
 	/* Verify data descriptor of file entry, except compressed size (offset 8). */
 	assertEqualMem(q, "PK\007\010", 4); /* Signature */
-	assertEqualInt(i4(q + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i4le(q + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
 	q = q + 16;
 
 	/* Verify folder entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 20); /* Version made by */
-	assertEqualInt(i2(p + 6), 20); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 0); /* Flags */
-	assertEqualInt(i2(p + 10), 0); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 20); /* Version made by */
+	assertEqualInt(i2le(p + 6), 20); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 0); /* Flags */
+	assertEqualInt(i2le(p + 10), 0); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = 0;
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 20), 0); /* Compressed size */
-	assertEqualInt(i4(p + 24), 0); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), q - buff); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 20), 0); /* Compressed size */
+	assertEqualInt(i4le(p + 24), 0); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), q - buff); /* Offset of local header */
 	assertEqualMem(p + 46, folder_name, strlen(folder_name)); /* Pathname */
 	p = p + 46 + strlen(folder_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(p + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), folder_gid); /* 'ux' GID */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), folder_gid); /* 'ux' GID */
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of folder entry. */
 	local_header = q;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 20); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 0); /* Flags */
-	assertEqualInt(i2(q + 8), 0); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size */
-	assertEqualInt(i2(q + 26), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 20); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 0); /* Flags */
+	assertEqualInt(i2le(q + 8), 0); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size */
+	assertEqualInt(i2le(q + 26), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, folder_name, strlen(folder_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(folder_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(q + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), folder_gid); /* 'ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), folder_gid); /* 'ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 5); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 5); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 5); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* bitmap of fields */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* There should not be any data in the folder entry,
 	 * so the first central directory entry should be next: */

--- a/libarchive/test/test_write_format_zip_compression_store.c
+++ b/libarchive/test/test_write_format_zip_compression_store.c
@@ -106,21 +106,6 @@ static void verify_write_uncompressed(struct archive *a)
 	archive_entry_free(entry);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned int
-i2(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (p[0] | (p[1] << 8));
-}
-
-static unsigned int
-i4(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (i2(p) | (i2(p + 2) << 16));
-}
-
 static void verify_uncompressed_contents(const char *buff, size_t used)
 {
 	const char *buffend;
@@ -152,99 +137,99 @@ static void verify_uncompressed_contents(const char *buff, size_t used)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
 	failure("CD start (%d) + CD length (%d) should == archive size - 22",
-	    i4(p + 12), i4(p + 16));
-	assertEqualInt(i4(p + 12) + i4(p + 16), used - 22);
+	    i4le(p + 12), i4le(p + 16));
+	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	p = buff + i4(buffend - 6);
+	p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 10); /* Version made by */
-	assertEqualInt(i2(p + 6), 10); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), 0); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 10); /* Version made by */
+	assertEqualInt(i2le(p + 6), 10); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), 0); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = bitcrc32(0, file_data1, sizeof(file_data1));
 	crc = bitcrc32(crc, file_data2, sizeof(file_data2));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 20), sizeof(file_data1) + sizeof(file_data2)); /* Compressed size */
-	assertEqualInt(i4(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 20), sizeof(file_data1) + sizeof(file_data2)); /* Compressed size */
+	assertEqualInt(i4le(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = p + 46 + strlen(file_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 /* TODO */
-	p = p + 4 + i2(p + 2);
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of file entry. */
 	local_header = q = buff;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 10); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 8); /* Flags: bit 3 = length-at-end.  Required because CRC32 is unknown */
-	assertEqualInt(i2(q + 8), 0); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
-	assertEqualInt(i2(q + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 10); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 8); /* Flags: bit 3 = length-at-end.  Required because CRC32 is unknown */
+	assertEqualInt(i2le(q + 8), 0); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
+	assertEqualInt(i2le(q + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, file_name, strlen(file_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(file_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(q + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), file_gid); /* 'Ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), file_gid); /* 'Ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 3); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 3); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 3); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* Bitmap of fields included. */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* Verify data of file entry. */
 	assertEqualMem(q, file_data1, sizeof(file_data1));
@@ -253,90 +238,90 @@ static void verify_uncompressed_contents(const char *buff, size_t used)
 
 	/* Verify data descriptor of file entry. */
 	assertEqualMem(q, "PK\007\010", 4); /* Signature */
-	assertEqualInt(i4(q + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(q + 8), sizeof(file_data1) + sizeof(file_data2)); /* Compressed size */
-	assertEqualInt(i4(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i4le(q + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(q + 8), sizeof(file_data1) + sizeof(file_data2)); /* Compressed size */
+	assertEqualInt(i4le(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
 	q = q + 16;
 
 	/* Verify folder entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 20); /* Version made by */
-	assertEqualInt(i2(p + 6), 20); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 0); /* Flags */
-	assertEqualInt(i2(p + 10), 0); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 20); /* Version made by */
+	assertEqualInt(i2le(p + 6), 20); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 0); /* Flags */
+	assertEqualInt(i2le(p + 10), 0); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = 0;
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 20), 0); /* Compressed size */
-	assertEqualInt(i4(p + 24), 0); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), q - buff); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 20), 0); /* Compressed size */
+	assertEqualInt(i4le(p + 24), 0); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), q - buff); /* Offset of local header */
 	assertEqualMem(p + 46, folder_name, strlen(folder_name)); /* Pathname */
 	p = p + 46 + strlen(folder_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(p + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), folder_gid); /* 'ux' GID */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), folder_gid); /* 'ux' GID */
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of folder entry. */
 	local_header = q;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 20); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 0); /* Flags */
-	assertEqualInt(i2(q + 8), 0); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size */
-	assertEqualInt(i2(q + 26), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 20); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 0); /* Flags */
+	assertEqualInt(i2le(q + 8), 0); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size */
+	assertEqualInt(i2le(q + 26), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, folder_name, strlen(folder_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(folder_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(q + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), folder_gid); /* 'ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), folder_gid); /* 'ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 5); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 5); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 5); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* bitmap of fields */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* There should not be any data in the folder entry,
 	 * so the first central directory entry should be next: */

--- a/libarchive/test/test_write_format_zip_compression_zstd.c
+++ b/libarchive/test/test_write_format_zip_compression_zstd.c
@@ -85,21 +85,6 @@ static void verify_write_zstd(struct archive *a)
 	archive_entry_free(entry);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned int
-i2(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (p[0] | (p[1] << 8));
-}
-
-static unsigned int
-i4(const void *p_)
-{
-	const unsigned char *p = p_;
-	return (i2(p) | (i2(p + 2) << 16));
-}
-
 static void verify_zstd_contents(const char *buff, size_t used)
 {
 	const char *buffend;
@@ -140,98 +125,98 @@ static void verify_zstd_contents(const char *buff, size_t used)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
 	failure("CD start (%d) + CD length (%d) should == archive size - 22",
-	    i4(p + 12), i4(p + 16));
-	assertEqualInt(i4(p + 12) + i4(p + 16), used - 22);
+	    i4le(p + 12), i4le(p + 16));
+	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	p = buff + i4(buffend - 6);
+	p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory, except compressed size (offset 20). */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 63); /* Version made by */
-	assertEqualInt(i2(p + 6), 63); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), 93); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 63); /* Version made by */
+	assertEqualInt(i2le(p + 6), 63); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), 93); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = bitcrc32(0, file_data1, sizeof(file_data1));
 	crc = bitcrc32(crc, file_data2, sizeof(file_data2));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 24), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = p + 46 + strlen(file_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 /* TODO */
-	p = p + 4 + i2(p + 2);
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of file entry. */
 	local_header = q = buff;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 63); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 8); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) */
-	assertEqualInt(i2(q + 8), 93); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
-	assertEqualInt(i2(q + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 63); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 8); /* Flags: bit 3 = length-at-end (required because CRC32 is unknown) */
+	assertEqualInt(i2le(q + 8), 93); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size, must be zero because of length-at-end */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size, must be zero because of length-at-end */
+	assertEqualInt(i2le(q + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, file_name, strlen(file_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(file_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(q + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), file_gid); /* 'Ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), file_gid); /* 'Ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 3); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 3); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 3); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* Bitmap of fields included. */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* Verify data of file entry, using our own zip reader to test. */
 	assertEqualIntA(zip_archive, ARCHIVE_OK, archive_read_next_header(zip_archive, &ae));
@@ -251,89 +236,89 @@ static void verify_zstd_contents(const char *buff, size_t used)
 
 	/* Verify data descriptor of file entry, except compressed size (offset 8). */
 	assertEqualMem(q, "PK\007\010", 4); /* Signature */
-	assertEqualInt(i4(q + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
+	assertEqualInt(i4le(q + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(q + 12), sizeof(file_data1) + sizeof(file_data2)); /* Uncompressed size */
 	q = q + 16;
 
 	/* Verify folder entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + 20); /* Version made by */
-	assertEqualInt(i2(p + 6), 20); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 0); /* Flags */
-	assertEqualInt(i2(p + 10), 0); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + 20); /* Version made by */
+	assertEqualInt(i2le(p + 6), 20); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 0); /* Flags */
+	assertEqualInt(i2le(p + 10), 0); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = 0;
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 20), 0); /* Compressed size */
-	assertEqualInt(i4(p + 24), 0); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(p + 30), 24); /* Extra field length */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), q - buff); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 20), 0); /* Compressed size */
+	assertEqualInt(i4le(p + 24), 0); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 30), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, folder_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), q - buff); /* Offset of local header */
 	assertEqualMem(p + 46, folder_name, strlen(folder_name)); /* Pathname */
 	p = p + 46 + strlen(folder_name);
 
-	assertEqualInt(i2(p), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(p + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), folder_gid); /* 'ux' GID */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), folder_gid); /* 'ux' GID */
+	p = p + 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), now); /* 'UT' mtime */
-	p = p + 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), now); /* 'UT' mtime */
+	p = p + 4 + i2le(p + 2);
 
 	/* Verify local header of folder entry. */
 	local_header = q;
 	assertEqualMem(q, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(q + 4), 20); /* Version needed to extract */
-	assertEqualInt(i2(q + 6), 0); /* Flags */
-	assertEqualInt(i2(q + 8), 0); /* Compression method */
-	assertEqualInt(i2(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(q + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(q + 18), 0); /* Compressed size */
-	assertEqualInt(i4(q + 22), 0); /* Uncompressed size */
-	assertEqualInt(i2(q + 26), strlen(folder_name)); /* Pathname length */
-	assertEqualInt(i2(q + 28), 41); /* Extra field length */
+	assertEqualInt(i2le(q + 4), 20); /* Version needed to extract */
+	assertEqualInt(i2le(q + 6), 0); /* Flags */
+	assertEqualInt(i2le(q + 8), 0); /* Compression method */
+	assertEqualInt(i2le(q + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(q + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(q + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(q + 18), 0); /* Compressed size */
+	assertEqualInt(i4le(q + 22), 0); /* Uncompressed size */
+	assertEqualInt(i2le(q + 26), strlen(folder_name)); /* Pathname length */
+	assertEqualInt(i2le(q + 28), 41); /* Extra field length */
 	assertEqualMem(q + 30, folder_name, strlen(folder_name)); /* Pathname */
 	extra_start = q = q + 30 + strlen(folder_name);
 
-	assertEqualInt(i2(q), 0x7875); /* 'ux' extension header */
-	assertEqualInt(i2(q + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(q), 0x7875); /* 'ux' extension header */
+	assertEqualInt(i2le(q + 2), 11); /* 'ux' size */
 	assertEqualInt(q[4], 1); /* 'ux' version */
 	assertEqualInt(q[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(q + 6), folder_uid); /* 'ux' UID */
+	assertEqualInt(i4le(q + 6), folder_uid); /* 'ux' UID */
 	assertEqualInt(q[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(q + 11), folder_gid); /* 'ux' GID */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 11), folder_gid); /* 'ux' GID */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x5455); /* 'UT' extension header */
-	assertEqualInt(i2(q + 2), 9); /* 'UT' size */
+	assertEqualInt(i2le(q), 0x5455); /* 'UT' extension header */
+	assertEqualInt(i2le(q + 2), 9); /* 'UT' size */
 	assertEqualInt(q[4], 5); /* 'UT' flags */
-	assertEqualInt(i4(q + 5), now); /* 'UT' mtime */
-	assertEqualInt(i4(q + 9), now + 5); /* 'UT' atime */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i4le(q + 5), now); /* 'UT' mtime */
+	assertEqualInt(i4le(q + 9), now + 5); /* 'UT' atime */
+	q = q + 4 + i2le(q + 2);
 
-	assertEqualInt(i2(q), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(q + 2), 9); /* size */
+	assertEqualInt(i2le(q), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(q + 2), 9); /* size */
 	assertEqualInt(q[4], 7); /* bitmap of fields */
-	assertEqualInt(i2(q + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(q + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
-	q = q + 4 + i2(q + 2);
+	assertEqualInt(i2le(q + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(q + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(q + 9) >> 16 & 01777, folder_perm); /* external file attributes */
+	q = q + 4 + i2le(q + 2);
 
-	assert(q == extra_start + i2(local_header + 28));
-	q = extra_start + i2(local_header + 28);
+	assert(q == extra_start + i2le(local_header + 28));
+	q = extra_start + i2le(local_header + 28);
 
 	/* There should not be any data in the folder entry,
 	 * so the first central directory entry should be next: */

--- a/libarchive/test/test_write_format_zip_entry_size_unset.c
+++ b/libarchive/test/test_write_format_zip_entry_size_unset.c
@@ -42,10 +42,6 @@ static const short folder_gid = 40;
 
 #define ZIP_ENTRY_FLAG_LENGTH_AT_END (1 << 3)
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned i2(const char *p) { return ((p[0] & 0xff) | ((p[1] & 0xff) << 8)); }
-static unsigned i4(const char *p) { return (i2(p) | (i2(p + 2) << 16)); }
-
 static unsigned long
 bitcrc32(unsigned long c, const void *_p, size_t s)
 {
@@ -116,52 +112,52 @@ static void verify_contents(const char *zip_buff, size_t size)
 	/* Check for end of central directory signature */
 	assertEqualMem(end_of_central_dir, "PK\x5\x6", 4);
 	/* Check for number of disk */
-	assertEqualInt(i2(end_of_central_dir + 4), 0);
+	assertEqualInt(i2le(end_of_central_dir + 4), 0);
 	/* Check for disk where central directory starts */
-	assertEqualInt(i2(end_of_central_dir + 6), 0);
+	assertEqualInt(i2le(end_of_central_dir + 6), 0);
 	/* Check for number of central directory records on disk */
-	assertEqualInt(i2(end_of_central_dir + 8), 2);
+	assertEqualInt(i2le(end_of_central_dir + 8), 2);
 	/* Check for total number of central directory records */
-	assertEqualInt(i2(end_of_central_dir + 10), 2);
+	assertEqualInt(i2le(end_of_central_dir + 10), 2);
 	/* Check for size of central directory and offset
     *  The size + offset must equal the end of the central directory */
-	assertEqualInt(i4(end_of_central_dir + 12) + i4(end_of_central_dir + 16), end_of_central_dir - zip_buff);
+	assertEqualInt(i4le(end_of_central_dir + 12) + i4le(end_of_central_dir + 16), end_of_central_dir - zip_buff);
 	/* Check for empty comment length */
-	assertEqualInt(i2(end_of_central_dir + 20), 0);
+	assertEqualInt(i2le(end_of_central_dir + 20), 0);
 
 	/* Get address of central directory */
-	const char *central_directory = zip_buff + i4(end_of_central_dir + 16);
+	const char *central_directory = zip_buff + i4le(end_of_central_dir + 16);
 
 	/* Check for entry in central directory signature */
 	assertEqualMem(central_directory, "PK\x1\x2", 4);
 	/* Check for version used to write entry */
-	assertEqualInt(i2(central_directory + 4), 3 * 256 + 10);
+	assertEqualInt(i2le(central_directory + 4), 3 * 256 + 10);
 	/* Check for version needed to extract entry */
-	assertEqualInt(i2(central_directory + 6), 10);
+	assertEqualInt(i2le(central_directory + 6), 10);
 	/* Check flags */
-	assertEqualInt(i2(central_directory + 8), ZIP_ENTRY_FLAG_LENGTH_AT_END);
+	assertEqualInt(i2le(central_directory + 8), ZIP_ENTRY_FLAG_LENGTH_AT_END);
 	/* Check compression method */
-	assertEqualInt(i2(central_directory + 10), 0);
+	assertEqualInt(i2le(central_directory + 10), 0);
 	/* Check crc value */
-	assertEqualInt(i4(central_directory + 16), crc);
+	assertEqualInt(i4le(central_directory + 16), crc);
 	/* Check compressed size*/
-	assertEqualInt(i4(central_directory + 20), sizeof(file_data1) + sizeof(file_data2));
+	assertEqualInt(i4le(central_directory + 20), sizeof(file_data1) + sizeof(file_data2));
 	/* Check uncompressed size */
-	assertEqualInt(i4(central_directory + 24), sizeof(file_data1) + sizeof(file_data2));
+	assertEqualInt(i4le(central_directory + 24), sizeof(file_data1) + sizeof(file_data2));
 	/* Check file name length */
-	assertEqualInt(i2(central_directory + 28), strlen(file_name));
+	assertEqualInt(i2le(central_directory + 28), strlen(file_name));
 	/* Check extra field length */
-	assertEqualInt(i2(central_directory + 30), 15);
+	assertEqualInt(i2le(central_directory + 30), 15);
 	/* Check file comment length */
-	assertEqualInt(i2(central_directory + 32), 0);
+	assertEqualInt(i2le(central_directory + 32), 0);
 	/* Check disk number where file starts */
-	assertEqualInt(i2(central_directory + 34), 0);
+	assertEqualInt(i2le(central_directory + 34), 0);
 	/* Check internal file attrs */
-	assertEqualInt(i2(central_directory + 36), 0);
+	assertEqualInt(i2le(central_directory + 36), 0);
 	/* Check external file attrs */
-	assertEqualInt(i4(central_directory + 38) >> 16 & 01777, file_perm);
+	assertEqualInt(i4le(central_directory + 38) >> 16 & 01777, file_perm);
 	/* Check offset of local header */
-	assertEqualInt(i4(central_directory + 42), 0);
+	assertEqualInt(i4le(central_directory + 42), 0);
 	/* Check for file name contents */
 	assertEqualMem(central_directory + 46, file_name, strlen(file_name));
 
@@ -171,28 +167,28 @@ static void verify_contents(const char *zip_buff, size_t size)
 	/* Check local file header signature */
 	assertEqualMem(local_file_header, "PK\x3\x4", 4);
 	/* Check version needed to extract */
-	assertEqualInt(i2(local_file_header + 4), 10);
+	assertEqualInt(i2le(local_file_header + 4), 10);
 	/* Check flags */
-	assertEqualInt(i2(local_file_header + 6), 8);
+	assertEqualInt(i2le(local_file_header + 6), 8);
 	/* Check compression method */
-	assertEqualInt(i2(local_file_header + 8), 0);
+	assertEqualInt(i2le(local_file_header + 8), 0);
 	/* Check crc */
-	assertEqualInt(i4(local_file_header + 14), 0);
+	assertEqualInt(i4le(local_file_header + 14), 0);
 	/* Check compressed size
     *  0 because it was unknown at time of writing */
-	assertEqualInt(i4(local_file_header + 18), 0);
+	assertEqualInt(i4le(local_file_header + 18), 0);
 	/* Check uncompressed size
     *  0 because it was unknown at time of writing */
-	assertEqualInt(i4(local_file_header + 22), 0);
+	assertEqualInt(i4le(local_file_header + 22), 0);
 	/* Check pathname length */
-	assertEqualInt(i2(local_file_header + 26), strlen(file_name));
+	assertEqualInt(i2le(local_file_header + 26), strlen(file_name));
 	/* Check extra field length */
-	assertEqualInt(i2(local_file_header + 28), 15);
+	assertEqualInt(i2le(local_file_header + 28), 15);
 	/* Check path name match */
 	assertEqualMem(local_file_header + 30, file_name, strlen(file_name));
 
 	/* Start of data */
-	const char *data = local_file_header + i2(local_file_header + 28) + strlen(file_name) + 30;
+	const char *data = local_file_header + i2le(local_file_header + 28) + strlen(file_name) + 30;
 	/* Check for file data match */
 	assertEqualMem(data, file_data1, sizeof(file_data1));
 	assertEqualMem(data + sizeof(file_data1), file_data2, sizeof(file_data2));
@@ -202,14 +198,14 @@ static void verify_contents(const char *zip_buff, size_t size)
 	/* Check data descriptor signature */
 	assertEqualMem(data_descriptor, "PK\x7\x8", 4);
 	/* Check crc value */
-	assertEqualInt(i4(data_descriptor + 4), crc);
+	assertEqualInt(i4le(data_descriptor + 4), crc);
 	/* Check compressed size */
-	assertEqualInt(i4(data_descriptor + 8), sizeof(file_data1) + sizeof(file_data2));
+	assertEqualInt(i4le(data_descriptor + 8), sizeof(file_data1) + sizeof(file_data2));
 	/* Check uncompressed size */
-	assertEqualInt(i4(data_descriptor + 12), sizeof(file_data1) + sizeof(file_data2));
+	assertEqualInt(i4le(data_descriptor + 12), sizeof(file_data1) + sizeof(file_data2));
 
 	/* Get folder entry in central directory */
-	const char *central_directory_folder_entry = central_directory + 46 + i2(local_file_header + 28) + strlen(file_name);
+	const char *central_directory_folder_entry = central_directory + 46 + i2le(local_file_header + 28) + strlen(file_name);
 
 	/* Get start of folder entry */
 	const char *local_folder_header = data_descriptor + 16;
@@ -217,58 +213,58 @@ static void verify_contents(const char *zip_buff, size_t size)
 	/* Check for entry in central directory signature */
 	assertEqualMem(central_directory_folder_entry, "PK\x1\x2", 4);
 	/* Check version made by */
-	assertEqualInt(i2(central_directory_folder_entry + 4), 3 * 256 + 20);
+	assertEqualInt(i2le(central_directory_folder_entry + 4), 3 * 256 + 20);
 	/* Check version needed to extract */
-	assertEqualInt(i2(central_directory_folder_entry + 6), 20);
+	assertEqualInt(i2le(central_directory_folder_entry + 6), 20);
 	/* Check flags */
-	assertEqualInt(i2(central_directory_folder_entry + 8), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 8), 0);
 	/* Check compression method */
-	assertEqualInt(i2(central_directory_folder_entry + 10), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 10), 0);
 	/* Check crc */
-	assertEqualInt(i2(central_directory_folder_entry + 16), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 16), 0);
 	/* Check compressed size */
-	assertEqualInt(i4(central_directory_folder_entry + 20), 0);
+	assertEqualInt(i4le(central_directory_folder_entry + 20), 0);
 	/* Check uncompressed size */
-	assertEqualInt(i4(central_directory_folder_entry + 24), 0);
+	assertEqualInt(i4le(central_directory_folder_entry + 24), 0);
 	/* Check path name length */
-	assertEqualInt(i2(central_directory_folder_entry + 28), strlen(folder_name));
+	assertEqualInt(i2le(central_directory_folder_entry + 28), strlen(folder_name));
 	/* Check extra field length */
-	assertEqualInt(i2(central_directory_folder_entry + 30), 15);
+	assertEqualInt(i2le(central_directory_folder_entry + 30), 15);
 	/* Check file comment length */
-	assertEqualInt(i2(central_directory_folder_entry + 32), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 32), 0);
 	/* Check disk number start */
-	assertEqualInt(i2(central_directory_folder_entry + 34), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 34), 0);
 	/* Check internal file attrs */
-	assertEqualInt(i2(central_directory_folder_entry + 36), 0);
+	assertEqualInt(i2le(central_directory_folder_entry + 36), 0);
 	/* Check external file attrs */
-	assertEqualInt(i4(central_directory_folder_entry + 38) >> 16 & 01777, folder_perm);
+	assertEqualInt(i4le(central_directory_folder_entry + 38) >> 16 & 01777, folder_perm);
 	/* Check offset of local header*/
-	assertEqualInt(i4(central_directory_folder_entry + 42), local_folder_header - zip_buff);
+	assertEqualInt(i4le(central_directory_folder_entry + 42), local_folder_header - zip_buff);
 	/* Check path name */
 	assertEqualMem(central_directory_folder_entry + 46, folder_name, strlen(folder_name));
 
 	/* Check local header */
 	assertEqualMem(local_folder_header, "PK\x3\x4", 4);
 	/* Check version to extract */
-	assertEqualInt(i2(local_folder_header + 4), 20);
+	assertEqualInt(i2le(local_folder_header + 4), 20);
 	/* Check flags */
-	assertEqualInt(i2(local_folder_header + 6), 0);
+	assertEqualInt(i2le(local_folder_header + 6), 0);
 	/* Check compression method */
-	assertEqualInt(i2(local_folder_header + 8), 0);
+	assertEqualInt(i2le(local_folder_header + 8), 0);
 	/* Check crc */
-	assertEqualInt(i4(local_folder_header + 14), 0);
+	assertEqualInt(i4le(local_folder_header + 14), 0);
 	/* Check compressed size */
-	assertEqualInt(i2(local_folder_header + 18), 0);
+	assertEqualInt(i2le(local_folder_header + 18), 0);
 	/* Check uncompressed size */
-	assertEqualInt(i4(local_folder_header + 22), 0);
+	assertEqualInt(i4le(local_folder_header + 22), 0);
 	/* Check path name length */
-	assertEqualInt(i2(local_folder_header + 26), strlen(folder_name));
+	assertEqualInt(i2le(local_folder_header + 26), strlen(folder_name));
 	/* Check extra field length */
-	assertEqualInt(i2(local_folder_header + 28), 15);
+	assertEqualInt(i2le(local_folder_header + 28), 15);
 	/* Check path name */
 	assertEqualMem(local_folder_header + 30, folder_name, strlen(folder_name));
 
-	const char *post_local_folder = local_folder_header + 30 + i2(local_folder_header + 28) + strlen(folder_name);
+	const char *post_local_folder = local_folder_header + 30 + i2le(local_folder_header + 28) + strlen(folder_name);
 	assertEqualMem(post_local_folder, central_directory, 4);
 }
 

--- a/libarchive/test/test_write_format_zip_file.c
+++ b/libarchive/test/test_write_format_zip_file.c
@@ -63,10 +63,6 @@ bitcrc32(unsigned long c, void *_p, size_t s)
 	return (c);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned i2(const unsigned char *p) { return ((p[0] & 0xff) | ((p[1] & 0xff) << 8)); }
-static unsigned i4(const unsigned char *p) { return (i2(p) | (i2(p + 2) << 16)); }
-
 DEFINE_TEST(test_write_format_zip_file)
 {
 	struct archive *a;
@@ -131,60 +127,60 @@ DEFINE_TEST(test_write_format_zip_file)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
-	eocd = buff + i4(p + 12) + i4(p + 16);
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
+	eocd = buff + i4le(p + 12) + i4le(p + 16);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	central_header = p = buff + i4(buffend - 6);
+	central_header = p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + zip_version); /* Version made by */
-	assertEqualInt(i2(p + 6), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + zip_version); /* Version made by */
+	assertEqualInt(i2le(p + 6), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = bitcrc32(0, file_data, sizeof(file_data));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	/* assertEqualInt(i4(p + 20), sizeof(file_data)); */ /* Compressed size */
-	assertEqualInt(i4(p + 24), sizeof(file_data)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	/* assertEqualInt(i2(p + 30), 28); */ /* Extra field length: See below */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	/* assertEqualInt(i4le(p + 20), sizeof(file_data)); */ /* Compressed size */
+	assertEqualInt(i4le(p + 24), sizeof(file_data)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	/* assertEqualInt(i2le(p + 30), 28); */ /* Extra field length: See below */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = central_header + 46 + strlen(file_name);
-	extension_end = extension_start + i2(central_header + 30);
+	extension_end = extension_start + i2le(central_header + 30);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	/* TODO: verify 'ux' contents */
-	p += 4 + i2(p + 2);
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), t); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), t); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -198,48 +194,48 @@ DEFINE_TEST(test_write_format_zip_file)
 	/* Verify local header of file entry. */
 	p = local_header = buff;
 	assertEqualMem(p, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(p + 4), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 6), 8); /* Flags: bit 3 = length-at-end */
-	assertEqualInt(i2(p + 8), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(p + 14), 0); /* CRC-32 stored as zero because we're using length-at-end */
-	assertEqualInt(i4(p + 18), 0); /* Compressed size stored as zero because we're using length-at-end. */
-	assertEqualInt(i4(p + 22), 0); /* Uncompressed size stored as zero because we're using length-at-end. */
-	assertEqualInt(i2(p + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 28), 37); /* Extra field length */
+	assertEqualInt(i2le(p + 4), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 6), 8); /* Flags: bit 3 = length-at-end */
+	assertEqualInt(i2le(p + 8), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(p + 14), 0); /* CRC-32 stored as zero because we're using length-at-end */
+	assertEqualInt(i4le(p + 18), 0); /* Compressed size stored as zero because we're using length-at-end. */
+	assertEqualInt(i4le(p + 22), 0); /* Uncompressed size stored as zero because we're using length-at-end. */
+	assertEqualInt(i2le(p + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 28), 37); /* Extra field length */
 	assertEqualMem(p + 30, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = local_header + 30 + strlen(file_name);
-	extension_end = extension_start + i2(local_header + 28);
+	extension_end = extension_start + i2le(local_header + 28);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(p + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), file_gid); /* 'Ux' GID */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), file_gid); /* 'Ux' GID */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), t); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), t); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x6c78); /* 'xl' experimental extension block */
-	assertEqualInt(i2(p + 2), 9); /* size */
+	assertEqualInt(i2le(p), 0x6c78); /* 'xl' experimental extension block */
+	assertEqualInt(i2le(p + 2), 9); /* size */
 	assertEqualInt(p[4], 7); /* bitmap of fields in this block */
-	assertEqualInt(i2(p + 5) >> 8, 3); /* System & version made by */
-	assertEqualInt(i2(p + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i2le(p + 5) >> 8, 3); /* System & version made by */
+	assertEqualInt(i2le(p + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	p += 4 + i2le(p + 2);
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -249,9 +245,9 @@ DEFINE_TEST(test_write_format_zip_file)
 	while (p < central_header && memcmp(p, "PK\007\010", 4) != 0)
 		++p;
 	assertEqualMem(p, "PK\007\010", 4);
-	assertEqualInt(i4(p + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 8), p - extension_end); /* compressed size */
-	assertEqualInt(i4(p + 12), sizeof(file_data)); /* uncompressed size */
+	assertEqualInt(i4le(p + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 8), p - extension_end); /* compressed size */
+	assertEqualInt(i4le(p + 12), sizeof(file_data)); /* uncompressed size */
 
 	/* Central directory should immediately follow the only entry. */
 	assertEqualAddress(p + 16, central_header);

--- a/libarchive/test/test_write_format_zip_file_zip64.c
+++ b/libarchive/test/test_write_format_zip_file_zip64.c
@@ -63,12 +63,6 @@ bitcrc32(unsigned long c, void *_p, size_t s)
 	return (c);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned i2(const unsigned char *p) { return ((p[0] & 0xff) | ((p[1] & 0xff) << 8)); }
-static unsigned i4(const unsigned char *p) { return (i2(p) | (i2(p + 2) << 16)); }
-/* We're only working with small values here; ignore the 4 high bytes. */
-static unsigned i8(const unsigned char *p) { return (i4(p)); }
-
 DEFINE_TEST(test_write_format_zip_file_zip64)
 {
 	struct archive *a;
@@ -134,54 +128,54 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
-	eocd = buff + i4(p + 12) + i4(p + 16);
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
+	eocd = buff + i4le(p + 12) + i4le(p + 16);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	central_header = p = buff + i4(buffend - 6);
+	central_header = p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + zip_version); /* Version made by */
-	assertEqualInt(i2(p + 6), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + zip_version); /* Version made by */
+	assertEqualInt(i2le(p + 6), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 12), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 14), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
 	crc = bitcrc32(0, file_data, sizeof(file_data));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	/* assertEqualInt(i4(p + 20), sizeof(file_data)); */ /* Compressed size */
-	assertEqualInt(i4(p + 24), sizeof(file_data)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	/* assertEqualInt(i2(p + 30), 28); */ /* Extra field length: See below */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	/* assertEqualInt(i4le(p + 20), sizeof(file_data)); */ /* Compressed size */
+	assertEqualInt(i4le(p + 24), sizeof(file_data)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	/* assertEqualInt(i2le(p + 30), 28); */ /* Extra field length: See below */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = central_header + 46 + strlen(file_name);
-	extension_end = extension_start + i2(central_header + 30);
+	extension_end = extension_start + i2le(central_header + 30);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	/* TODO: verify 'ux' contents */
-	p += 4 + i2(p + 2);
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), t); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), t); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
 	/* Note: We don't expect to see zip64 extension in the central
 	 * directory, since the writer knows the actual full size by
@@ -191,9 +185,9 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -203,21 +197,21 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 
 	/* After Central dir, we find Zip64 eocd and Zip64 eocd locator. */
 	assertEqualMem(p, "PK\006\006", 4); /* Zip64 eocd */
-	assertEqualInt(i8(p + 4), 44); /* We're using v1 Zip64 eocd */
-	assertEqualInt(i2(p + 12), 45); /* Written by Version 4.5 */
-	assertEqualInt(i2(p + 14), 45); /* Needs version 4.5 to extract */
-	assertEqualInt(i4(p + 16), 0); /* This is disk #0 */
-	assertEqualInt(i4(p + 20), 0); /* Dir starts on disk #0 */
-	assertEqualInt(i8(p + 24), 1); /* 1 entry on this disk */
-	assertEqualInt(i8(p + 32), 1); /* 1 entry total */
-	assertEqualInt(i8(p + 40), eocd - central_header); /* size of cd */
-	assertEqualInt(i8(p + 48), central_header - buff); /* start of cd */
-	p += 12 + i8(p + 4);
+	assertEqualInt(i8le(p + 4), 44); /* We're using v1 Zip64 eocd */
+	assertEqualInt(i2le(p + 12), 45); /* Written by Version 4.5 */
+	assertEqualInt(i2le(p + 14), 45); /* Needs version 4.5 to extract */
+	assertEqualInt(i4le(p + 16), 0); /* This is disk #0 */
+	assertEqualInt(i4le(p + 20), 0); /* Dir starts on disk #0 */
+	assertEqualInt(i8le(p + 24), 1); /* 1 entry on this disk */
+	assertEqualInt(i8le(p + 32), 1); /* 1 entry total */
+	assertEqualInt(i8le(p + 40), eocd - central_header); /* size of cd */
+	assertEqualInt(i8le(p + 48), central_header - buff); /* start of cd */
+	p += 12 + i8le(p + 4);
 
 	assertEqualMem(p, "PK\006\007", 4); /* Zip64 eocd locator */
-	assertEqualInt(i4(p + 4), 0); /* Zip64 eocd is on disk #0 */
-	assertEqualInt(i8(p + 8), eocd - buff); /* Offset of Zip64 eocd */
-	assertEqualInt(i4(p + 16), 1); /* 1 disk */
+	assertEqualInt(i4le(p + 4), 0); /* Zip64 eocd is on disk #0 */
+	assertEqualInt(i8le(p + 8), eocd - buff); /* Offset of Zip64 eocd */
+	assertEqualInt(i4le(p + 16), 1); /* 1 disk */
 	p += 20;
 
 	/* Regular EOCD immediately follows Zip64 records. */
@@ -226,48 +220,48 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 	/* Verify local header of file entry. */
 	p = local_header = buff;
 	assertEqualMem(p, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(p + 4), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 6), 8); /* Flags: bit 3 = length-at-end */
-	assertEqualInt(i2(p + 8), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
-	assertEqualInt(i2(p + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
-	assertEqualInt(i4(p + 14), 0); /* CRC-32 must be 0 because of length-at-end */
-	assertEqualInt(i4(p + 18), 0); /* Compressed size must be 0 because of length-at-end */
-	assertEqualInt(i4(p + 22), 0); /* Uncompressed size must be 0 because of length-at-end. */
-	assertEqualInt(i2(p + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 28), 37); /* Extra field length */
+	assertEqualInt(i2le(p + 4), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 6), 8); /* Flags: bit 3 = length-at-end */
+	assertEqualInt(i2le(p + 8), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 10), (tm->tm_hour * 2048) + (tm->tm_min * 32) + (tm->tm_sec / 2)); /* File time */
+	assertEqualInt(i2le(p + 12), ((tm->tm_year - 80) * 512) + ((tm->tm_mon + 1) * 32) + tm->tm_mday); /* File date */
+	assertEqualInt(i4le(p + 14), 0); /* CRC-32 must be 0 because of length-at-end */
+	assertEqualInt(i4le(p + 18), 0); /* Compressed size must be 0 because of length-at-end */
+	assertEqualInt(i4le(p + 22), 0); /* Uncompressed size must be 0 because of length-at-end. */
+	assertEqualInt(i2le(p + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 28), 37); /* Extra field length */
 	assertEqualMem(p + 30, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = local_header + 30 + strlen(file_name);
-	extension_end = extension_start + i2(local_header + 28);
+	extension_end = extension_start + i2le(local_header + 28);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(p + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), file_gid); /* 'Ux' GID */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), file_gid); /* 'Ux' GID */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), t); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), t); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x6c78); /* 'xl' experimental extension header */
-	assertEqualInt(i2(p + 2), 9); /* size */
+	assertEqualInt(i2le(p), 0x6c78); /* 'xl' experimental extension header */
+	assertEqualInt(i2le(p + 2), 9); /* size */
 	assertEqualInt(p[4], 7); /* bitmap of included fields */
-	assertEqualInt(i2(p + 5) >> 8, 3); /* system & version made by */
-	assertEqualInt(i2(p + 7), 0); /* internal file attributes */
-	assertEqualInt(i4(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i2le(p + 5) >> 8, 3); /* system & version made by */
+	assertEqualInt(i2le(p + 7), 0); /* internal file attributes */
+	assertEqualInt(i4le(p + 9) >> 16 & 01777, file_perm); /* external file attributes */
+	p += 4 + i2le(p + 2);
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -277,9 +271,9 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 	while (p < central_header && memcmp(p, "PK\007\010", 4) != 0)
 		++p;
 	assertEqualMem(p, "PK\007\010", 4);
-	assertEqualInt(i4(p + 4), crc); /* CRC-32 */
-	assertEqualInt(i8(p + 8), p - extension_end); /* compressed size */
-	assertEqualInt(i8(p + 16), sizeof(file_data)); /* uncompressed size */
+	assertEqualInt(i4le(p + 4), crc); /* CRC-32 */
+	assertEqualInt(i8le(p + 8), p - extension_end); /* compressed size */
+	assertEqualInt(i8le(p + 16), sizeof(file_data)); /* uncompressed size */
 
 	/* Central directory should immediately follow the only entry. */
 	assertEqualAddress(p + 24, central_header);

--- a/libarchive/test/test_write_format_zip_stream.c
+++ b/libarchive/test/test_write_format_zip_stream.c
@@ -59,10 +59,6 @@ bitcrc32(unsigned long c, void *_p, size_t s)
 	return (c);
 }
 
-/* Quick and dirty: Read 2-byte and 4-byte integers from Zip file. */
-static unsigned i2(const unsigned char *p) { return ((p[0] & 0xff) | ((p[1] & 0xff) << 8)); }
-static unsigned i4(const unsigned char *p) { return (i2(p) | (i2(p + 2) << 16)); }
-
 DEFINE_TEST(test_write_format_zip_stream)
 {
 	struct archive *a;
@@ -120,58 +116,58 @@ DEFINE_TEST(test_write_format_zip_stream)
 	failure("End-of-central-directory begins with PK\\005\\006 signature");
 	assertEqualMem(p, "PK\005\006", 4);
 	failure("This must be disk 0");
-	assertEqualInt(i2(p + 4), 0);
+	assertEqualInt(i2le(p + 4), 0);
 	failure("Central dir must start on disk 0");
-	assertEqualInt(i2(p + 6), 0);
+	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
-	assertEqualInt(i2(p + 8), i2(p + 10));
-	eocd = buff + i4(p + 12) + i4(p + 16);
+	assertEqualInt(i2le(p + 8), i2le(p + 10));
+	eocd = buff + i4le(p + 12) + i4le(p + 16);
 	failure("no zip comment");
-	assertEqualInt(i2(p + 20), 0);
+	assertEqualInt(i2le(p + 20), 0);
 
 	/* Get address of first entry in central directory. */
-	central_header = p = buff + i4(buffend - 6);
+	central_header = p = buff + i4le(buffend - 6);
 	failure("Central file record at offset %d should begin with"
 	    " PK\\001\\002 signature",
-	    i4(buffend - 10));
+	    i4le(buffend - 10));
 
 	/* Verify file entry in central directory. */
 	assertEqualMem(p, "PK\001\002", 4); /* Signature */
-	assertEqualInt(i2(p + 4), 3 * 256 + zip_version); /* Version made by */
-	assertEqualInt(i2(p + 6), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 8), 8); /* Flags */
-	assertEqualInt(i2(p + 10), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 12), 0); /* File time */
-	assertEqualInt(i2(p + 14), 33); /* File date */
+	assertEqualInt(i2le(p + 4), 3 * 256 + zip_version); /* Version made by */
+	assertEqualInt(i2le(p + 6), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 8), 8); /* Flags */
+	assertEqualInt(i2le(p + 10), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 12), 0); /* File time */
+	assertEqualInt(i2le(p + 14), 33); /* File date */
 	crc = bitcrc32(0, file_data, sizeof(file_data));
-	assertEqualInt(i4(p + 16), crc); /* CRC-32 */
-	compressed_size = i4(p + 20);  /* Compressed size */
-	assertEqualInt(i4(p + 24), sizeof(file_data)); /* Uncompressed size */
-	assertEqualInt(i2(p + 28), strlen(file_name)); /* Pathname length */
-	/* assertEqualInt(i2(p + 30), 28); */ /* Extra field length: See below */
-	assertEqualInt(i2(p + 32), 0); /* File comment length */
-	assertEqualInt(i2(p + 34), 0); /* Disk number start */
-	assertEqualInt(i2(p + 36), 0); /* Internal file attrs */
-	assertEqualInt(i4(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
-	assertEqualInt(i4(p + 42), 0); /* Offset of local header */
+	assertEqualInt(i4le(p + 16), crc); /* CRC-32 */
+	compressed_size = i4le(p + 20);  /* Compressed size */
+	assertEqualInt(i4le(p + 24), sizeof(file_data)); /* Uncompressed size */
+	assertEqualInt(i2le(p + 28), strlen(file_name)); /* Pathname length */
+	/* assertEqualInt(i2le(p + 30), 28); */ /* Extra field length: See below */
+	assertEqualInt(i2le(p + 32), 0); /* File comment length */
+	assertEqualInt(i2le(p + 34), 0); /* Disk number start */
+	assertEqualInt(i2le(p + 36), 0); /* Internal file attrs */
+	assertEqualInt(i4le(p + 38) >> 16 & 01777, file_perm); /* External file attrs */
+	assertEqualInt(i4le(p + 42), 0); /* Offset of local header */
 	assertEqualMem(p + 46, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = central_header + 46 + strlen(file_name);
-	extension_end = extension_start + i2(central_header + 30);
+	extension_end = extension_start + i2le(central_header + 30);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(p + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), file_gid); /* 'Ux' GID */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), file_gid); /* 'Ux' GID */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), 0); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), 0); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
 	/* Note: We don't expect to see zip64 extension in the central
 	 * directory, since the writer knows the actual full size by
@@ -181,9 +177,9 @@ DEFINE_TEST(test_write_format_zip_stream)
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -195,40 +191,40 @@ DEFINE_TEST(test_write_format_zip_stream)
 	/* Verify local header of file entry. */
 	p = local_header = buff;
 	assertEqualMem(p, "PK\003\004", 4); /* Signature */
-	assertEqualInt(i2(p + 4), zip_version); /* Version needed to extract */
-	assertEqualInt(i2(p + 6), 8); /* Flags */
-	assertEqualInt(i2(p + 8), zip_compression); /* Compression method */
-	assertEqualInt(i2(p + 10), 0); /* File time */
-	assertEqualInt(i2(p + 12), 33); /* File date */
-	assertEqualInt(i4(p + 14), 0); /* CRC-32 */
-	assertEqualInt(i4(p + 18), 0); /* Compressed size */
-	assertEqualInt(i4(p + 22), 0); /* Uncompressed size */
-	assertEqualInt(i2(p + 26), strlen(file_name)); /* Pathname length */
-	assertEqualInt(i2(p + 28), 24); /* Extra field length */
+	assertEqualInt(i2le(p + 4), zip_version); /* Version needed to extract */
+	assertEqualInt(i2le(p + 6), 8); /* Flags */
+	assertEqualInt(i2le(p + 8), zip_compression); /* Compression method */
+	assertEqualInt(i2le(p + 10), 0); /* File time */
+	assertEqualInt(i2le(p + 12), 33); /* File date */
+	assertEqualInt(i4le(p + 14), 0); /* CRC-32 */
+	assertEqualInt(i4le(p + 18), 0); /* Compressed size */
+	assertEqualInt(i4le(p + 22), 0); /* Uncompressed size */
+	assertEqualInt(i2le(p + 26), strlen(file_name)); /* Pathname length */
+	assertEqualInt(i2le(p + 28), 24); /* Extra field length */
 	assertEqualMem(p + 30, file_name, strlen(file_name)); /* Pathname */
 	p = extension_start = local_header + 30 + strlen(file_name);
-	extension_end = extension_start + i2(local_header + 28);
+	extension_end = extension_start + i2le(local_header + 28);
 
-	assertEqualInt(i2(p), 0x7875);  /* 'ux' extension header */
-	assertEqualInt(i2(p + 2), 11); /* 'ux' size */
+	assertEqualInt(i2le(p), 0x7875);  /* 'ux' extension header */
+	assertEqualInt(i2le(p + 2), 11); /* 'ux' size */
 	assertEqualInt(p[4], 1); /* 'ux' version */
 	assertEqualInt(p[5], 4); /* 'ux' uid size */
-	assertEqualInt(i4(p + 6), file_uid); /* 'Ux' UID */
+	assertEqualInt(i4le(p + 6), file_uid); /* 'Ux' UID */
 	assertEqualInt(p[10], 4); /* 'ux' gid size */
-	assertEqualInt(i4(p + 11), file_gid); /* 'Ux' GID */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 11), file_gid); /* 'Ux' GID */
+	p += 4 + i2le(p + 2);
 
-	assertEqualInt(i2(p), 0x5455);  /* 'UT' extension header */
-	assertEqualInt(i2(p + 2), 5); /* 'UT' size */
+	assertEqualInt(i2le(p), 0x5455);  /* 'UT' extension header */
+	assertEqualInt(i2le(p + 2), 5); /* 'UT' size */
 	assertEqualInt(p[4], 1); /* 'UT' flags */
-	assertEqualInt(i4(p + 5), 0); /* 'UT' mtime */
-	p += 4 + i2(p + 2);
+	assertEqualInt(i4le(p + 5), 0); /* 'UT' mtime */
+	p += 4 + i2le(p + 2);
 
 	/* Just in case: Report any extra extensions. */
 	while (p < extension_end) {
-		failure("Unexpected extension 0x%04X", i2(p));
+		failure("Unexpected extension 0x%04X", i2le(p));
 		assert(0);
-		p += 4 + i2(p + 2);
+		p += 4 + i2le(p + 2);
 	}
 
 	/* Should have run exactly to end of extra data. */
@@ -241,9 +237,9 @@ DEFINE_TEST(test_write_format_zip_stream)
 	data_end = p;
 	assertEqualInt(data_end - data_start, compressed_size);
 	assertEqualMem(p, "PK\007\010", 4);
-	assertEqualInt(i4(p + 4), crc); /* CRC-32 */
-	assertEqualInt(i4(p + 8), compressed_size); /* compressed size */
-	assertEqualInt(i4(p + 12), sizeof(file_data)); /* uncompressed size */
+	assertEqualInt(i4le(p + 4), crc); /* CRC-32 */
+	assertEqualInt(i4le(p + 8), compressed_size); /* compressed size */
+	assertEqualInt(i4le(p + 12), sizeof(file_data)); /* uncompressed size */
 
 	/* Central directory should immediately follow the data descriptor. */
 	assert(p + 16 == central_header);

--- a/test_utils/test_utils.c
+++ b/test_utils/test_utils.c
@@ -109,3 +109,23 @@ fill_with_pseudorandom_data(void *buffer, size_t size)
 	}
 	fill_with_pseudorandom_data_seed(seed, buffer, size);
 }
+
+/* Read little-endian integers */
+unsigned short
+i2le(const void* p_)
+{
+	const unsigned char *p = p_;
+	return (p[0] | (p[1] << 8));
+}
+unsigned int
+i4le(const void* p_)
+{
+	const char *p = p_;
+	return (i2le(p) | (i2le(p + 2) << 16));
+}
+unsigned long long
+i8le(const void* p_)
+{
+	const char *p = p_;
+	return (i4le(p) | ((unsigned long long)i4le(p + 4) << 32));
+}

--- a/test_utils/test_utils.h
+++ b/test_utils/test_utils.h
@@ -32,5 +32,8 @@
 
 /* Fill a buffer with pseudorandom data */
 void fill_with_pseudorandom_data(void* buffer, size_t size);
-
+/* Read little-endian integers */
+unsigned short i2le(const void*);
+unsigned int i4le(const void*);
+unsigned long long i8le(const void*);
 #endif /* TEST_UTILS_H */


### PR DESCRIPTION
Moving the tests' integer reading functions to test_utils so that they all use the same as well as moving the few using the archive_endian functions over to the test_utils helper.

Follow-up from libarchive#2390.