### PR TITLE
rar: Fix rar_read_ahead call stack overflow

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3180,8 +3180,12 @@ static const void *
 rar_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
 {
   struct rar *rar = (struct rar *)(a->format->data);
-  const void *h = __archive_read_ahead(a, min, avail);
+  const void *h;
   int ret;
+
+again:
+  h = __archive_read_ahead(a, min, avail);
+
   if (avail)
   {
     if (a->archive.read_data_is_posix_read && *avail > (ssize_t)a->archive.read_data_requested)
@@ -3203,7 +3207,7 @@ rar_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
       rar->filename_must_match = 0;
       if (ret != (ARCHIVE_OK))
         return NULL;
-      return rar_read_ahead(a, min, avail);
+      goto again;
     }
   }
   return h;


### PR DESCRIPTION
It is possible to trigger a call stack overflow by repeatedly entering the rar_read_ahead function. In normal circumstances, this recursion is optimized away by common compilers, but default settings with MSVC keep the recursion in place. Explicitly turn the recursion into a goto-loop to avoid the overflow even with no compiler optimizations.