### PR TITLE
Fix GCC version detection for __attribute__((deprecated))

### DIFF
--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -127,7 +127,8 @@ typedef ssize_t la_ssize_t;
 # define __LA_DECL
 #endif
 
-#if defined(__GNUC__) && __GNUC__ >= 3 && __GNUC_MINOR__ >= 1
+#if defined(__GNUC__) && (__GNUC__ > 3 || \
+    (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 # define __LA_DEPRECATED __attribute__((deprecated))
 #else
 # define __LA_DEPRECATED


### PR DESCRIPTION
The #if condition as-written fails for any major >= 3 if minor < 1, e.g. GCC 15.0 (while in development).

Use the idiom described in the GCC docs [0] to avoid this.

[0] https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html

Fixes: ab94a813b0f64cbc1bcb952bf55424a2d9c7f1d9