### PR TITLE
rar: Support large headers on 32 bit systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -888,6 +888,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar_encryption_data.rar.uu \
 	libarchive/test/test_read_format_rar_encryption_header.rar.uu \
 	libarchive/test/test_read_format_rar_encryption_partially.rar.uu \
+	libarchive/test/test_read_format_rar_endarc_huge.rar.uu \
 	libarchive/test/test_read_format_rar_filter.rar.uu \
 	libarchive/test/test_read_format_rar_invalid1.rar.uu \
 	libarchive/test/test_read_format_rar_multi_lzss_blocks.rar.uu \

--- a/libarchive/test/test_read_format_rar.c
+++ b/libarchive/test/test_read_format_rar.c
@@ -3810,6 +3810,26 @@ DEFINE_TEST(test_read_format_rar_multivolume_uncompressed_files)
   assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
 }
 
+DEFINE_TEST(test_read_format_rar_endarc_huge)
+{
+  const char* reffile = "test_read_format_rar_endarc_huge.rar";
+
+  struct archive_entry *ae;
+  struct archive *a;
+
+  extract_reference_file(reffile);
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_support_filter_all(a));
+  assertA(0 == archive_read_support_format_all(a));
+  assertA(0 == archive_read_open_filename(a, reffile, 10240));
+
+  /* Test for truncation */
+  assertA(ARCHIVE_FATAL == archive_read_next_header(a, &ae));
+
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_read_format_rar_ppmd_use_after_free)
 {
   uint8_t buf[16];

--- a/libarchive/test/test_read_format_rar_endarc_huge.rar.uu
+++ b/libarchive/test/test_read_format_rar_endarc_huge.rar.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_format_rar_endarc_huge.rar
+24F%R(1H'````>P"`"P#W____
+`
+end


### PR DESCRIPTION
Support header sizes larger than 32 bit even on 32 bit systems, since these normally have large file support. Otherwise an unsigned integer overflow could occur, leading to erroneous parsing on these systems.