### PR TITLE
tar: fix bug when -s/a/b/ used more than once with b flag

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -229,6 +229,7 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result,
 
 		if (rule->from_begin && *result) {
 			realloc_strcat(result, name);
+			if (buffer) buffer[0] = 0;
 			realloc_strcat(&buffer, *result);
 			name = buffer;
 			(*result)[0] = 0;

--- a/tar/test/test_option_s.c
+++ b/tar/test/test_option_s.c
@@ -70,7 +70,7 @@ DEFINE_TEST(test_option_s)
 	assertFileContents("bar", 3, "test4/in/d1/baz");
 
 	/*
-	 * Test 4b: Multiple substitutions behavior with option b).
+	 * Test 4b: Multiple substitutions behavior with option b.
 	 */
 	assertMakeDir("test4b", 0755);
 	systemf("%s -cf test4b.tar in/d1/foo in/d1/bar",
@@ -79,6 +79,18 @@ DEFINE_TEST(test_option_s)
 	    testprog);
 	assertFileContents("foo", 3, "test4b/in/d1/faz");
 	assertFileContents("bar", 3, "test4b/in/d1/baz");
+
+	/*
+	 * Test 4bb: Multiple substitutions with option b
+	 * (libarchive/libarchive#2414 GitHub issue regression test).
+	 */
+	assertMakeDir("test4bb", 0755);
+	systemf("%s -cf test4bb.tar in/d1/foo in/d1/bar",
+	    testprog);
+	systemf("%s -xf test4bb.tar -s /oo/ar/ -s }ar}az}b -s :az:end:b -C test4bb",
+	    testprog);
+	assertFileContents("foo", 3, "test4bb/in/d1/fend");
+	assertFileContents("bar", 3, "test4bb/in/d1/bend");
 
 	/*
 	 * Test 5: Name-switching substitutions when extracting archive.


### PR DESCRIPTION
When the -s/regexp/replacement/ option was used with the b flag more than once, the result of the previous substitution was appended to the previous subject instead of replacing it. Fixed it by making sure the subject is made the empty string before the call to realloc_strcat(). That in effect makes it more like a realloc_strcpy(), but creating a new realloc_strcpy() function for that one usage doesn't feel worth it.

Resolves Issue libarchive/libarchive#2414