### PR TITLE
Assign skip to the right variable type

### DIFF
--- a/libarchive/archive_read_open_fd.c
+++ b/libarchive/archive_read_open_fd.c
@@ -131,15 +131,22 @@ static int64_t
 file_skip(struct archive *a, void *client_data, int64_t request)
 {
 	struct read_fd_data *mine = (struct read_fd_data *)client_data;
+#if HAVE__FSEEKI64
+	int64_t skip = request;
+#elif HAVE_FSEEKO
 	off_t skip = (off_t)request;
+#else
+	long skip = (long)request;
+#endif
+
 	int64_t old_offset, new_offset;
-	int skip_bits = sizeof(skip) * 8 - 1;  /* off_t is a signed type. */
 
 	if (!mine->use_lseek)
 		return (0);
 
 	/* Reduce a request that would overflow the 'skip' variable. */
 	if (sizeof(request) > sizeof(skip)) {
+		const int skip_bits = sizeof(skip) * 8 - 1;  /* off_t is a signed type. */
 		const int64_t max_skip =
 		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
 		if (request > max_skip)

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -130,7 +130,6 @@ FILE_skip(struct archive *a, void *client_data, int64_t request)
 #else
 	long skip = (long)request;
 #endif
-	int skip_bits = sizeof(skip) * 8 - 1;
 
 	(void)a; /* UNUSED */
 
@@ -145,6 +144,7 @@ FILE_skip(struct archive *a, void *client_data, int64_t request)
 
 	/* If request is too big for a long or an off_t, reduce it. */
 	if (sizeof(request) > sizeof(skip)) {
+		const int skip_bits = sizeof(skip) * 8 - 1;  /* off_t is a signed type. */
 		const int64_t max_skip =
 		    (((int64_t)1 << (skip_bits - 1)) - 1) * 2 + 1;
 		if (request > max_skip)


### PR DESCRIPTION
This is for consistency with file_skip in both implementations.

Furthermore, just calculate skip_bits in the branch where the calculation is used. Chances are, the compiler may have done this anyway, but it is good just in case.