### PR TITLE
ci: make skipped tests more obvious

### DIFF
--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3526,7 +3526,7 @@ test_summarize(int failed, int skips_num)
 		fflush(stdout);
 		break;
 	case VERBOSITY_PASSFAIL:
-		printf(failed ? "FAIL\n" : skips_num ? "ok (S)\n" : "ok\n");
+		printf(failed ? "FAIL\n" : skips_num ? "skipped\n" : "ok\n");
 		break;
 	}
 


### PR DESCRIPTION
Previously skipped tests were reported like this when running the *_test binaries:
```
 4: test_acl_platform_nfs4                                          ok (S)
```

Let's make this more obvious:
```
  4: test_acl_platform_nfs4                                         skipped
```