### PR TITLE
windows: remove support for WinCrypt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,12 +778,22 @@ IF(ENABLE_CNG)
   LA_CHECK_INCLUDE_FILE("bcrypt.h" HAVE_BCRYPT_H)
   IF(HAVE_BCRYPT_H)
     LIST(APPEND ADDITIONAL_LIBS "bcrypt")
+    # bcrypt supports these algorithms on all available versions
+    SET(ARCHIVE_CRYPTO_MD5        1)
+    SET(ARCHIVE_CRYPTO_MD5_WIN    1)
+    SET(ARCHIVE_CRYPTO_SHA1       1)
+    SET(ARCHIVE_CRYPTO_SHA1_WIN   1)
+    SET(ARCHIVE_CRYPTO_SHA256     1)
+    SET(ARCHIVE_CRYPTO_SHA256_WIN 1)
+    SET(ARCHIVE_CRYPTO_SHA384     1)
+    SET(ARCHIVE_CRYPTO_SHA384_WIN 1)
+    SET(ARCHIVE_CRYPTO_SHA512     1)
+    SET(ARCHIVE_CRYPTO_SHA512_WIN 1)
   ENDIF(HAVE_BCRYPT_H)
 ELSE(ENABLE_CNG)
   UNSET(HAVE_BCRYPT_H CACHE)
 ENDIF(ENABLE_CNG)
 # Following files need windows.h, so we should test it after windows.h test.
-LA_CHECK_INCLUDE_FILE("wincrypt.h" HAVE_WINCRYPT_H)
 LA_CHECK_INCLUDE_FILE("winioctl.h" HAVE_WINIOCTL_H)
 
 #
@@ -991,85 +1001,6 @@ main(int argc, char **argv)
       ENDIF(NOT ARCHIVE_CRYPTO_${ALGORITHM})
     ENDFOREACH(ALGORITHM ${ALGORITHMS})
 ENDMACRO(CHECK_CRYPTO ALGORITHMS IMPLEMENTATION)
