### PR TITLE
correct only modes of `--no-mac-metadata` in bsdtar.1

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -472,7 +472,7 @@ and the default behavior if
 .Nm
 is run as non-root in x mode.
 .It Fl Fl no-mac-metadata
-(x mode only)
+(c, r, u and x mode only)
 Mac OS X specific.
 Do not archive or extract ACLs and extended file attributes
 using


### PR DESCRIPTION
As is written in `tar/bsdtar.c`

```c
	if (bsdtar->flags & OPTFLAG_NO_MAC_METADATA)
		only_mode(bsdtar, "--no-mac-metadata", "crux");
```

`--no-mac-metadata` is c, r, u and x mode only