### PR TITLE
Prefer __CYGWIN__ over CYGWIN definition

### DIFF
--- a/cpio/test/test_format_newc.c
+++ b/cpio/test/test_format_newc.c
@@ -219,7 +219,7 @@ DEFINE_TEST(test_format_newc)
 		assert(is_hex(e, 110));
 		assertEqualMem(e + 0, "070701", 6); /* Magic */
 		assert(is_hex(e + 6, 8)); /* ino */
-#if defined(_WIN32) && !defined(CYGWIN)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 		/* Mode: Group members bits and others bits do not work. */
 		assertEqualInt(0xa180, from_hex(e + 14, 8) & 0xffc0);
 #else

--- a/cpio/test/test_option_a.c
+++ b/cpio/test/test_option_a.c
@@ -52,7 +52,7 @@ test_create(void)
 		 * #ifdef this section out.  Most of the test below is
 		 * still valid. */
 		memset(&times, 0, sizeof(times));
-#if defined(_WIN32) && !defined(CYGWIN)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 		times.actime = 86400;
 		times.modtime = 86400;
 #else

--- a/libarchive/test/test_entry.c
+++ b/libarchive/test/test_entry.c
@@ -436,7 +436,7 @@ DEFINE_TEST(test_entry)
 	archive_entry_fflags(e, &set, &clear);
 	assertEqualInt(UF_HIDDEN, set);
 	assertEqualInt(UF_NODUMP | UF_IMMUTABLE | UF_APPEND, clear);
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	archive_entry_copy_fflags_text_w(e, L"rdonly,hidden,nosystem");
 	archive_entry_fflags(e, &set, &clear);
 	assertEqualInt(FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN, set);

--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -39,7 +39,7 @@ atimeIsUpdated(void)
 {
 	const char *fn = "fs_noatime";
 	struct stat st;
-#if defined(_WIN32) && !defined(CYGWIN)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 	char *buff = NULL;
 	char *ptr;
 	int r;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1126,7 +1126,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_READONLY;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_READONLY;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1138,7 +1138,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_HIDDEN;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_HIDDEN;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1150,7 +1150,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_SYSTEM;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_SYSTEM;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1162,7 +1162,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_READONLY | UF_HIDDEN;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1174,7 +1174,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_READONLY;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_READONLY;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1186,7 +1186,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_HIDDEN;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_HIDDEN;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1198,7 +1198,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_SYSTEM;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_SYSTEM;
 #endif
 	assertEqualInt(flag, set & flag);
@@ -1210,7 +1210,7 @@ DEFINE_TEST(test_read_format_rar5_fileattr)
 	archive_entry_fflags(ae, &set, &clear);
 #if defined(__FreeBSD__)
 	flag = UF_READONLY | UF_HIDDEN;
-#elif defined(_WIN32) && !defined(CYGWIN)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 	flag = FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN;
 #endif
 	assertEqualInt(flag, set & flag);

--- a/tar/test/test_option_C_mtree.c
+++ b/tar/test/test_option_C_mtree.c
@@ -17,7 +17,7 @@ DEFINE_TEST(test_option_C_mtree)
 	p0 = NULL;
 	char *content = "./foo type=file uname=root gname=root mode=0755\n";
 	char *filename = "output.tar";
-#if defined(_WIN32) && !defined(CYGWIN)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 	char *p;
 #endif
 
@@ -32,7 +32,7 @@ DEFINE_TEST(test_option_C_mtree)
 	assertMakeDir("bar", 0775);
 	assertMakeFile("bar/foo", 0777, "abc");
 
-#if defined(_WIN32) && !defined(CYGWIN)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 	p = absolute_path;
 	while(*p != '\0') {
 		if (*p == '/')


### PR DESCRIPTION
The cygwin FAQ states that __CYGWIN__ is defined when building for a Cygwin environment. Only a few test files check (inconsistently) for CYGWIN, so adjust them to the recommended __CYGWIN__ definition.