### PR TITLE
Support @-prefixed Unix epoch timestamps as date strings

### DIFF
--- a/libarchive/test/test_archive_parse_date.c
+++ b/libarchive/test/test_archive_parse_date.c
@@ -81,5 +81,17 @@ DEFINE_TEST(test_archive_parse_date)
 	/* "last tuesday" is one week before "tuesday" */
 	assertEqualInt(get_date(now, "last tuesday UTC"),
 	    now - 6 * 24 * 60 * 60);
+
+	/* Unix epoch timestamps */
+	assertEqualInt(get_date(now, "@0"), 0);
+	assertEqualInt(get_date(now, "@100"), 100);
+	assertEqualInt(get_date(now, "@+100"), 100);
+
+	assertEqualInt(get_date(now, "@"), -1);
+	assertEqualInt(get_date(now, "@-"), -1);
+	assertEqualInt(get_date(now, "@+"), -1);
+	assertEqualInt(get_date(now, "@tenth"), -1);
+	assertEqualInt(get_date(now, "@100 tomorrow"), -1);
+
 	/* TODO: Lots more tests here. */
 }


### PR DESCRIPTION
This PR adds support for parsing @-prefixed Unix epoch timestamps as date strings, such as `@0` and `@315532800`. As an example, it enables setting `--mtime "@${SOURCE_DATE_EPOCH}"`[^1]  where `${SOURCE_DATE_EPOCH}` is [defined](https://reproducible-builds.org/specs/source-date-epoch) to contain a Unix timestamp. Being able to specify a Unix timestamp directly also avoids complex interactions with timezones which can be a [common footgun](https://reproducible-builds.org/docs/timezones) and a pain in general.

From cursory black-box testing, GNU tar also accepts whitespace in the timestamp. This is not implemented here to keep things simple, and the current implementation already covers common use cases.

I chose not to add this into the date tokenizer to minimize complexity. I could add a new `tAT` type for `@` and parse a sequence of `{ tAT, tUNUMBER }` tokens, but then it would accept invalid strings such as `@tenth` (because `tenth` is parsed as a `tUNUMBER`).

This is a follow-up to #2601.

[^1]: As suggested in <https://reproducible-builds.org/docs/archives/#full-example>