### PR TITLE
Draft archive_read_data_into_FILE

### DIFF
--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -93,7 +93,7 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	archive_check_magic(a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_DATA,
 	    "archive_read_data_into_fd");
 
-	can_lseek = (fstat(fd, &st) == 0) && S_ISREG(st.st_mode);
+	can_lseek = 0; //(fstat(fd, &st) == 0) && S_ISREG(st.st_mode);
 	if (!can_lseek) {
 		nulls = calloc(1, nulls_size);
 		if (!nulls) {
@@ -116,6 +116,95 @@ archive_read_data_into_fd(struct archive *a, int fd)
 			bytes_to_write = size;
 			if (bytes_to_write > MAX_WRITE)
 				bytes_to_write = MAX_WRITE;
+			bytes_written = fwrite(p, 1, bytes_to_write, f);
+			if (bytes_written < bytes_to_write) {
+				archive_set_error(a, errno, "Write error");
+				r = ARCHIVE_FATAL;
+				goto cleanup;
+			}
+			actual_offset += bytes_written;
+			p += bytes_written;
+			size -= bytes_written;
+		}
+	}
+
+	if (r == ARCHIVE_EOF && target_offset > actual_offset) {
+		r2 = pad_to(a, fd, can_lseek, nulls_size, nulls,
+		    target_offset, actual_offset);
+		if (r2 != ARCHIVE_OK)
+			r = r2;
+	}
+
+cleanup:
+	free(nulls);
+	if (r != ARCHIVE_EOF)
+		return (r);
+	return (ARCHIVE_OK);
+}
+
+static int
+pad_to_FILE(struct archive *a, FILE* f,
+    size_t nulls_size, const char *nulls,
+    int64_t target_offset, int64_t actual_offset)
+{
+	size_t to_write;
+	ssize_t bytes_written;
+
+	int seek_result = fseek(f,
+	    (long)(target_offset - actual_offset), SEEK_CUR);
+	if (seek_result != 0) {
+		while (target_offset > actual_offset) {
+			to_write = nulls_size;
+			if (target_offset < actual_offset + (int64_t)nulls_size)
+				to_write = (size_t)(target_offset - actual_offset);
+			bytes_written = fwrite(nulls, 1, to_write, f);
+			if (bytes_written < to_write) {
+				archive_set_error(a, errno, "Write error");
+				return (ARCHIVE_FATAL);
+			}
+			actual_offset += bytes_written;
+		}
+	}
+	return (ARCHIVE_OK);
+}
+
+int
+archive_read_data_into_FILE(struct archive *a, FILE* f)
+{
+	struct stat st;
+	int r, r2;
+	const void *buff;
+	size_t size, bytes_to_write;
+	ssize_t bytes_written;
+	int64_t target_offset;
+	int64_t actual_offset = 0;
+	int can_fseek;
+	char *nulls = NULL;
+	size_t nulls_size = 16384;
+
+	archive_check_magic(a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_DATA,
+	    "archive_read_data_into_FILE");
+
+	nulls = calloc(1, nulls_size);
+	if (!nulls) {
+		r = ARCHIVE_FATAL;
+		goto cleanup;
+	}
+
+	while ((r = archive_read_data_block(a, &buff, &size, &target_offset)) ==
+	    ARCHIVE_OK) {
+		const char *p = buff;
+		if (target_offset > actual_offset) {
+			r = pad_to_FILE(a, f, nulls_size, nulls,
+			    target_offset, actual_offset);
+			if (r != ARCHIVE_OK)
+				break;
+			actual_offset = target_offset;
+		}
+		while (size > 0) {
+			bytes_to_write = size;
+			if (bytes_to_write > MAX_WRITE)
+				bytes_to_write = MAX_WRITE;
 			bytes_written = write(fd, p, bytes_to_write);
 			if (bytes_written < 0) {
 				archive_set_error(a, errno, "Write error");
@@ -129,7 +218,7 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	}
 
 	if (r == ARCHIVE_EOF && target_offset > actual_offset) {
-		r2 = pad_to(a, fd, can_lseek, nulls_size, nulls,
+		r2 = pad_to_FILE(a, f, nulls_size, nulls,
 		    target_offset, actual_offset);
 		if (r2 != ARCHIVE_OK)
 			r = r2;


### PR DESCRIPTION
WIP for https://github.com/libarchive/libarchive/issues/2299

- still no test
- for now put the `archive_read_data_into_FILE` function in `libarchive/archive_read_data_into_fd.c` - to be moved into a new file
- no integration in the build system

Questions:
- Should use `fseeko` instead of `fseek`?
- Is the approach of trying seeking and then falling back to writing nulls okay?
  - For the `archive_read_data_into_fd` libarchive uses `fstat` to do the test, but for working with FILE stat might not be available, or fileno might not be supported (e.g. for `fmemopen` or `open_memstream`-produced FILEs)
  - Should I instead still try retrieving `fileno` and if it's >= do the `stat`?