### PR TITLE
archive_cryptor_private.h: check message digest functions are enabled for windows

### DIFF
--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -144,8 +144,14 @@ typedef struct {
 
 #else
 
+#if defined(ARCHIVE_CRYPTO_MD5_WIN)    ||\
+	defined(ARCHIVE_CRYPTO_SHA1_WIN)   ||\
+	defined(ARCHIVE_CRYPTO_SHA256_WIN) ||\
+	defined(ARCHIVE_CRYPTO_SHA384_WIN) ||\
+	defined(ARCHIVE_CRYPTO_SHA512_WIN)
 #if defined(_WIN32) && !defined(__CYGWIN__) && !(defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA)
 #define ARCHIVE_CRYPTOR_USE_WINCRYPT 1
+#endif
 #endif
 
 #define AES_BLOCK_SIZE	16


### PR DESCRIPTION
archive_cryptor_private.h missed check for message digest functions are enabled for windows:

Got compilation error if message digest functions for windows are disabled:

```
src\libarchive\archive_version_details.c(435): error C2065: 'HCRYPTPROV': undeclared identifier
src\libarchive\archive_version_details.c(435): error C2146: syntax error: missing ';' before identifier 'prov'
src\libarchive\archive_version_details.c(435): error C2065: 'prov': undeclared identifier
src\libarchive\archive_version_details.c(436): error C2065: 'prov': undeclared identifier
src\libarchive\archive_version_details.c(436): error C2065: 'PROV_RSA_FULL': undeclared identifier
src\libarchive\archive_version_details.c(436): error C2065: 'CRYPT_VERIFYCONTEXT': undeclared identifier
src\libarchive\archive_version_details.c(439): error C2065: 'prov': undeclared identifier
src\libarchive\archive_version_details.c(439): error C2065: 'PROV_RSA_FULL': undeclared identifier
src\libarchive\archive_version_details.c(439): error C2065: 'CRYPT_NEWKEYSET': undeclared identifier
src\libarchive\archive_version_details.c(443): error C2065: 'prov': undeclared identifier
src\libarchive\archive_version_details.c(443): error C2065: 'PP_VERSION': undeclared identifier
```