### PR TITLE
clear_nochange_fflags: Use linux FS flags

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -3930,10 +3930,14 @@ clear_nochange_fflags(struct archive_write_disk *a)
 #ifdef UF_APPEND
 	    | UF_APPEND
 #endif
-#ifdef EXT2_APPEND_FL
+#if defined(FS_APPEND_FL)
+	    | FS_APPEND_FL
+#elif defined(EXT2_APPEND_FL)
 	    | EXT2_APPEND_FL
 #endif
-#ifdef EXT2_IMMUTABLE_FL
+#if defined(FS_IMMUTABLE_FL)
+	    | FS_IMMUTABLE_FL
+#elif defined(EXT2_IMMUTABLE_FL)
 	    | EXT2_IMMUTABLE_FL
 #endif
 	;


### PR DESCRIPTION
It seems when the more generic linux `FS_*` flags [were adopted](a9c5818b92c7800241387c8e5389c66e724b19fa), this function was left out.

After investigating why NixOS's `libarchive` package depends on its `e2fsprogs` package, I found that the only reason it produces different results without the dependency is this function. With this patch, the package builds bit-for-bit identical results with or without the `e2fsprogs` dependency.

It seems to me that the support for the `EXT2_*` style flags is just legacy code. I wonder if they should be removed altogether?