### PR TITLE
7z: fix another out-of-bounds read in 7z SFX archive detection

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -856,7 +856,7 @@ find_elf_data_sec(struct archive_read *a)
 				}
 				break;
 			}
-			sec_tbl_offset += format_64 ? 0x40 : 0x28;
+			sec_tbl_offset += e_shentsize;
 			e_shnum--;
 		}
 		break;


### PR DESCRIPTION
When looping over program header entries (e_shnum) we need to increment sec_tbl_offset by e_shentsize and not by fixed values.

Fixes OSS-Fuzz issue 418349489