### PR TITLE
Ignore over-long gzip filename

### DIFF
--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -229,14 +229,16 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 		data->compressed[5] = (uint8_t)(t>>8)&0xff;
 		data->compressed[6] = (uint8_t)(t>>16)&0xff;
 		data->compressed[7] = (uint8_t)(t>>24)&0xff;
-	} else
+	} else {
 		memset(&data->compressed[4], 0, 4);
-    if (data->compression_level == 9)
-	    data->compressed[8] = 2;
-    else if(data->compression_level == 1)
-	    data->compressed[8] = 4;
-    else
-	    data->compressed[8] = 0;
+	}
+	if (data->compression_level == 9) {
+		data->compressed[8] = 2;
+	} else if(data->compression_level == 1) {
+		data->compressed[8] = 4;
+	} else {
+		data->compressed[8] = 0;
+	}
 	data->compressed[9] = 3; /* OS=Unix */
 	data->stream.next_out += 10;
 	data->stream.avail_out -= 10;

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -263,7 +263,7 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 			data->stream.next_out += ofn_length + 1;
 			data->stream.avail_out -= ofn_length + 1;
 		} else {
-			archive_set_error(&a->archive, ENOMEM,
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 					  "Gzip 'Original Filename' ignored because it is too long");
 			ret = ARCHIVE_WARN;
 		}

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -222,7 +222,7 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	data->compressed[0] = 0x1f; /* GZip signature bytes */
 	data->compressed[1] = 0x8b;
 	data->compressed[2] = 0x08; /* "Deflate" compression */
-	data->compressed[3] = data->original_filename == NULL ? 0 : 0x8;
+	data->compressed[3] = 0x00; /* Flags */
 	if (data->timestamp >= 0) {
 		time_t t = time(NULL);
 		data->compressed[4] = (uint8_t)(t)&0xff;  /* Timestamp */
@@ -257,6 +257,7 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 			ofn_max_length = ofn_space_available;
 		}
 		if (ofn_length < ofn_max_length) {
+			data->compressed[3] |= 0x8;
 			strcpy((char*)data->compressed + 10,
 			       data->original_filename);
 			data->stream.next_out += ofn_length + 1;


### PR DESCRIPTION
The gzip:original_filename option just blindly copied its argument into the fixed-size buffer where we build the gzip header.  This could result in overflow.

This PR changes this to ignore the original-filename argument if it's bigger than 32k (or bigger than the buffer in case someone someday makes the default buffer smaller).

Thanks to @ttuurrnn for pointing this out.