### PR TITLE
Add a clang module map for libarchive

### DIFF
--- a/libarchive/module.modulemap
+++ b/libarchive/module.modulemap
@@ -1,0 +1,4 @@
+module CArchive {
+  header "archive.h"
+  header "archive_entry.h"
+}


### PR DESCRIPTION
When compiling libarchive using clang in module mode a special module.modulemap file describes the structure of the header files so that they can be imported modularly. Having this file makes it easier for modular uses of the library out of the box so that clients don't need to write their own, potentially making errors in doing so.

Add a module.modulemap in the public header file location so that clang and related tools can find it easily.