### PR TITLE
rar: Fix double free with over 4 billion nodes

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -335,8 +335,8 @@ struct rar
   int found_first_header;
   char has_endarc_header;
   struct data_block_offsets *dbo;
-  unsigned int cursor;
-  unsigned int nodes;
+  size_t cursor;
+  size_t nodes;
   char filename_must_match;
 
   /* LZSS members */
@@ -1192,7 +1192,7 @@ archive_read_format_rar_seek_data(struct archive_read *a, int64_t offset,
     int whence)
 {
   int64_t client_offset, ret;
-  unsigned int i;
+  size_t i;
   struct rar *rar = (struct rar *)(a->format->data);
 
   if (rar->compression_method == COMPRESS_METHOD_STORE)


### PR DESCRIPTION
If a system is capable of handling 4 billion nodes in memory, a double free could occur because of an unsigned integer overflow leading to a realloc call with size argument of 0. Eventually, the client will release that memory again, triggering a double free.