### PR TITLE
contrib/psota-benchmark/tcp.sh is a bash script

### DIFF
--- a/contrib/psota-benchmark/tcp.sh
+++ b/contrib/psota-benchmark/tcp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # tar comparison program
 # 2007-10-25 Jan Psota
 


### PR DESCRIPTION
I am unsure if this is still used, but it fails to run in Bourne shell.