### PR TITLE
Avoid unreachable code in this test

### DIFF
--- a/tar/test/test_option_ignore_zeros.c
+++ b/tar/test/test_option_ignore_zeros.c
@@ -76,8 +76,7 @@ DEFINE_TEST(test_option_ignore_zeros_mode_c)
 	// bsdtar.exe: b: Can't translate uname '(null)' to UTF-8
 	skipping("TODO: figure out why this test fails on github workflows with MSVC");
 	return;
-#endif
-
+#else
 	if (make_files())
 		return;
 
@@ -97,6 +96,7 @@ DEFINE_TEST(test_option_ignore_zeros_mode_c)
 	assertEqualFile("out/a", "in/a");
 	assertEqualFile("out/b", "in/b");
 	assertEqualFile("out/c", "in/c");
+#endif
 }
 
 static void


### PR DESCRIPTION
As remarked in #2521, this test has unreachable code on Windows, which triggers a build failure in development due to warnings-as-errors.  (Release versions should not have warnings-as-errors.)