### PR TITLE
autotools: Fix iconv issues in generated .pc file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -458,14 +458,17 @@ if test "x$with_iconv" != "xno"; then
   AC_CHECK_HEADERS([iconv.h],[],[],[#include <stdlib.h>])
   if test "x$am_cv_func_iconv" = "xyes"; then
     AC_CHECK_HEADERS([localcharset.h])
-    am_save_LIBS="$LIBS"
     LIBS="${LIBS} ${LIBICONV}"
     if test -n "$LIBICONV"; then
-	  AC_DEFINE([HAVE_LIBICONV], [1], [Define to 1 if you have the `iconv' library (-liconv).])
-      LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
+      AC_DEFINE([HAVE_LIBICONV], [1], [Define to 1 if you have the `iconv' library (-liconv).])
+
+      # Most platforms do not provide iconv.pc, but MSYS2 MinGW does.
+      # We add it to our Requires.private only if it exists.
+      PKG_CHECK_MODULES(ICONV_PC, [iconv], [
+        LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }iconv"
+      ], [true])
     fi
     AC_CHECK_FUNCS([locale_charset])
-    LIBS="${am_save_LIBS}"
     if test "x$ac_cv_func_locale_charset" != "xyes"; then
       # If locale_charset() is not in libiconv, we have to find libcharset.
       AC_CHECK_LIB(charset,locale_charset)


### PR DESCRIPTION
Here we go again... But this time we will make everyone (including MSYS2) happy 😃

This PR fixes two issues encountered when statically linking a program that depends on libarchive on non-glibc platforms:

1. `-liconv` is missing from `Libs.private` (#1766)
2. `Requires.private` depends on missing `iconv.pc` (#1819)

Most platforms do not provide an `iconv.pc`, but MSYS2 MinGW does. This PR adds a `PKG_CHECK_MODULES` to detect the presence of this non-standard `iconv.pc`. The result only affects the generation of `libarchive.pc`.
## Situation

There are 3 separate states:

1. Having `iconv` functions available
2. Needing `-liconv`
	- If true, `-liconv` must be added to `Libs.private` (#1766)
3. Having `iconv.pc`
	- If not (most platforms), `iconv` must _not_ exist in `Requires.private` (#1819)

|                 | Needs -liconv | Has iconv.pc | Happy? |
| --------------- | ------------- | ------------ | ------ |
| glibc platforms | ❌             | ❌            | 😊     |
| macOS           | ☑️            | ❌            | 😰     |
| MSYS2 MSYS      | ☑️             | ❌            | 😰     |
| MSYS2 MinGW     | ☑️            | ☑️           | 😊     |
## Downstream Workarounds

Distros that need to statically link libarchive on non-glibc platforms are not happy. This PR will hopefully remove the need for any downstream patching:

- MSYS2 MSYS (`/usr`) patches the generated `.pc`: Removes `iconv` from `Requires.private`
	- https://github.com/msys2/MSYS2-packages/commit/2b3ff25ac6d67673b6a56e25fc34e8330614b3c7
	- Added by the author of #1812 and #1813
	- I tested that static linking with `pkg-config --static --libs libarchive` is broken since `-liconv` is not there. This PR fixes this issue.
- Nixpkgs patches `configure.ac`: Adds `-liconv` to `LIBS`/`Libs.private` if needed (e.g., on macOS), removes `iconv` from `LIBSREQUIRED`/`Requires.private`
	- Patch: https://github.com/NixOS/nixpkgs/blob/adaa24fbf46737f3f1b5497bf64bae750f82942e/pkgs/by-name/li/libarchive/fix-pkg-config-iconv.patch
	- Comment: https://github.com/NixOS/nixpkgs/blob/adaa24fbf46737f3f1b5497bf64bae750f82942e/pkgs/by-name/li/libarchive/package.nix#L46-L58
	- https://github.com/NixOS/nixpkgs/pull/357284
- Homebrew patches the generated `.pc`: Adds `-liconv` to `Libs.private`, removes `iconv` from `Requires.private`
	- https://github.com/Homebrew/homebrew-core/blob/a5078e689417bbad45f129214c08eef91205fa6e/Formula/lib/libarchive.rb#L49-L53
- Buildroot patches `configure.ac`: Removes `iconv` from `LIBSREQUIRED`/`Requires.private`
	- https://github.com/buildroot/buildroot/commit/9ac63a33609fd4fee17874bc9569688c78613e1c
- Gentoo patches the generated `.pc`: Removes `iconv` from `Requires.private`
	- https://github.com/gentoo-mirror/gentoo/blob/4dd2510d19731b7a530249f65550e4446e35955f/app-arch/libarchive/libarchive-3.7.9.ebuild#L170-L172
- MSYS2 MinGW (`/mingw64`) is happy... at everyone else's expense
	- It does patch the generated `.pc` to [fix the path](https://github.com/msys2/MINGW-packages/blob/a6d5b49d986e56731ec92908ad639b2957da9a72/mingw-w64-libarchive/PKGBUILD#L66-L67), but it's a separate issue
## MSYS2

I installed MSYS2 and tested with two environments:

- The MSYS toolchain (`/usr`) does not have `iconv.pc` and static linking is therefore broken without [patching `iconv` out](https://github.com/msys2/MSYS2-packages/commit/2b3ff25ac6d67673b6a56e25fc34e8330614b3c7). Even with the downstream patch, static linking with `pkg-config --static --libs libarchive` still fails because `-liconv` is missing. This PR fixes this issue.
- The MinGW toolchain (`/mingw64`) contains the non-standard `iconv.pc`. This PR does not break this use case.

Note that I'm not a part of the MSYS2 community and I only tested the fix as a user.
## Previous Attempts

- #1825 (incorrect fix, merged)
- #1813
- #1817

---

GitHub: Fixes #1766, fixes #1819.