### PR TITLE
Fix error checking in writing files

### DIFF
--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -30,6 +30,7 @@
 #endif
 
 #include <stdio.h>
+#include <errno.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
@@ -54,8 +55,14 @@ errmsg(const char *m)
 
 	while (s > 0) {
 		written = write(2, m, s);
-		if (written <= 0)
+		if (written == 0)
 			return;
+		if (written < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			return;
+		}
 		m += written;
 		s -= written;
 	}

--- a/libarchive/archive_write_open_fd.c
+++ b/libarchive/archive_write_open_fd.c
@@ -122,7 +122,7 @@ file_write(struct archive *a, void *client_data, const void *buff, size_t length
 	mine = (struct write_fd_data *)client_data;
 	for (;;) {
 		bytesWritten = write(mine->fd, buff, length);
-		if (bytesWritten <= 0) {
+		if (bytesWritten < 0) {
 			if (errno == EINTR)
 				continue;
 			archive_set_error(a, errno, "Write error");

--- a/libarchive/archive_write_open_file.c
+++ b/libarchive/archive_write_open_file.c
@@ -85,16 +85,12 @@ file_write(struct archive *a, void *client_data, const void *buff, size_t length
 	size_t	bytesWritten;
 
 	mine = client_data;
-	for (;;) {
-		bytesWritten = fwrite(buff, 1, length, mine->f);
-		if (bytesWritten <= 0) {
-			if (errno == EINTR)
-				continue;
-			archive_set_error(a, errno, "Write error");
-			return (-1);
-		}
-		return (bytesWritten);
+	bytesWritten = fwrite(buff, 1, length, mine->f);
+	if (bytesWritten != length) {
+		archive_set_error(a, errno, "Write error");
+		return (-1);
 	}
+	return (bytesWritten);
 }
 
 static int

--- a/libarchive/archive_write_open_filename.c
+++ b/libarchive/archive_write_open_filename.c
@@ -228,7 +228,7 @@ file_write(struct archive *a, void *client_data, const void *buff,
 	mine = (struct write_file_data *)client_data;
 	for (;;) {
 		bytesWritten = write(mine->fd, buff, length);
-		if (bytesWritten <= 0) {
+		if (bytesWritten < 0) {
 			if (errno == EINTR)
 				continue;
 			archive_set_error(a, errno, "Write error");


### PR DESCRIPTION
For write, 0 may not mean an error at all. We need to instead check for the length not being the same.

With fwrite, because 0 could mean an error, but not always. We must check that we wrote the entire file!

Note that unlike write, fwrite's description according to POSIX does not mention returning a negative type at all. Nor does it say you can retry unlike write.