### PR TITLE
bsdtar: Disallow multiple --files-from/-T options

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -755,6 +755,8 @@ main(int argc, char **argv)
 			bsdtar->strip_components = (int)l;
 			break;
 		case 'T': /* GNU tar */
+			if (bsdtar->names_from_file)
+				lafe_errc(1, 0, "Multiple --files-from/-T options are not supported");
 			bsdtar->names_from_file = bsdtar->argument;
 			break;
 		case 't': /* SUSv2 */


### PR DESCRIPTION
When multiple `--files-from`/`-T` options are specified, only the last one is handled and the rest are silently discarded. We should implement this, but for now let's fail fast and disallow such invocations.

GNU tar supports multiple `--files-from`/`-T` options and they are positional - The ordering affects where the entries are placed in the output. I have done some black-box testing of GNU tar, and will discuss my findings in a separate issue.