### PR TITLE
Remove unnecessary HAVE_LZMA_FILTER_ARM64 feature check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -518,19 +518,6 @@ if test "x$with_lzma" != "xno"; then
   if test "x$ac_cv_lzma_has_mt" != xno; then
 	  AC_DEFINE([HAVE_LZMA_STREAM_ENCODER_MT], [1], [Define to 1 if you have the `lzma_stream_encoder_mt' function.])
   fi
-
-  AC_CACHE_CHECK(
-    [whether we have ARM64 filter support in lzma],
-    ac_cv_lzma_has_arm64,
-    [AC_LINK_IFELSE([
-      AC_LANG_PROGRAM([[#include <lzma.h>]
-                       [#ifndef LZMA_FILTER_ARM64]
-                       [#error unsupported]
-                       [#endif]])],
-      [ac_cv_lzma_has_arm64=yes], [ac_cv_lzma_has_arm64=no])])
-  if test "x$ac_cv_lzma_has_arm64" != xno; then
-	  AC_DEFINE([HAVE_LZMA_FILTER_ARM64], [1], [Define to 1 if you have the `LZMA_FILTER_ARM64' macro.])
-  fi
 fi
 
 AC_ARG_WITH([lzo2],

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -24,6 +24,10 @@
  */
 #include "test.h"
 
+#if HAVE_LZMA_H
+#include <lzma.h>
+#endif
+
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define	close		_close
 #define	open		_open
@@ -1158,7 +1162,7 @@ test_arm64_filter(const char *refname)
 
 DEFINE_TEST(test_read_format_7zip_lzma2_arm64)
 {
-#ifdef HAVE_LZMA_FILTER_ARM64
+#ifdef LZMA_FILTER_ARM64
 	struct archive *a;
 
 	assert((a = archive_read_new()) != NULL);


### PR DESCRIPTION
It is sufficent to use HAVE_LZMA_H and then check for macros defined in lzma.h