### PR TITLE
Skip tests if respective support is missing

### DIFF
--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -151,7 +151,7 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	(void)rounds; /* UNUSED */
 	(void)derived_key; /* UNUSED */
 	(void)derived_key_len; /* UNUSED */
-	return -1; /* UNSUPPORTED */
+	return CRYPTOR_STUB_FUNCTION; /* UNSUPPORTED */
 }
 
 #endif
@@ -439,14 +439,14 @@ aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
 	(void)ctx; /* UNUSED */
 	(void)key; /* UNUSED */
 	(void)key_len; /* UNUSED */
-	return -1;
+	return CRYPTOR_STUB_FUNCTION;
 }
 
 static int
 aes_ctr_encrypt_counter(archive_crypto_ctx *ctx)
 {
 	(void)ctx; /* UNUSED */
-	return -1;
+	return CRYPTOR_STUB_FUNCTION;
 }
 
 static int
@@ -469,7 +469,7 @@ aes_ctr_update(archive_crypto_ctx *ctx, const uint8_t * const in,
 	(void)out; /* UNUSED */
 	(void)out_len; /* UNUSED */
 	aes_ctr_encrypt_counter(ctx); /* UNUSED */ /* Fix unused function warning */
-	return -1;
+	return CRYPTOR_STUB_FUNCTION;
 }
 
 #else

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -172,6 +172,9 @@ typedef int archive_crypto_ctx;
 #define archive_encrypto_aes_ctr_release(ctx) \
   __archive_cryptor.encrypto_aes_ctr_release(ctx)
 
+/* Stub return value if no encryption support exists. */
+#define CRYPTOR_STUB_FUNCTION	-2
+
 /* Minimal interface to cryptographic functionality for internal use in
  * libarchive */
 struct archive_cryptor

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3015,8 +3015,8 @@ init_WinZip_AES_decryption(struct archive_read *a)
 		    p, salt_len, 1000, derived_key, key_len * 2 + 2);
 		if (r != 0) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "Decryption is unsupported due to lack of "
-			    "crypto library");
+			    r == CRYPTOR_STUB_FUNCTION ? "Decryption is unsupported due "
+				"to lack of crypto library" : "Failed to process passphrase");
 			return (ARCHIVE_FAILED);
 		}
 

--- a/libarchive/test/test_archive_string_conversion.c
+++ b/libarchive/test/test_archive_string_conversion.c
@@ -991,6 +991,7 @@ DEFINE_TEST(test_archive_string_update_utf8_koi8)
 	static const char koi8_string[] = "\xD0\xD2\xC9";
 	static const wchar_t wcs_string[] = L"\U0000043f\U00000440\U00000438";
 	struct archive_mstring mstr;
+	struct archive *a;
 	int r;
 
 	memset(&mstr, 0, sizeof(mstr));
@@ -999,6 +1000,15 @@ DEFINE_TEST(test_archive_string_update_utf8_koi8)
 		skipping("KOI8-R locale not available on this system.");
 		return;
 	}
+	a = archive_write_new();
+	assertEqualInt(ARCHIVE_OK, archive_write_set_format_pax(a));
+	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
+		skipping("This system cannot convert character-set"
+		    " from KOI8-R to UTF-8.");
+		archive_write_free(a);
+		return;
+	}
+	archive_write_free(a);
 
 	r = archive_mstring_update_utf8(NULL, &mstr, utf8_string);
 

--- a/libarchive/test/test_read_filter_gzip_recursive.c
+++ b/libarchive/test/test_read_filter_gzip_recursive.c
@@ -29,8 +29,8 @@ DEFINE_TEST(test_read_filter_gzip_recursive)
 	const char *name = "test_read_filter_gzip_recursive.gz";
 	struct archive *a;
 
