### PR TITLE
Remove liblzmadec remnants

### DIFF
--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -735,9 +735,6 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the `lzma' library (-llzma). */
 #cmakedefine HAVE_LIBLZMA 1
 
-/* Define to 1 if you have the `lzmadec' library (-llzmadec). */
-#cmakedefine HAVE_LIBLZMADEC 1
-
 /* Define to 1 if you have the `lzo2' library (-llzo2). */
 #cmakedefine HAVE_LIBLZO2 1
 
@@ -849,9 +846,6 @@ typedef uint64_t uintmax_t;
 
 /* Define to 1 if you have the <lz4.h> header file. */
 #cmakedefine HAVE_LZ4_H 1
-
-/* Define to 1 if you have the <lzmadec.h> header file. */
-#cmakedefine HAVE_LZMADEC_H 1
 
 /* Define to 1 if you have the <lzma.h> header file. */
 #cmakedefine HAVE_LZMA_H 1

--- a/contrib/android/config/windows_host.h
+++ b/contrib/android/config/windows_host.h
@@ -530,9 +530,6 @@
 /* Define to 1 if you have the <lz4.h> header file. */
 /* #undef HAVE_LZ4_H */
 
-/* Define to 1 if you have the <lzmadec.h> header file. */
-/* #undef HAVE_LZMADEC_H */
-
 /* Define to 1 if you have the <lzma.h> header file. */
 /* #undef HAVE_LZMA_H */
 

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1745,15 +1745,6 @@ decompression_cleanup(struct archive_read *a)
 #if defined(HAVE_LZMA_H) && defined(HAVE_LIBLZMA)
 	if (xar->lzstream_valid)
 		lzma_end(&(xar->lzstream));
-#elif defined(HAVE_LZMA_H) && defined(HAVE_LIBLZMA)
-	if (xar->lzstream_valid) {
-		if (lzmadec_end(&(xar->lzstream)) != LZMADEC_OK) {
-			archive_set_error(&a->archive,
-			    ARCHIVE_ERRNO_MISC,
-			    "Failed to clean up lzmadec decompressor");
-			r = ARCHIVE_FATAL;
-		}
-	}
 #endif
 	return (r);
 }


### PR DESCRIPTION
It looks like support for this library was removed in 2016, but we still had some unused cmake code and a dead preprocessor block.