### PR TITLE
compress: Prevent call stack overflow

### DIFF
--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -328,6 +328,7 @@ next_code(struct archive_read_filter *self)
 	static int debug_buff[1024];
 	static unsigned debug_index;
 
+again:
 	code = newcode = getbits(self, state->bits);
 	if (code < 0)
 		return (code);
@@ -360,7 +361,7 @@ next_code(struct archive_read_filter *self)
 		state->section_end_code = (1 << state->bits) - 1;
 		state->free_ent = 257;
 		state->oldcode = -1;
-		return (next_code(self));
+		goto again;
 	}
 
 	if (code > state->free_ent


### PR DESCRIPTION
Explicitly use goto to turn a recursive call into an iterative one. Most compilers do this on their own with default settings, but MSVC with default settings would create a binary which actually performs recursive calls.

Fixes call stack overflow in binaries compiled with low optimization.