-	if (!canGzip()) {
-		skipping("gzip not available");
+	if (archive_zlib_version() == NULL) {
+		skipping("zlib not available");
 		return;
 	}
 

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -1285,19 +1285,26 @@ DEFINE_TEST(test_read_format_7zip_sfx_pe)
 	const char test_txt[] = "123";
 	int size = sizeof(test_txt) - 1;
 
-	extract_reference_file(reffile);
 	assert((a = archive_read_new()) != NULL);
-	assertA(0 == archive_read_support_filter_all(a));
-	assertA(0 == archive_read_support_format_all(a));
-	assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(0 == archive_read_next_header(a, &ae));
-	assertEqualString("test.txt.txt", archive_entry_pathname(ae));
+	if (ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
+		skipping(
+		    "7zip:lzma decoding is not supported on this platform");
+	} else {
+		extract_reference_file(reffile);
+		assertA(0 == archive_read_support_filter_all(a));
+		assertA(0 == archive_read_support_format_all(a));
+		assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(size == archive_read_data(a, buff, size));
-	assertEqualMem(buff, test_txt, size);
+		assertA(0 == archive_read_next_header(a, &ae));
+		assertEqualString("test.txt.txt", archive_entry_pathname(ae));
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertA(size == archive_read_data(a, buff, size));
+		assertEqualMem(buff, test_txt, size);
+
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	}
+
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1316,19 +1323,26 @@ DEFINE_TEST(test_read_format_7zip_sfx_modified_pe)
 	const char test_txt[] = "123";
 	int size = sizeof(test_txt) - 1;
 
-	extract_reference_file(reffile);
 	assert((a = archive_read_new()) != NULL);
-	assertA(0 == archive_read_support_filter_all(a));
-	assertA(0 == archive_read_support_format_all(a));
-	assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(0 == archive_read_next_header(a, &ae));
-	assertEqualString("test.txt.txt", archive_entry_pathname(ae));
+	if (ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
+		skipping(
+		    "7zip:lzma decoding is not supported on this platform");
+	} else {
+		extract_reference_file(reffile);
+		assertA(0 == archive_read_support_filter_all(a));
+		assertA(0 == archive_read_support_format_all(a));
+		assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(size == archive_read_data(a, buff, size));
-	assertEqualMem(buff, test_txt, size);
+		assertA(0 == archive_read_next_header(a, &ae));
+		assertEqualString("test.txt.txt", archive_entry_pathname(ae));
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertA(size == archive_read_data(a, buff, size));
+		assertEqualMem(buff, test_txt, size);
+
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	}
+
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1346,20 +1360,27 @@ DEFINE_TEST(test_read_format_7zip_sfx_elf)
 	const char test_txt[] = "123";
 	int size = sizeof(test_txt) - 1;
 
-	extract_reference_file(reffile);
 	assert((a = archive_read_new()) != NULL);
-	assertA(0 == archive_read_support_filter_all(a));
-	assertA(0 == archive_read_support_format_all(a));
-	assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(0 == archive_read_next_header(a, &ae));
-	assertEqualString("test.txt.txt", archive_entry_pathname(ae));
+	if (ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
+		skipping(
+		    "7zip:lzma decoding is not supported on this platform");
+	} else {
+		extract_reference_file(reffile);
+		assertA(0 == archive_read_support_filter_all(a));
+		assertA(0 == archive_read_support_format_all(a));
+		assertA(0 == archive_read_open_filename(a, reffile, bs));
 
-	assertA(size == archive_read_data(a, buff, size));
-	assertEqualMem(buff, test_txt, size);
+		assertA(0 == archive_read_next_header(a, &ae));
+		assertEqualString("test.txt.txt", archive_entry_pathname(ae));
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		assertA(size == archive_read_data(a, buff, size));
+		assertEqualMem(buff, test_txt, size);
+
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	}
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_7zip_extract_second)
@@ -1597,9 +1618,9 @@ DEFINE_TEST(test_read_format_7zip_lzma2_powerpc)
 
 	assert((a = archive_read_new()) != NULL);
 
-	if (ARCHIVE_OK != archive_read_support_filter_gzip(a)) {
+	if (ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
 		skipping(
-		    "7zip:deflate decoding is not supported on this platform");
+		    "7zip:lzma decoding is not supported on this platform");
 	} else {
 		test_powerpc_filter("test_read_format_7zip_lzma2_powerpc.7z");
 	}

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -138,7 +138,10 @@ DEFINE_TEST(test_read_append_filter)
     assertEqualInt(ARCHIVE_OK, archive_read_free(a));
     return;
   }
-  assertEqualIntA(a, ARCHIVE_OK, r);
+  if (r == ARCHIVE_WARN && canGzip())
+    assertEqualString(archive_error_string(a), "Using external gzip program");
+  else
+    assertEqualIntA(a, ARCHIVE_OK, r);
   assertEqualInt(ARCHIVE_OK,
       archive_read_open_memory(a, archive, sizeof(archive)));
   assertEqualInt(ARCHIVE_OK, archive_read_next_header(a, &ae));

--- a/libarchive/test/test_write_filter_gzip.c
+++ b/libarchive/test/test_write_filter_gzip.c
@@ -166,9 +166,15 @@ DEFINE_TEST(test_write_filter_gzip)
 	assertEqualInt(rbuff[0], 0x1f);
 	assertEqualInt(rbuff[1], 0x8b);
 	assertEqualInt(rbuff[2], 0x08);
