### PR TITLE
Add ll length modifier to archive_string_vsprintf

### DIFF
--- a/libarchive/archive_string_sprintf.c
+++ b/libarchive/archive_string_sprintf.c
@@ -116,8 +116,14 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 
 		long_flag = '\0';
 		switch(*p) {
-		case 'j':
 		case 'l':
+			if (p[1] == 'l') {
+				long_flag = 'L';
+				p += 2;
+				break;
+			}
+			__LA_FALLTHROUGH;
+		case 'j':
 		case 'z':
 			long_flag = *p;
 			p++;
@@ -136,6 +142,7 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 			switch(long_flag) {
 			case 'j': s = va_arg(ap, intmax_t); break;
 			case 'l': s = va_arg(ap, long); break;
+			case 'L': s = va_arg(ap, long long); break;
 			case 'z': s = va_arg(ap, ssize_t); break;
 			default:  s = va_arg(ap, int); break;
 			}
@@ -144,6 +151,7 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 		case 's':
 			switch(long_flag) {
 			case 'l':
+			case 'L':
 				pw = va_arg(ap, wchar_t *);
 				if (pw == NULL)
 					pw = L"(null)";
@@ -172,6 +180,7 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 			switch(long_flag) {
 			case 'j': u = va_arg(ap, uintmax_t); break;
 			case 'l': u = va_arg(ap, unsigned long); break;
+			case 'L': u = va_arg(ap, unsigned long long); break;
 			case 'z': u = va_arg(ap, size_t); break;
 			default:  u = va_arg(ap, unsigned int); break;
 			}


### PR DESCRIPTION
Some error messages already use the ll length modifier, which results in raw formatter output, i.e. "%lld" instead of a number.