### PR TITLE
Fixed XML_ExpatVersion not found if you have LibXML2

### DIFF
--- a/libarchive/archive_version_details.c
+++ b/libarchive/archive_version_details.c
@@ -53,7 +53,8 @@
 #endif
 #if HAVE_LIBXML_XMLVERSION_H
 #include <libxml/xmlversion.h>
-#elif HAVE_BSDXML_H
+#endif
+#if HAVE_BSDXML_H
 #include <bsdxml.h>
 #elif HAVE_EXPAT_H
 #include <expat.h>


### PR DESCRIPTION
We have Expat and LibXML2, so we need to include expat.h to get XML_ExpatVersion() function. But if elif is used, it won't get included, so it won't compile. The fix is to include both if available.