### PR TITLE
xar: avoid libxml2 deprecation warnings

### DIFF
--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -3418,8 +3418,8 @@ static int
 xml_writer_get_final_content_and_length(struct xml_writer *ctx,
     const char **out, size_t *size)
 {
-	*out = (const char*)ctx->bp->content;
-	*size = (size_t)ctx->bp->use;
+	*out = (const char*)xmlBufferContent(ctx->bp);
+	*size = (size_t)xmlBufferLength(ctx->bp);
 	return (0);
 }
 


### PR DESCRIPTION
This makes the FreeBSD BS:cmake freebsd_instance:family/freebsd-13-5 and FreeBSD BS:cmake freebsd_instance:family/freebsd-14-2 CI checks pass.