-	assertEqualInt(rbuff[3], 0x08);
-	assertEqualInt(rbuff[8], 2); /* RFC 1952 flag for compression level 9 */
-	assertEqualString((const char*)rbuff+10, "testorgfilename");
+	/* RFC 1952 flag for compression level 9 */
+	assertEqualInt(rbuff[8], 2);
+	/* External gzip program might not save filename */
+	if (!use_prog || rbuff[3] == 0x08) {
+		assertEqualInt(rbuff[3], 0x08);
+		assertEqualString((const char*)rbuff+10, "testorgfilename");
+	} else {
+		assertEqualInt(rbuff[3], 0x00);
+	}
 
 	/* Curiously, this test fails; the test data above compresses
 	 * better at default compression than at level 9. */

--- a/libarchive/test/test_write_filter_gzip_timestamp.c
+++ b/libarchive/test/test_write_filter_gzip_timestamp.c
@@ -81,8 +81,11 @@ DEFINE_TEST(test_write_filter_gzip_timestamp)
 	archive_entry_free(ae);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
-	failure("Timestamp should be recorded");
-	assert(memcmp(buff + 4, "\x00\x00\x00\x00", 4) != 0);
+	/* External gzip program might not save timestamp */
+	if (!use_prog) {
+		failure("Timestamp should be recorded");
+		assert(memcmp(buff + 4, "\x00\x00\x00\x00", 4) != 0);
+	}
 
 	/* Test2: set "gzip:!timestamp" option. */
 	assert((a = archive_write_new()) != NULL);

--- a/unzip/test/test_C.c
+++ b/unzip/test/test_C.c
@@ -9,6 +9,7 @@
 /* Test C arg - match case-insensitive */
 DEFINE_TEST(test_C)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -19,4 +20,7 @@ DEFINE_TEST(test_C)
 	assertEmptyFile("test.err");
 
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_L.c
+++ b/unzip/test/test_L.c
@@ -9,6 +9,7 @@
 /* Test L arg - make names lowercase */
 DEFINE_TEST(test_L)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_L)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/caps");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_P_encryption.c
+++ b/unzip/test/test_P_encryption.c
@@ -14,9 +14,13 @@ DEFINE_TEST(test_P_encryption)
 
 	extract_reference_file(reffile);
 	r = systemf("%s -P password %s >test.out 2>test.err", testprog, reffile);
-	assertEqualInt(0, r);
-	assertNonEmptyFile("test.out");
-	assertEmptyFile("test.err");
+	if (r == 256) {
+		assertTextFileContents("unzip: Decryption is unsupported due to lack of crypto library\n", "test.err");
+	} else {
+		assertEqualInt(0, r);
+		assertNonEmptyFile("test.out");
+		assertEmptyFile("test.err");
 
-	assertTextFileContents("plaintext\n", "encrypted/file.txt");
+		assertTextFileContents("plaintext\n", "encrypted/file.txt");
+	}
 }

--- a/unzip/test/test_basic.c
+++ b/unzip/test/test_basic.c
@@ -9,6 +9,7 @@
 /* This test just does a basic zip decompression */
 DEFINE_TEST(test_basic)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_basic)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_d.c