-
-#
-# CRYPTO functions on Windows is defined at archive_windows.c, thus we do not
-# need the test what the functions can be mapped to archive_{crypto name}_init,
-# archive_{crypto name}_update and archive_{crypto name}_final.
-# The functions on Windows use CALG_{crypto name} macro to create a crypt object
-# and then we need to know what CALG_{crypto name} macros is available to show
-# ARCHIVE_CRYPTO_{crypto name}_WIN macros because Windows 2000 and earlier version
-# of Windows XP do not support SHA256, SHA384 and SHA512.
-#
-MACRO(CHECK_CRYPTO_WIN CRYPTO_LIST)
-  IF(WIN32 AND NOT CYGWIN)
-    FOREACH(CRYPTO ${CRYPTO_LIST})
-      IF(NOT ARCHIVE_CRYPTO_${CRYPTO})
-      IF(NOT DEFINED ARCHIVE_CRYPTO_${CRYPTO}_WIN)
-	STRING(TOUPPER "${CRYPTO}" crypto)
-	SET(ALGID "")
-	IF ("${CRYPTO}" MATCHES "^MD5$")
-	    SET(ALGID "CALG_MD5")
-	ENDIF ("${CRYPTO}" MATCHES "^MD5$")
-	IF ("${CRYPTO}" MATCHES "^SHA1$")
-	    SET(ALGID "CALG_SHA1")
-	ENDIF ("${CRYPTO}" MATCHES "^SHA1$")
-	IF ("${CRYPTO}" MATCHES "^SHA256$")
-	    SET(ALGID "CALG_SHA_256")
-	ENDIF ("${CRYPTO}" MATCHES "^SHA256$")
-	IF ("${CRYPTO}" MATCHES "^SHA384$")
-	    SET(ALGID "CALG_SHA_384")
-	ENDIF ("${CRYPTO}" MATCHES "^SHA384$")
-	IF ("${CRYPTO}" MATCHES "^SHA512$")
-	    SET(ALGID "CALG_SHA_512")
-	ENDIF ("${CRYPTO}" MATCHES "^SHA512$")
-
-    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.h.in
-      ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/confdefs.h)
-	FILE(READ "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/confdefs.h"
-	     CONFDEFS_H)
-
-	SET(SOURCE "${CONFDEFS_H}
-
-#define ${crypto}_COMPILE_TEST
-#include <windows.h>
-#include <wincrypt.h>
-
-int
-main(int argc, char **argv)
-{
-	return ${ALGID};
-}
-")
-	SET(SOURCE_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/check_crypto_win.c")
-
-	FILE(WRITE "${SOURCE_FILE}" "${SOURCE}")
-	MESSAGE(STATUS "Checking support for ARCHIVE_CRYPTO_${CRYPTO}_WIN")
-
-	TRY_COMPILE(ARCHIVE_CRYPTO_${CRYPTO}_WIN
-	  ${CMAKE_BINARY_DIR}
-	  ${SOURCE_FILE}
-	  CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_BINARY_DIR};${CMAKE_CURRENT_SOURCE_DIR}/libarchive"
-	  OUTPUT_VARIABLE OUTPUT)
-
-	IF (ARCHIVE_CRYPTO_${CRYPTO}_WIN)
-	    MESSAGE(STATUS
-	        "Checking support for ARCHIVE_CRYPTO_${CRYPTO}_WIN -- found")
-		SET(ARCHIVE_CRYPTO_${CRYPTO} 1)
-	ELSE (ARCHIVE_CRYPTO_${CRYPTO}_WIN)
-	    MESSAGE(STATUS
-	         "Checking support for ARCHIVE_CRYPTO_${CRYPTO}_WIN -- not found")
-    	    FILE(APPEND
-	        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
-                "Checking support for ARCHIVE_CRYPTO_${CRYPTO}_WIN failed with the following output:\n"
-        	"${OUTPUT}\n"
-        	"Source file was:\n${SOURCE}\n")
-	ENDIF (ARCHIVE_CRYPTO_${CRYPTO}_WIN)
-      ENDIF(NOT DEFINED ARCHIVE_CRYPTO_${CRYPTO}_WIN)
-      ENDIF(NOT ARCHIVE_CRYPTO_${CRYPTO})
-    ENDFOREACH(CRYPTO)
-  ENDIF(WIN32 AND NOT CYGWIN)
-ENDMACRO(CHECK_CRYPTO_WIN CRYPTO_LIST)
 
 #
 # Find iconv
@@ -2178,8 +2109,6 @@ CHECK_CRYPTO("MD5;RMD160;SHA1;SHA256;SHA384;SHA512" OPENSSL)
 
 # Libmd has to be probed after OpenSSL.
 CHECK_CRYPTO("MD5;RMD160;SHA1;SHA256;SHA512" LIBMD)
-
-CHECK_CRYPTO_WIN("MD5;SHA1;SHA256;SHA384;SHA512")
 
 # Check visibility annotations
 SET(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")

--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,7 @@ AC_CHECK_HEADERS([time.h unistd.h utime.h wchar.h wctype.h])
 AC_CHECK_TYPE([suseconds_t])
 AC_CHECK_HEADERS([windows.h])
 # check windows.h first; the other headers require it.
-AC_CHECK_HEADERS([wincrypt.h winioctl.h],[],[],
+AC_CHECK_HEADERS([winioctl.h],[],[],
 [[#ifdef HAVE_WINDOWS_H
 # include <windows.h>
 #endif

--- a/contrib/android/config/windows_host.h
+++ b/contrib/android/config/windows_host.h
@@ -899,9 +899,6 @@
 /* Define to 1 if you have the <wctype.h> header file. */
 #define HAVE_WCTYPE_H 1
 
-/* Define to 1 if you have the <wincrypt.h> header file. */
-#define HAVE_WINCRYPT_H 1
-
 /* Define to 1 if you have the <windows.h> header file. */
 #define HAVE_WINDOWS_H 1
 

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -210,7 +210,9 @@ __LA_DECL const char *  archive_openssl_version(void);
 __LA_DECL const char *  archive_libmd_version(void);
 __LA_DECL const char *  archive_commoncrypto_version(void);
 __LA_DECL const char *  archive_cng_version(void);
+#if ARCHIVE_VERSION_NUMBER < 4000000
 __LA_DECL const char *  archive_wincrypt_version(void);
+#endif
 __LA_DECL const char *  archive_librichacl_version(void);
 __LA_DECL const char *  archive_libacl_version(void);
 __LA_DECL const char *  archive_libattr_version(void);

--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -57,7 +57,7 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return 0;
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 #ifdef _MSC_VER
 #pragma comment(lib, "Bcrypt.lib")
 #endif
@@ -197,7 +197,7 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 	return 0;
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 
 static int
 aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -62,7 +62,7 @@ typedef struct {
 	unsigned	encr_pos;
 } archive_crypto_ctx;
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 #define	ARCHIVE_CRYPTOR_USE_CNG 1
 
@@ -143,16 +143,6 @@ typedef struct {
 } archive_crypto_ctx;
 
 #else
-
-#if defined(ARCHIVE_CRYPTO_MD5_WIN)    ||\
-	defined(ARCHIVE_CRYPTO_SHA1_WIN)   ||\
-	defined(ARCHIVE_CRYPTO_SHA256_WIN) ||\
-	defined(ARCHIVE_CRYPTO_SHA384_WIN) ||\
-	defined(ARCHIVE_CRYPTO_SHA512_WIN)
-#if defined(_WIN32) && !defined(__CYGWIN__) && !(defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA)
-#define ARCHIVE_CRYPTOR_USE_WINCRYPT 1
-#endif
-#endif
 
 #define AES_BLOCK_SIZE	16
 #define AES_MAX_KEY_SIZE 32

--- a/libarchive/archive_digest_private.h
+++ b/libarchive/archive_digest_private.h
@@ -165,23 +165,13 @@
   defined(ARCHIVE_CRYPTO_SHA256_WIN) ||\
   defined(ARCHIVE_CRYPTO_SHA384_WIN) ||\
   defined(ARCHIVE_CRYPTO_SHA512_WIN)
-#if defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
-/* don't use bcrypt when XP needs to be supported */
+#if defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 #define	ARCHIVE_CRYPTO_CNG 1
 typedef struct {
   int   valid;
   BCRYPT_ALG_HANDLE  hAlg;
   BCRYPT_HASH_HANDLE hHash;
-} Digest_CTX;
-#else
-#include <windows.h>
-#include <wincrypt.h>
-#define	ARCHIVE_CRYPTO_WINCRYPT 1
-typedef struct {
-  int   valid;
-  HCRYPTPROV  cryptProv;
-  HCRYPTHASH  hash;
 } Digest_CTX;
 #endif
 #endif

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -74,7 +74,7 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 
 #ifndef BCRYPT_HASH_REUSABLE_FLAG
 # define BCRYPT_HASH_REUSABLE_FLAG 0x00000020

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -52,7 +52,7 @@ int __libarchive_hmac_build_hack(void);
 
 typedef	CCHmacContext archive_hmac_sha1_ctx;
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 
 typedef struct {

--- a/libarchive/archive_version_details.c
+++ b/libarchive/archive_version_details.c
@@ -158,10 +158,6 @@ archive_crypto_version(struct archive_string* str)
 	archive_strcat(str, " libmd/");
 	archive_strcat(str, archive_libmd_version());
 #endif
-#if defined(ARCHIVE_CRYPTOR_USE_WINCRYPT)
-	archive_strcat(str, " WinCrypt/");
-	archive_strcat(str, archive_wincrypt_version());
-#endif
 	// Just in case
 	(void)str; /* UNUSED */
 }
@@ -431,27 +427,7 @@ archive_cng_version(void)
 const char *
 archive_wincrypt_version(void)
 {
-#if defined(ARCHIVE_CRYPTOR_USE_WINCRYPT) || defined(ARCHIVE_CRYPTO_WINCRYPT)
-	HCRYPTPROV prov;
-	if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
-		if (GetLastError() != (DWORD)NTE_BAD_KEYSET)
-			return NULL;
-		if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_NEWKEYSET))
-			return NULL;
-	}
-	DWORD version, length = sizeof(version);
-	if (!CryptGetProvParam(prov, PP_VERSION, (BYTE *)&version, &length, 0)) {
-		return NULL;
-	} else {
-		char major = (version >> 8) & 0xFF;
-		char minor = version & 0xFF;
-		static char wincrypt_version[6];
-		snprintf(wincrypt_version, 6, "%hhd.%hhd", major, minor);
-		return wincrypt_version;
-	}
-#else
 	return NULL;
-#endif
 }
 
 const char *


### PR DESCRIPTION
_As discussed in #2595_.

This has been locally tested with the cmake-based MSVC build system from Windows (Visual Studio 2022) and the autotools-based GCC build via msys2/mingw64.

## Open Questions

Considering that bcrypt is supported on all versions of Windows libarchive currently targets, should we drop the check for `bcrypt.h` and take it as a given? That will simplify a couple other code paths.

Same question for any platform toolchains that predate VS2008. Can we remove support for those?

Closes #2595