### PR TITLE
days should be a long type

### DIFF
--- a/libarchive/archive_parse_date.c
+++ b/libarchive/archive_parse_date.c
@@ -928,7 +928,7 @@ difftm (struct tm *a, struct tm *b)
 {
 	int ay = a->tm_year + (TM_YEAR_ORIGIN - 1);
 	int by = b->tm_year + (TM_YEAR_ORIGIN - 1);
-	int days = (
+	long days = (
 		/* difference in day of year */
 		a->tm_yday - b->tm_yday
 		/* + intervening leap days */


### PR DESCRIPTION
The difference in years is cast to a long and then multiplied by 365. The return value of the function is also a long.