### PR TITLE
Handle possible errors from system calls

### DIFF
--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -2112,8 +2112,11 @@ tree_dup(int fd)
 	}
 #endif /* F_DUPFD_CLOEXEC */
 	new_fd = dup(fd);
-	__archive_ensure_cloexec_flag(new_fd);
-	return (new_fd);
+	if (new_fd != -1) {
+		__archive_ensure_cloexec_flag(new_fd);
+		return (new_fd);
+	}
+	return (-1);
 }
 
 /*
@@ -2235,11 +2238,16 @@ tree_reopen(struct tree *t, const char *path, int restore_time)
 	 * so try again for execute. The consequences of not opening this are
 	 * unhelpful and unnecessary errors later.
 	 */
-	if (t->initial_dir_fd < 0)
+	if (t->initial_dir_fd < 0) {
 		t->initial_dir_fd = open(".", o_flag | O_CLOEXEC);
+		if (t->initial_dir_fd < 0)
+			return NULL;
+	}
 #endif
 	__archive_ensure_cloexec_flag(t->initial_dir_fd);
 	t->working_dir_fd = tree_dup(t->initial_dir_fd);
+	if (t->working_dir_fd < 0)
+		return NULL;
 	return (t);
 }
 
@@ -2454,7 +2462,9 @@ tree_dir_next_posix(struct tree *t)
 #endif
 
 #if defined(HAVE_FDOPENDIR)
-		t->d = fdopendir(tree_dup(t->working_dir_fd));
+		int fd = tree_dup(t->working_dir_fd);
+		if (fd != -1)
+			t->d = fdopendir(fd);
 #else /* HAVE_FDOPENDIR */
 		if (tree_enter_working_dir(t) == 0) {
 			t->d = opendir(".");

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1251,7 +1251,7 @@ parse_file(struct archive_read *a, struct archive_entry *entry,
 				archive_entry_filetype(entry) == AE_IFDIR) {
 			mtree->fd = open(path, O_RDONLY | O_BINARY | O_CLOEXEC);
 			__archive_ensure_cloexec_flag(mtree->fd);
-			if (mtree->fd == -1 && (
+			if (mtree->fd < 0 && (
 #if defined(_WIN32) && !defined(__CYGWIN__)
         /*
          * On Windows, attempting to open a file with an

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2559,9 +2559,9 @@ _archive_write_disk_close(struct archive *_a)
 			 * for directories. For other file types
 			 * we need to verify via fstat() or lstat()
 			 */
-			if (fd == -1 || p->filetype != AE_IFDIR) {
+			if (fd < 0 || p->filetype != AE_IFDIR) {
 #if HAVE_FSTAT
-				if (fd > 0 && (
+				if (fd >= 0 && (
 				    fstat(fd, &st) != 0 ||
 				    la_verify_filetype(st.st_mode,
 				    p->filetype) == 0)) {
@@ -4437,7 +4437,7 @@ fixup_appledouble(struct archive_write_disk *a, const char *pathname)
 	 */
 	fd = open(pathname, O_RDONLY | O_BINARY | O_CLOEXEC);
 	__archive_ensure_cloexec_flag(fd);
-	if (fd == -1) {
+	if (fd < 0) {
 		archive_set_error(&a->archive, errno,
 		    "Failed to open a restoring file");
 		ret = ARCHIVE_WARN;


### PR DESCRIPTION
dup, open, etc, can fail and we should not assume they do not.