### PR TITLE
Fix %d -> %u for unsigned int from i4le()

### DIFF
--- a/libarchive/test/test_write_format_zip64_stream.c
+++ b/libarchive/test/test_write_format_zip64_stream.c
@@ -124,7 +124,7 @@ DEFINE_TEST(test_write_format_zip64_stream)
 
 	/* Get address of first entry in central directory. */
 	central_header = p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_compression_bzip2.c
+++ b/libarchive/test/test_write_format_zip_compression_bzip2.c
@@ -130,7 +130,7 @@ static void verify_bzip2_contents(const char *buff, size_t used)
 	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
 	assertEqualInt(i2le(p + 8), i2le(p + 10));
-	failure("CD start (%d) + CD length (%d) should == archive size - 22",
+	failure("CD start (%u) + CD length (%u) should == archive size - 22",
 	    i4le(p + 12), i4le(p + 16));
 	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
@@ -138,7 +138,7 @@ static void verify_bzip2_contents(const char *buff, size_t used)
 
 	/* Get address of first entry in central directory. */
 	p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_compression_lzmaxz.c
+++ b/libarchive/test/test_write_format_zip_compression_lzmaxz.c
@@ -105,7 +105,7 @@ static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
 	assertEqualInt(i2le(p + 8), i2le(p + 10));
-	failure("CD start (%d) + CD length (%d) should == archive size - 22",
+	failure("CD start (%u) + CD length (%u) should == archive size - 22",
 	    i4le(p + 12), i4le(p + 16));
 	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
@@ -113,7 +113,7 @@ static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 
 	/* Get address of first entry in central directory. */
 	p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_compression_store.c
+++ b/libarchive/test/test_write_format_zip_compression_store.c
@@ -142,7 +142,7 @@ static void verify_uncompressed_contents(const char *buff, size_t used)
 	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
 	assertEqualInt(i2le(p + 8), i2le(p + 10));
-	failure("CD start (%d) + CD length (%d) should == archive size - 22",
+	failure("CD start (%u) + CD length (%u) should == archive size - 22",
 	    i4le(p + 12), i4le(p + 16));
 	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
@@ -150,7 +150,7 @@ static void verify_uncompressed_contents(const char *buff, size_t used)
 
 	/* Get address of first entry in central directory. */
 	p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_compression_zstd.c
+++ b/libarchive/test/test_write_format_zip_compression_zstd.c
@@ -130,7 +130,7 @@ static void verify_zstd_contents(const char *buff, size_t used)
 	assertEqualInt(i2le(p + 6), 0);
 	failure("All central dir entries are on this disk");
 	assertEqualInt(i2le(p + 8), i2le(p + 10));
-	failure("CD start (%d) + CD length (%d) should == archive size - 22",
+	failure("CD start (%u) + CD length (%u) should == archive size - 22",
 	    i4le(p + 12), i4le(p + 16));
 	assertEqualInt(i4le(p + 12) + i4le(p + 16), used - 22);
 	failure("no zip comment");
@@ -138,7 +138,7 @@ static void verify_zstd_contents(const char *buff, size_t used)
 
 	/* Get address of first entry in central directory. */
 	p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_file.c
+++ b/libarchive/test/test_write_format_zip_file.c
@@ -138,7 +138,7 @@ DEFINE_TEST(test_write_format_zip_file)
 
 	/* Get address of first entry in central directory. */
 	central_header = p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_file_zip64.c
+++ b/libarchive/test/test_write_format_zip_file_zip64.c
@@ -139,7 +139,7 @@ DEFINE_TEST(test_write_format_zip_file_zip64)
 
 	/* Get address of first entry in central directory. */
 	central_header = p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 

--- a/libarchive/test/test_write_format_zip_stream.c
+++ b/libarchive/test/test_write_format_zip_stream.c
@@ -127,7 +127,7 @@ DEFINE_TEST(test_write_format_zip_stream)
 
 	/* Get address of first entry in central directory. */
 	central_header = p = buff + i4le(buffend - 6);
-	failure("Central file record at offset %d should begin with"
+	failure("Central file record at offset %u should begin with"
 	    " PK\\001\\002 signature",
 	    i4le(buffend - 10));
 


### PR DESCRIPTION
`i4le()` returns an unsigned int, so `'%d'` is incorrect.

Reported by `clang -Wformat`.  (Many more such fixes to come, but this is the simplest set of them.)