### PR TITLE
Add missing definition for getline polyfill

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1499,6 +1499,7 @@ bsdunzip_SOURCES= \
 		unzip/bsdunzip_platform.h \
 		unzip/cmdline.c \
 		unzip/la_getline.c \
+		unzip/la_getline.h \
 		unzip/la_queue.h
 
 if INC_WINDOWS_FILES

--- a/unzip/CMakeLists.txt
+++ b/unzip/CMakeLists.txt
@@ -14,6 +14,7 @@ IF(ENABLE_UNZIP)
     bsdunzip_platform.h
     cmdline.c
     la_getline.c
+    la_getline.h
     la_queue.h
     ../libarchive_fe/err.c
     ../libarchive_fe/err.h

--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -9,6 +9,7 @@
 #include "bsdunzip_platform.h"
 
 #include "la_queue.h"
+#include "la_getline.h"
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif

--- a/unzip/la_getline.h
+++ b/unzip/la_getline.h
@@ -1,0 +1,16 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2011 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ */
+
+#ifndef LA_GETLINE_H_INCLUDED
+#define LA_GETLINE_H_INCLUDED
+
+#include <stdio.h>
+#ifndef HAVE_GETLINE
+ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);
+#endif
+
+#endif /* !LA_GETLINE_H_INCLUDED */


### PR DESCRIPTION
The fallback for when `getline` is not implemented in libc was not compiling due to the fact that the definition for it was missing, so add the definition.