### PR TITLE
ci: log bsdtar's version text, so we can see which support libraries were used

### DIFF
--- a/build/ci/build.sh
+++ b/build/ci/build.sh
@@ -147,6 +147,7 @@ for action in ${ACTIONS}; do
 			${MAKE} ${MAKE_ARGS} install DESTDIR="${BUILDDIR}/destdir"
 			RET="$?"
 			cd "${BUILDDIR}/destdir" && ls -lR .
+			./usr/local/bin/bsdtar --version
 		;;
 		distcheck)
 			${MAKE} ${MAKE_ARGS} distcheck || (

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -150,6 +150,7 @@ IF "%1"=="deplibs" (
     CD build_ci\cmake
     cmake --build . --target INSTALL --config Release || EXIT /b 1
   )
+  "C:\Program Files (x86)\libarchive\bin\bsdtar.exe" --version
 ) ELSE IF "%1"=="artifact" (
     C:\windows\system32\tar.exe -c -C "C:\Program Files (x86)" --format=zip -f libarchive.zip libarchive
 ) ELSE (


### PR DESCRIPTION
A few of libarchive's CI jobs don't find all the local support libraries that they could be using. This change makes it easier to see which of them are used.