### PR TITLE
Label error and errorx as __LA_NORETURN

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -111,7 +111,7 @@ static int noeol;
 static char *passphrase_buf;
 
 /* fatal error message + errno */
-static void
+static void __LA_NORETURN
 error(const char *fmt, ...)
 {
 	va_list ap;
@@ -128,7 +128,7 @@ error(const char *fmt, ...)
 }
 
 /* fatal error message, no errno */
-static void
+static void __LA_NORETURN
 errorx(const char *fmt, ...)
 {
 	va_list ap;


### PR DESCRIPTION
This also prevents clang-tidy from reporting some false bugs.