### PR TITLE
Fix mkstemp path in setup_mac_metadata

### DIFF
--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -364,7 +364,7 @@ setup_mac_metadata(struct archive_read_disk *a,
 		tempdir = _PATH_TMP;
 	archive_string_init(&tempfile);
 	archive_strcpy(&tempfile, tempdir);
-	archive_strcat(&tempfile, "tar.md.XXXXXX");
+	archive_strcat(&tempfile, "/tar.md.XXXXXX");
 	tempfd = mkstemp(tempfile.s);
 	if (tempfd < 0) {
 		archive_set_error(&a->archive, errno,


### PR DESCRIPTION
setup_mac_metadata currently concates the template after TMPDIR without adding a path separator, which causes mkstemp to create a temporary file next to TMPDIR instead of in TMPDIR. Add a path separator to the template to ensure that the temporary file is created under TMPDIR.

I hit this while rebuilding libarchive in nixpkgs. [Lix recently started using a dedicated build directory (under /nix/var/nix/builds) instead of using a directory under /tmp][1]. nixpkgs & Lix support (optional) on macOS sandboxing. The default sandbox profile allows builds to access paths under the build directory and any path under /tmp. Because the build directory is no longer under /tmp, some of libarchive's tests started to fail as they accessed paths next to (but not under) the build directory:

```
cpio/test/test_basic.c:65: Contents don't match
   Description: Expected: 2 blocks
, options=
  file="pack.err"
0000_62_73_64_63_70_69_6f_3a_20_43_6f_75_6c_64_20_6e_bsdcpio: Could n 0010_6f_74_20_6f_70_65_6e_20_65_78_74_65_6e_64_65_64_ot open extended 0020_20_61_74_74_72_69_62_75_74_65_20_66_69_6c_65_0a_ attribute file.
```
```
Sandbox: bsdcpio(11215) deny(1) file-write-create /nix/var/nix/builds/nix-build-libarchive-3.8.0.drv-7tar.md.5EUrQu
```

[1]: https://lix.systems/blog/2025-06-24-lix-cves/