### PR TITLE
Change error message from "fwrite function failed" to "write function failed"

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -686,7 +686,7 @@ write_to_temp(struct archive_write *a, const void *buff, size_t s)
 		ws = write(zip->temp_fd, p, s);
 		if (ws < 0) {
 			archive_set_error(&(a->archive), errno,
-			    "fwrite function failed");
+			    "write function failed");
 			return (ARCHIVE_FATAL);
 		}
 		s -= ws;

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -689,7 +689,7 @@ write_to_temp(struct archive_write *a, const void *buff, size_t s)
 		ws = write(xar->temp_fd, p, s);
 		if (ws < 0) {
 			archive_set_error(&(a->archive), errno,
-			    "fwrite function failed");
+			    "write function failed");
 			return (ARCHIVE_FATAL);
 		}
 		s -= ws;


### PR DESCRIPTION
We are checking the return value from write, not fwrite, so this message is wrong.