### PR TITLE
Move archive_entry_set_digest() to public API

### DIFF
--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -438,6 +438,7 @@ __LA_DECL void archive_entry_copy_mac_metadata(struct archive_entry *, const voi
 #define ARCHIVE_ENTRY_DIGEST_SHA512           0x00000006
 
 __LA_DECL const unsigned char * archive_entry_digest(struct archive_entry *, int /* type */);
+__LA_DECL int archive_entry_set_digest(struct archive_entry *, int, const unsigned char *);
 
 /*
  * ACL routines.  This used to simply store and return text-format ACL

--- a/libarchive/archive_entry_private.h
+++ b/libarchive/archive_entry_private.h
@@ -195,8 +195,4 @@ struct archive_entry {
 	int ae_symlink_type;
 };
 
-int
-archive_entry_set_digest(struct archive_entry *entry, int type,
-    const unsigned char *digest);
-
 #endif /* ARCHIVE_ENTRY_PRIVATE_H_INCLUDED */


### PR DESCRIPTION
Moving archive_entry_set_digest() to the public API simplifies porting non-archive formats to archive formats while preserving supported message digests specifically in cases where recomputing digests is not viable.
