### PR TITLE
Supress restrict keyword for msc_ver older than 1927

### DIFF
--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -16,6 +16,10 @@
 #define ENV_WRITER_OPTIONS	"TAR_WRITER_OPTIONS"
 #define IGNORE_WRONG_MODULE_NAME "__ignore_wrong_module_name__,"
 
+#if defined(_MSC_VER ) && (_MSC_VER < 1927 )	/* Check if compiler pre-dated Visual Studio 2019 Release 16.8 */
+#define restrict  		/* The restrict keyword is not supported.  */
+#endif
+
 struct creation_set;
 /*
  * The internal state for the "bsdtar" program.

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -17,7 +17,9 @@
 #define IGNORE_WRONG_MODULE_NAME "__ignore_wrong_module_name__,"
 
 #if defined(_MSC_VER ) && (_MSC_VER < 1927 )	/* Check if compiler pre-dated Visual Studio 2019 Release 16.8 */
-#define restrict  		/* The restrict keyword is not supported.  */
+#define ARCHIVE_RESTRICT
+#else
+#define ARCHIVE_RESTRICT restrict
 #endif
 
 struct creation_set;
@@ -192,7 +194,7 @@ int	edit_pathname(struct bsdtar *, struct archive_entry *);
 void	edit_mtime(struct bsdtar *, struct archive_entry *);
 int	need_report(void);
 int	pathcmp(const char *a, const char *b);
-void	safe_fprintf(FILE * restrict, const char * restrict fmt, ...) __LA_PRINTF(2, 3);
+void	safe_fprintf(FILE * ARCHIVE_RESTRICT, const char * ARCHIVE_RESTRICT fmt, ...) __LA_PRINTF(2, 3);
 void	set_chdir(struct bsdtar *, const char *newdir);
 const char *tar_i64toa(int64_t);
 void	tar_mode_c(struct bsdtar *bsdtar);


### PR DESCRIPTION
`restrict` keyword is not supported in msc_ver compilers older than version 1927. (before Visual Studio 2019 version 16.7)
This macro will allow user to maintain backward compatibility with those compilers.

This PR addresses issue: https://github.com/libarchive/libarchive/issues/2674


