### PR TITLE
archive_match: Simplify and clean up code

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -53,7 +53,6 @@ struct match {
 struct match_list {
 	struct match		*first;
 	struct match		**last;
-	int			 count;
 	int			 unmatched_count;
 	struct match		*unmatched_next;
 	int			 unmatched_eof;
@@ -73,7 +72,6 @@ struct match_file {
 struct entry_list {
 	struct match_file	*first;
 	struct match_file	**last;
-	int			 count;
 };
 
 struct id_array {
@@ -837,7 +835,6 @@ match_list_init(struct match_list *list)
 {
 	list->first = NULL;
 	list->last = &(list->first);
-	list->count = 0;
 }
 
 static void
@@ -858,7 +855,6 @@ match_list_add(struct match_list *list, struct match *m)
 {
 	*list->last = m;
 	list->last = &(m->next);
-	list->count++;
 	list->unmatched_count++;
 }
 
@@ -1343,7 +1339,6 @@ entry_list_init(struct entry_list *list)
 {
 	list->first = NULL;
 	list->last = &(list->first);
-	list->count = 0;
 }
 
 static void
@@ -1364,7 +1359,6 @@ entry_list_add(struct entry_list *list, struct match_file *file)
 {
 	*list->last = file;
 	list->last = &(file->next);
-	list->count++;
 }
 
 static int
@@ -1519,7 +1513,7 @@ time_excluded(struct archive_match *a, struct archive_entry *entry)
 	}
 
 	/* If there is no exclusion list, include the file. */
-	if (a->exclusion_entry_list.count == 0)
+	if (a->exclusion_entry_list.first == NULL)
 		return (0);
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -1816,7 +1810,7 @@ owner_excluded(struct archive_match *a, struct archive_entry *entry)
 			return (1);
 	}
 
-	if (a->inclusion_unames.count) {
+	if (a->inclusion_unames.first != NULL) {
 #if defined(_WIN32) && !defined(__CYGWIN__)
 		r = match_owner_name_wcs(a, &(a->inclusion_unames),
 			archive_entry_uname_w(entry));
@@ -1830,7 +1824,7 @@ owner_excluded(struct archive_match *a, struct archive_entry *entry)
 			return (r);
 	}
 
-	if (a->inclusion_gnames.count) {
+	if (a->inclusion_gnames.first != NULL) {
 #if defined(_WIN32) && !defined(__CYGWIN__)
 		r = match_owner_name_wcs(a, &(a->inclusion_gnames),
 			archive_entry_gname_w(entry));

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -1680,7 +1680,7 @@ archive_match_owner_excluded(struct archive *_a,
 static int
 add_owner_id(struct archive_match *a, struct id_array *ids, int64_t id)
 {
-	unsigned i;
+	size_t i;
 
 	if (ids->count + 1 >= ids->size) {
 		void *p;
@@ -1717,10 +1717,10 @@ add_owner_id(struct archive_match *a, struct id_array *ids, int64_t id)
 static int
 match_owner_id(struct id_array *ids, int64_t id)
 {
-	unsigned b, m, t;
+	size_t b, m, t;
 
 	t = 0;
-	b = (unsigned)ids->count;
+	b = ids->count;
 	while (t < b) {
 		m = (t + b)>>1;
 		if (ids->ids[m] == id)

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -35,6 +35,9 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 
 #include "archive.h"
 #include "archive_private.h"
@@ -53,7 +56,7 @@ struct match {
 struct match_list {
 	struct match		*first;
 	struct match		**last;
-	int			 unmatched_count;
+	size_t			 unmatched_count;
 	struct match		*unmatched_next;
 	int			 unmatched_eof;
 };
@@ -508,7 +511,9 @@ archive_match_path_unmatched_inclusions(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_match_unmatched_inclusions");
 	a = (struct archive_match *)_a;
 
-	return (a->inclusions.unmatched_count);
+	if (a->inclusions.unmatched_count > (size_t)INT_MAX)
+		return INT_MAX;
+	return (int)(a->inclusions.unmatched_count);
 }
 
 int

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -656,7 +656,7 @@ add_pattern_from_file(struct archive_match *a, struct match_list *mlist,
 						break;
 					}
 				} else {
-			            	if (*b == 0x0d || *b == 0x0a) {
+					if (*b == 0x0d || *b == 0x0a) {
 						found_separator = 1;
 						break;
 					}
@@ -741,7 +741,7 @@ path_excluded(struct archive_match *a, int mbs, const void *pathname)
 		}
 	}
 
-	/* Exclusions take priority */
+	/* Exclusions take priority. */
 	for (match = a->exclusions.first; match != NULL;
 	    match = match->next){
 		r = match_path_exclusion(a, match, mbs, pathname);
@@ -1296,7 +1296,7 @@ cmp_node_mbs(const struct archive_rb_node *n1,
 		return (-1);
 	return (strcmp(p1, p2));
 }
-        
+
 static int
 cmp_key_mbs(const struct archive_rb_node *n, const void *key)
 {
@@ -1325,7 +1325,7 @@ cmp_node_wcs(const struct archive_rb_node *n1,
 		return (-1);
 	return (wcscmp(p1, p2));
 }
-        
+
 static int
 cmp_key_wcs(const struct archive_rb_node *n, const void *key)
 {


### PR DESCRIPTION
- Operators for red black tree don't change during runtime, so set them only once
- Use `size_t` for sizes to avoid signed integer overflows (regardsless of how unlikely they are)
- Use `size_t` when iterating over `size_t` instead of `unsigned` to avoid endless loops
- Remove unneeded counters
- Fix style (whitespaces and full stop in a comment)

Slightly reduces required heap, required execution time, and resulting in a slightly smaller library.
No bug fixes, so greatly appreciated for careful review to not introduce any regressions.