### PR TITLE
safe_printf should annotate with restrict

### DIFF
--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -182,7 +182,7 @@ void	do_chdir(struct bsdtar *);
 int	edit_pathname(struct bsdtar *, struct archive_entry *);
 int	need_report(void);
 int	pathcmp(const char *a, const char *b);
-void	safe_fprintf(FILE *, const char *fmt, ...) __LA_PRINTF(2, 3);
+void	safe_fprintf(FILE * restrict, const char * restrict fmt, ...) __LA_PRINTF(2, 3);
 void	set_chdir(struct bsdtar *, const char *newdir);
 const char *tar_i64toa(int64_t);
 void	tar_mode_c(struct bsdtar *bsdtar);

--- a/tar/util.c
+++ b/tar/util.c
@@ -72,7 +72,7 @@ static const char *strip_components(const char *path, int elements);
  */
 
 void
-safe_fprintf(FILE *f, const char *fmt, ...)
+safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 {
 	char fmtbuff_stack[256]; /* Place to format the printf() string. */
 	char outbuff[256]; /* Buffer for outgoing characters. */


### PR DESCRIPTION
printf has restrict for its parameters, and safe_printf should do the same.