### PR TITLE
Fix GNU sparse handling

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -2301,7 +2301,6 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 					/* GNU.sparse.size */
 					if ((err = pax_attribute_read_number(a, value_length, &t)) == ARCHIVE_OK) {
 						tar->realsize = t;
-						archive_entry_set_size(entry, tar->realsize);
 						tar->realsize_override = 1;
 					}
 					return (err);
@@ -2373,7 +2372,6 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 					/* GNU.sparse.realsize */
 					if ((err = pax_attribute_read_number(a, value_length, &t)) == ARCHIVE_OK) {
 						tar->realsize = t;
-						archive_entry_set_size(entry, tar->realsize);
 						tar->realsize_override = 1;
 					}
 					return (err);


### PR DESCRIPTION
Sparse files have a different file size than their entry size. While the tar->realsize has to be set, calling archive_entry_set_size too early leads to a wrong value for tar->entry_bytes_left.

The easiest way is to remove the explicit calls when parsing pax attributes. This still feels like it's not a fully functional approach especially if sparse entries take more than 2 GB in size and would lead to yet another pax size entry.