### PR TITLE
archive_read_disk_posix: Don't pass -1 to a function expecting errno

### DIFF
--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -862,7 +862,7 @@ next_entry(struct archive_read_disk *a, struct tree *t,
 			tree_enter_initial_dir(t);
 			return (ARCHIVE_FATAL);
 		case TREE_ERROR_DIR:
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			archive_set_error(&a->archive, t->tree_errno,
 			    "%s: Couldn't visit directory",
 			    tree_current_path(t));
 			tree_enter_initial_dir(t);


### PR DESCRIPTION
This fixes an unhelpful "Couldn't visit directory: Unknown error: -1" message.

Fixes:		3311bb52cbe4 ("Bring the code supporting directory traversals from bsdtar/tree.[ch] into archive_read_disk.c and modify it. Introduce new APIs archive_read_disk_open and archive_read_disk_descend.")