### PR TITLE
tar: Handle more edge cases in safe_fprintf

### DIFF
--- a/tar/util.c
+++ b/tar/util.c
@@ -106,8 +106,8 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 		else if (fmtbuff_length < 1000000)
 			fmtbuff_length += fmtbuff_length / 4;
 		else {
-			length = fmtbuff_length;
-			fmtbuff_heap[length-1] = '\0';
+			fmtbuff[fmtbuff_length - 1] = '\0';
+			length = (int)strlen(fmtbuff);
 			break;
 		}
 		free(fmtbuff_heap);
@@ -122,8 +122,9 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 		} else {
 			/* Leave fmtbuff pointing to the truncated
 			 * string in fmtbuff_stack. */
+			fmtbuff_stack[sizeof(fmtbuff_stack) - 1] = '\0';
 			fmtbuff = fmtbuff_stack;
-			length = sizeof(fmtbuff_stack) - 1;
+			length = (int)strlen(fmtbuff);
 			break;
 		}
 	}

--- a/tar/util.c
+++ b/tar/util.c
@@ -67,8 +67,7 @@ static const char *strip_components(const char *path, int elements);
  * malloc()), partly out of expedience (we have to call vsnprintf()
  * before malloc() anyway to find out how big a buffer we need; we may
  * as well point that first call at a small local buffer in case it
- * works), but mostly for safety (so we can use this to print messages
- * about out-of-memory conditions).
+ * works).
  */
 
 void

--- a/tar/util.c
+++ b/tar/util.c
@@ -78,7 +78,7 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 	char outbuff[256]; /* Buffer for outgoing characters. */
 	char *fmtbuff_heap; /* If fmtbuff_stack is too small, we use malloc */
 	char *fmtbuff;  /* Pointer to fmtbuff_stack or fmtbuff_heap. */
-	int fmtbuff_length;
+	size_t fmtbuff_length;
 	int length, n;
 	va_list ap;
 	const char *p;
@@ -98,9 +98,9 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 	va_end(ap);
 
 	/* If the result was too large, allocate a buffer on the heap. */
-	while (length < 0 || length >= fmtbuff_length) {
-		if (length >= fmtbuff_length)
-			fmtbuff_length = length+1;
+	while (length < 0 || (size_t)length >= fmtbuff_length) {
+		if (length >= 0 && (size_t)length >= fmtbuff_length)
+			fmtbuff_length = (size_t)length + 1;
 		else if (fmtbuff_length < 8192)
 			fmtbuff_length *= 2;
 		else if (fmtbuff_length < 1000000)

--- a/tar/util.c
+++ b/tar/util.c
@@ -87,6 +87,7 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 	char try_wc;
 
 	/* Use a stack-allocated buffer if we can, for speed and safety. */
+	memset(fmtbuff_stack, '\0', sizeof(fmtbuff_stack));
 	fmtbuff_heap = NULL;
 	fmtbuff_length = sizeof(fmtbuff_stack);
 	fmtbuff = fmtbuff_stack;

--- a/tar/util.c
+++ b/tar/util.c
@@ -96,6 +96,10 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 	length = vsnprintf(fmtbuff, fmtbuff_length, fmt, ap);
 	va_end(ap);
 
+	/* If vsnprintf will always fail, stop early. */
+	if (length < 0 && errno == EOVERFLOW)
+		return;
+
 	/* If the result was too large, allocate a buffer on the heap. */
 	while (length < 0 || (size_t)length >= fmtbuff_length) {
 		if (length >= 0 && (size_t)length >= fmtbuff_length)


### PR DESCRIPTION
The safe_fprintf function must handle more edge cases:

- vsnprintf might return INT_MAX. This would lead to a signed integer
  overflow in safe_fprintf.
- vsnprintf might consistently return -1. The buffer content is highly
  implementation dependent and should be cleared to avoid any exposure
  of stack content. Also make sure that it's always nul terminated.
- If a truncated heap buffer is used, calculate the correct length
  instead of erroneously counting the terminating nul byte as well to
  match vsnprintf behavior.

While at it, fix the comment which implies that the stack buffer is
used for out of memory warnings, which is not true (anymore).