### PR TITLE
open_filename: Free memory on error paths

### DIFF
--- a/libarchive/archive_read_open_filename.c
+++ b/libarchive/archive_read_open_filename.c
@@ -136,8 +136,10 @@ archive_read_open_filenames(struct archive *a, const char **filenames,
 			mine->filename_type = FNT_STDIN;
 		} else
 			mine->filename_type = FNT_MBS;
-		if (archive_read_append_callback_data(a, mine) != (ARCHIVE_OK))
+		if (archive_read_append_callback_data(a, mine) != (ARCHIVE_OK)) {
+			free(mine);
 			return (ARCHIVE_FATAL);
+		}
 		if (filenames == NULL)
 			break;
 		filename = *(filenames++);
@@ -216,8 +218,10 @@ archive_read_open_filenames_w(struct archive *a, const wchar_t **wfilenames,
 			archive_string_free(&fn);
 #endif
 		}
-		if (archive_read_append_callback_data(a, mine) != (ARCHIVE_OK))
+		if (archive_read_append_callback_data(a, mine) != (ARCHIVE_OK)) {
+			free(mine);
 			return (ARCHIVE_FATAL);
+		}
 		if (wfilenames == NULL)
 			break;
 		wfilename = *(wfilenames++);

--- a/libarchive/archive_write_open_filename.c
+++ b/libarchive/archive_write_open_filename.c
@@ -108,6 +108,7 @@ open_filename(struct archive *a, int mbs_fn, const void *filename)
 	else
 		r = archive_mstring_copy_wcs(&mine->filename, filename);
 	if (r < 0) {
+		free(mine);
 		if (errno == ENOMEM) {
 			archive_set_error(a, ENOMEM, "No memory");
 			return (ARCHIVE_FATAL);


### PR DESCRIPTION
If opening a filename fails, make sure that allocated memory which is not inserted into any remaining structure is freed.