### PR TITLE
tests: accept underscore in arbitrary third-party version strings

### DIFF
--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -2456,7 +2456,7 @@ void assertVersion(const char *prog, const char *base)
 
 	/* Skip arbitrary third-party version numbers. */
 	while (s > 0 && (*q == ' ' || *q == '-' || *q == '/' || *q == '.' ||
-	    isalnum((unsigned char)*q))) {
+	    *q == '_' || isalnum((unsigned char)*q))) {
 		++q;
 		--s;
 	}


### PR DESCRIPTION
Fixes #2626