### PR TITLE
Fix archive_read_append_filter() for lzop and grzip

### DIFF
--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -104,6 +104,10 @@ archive_read_append_filter(struct archive *_a, int code)
       strcpy(str, "lrzip");
       r1 = archive_read_support_filter_lrzip(_a);
       break;
+    case ARCHIVE_FILTER_GRZIP:
+      strcpy(str, "grzip");
+      r1 = archive_read_support_filter_grzip(_a);
+      break;
     default:
       archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
           "Invalid filter code specified");

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -62,7 +62,7 @@ archive_read_support_filter_grzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "grzip",
 				&grzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -110,7 +110,7 @@ archive_read_support_filter_lzop(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "lzop",
 				&lzop_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -186,17 +186,23 @@ DEFINE_TEST(test_read_append_lzop_filter)
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
   if (archive_liblzo2_version() == NULL) {
-	  // Libarchive was not linked with liblzo2, so we must use an external program
-	  if (!canLzop()) {
+	  // Libarchive was not linked with liblzo2 ...
+	  if (canLzop()) {
+		  // We're using an external program
+		  assertEqualIntA(a, ARCHIVE_WARN, r);
+		  // The `lzop` command-line program exits with an error
+		  // on an empty input, which reflects as an error here
+		  // in that case.
+		  assertEqualIntA(a, ARCHIVE_FAILED, archive_read_free(a));
+	  } else {
 		  // The external program doesn't exist
 		  assertEqualIntA(a, ARCHIVE_FATAL, r);
-	  } else {
-		  assertEqualIntA(a, ARCHIVE_WARN, r);
+		  assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
 	  }
   } else {
 	  assertEqualIntA(a, ARCHIVE_OK, r);
+	  assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
   }
-  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_grzip_filter)

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -177,6 +177,18 @@ DEFINE_TEST(test_read_append_wrong_filter)
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 
+DEFINE_TEST(test_read_append_lzop_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
+  assertEqualIntA(a, ARCHIVE_OK, r);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_read_append_filter_program)
 {
   struct archive_entry *ae;

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -185,8 +185,14 @@ DEFINE_TEST(test_read_append_lzop_filter)
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
-  if (r != ARCHIVE_OK && !canLzop()) {
-	  skipping("lzop reading not fully supported on this platform");
+  if (archive_liblzo2_version() == NULL) {
+	  // Libarchive was not linked with liblzo2, so we must use an external program
+	  if (!canLzop()) {
+		  // The external program doesn't exist
+		  assertEqualIntA(a, ARCHIVE_FATAL, r);
+	  } else {
+		  assertEqualIntA(a, ARCHIVE_WARN, r);
+	  }
   } else {
 	  assertEqualIntA(a, ARCHIVE_OK, r);
   }
@@ -201,10 +207,11 @@ DEFINE_TEST(test_read_append_grzip_filter)
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP);
-  if (r != ARCHIVE_OK && !canGrzip()) {
-	  skipping("grzip reading not fully supported on this platform");
+    // Grzip currently always uses an external program.
+  if (!canGrzip()) {
+	  assertEqualIntA(a, ARCHIVE_FATAL, r);
   } else {
-	  assertEqualIntA(a, ARCHIVE_OK, r);
+	  assertEqualIntA(a, ARCHIVE_WARN, r);
   }
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -185,7 +185,27 @@ DEFINE_TEST(test_read_append_lzop_filter)
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
-  assertEqualIntA(a, ARCHIVE_OK, r);
+  if (r != ARCHIVE_OK && !canLzop()) {
+	  skipping("lzop reading not fully supported on this platform");
+  } else {
+	  assertEqualIntA(a, ARCHIVE_OK, r);
+  }
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
+DEFINE_TEST(test_read_append_grzip_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP);
+  if (r != ARCHIVE_OK && !canGrzip()) {
+	  skipping("grzip reading not fully supported on this platform");
+  } else {
+	  assertEqualIntA(a, ARCHIVE_OK, r);
+  }
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 


### PR DESCRIPTION
These two filters failed to correctly set a name during registration, which made them unusable with archive_read_append_filter().

In addition, grzip was never added to archive_read_append_filter() at all.

Thanks to @fdegros for providing the test case that showed the lrzip failure.

Resolves #2525 and #2513