### PR TITLE
Perform various cleanups

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ Please provide the following information in your report:
 - How to reproduce the issue
 
 This project is maintained by volunteers on a reasonable-effort basis. As such, we ask
-that you give me 90 days to work on a fix before public exposure.
+that you give us 90 days to work on a fix before public exposure.

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -43,7 +43,7 @@ int __libarchive_cryptor_build_hack(void);
 #ifdef __APPLE__
 # include <AvailabilityMacros.h>
 # if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
-#  define ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
+#  define ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto 1
 # endif
 #endif
 

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -575,8 +575,7 @@ choose_filters(struct archive_read *a)
 			return (ARCHIVE_OK);
 		}
 
-		filter
-		    = calloc(1, sizeof(*filter));
+		filter = calloc(1, sizeof(*filter));
 		if (filter == NULL)
 			return (ARCHIVE_FATAL);
 		filter->bidder = best_bidder;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1453,7 +1453,7 @@ read_header(struct archive_read *a, struct archive_entry *entry,
     return (ARCHIVE_FATAL);
 #endif
   }
-  /* If no CRC error, Go on parsing File Header. */
+  /* If no CRC error, go on parsing File Header. */
   p = h;
   endp = p + header_size - 7;
   memcpy(&file_header, p, sizeof(file_header));
@@ -2366,8 +2366,8 @@ parse_codes(struct archive_read *a)
         return (ARCHIVE_FATAL);
       }
 
-      /* Make sure ppmd7_contest is freed before Ppmd7_Construct
-       * because reading a broken file cause this abnormal sequence. */
+      /* Make sure ppmd7_context is freed before Ppmd7_Construct
+       * because reading a broken file causes this abnormal sequence. */
       __archive_ppmd7_functions.Ppmd7_Free(&rar->ppmd7_context);
 
       rar->bytein.a = a;

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1255,7 +1255,7 @@ read_bytes_to_string(struct archive_read *a,
 	const void *src;
 
 	/* Fail if we can't make our buffer big enough. */
-	if (archive_string_ensure(as, (size_t)size+1) == NULL) {
+	if (archive_string_ensure(as, size + 1) == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "No memory");
 		return (ARCHIVE_FATAL);
@@ -1272,9 +1272,9 @@ read_bytes_to_string(struct archive_read *a,
 		*unconsumed = 0;
 		return (ARCHIVE_FATAL);
 	}
-	memcpy(as->s, src, (size_t)size);
+	memcpy(as->s, src, size);
 	as->s[size] = '\0';
-	as->length = (size_t)size;
+	as->length = size;
 	*unconsumed += size;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -2015,7 +2015,7 @@ archive_strncat_l(struct archive_string *as, const void *_p, size_t n,
 	/* We must allocate memory even if there is no data for conversion
 	 * or copy. This simulates archive_string_append behavior. */
 	if (length == 0) {
-		int tn = 1;
+		size_t tn = 1;
 		if (sc != NULL && (sc->flag & SCONV_TO_UTF16))
 			tn = 2;
 		if (archive_string_ensure(as, as->length + tn) == NULL)
@@ -2752,7 +2752,8 @@ archive_string_append_unicode(struct archive_string *as, const void *_p,
 	char *p, *endp;
 	uint32_t uc;
 	size_t w;
-	int n, ret = 0, ts, tm;
+	size_t ts, tm;
+	int n, ret = 0;
 	int (*parse)(uint32_t *, const char *, size_t);
 	size_t (*unparse)(char *, size_t, uint32_t);
 

--- a/libarchive/archive_string_sprintf.c
+++ b/libarchive/archive_string_sprintf.c
@@ -146,7 +146,7 @@ archive_string_vsprintf(struct archive_string *as, const char *fmt,
 			case 'z': s = va_arg(ap, ssize_t); break;
 			default:  s = va_arg(ap, int); break;
 			}
-		        append_int(as, s, 10);
+			append_int(as, s, 10);
 			break;
 		case 's':
 			switch(long_flag) {

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1927,7 +1927,7 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 	}
 
 	/*
-	 * Find out the position which points the last position of
+	 * Find out the position which points to the last position of
 	 * path separator('/').
 	 */
 	slash = NULL;
@@ -2024,7 +2024,7 @@ mtree_entry_add_child_tail(struct mtree_entry *parent,
 }
 
 /*
- * Find a entry from a parent entry with the name.
+ * Find an entry from a parent entry with given name.
  */
 static struct mtree_entry *
 mtree_entry_find_child(struct mtree_entry *parent, const char *child_name)
@@ -2148,10 +2148,10 @@ mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 
 		/* Find next sub directory. */
 		if (!np->dir_info) {
-			/* NOT Directory! */
+			/* NOT a directory! */
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_MISC,
-			    "`%s' is not directory, we cannot insert `%s' ",
+			    "`%s' is not a directory, we cannot insert `%s' ",
 			    np->pathname.s, file->pathname.s);
 			return (ARCHIVE_FAILED);
 		}
@@ -2243,10 +2243,7 @@ mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 	}
 
 same_entry:
-	/*
-	 * We have already has the entry the filename of which is
-	 * the same.
-	 */
+	/* We already have an entry with same filename. */
 	r = mtree_entry_exchange_same_entry(a, np, file);
 	if (r < ARCHIVE_WARN)
 		return (r);
@@ -2264,13 +2261,13 @@ mtree_entry_exchange_same_entry(struct archive_write *a, struct mtree_entry *np,
 
 	if ((np->mode & AE_IFMT) != (file->mode & AE_IFMT)) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-		    "Found duplicate entries `%s' and its file type is "
-		    "different",
+		    "Found duplicate entries for `%s' with "
+		    "differing file types.",
 		    np->pathname.s);
 		return (ARCHIVE_FAILED);
 	}
 
-	/* Update the existent mtree entry's attributes by the new one's. */
+	/* Update the existing mtree entry's attributes by the new one's. */
 	archive_string_empty(&np->symlink);
 	archive_string_concat(&np->symlink, &file->symlink);
 	archive_string_empty(&np->uname);


### PR DESCRIPTION
A collection of minor cleanups sitting in my tree for far too long now:

- Typos
- Formatting
- Data types (no side effects before or after)
- Use a value when using #define