### PR TITLE
Enable Zstandard's checksum feature in the zstd write filter

### DIFF
--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -391,6 +391,8 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 
 	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_nbWorkers, data->threads);
 
+	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_checksumFlag, 1);
+
 #if ZSTD_VERSION_NUMBER >= MINVER_LONG
 	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_windowLog, data->long_distance);
 #endif


### PR DESCRIPTION
Note that this is not enabled when writing .zip or .7z archive formats, because they already use their own checksums.

Implements #2675.