### PR TITLE
Fix setup_mac_metadata when TMPDIR does not end with a slash

### DIFF
--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -364,7 +364,7 @@ setup_mac_metadata(struct archive_read_disk *a,
 		tempdir = _PATH_TMP;
 	archive_string_init(&tempfile);
 	archive_strcpy(&tempfile, tempdir);
-	archive_strcat(&tempfile, "tar.md.XXXXXX");
+	archive_strcat(&tempfile, "/tar.md.XXXXXX");
 	tempfd = mkstemp(tempfile.s);
 	if (tempfd < 0) {
 		archive_set_error(&a->archive, errno,


### PR DESCRIPTION
Otherwise `TMPDIR=/nix/var/nix/builds/nix-build-libarchive-3.8.1.drv-6/b` tried to create a file like `/nix/var/nix/builds/nix-build-libarchive-3.8.1.drv-6/btar.md.CvYd75`, which resulted in a permissions error.