### PR TITLE
zip: fix writing with ZSTD compression

### DIFF
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1943,10 +1943,11 @@ archive_write_zip_finish_entry(struct archive_write *a)
 				return (ret);
 			zip->entry_compressed_written += remainder;
 			zip->written_bytes += remainder;
-			zip->stream.zstd.out.dst = zip->buf;
 			if (zip->stream.zstd.out.pos != zip->stream.zstd.out.size)
 				finishing = 0;
+			zip->stream.zstd.out.dst = zip->buf;
 			zip->stream.zstd.out.size = zip->len_buf;
+			zip->stream.zstd.out.pos = 0;
 		} while (finishing);
 		ZSTD_freeCStream(zip->stream.zstd.context);
 		break;


### PR DESCRIPTION
When testing the feature with `bsdtar -acf test.zip --options zip:compression=zstd …` on a tree of ~100MB, the execution would appear to "hang" while writing a multi-gigabytes ZIP file.