### PR TITLE
7zip: Fix out of boundary access

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -80,7 +80,7 @@
 /*
  * ELF format
  */
-#define ELF_HDR_MIN_LEN 0x34
+#define ELF_HDR_MIN_LEN 0x3f
 #define ELF_HDR_EI_CLASS_OFFSET 0x04
 #define ELF_HDR_EI_DATA_OFFSET 0x05
 

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -811,6 +811,8 @@ find_elf_data_sec(struct archive_read *a)
 			strtab_size = (*dec32)(
 			    h + e_shstrndx * e_shentsize + 0x14);
 		}
+		if (strtab_size < 6 || strtab_size > SIZE_MAX)
+			break;
 
 		/*
 		 * Read the STRTAB section to find the .data offset


### PR DESCRIPTION
libarchive 3.8.0 and libarchive 3.8.1 are vulnerable to a crash resulting from an out of boundary access during 7zip ELF detection.

The problem is that the code does not check if the string table size is smaller than 6, which would lead to a very high limit. This can eventually lead to a crash.

Also, it may read uninitialized memory if an ELF 64 bit format file is encountered.

Last but not least, this PR improves 32 bit support by disallowing ELF binaries with a string table not fitting into memory.

In general, the detection might be improved, but this PR is solely about stability.