### PR TITLE
ci: make autoconf look for headers and libraries in /opt/homebrew if those directories exist

### DIFF
--- a/build/ci/build.sh
+++ b/build/ci/build.sh
@@ -91,6 +91,12 @@ if [ -z "${MAKE_ARGS}" ]; then
 		MAKE_ARGS="VERBOSE=1"
 	fi
 fi
+if [ -d /opt/homebrew/include ]; then
+	export CFLAGS="${CFLAGS} -I/opt/homebrew/include"
+fi
+if [ -d /opt/homebrew/lib ]; then
+	export LDFLAGS="${LDFLAGS} -L/opt/homebrew/lib"
+fi
 if [ -n "${DEBUG}" ]; then
 	if [ -n "${CFLAGS}" ]; then
 		export CFLAGS="${CFLAGS} -g -fsanitize=address"


### PR DESCRIPTION
Prior to this change, the ci autoconf jobs weren't looking for homebrew headers or libraries unless pkg-config was used, so for example the "MacOS (autotools)" ci job wasn't testing lz4 or zstd code.

Relates to #2426.