### PR TITLE
*s != '\0' is redundant

### DIFF
--- a/libarchive/archive_cmdline.c
+++ b/libarchive/archive_cmdline.c
@@ -71,7 +71,7 @@ get_argument(struct archive_string *as, const char *p)
 	archive_string_empty(as);
 
 	/* Skip beginning space characters. */
-	while (*s != '\0' && *s == ' ')
+	while (*s == ' ')
 		s++;
 	/* Copy non-space characters. */
 	while (*s != '\0' && *s != ' ') {


### PR DESCRIPTION
Not that this does anything to codegen probably, but it is still redundant.