### PR TITLE
ci: use at most the number of make threads as there are cores on mac and linux github runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,20 @@ jobs:
       run: ./build/ci/build.sh -a build
       env:
         BS: ${{ matrix.bs }}
-        MAKE_ARGS: -j
+        MAKE_ARGS: -j3
     - name: Test
       run: ./build/ci/build.sh -a test
       env:
         BS: ${{ matrix.bs }}
         SKIP_OPEN_FD_ERR_TEST: 1
         IGNORE_TRAVERSALS_TEST4: 1
-        MAKE_ARGS: -j
+        MAKE_ARGS: -j3
         CTEST_OUTPUT_ON_FAILURE: ON
     - name: Install
       run: ./build/ci/build.sh -a install
       env:
         BS: ${{ matrix.bs }}
-        MAKE_ARGS: -j
+        MAKE_ARGS: -j3
     - name: Artifact
       run: ./build/ci/build.sh -a artifact
       env:
@@ -75,13 +75,13 @@ jobs:
       run: ./build/ci/build.sh -a build
       env:
         BS: ${{ matrix.bs }}
-        MAKE_ARGS: -j
+        MAKE_ARGS: -j4
     - name: Test
       run: ./build/ci/build.sh -a test
       env:
         BS: ${{ matrix.bs }}
         SKIP_OPEN_FD_ERR_TEST: 1
-        MAKE_ARGS: -j
+        MAKE_ARGS: -j4
         CTEST_OUTPUT_ON_FAILURE: ON
     - name: Install
       run: ./build/ci/build.sh -a install


### PR DESCRIPTION
We previously told make to run as many threads as it likes on these CI jobs, but that might sometimes hit resource limits like RAM or the allowed number of open files.

These numbers were found experimentally by using `sysctl -n hw.ncpu` on mac and `nproc` on linux.