### PR TITLE
Suppress macOS CC_MD5_* deprecation warnings in the autoconf build too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2200,11 +2200,6 @@ IF(MSVC)
   ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE)
 ENDIF(MSVC)
 
-IF(APPLE)
-  # CC_MD5_Init() functions are deprecated on macOS 10.15, but we want to use them
-  ADD_DEFINITIONS(-Wno-deprecated-declarations)
-ENDIF(APPLE)
-
 OPTION(DONT_FAIL_ON_CRC_ERROR "Ignore CRC errors during parsing (For fuzzing)" OFF)
 IF(DONT_FAIL_ON_CRC_ERROR)
   ADD_DEFINITIONS(-DDONT_FAIL_ON_CRC_ERROR=1)

--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -196,6 +196,13 @@ __archive_md5final(archive_md5_ctx *ctx, void *md)
 
 #elif defined(ARCHIVE_CRYPTO_MD5_LIBSYSTEM)
 
+// These functions are available in macOS 10.4 and later, but deprecated from 10.15 onwards.
+// We need to continue supporting this feature regardless, so suppress the warnings.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 static int
 __archive_md5init(archive_md5_ctx *ctx)
 {
@@ -217,6 +224,10 @@ __archive_md5final(archive_md5_ctx *ctx, void *md)
   CC_MD5_Final(md, ctx);
   return (ARCHIVE_OK);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #elif defined(ARCHIVE_CRYPTO_MD5_MBEDTLS)
 


### PR DESCRIPTION
This also limits the amount of code where deprecation warnings are suppressed.

Previously these warnings were only suppressed in the cmake build.