### PR TITLE
Remove extra newline from error messages

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -334,7 +334,7 @@ main(int argc, char **argv)
 			if (archive_match_exclude_pattern(
 			    bsdtar->matching, bsdtar->argument) != ARCHIVE_OK)
 				lafe_errc(1, 0,
-				    "Couldn't exclude %s\n", bsdtar->argument);
+				    "Couldn't exclude %s", bsdtar->argument);
 			break;
 		case OPTION_EXCLUDE_VCS: /* GNU tar */
 			for(t=0; vcs_files[t]; t++) {
@@ -342,7 +342,7 @@ main(int argc, char **argv)
 				    bsdtar->matching,
 				    vcs_files[t]) != ARCHIVE_OK)
 					lafe_errc(1, 0, "Couldn't "
-					    "exclude %s\n", vcs_files[t]);
+					    "exclude %s", vcs_files[t]);
 			}
 			break;
 		case OPTION_FFLAGS:

--- a/tar/util.c
+++ b/tar/util.c
@@ -329,7 +329,7 @@ do_chdir(struct bsdtar *bsdtar)
 		return;
 
 	if (chdir(bsdtar->pending_chdir) != 0) {
-		lafe_errc(1, 0, "could not chdir to '%s'\n",
+		lafe_errc(1, 0, "could not chdir to '%s'",
 		    bsdtar->pending_chdir);
 	}
 	free(bsdtar->pending_chdir);


### PR DESCRIPTION
The lafe_errc function adds a newline by itself already, so do not insert one into the message.

You can reproduce with the following commands:

```
touch archive.tar
bsdtar -xf archive.tar -C /non-existing
```

```
bsdtar --exclude ""
```