### PR TITLE
archive_read_data: Handle sparse holes at end of file correctly

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -834,7 +834,9 @@ archive_read_data(struct archive *_a, void *buff, size_t s)
 			r = archive_read_data_block(a, &read_buf,
 			    &a->read_data_remaining, &a->read_data_offset);
 			a->read_data_block = read_buf;
-			if (r == ARCHIVE_EOF)
+			if (r == ARCHIVE_EOF &&
+			    a->read_data_offset == a->read_data_output_offset &&
+			    a->read_data_remaining == 0)
 				return (bytes_read);
 			/*
 			 * Error codes are all negative, so the status

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1117,8 +1117,6 @@ archive_read_format_rar_read_data(struct archive_read *a, const void **buff,
   if (rar->entry_eof || rar->offset_seek >= rar->unp_size) {
     *size = 0;
     *offset = rar->offset;
-    if (*offset < rar->unp_size)
-      *offset = rar->unp_size;
     return (ARCHIVE_EOF);
   }
 

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -405,7 +405,7 @@ _warc_read(struct archive_read *a, const void **buf, size_t *bsz, int64_t *off)
 		/* it's our lucky day, no work, we can leave early */
 		*buf = NULL;
 		*bsz = 0U;
-		*off = w->cntoff + 4U/*for \r\n\r\n separator*/;
+		*off = w->cntoff;
 		w->unconsumed = 0U;
 		return (ARCHIVE_EOF);
 	}

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -930,7 +930,7 @@ xar_read_data(struct archive_read *a,
 abort_read_data:
 	*buff = NULL;
 	*size = 0;
-	*offset = xar->total;
+	*offset = (int64_t)xar->entry_total;
 	return (r);
 }
 


### PR DESCRIPTION
The problem here is that `archive_read_data` might stop processing as soon as `archive_read_data_block` returns `ARCHIVE_EOF` if archive data blocks line up perfectly with read blocks. But since `archive_read_data_block` might modify the entry offset, which is not the same as the output offset anymore, `archive_read_data` should continue and fill remaining bytes with zero.

But this revealed some issues with existing readers:

- rar claimed that links have a sparse hole by returning the link size as data size
- warc claimed that \r\n\r\n (4 bytes) at end of entry are a sparse hole
- xar returned the total bytes of archive read so far as offset, not the bytes read from entry

Fixes https://github.com/libarchive/libarchive/issues/1194
Fixes https://github.com/libarchive/libarchive/issues/2506 (adding it here to get the cross reference)