+++ b/unzip/test/test_d.c
@@ -9,6 +9,7 @@
 /* Test d arg - extract to target dir - before zipfile argument */
 DEFINE_TEST(test_d_before_zipfile)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,11 +23,15 @@ DEFINE_TEST(test_d_before_zipfile)
 	assertTextFileContents("contents b\n", "foobar/test_basic/b");
 	assertTextFileContents("contents c\n", "foobar/test_basic/c");
 	assertTextFileContents("contents CAPS\n", "foobar/test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }
 
 /* Test d arg - extract to target dir - after zipfile argument */
 DEFINE_TEST(test_d_after_zipfile)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -40,4 +45,7 @@ DEFINE_TEST(test_d_after_zipfile)
 	assertTextFileContents("contents b\n", "foobar/test_basic/b");
 	assertTextFileContents("contents c\n", "foobar/test_basic/c");
 	assertTextFileContents("contents CAPS\n", "foobar/test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_doubledash.c
+++ b/unzip/test/test_doubledash.c
@@ -9,6 +9,7 @@
 /* Test double dash arg - swallow "--" and use next argument as file name  */
 DEFINE_TEST(test_doubledash)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_doubledash)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_glob.c
+++ b/unzip/test/test_glob.c
@@ -9,6 +9,7 @@
 /* Test that the glob works */
 DEFINE_TEST(test_glob)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_glob)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertFileNotExists("test_basic/c");
 	assertFileNotExists("test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_j.c
+++ b/unzip/test/test_j.c
@@ -9,6 +9,7 @@
 /* Test j arg - don't make directories */
 DEFINE_TEST(test_j)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_j)
 	assertTextFileContents("contents b\n", "b");
 	assertTextFileContents("contents c\n", "c");
 	assertTextFileContents("contents CAPS\n", "CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_n.c
+++ b/unzip/test/test_n.c
@@ -9,6 +9,7 @@
 /* Test n arg - don't overwrite existing files */
 DEFINE_TEST(test_n)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -26,4 +27,7 @@ DEFINE_TEST(test_n)
 	assertTextFileContents("orig b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_o.c
+++ b/unzip/test/test_o.c
@@ -9,6 +9,7 @@
 /* Test o arg - overwrite existing files */
 DEFINE_TEST(test_o)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -25,4 +26,7 @@ DEFINE_TEST(test_o)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_p.c
+++ b/unzip/test/test_p.c
@@ -9,6 +9,7 @@
 /* Test p arg - Print to stdout */
 DEFINE_TEST(test_p)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -17,4 +18,7 @@ DEFINE_TEST(test_p)
 	assertEqualInt(0, r);
 	assertTextFileContents("contents a\ncontents b\ncontents c\ncontents CAPS\n", "test.out");
 	assertEmptyFile("test.err");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_q.c
+++ b/unzip/test/test_q.c
@@ -9,6 +9,7 @@
 /* Test q arg - Quiet */
 DEFINE_TEST(test_q)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,4 +23,7 @@ DEFINE_TEST(test_q)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertTextFileContents("contents c\n", "test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_singlefile.c
+++ b/unzip/test/test_singlefile.c
@@ -9,6 +9,7 @@
 /* Ensure single-file zips work */
 DEFINE_TEST(test_singlefile)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_singlefile.zip";
 	int r;
 
@@ -19,4 +20,7 @@ DEFINE_TEST(test_singlefile)
 	assertEmptyFile("test.err");
 
 	assertTextFileContents("hello\n", "file.txt");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_t.c
+++ b/unzip/test/test_t.c
@@ -9,6 +9,7 @@
 /* Test t arg - Test zip contents */
 DEFINE_TEST(test_t)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -17,4 +18,7 @@ DEFINE_TEST(test_t)
 	assertEqualInt(0, r);
 	assertNonEmptyFile("test.out");
 	assertEmptyFile("test.err");
+#else
+	skipping("zlib not available");
+#endif
 }

--- a/unzip/test/test_x.c
+++ b/unzip/test/test_x.c
@@ -9,6 +9,7 @@
 /* Test x arg with single exclude path */
 DEFINE_TEST(test_x_single)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -22,11 +23,15 @@ DEFINE_TEST(test_x_single)
 	assertTextFileContents("contents b\n", "test_basic/b");
 	assertFileNotExists("test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }
 
 /* Test x arg with multiple exclude paths */
 DEFINE_TEST(test_x_multiple)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -40,11 +45,15 @@ DEFINE_TEST(test_x_multiple)
 	assertFileNotExists("test_basic/b");
 	assertFileNotExists("test_basic/c");
 	assertTextFileContents("contents CAPS\n", "test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }
 
 /* Test x arg with multiple exclude paths and a d arg afterwards */
 DEFINE_TEST(test_x_multiple_with_d)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_basic.zip";
 	int r;
 
@@ -58,4 +67,7 @@ DEFINE_TEST(test_x_multiple_with_d)
 	assertFileNotExists("foobar/test_basic/b");
 	assertFileNotExists("foobar/test_basic/c");
 	assertTextFileContents("contents CAPS\n", "foobar/test_basic/CAPS");
+#else
+	skipping("zlib not available");
+#endif
 }


### PR DESCRIPTION
Some tests are active even if support for tested features is disabled through configuration.

To better detect missing decryption support in bsdunzip, I have added a special return value, otherwise we could falsely assume that encryption support is missing even though the library actually returned an error. Let me know if this should be in its own PR.

KOI8 conversion requires iconv on Unix.

LZMA tests require LZMA support. Please note that one test was mistakenly guarded by gzip support test.

Tested with instructions in https://github.com/libarchive/libarchive/issues/2628 to disable quite some features.

Fixes https://github.com/libarchive/libarchive/issues/2647

Update: Tests support missing zlib now, as well. Test runs pass on 32 and 64 bit systems.