### PR TITLE
Fix archive_time.c issues (concurrency, 32 bit)

### DIFF
--- a/libarchive/archive_time.c
+++ b/libarchive/archive_time.c
@@ -113,7 +113,7 @@ unix_to_dos(int64_t unix_time)
 	}
 }
 
-/* Convert NTFS time to Unix sec/ncse */
+/* Convert NTFS time to Unix sec/nsec */
 void
 ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs)
 {


### PR DESCRIPTION
The refactoring of https://github.com/libarchive/libarchive/pull/2553 introduced three issues:

1. Introduction of a modifiable global static variable

This violates the goal of having no global variables as stated in [the README.md](https://github.com/libarchive/libarchive/blob/b6f6557abb8235f604eced6facb42da8c7ab2a41/README.md?plain=1#L195) which in turn leads to concurrency issues. Without any form of mutex protection, multiple threads are not guaranteed to see the correct min/max values. Since these are not needed in regular use cases but only in edge cases, handle them in functions with local variables only.

Also the global variables are locale-dependent which can change during runtime. In that case, future calls leads to issues.

2. Broken 32 bit support

The writers for zip and others affected by the previously mentioned PR and test-suite on Debian 12 i686 are broken, because the calculation of maximum MS-DOS time is not possible with a 32 bit time_t. Treat these cases properly.

3. Edge case protection

Huge or tiny int64_t values can easily lead to unsigned integer overflows. While these do not affect stability of libarchive, the results are still wrong, i.e. are not capped at min/max as expected.

In total, the functions are much closer to their original versions again (+ more range checks).