### PR TITLE
Fix invalid quoting in archive_entry_paths.3

### DIFF
--- a/libarchive/archive_entry_paths.3
+++ b/libarchive/archive_entry_paths.3
@@ -64,7 +64,7 @@ Streaming Archive Library (libarchive, -larchive)
 .Ft void
 .Fn archive_entry_copy_hardlink "struct archive_entry *a" "const char *path"
 .Ft void
-.Fn archive_entry_copy_hardlink_w "struct archive_entry *a "const wchar_t *path"
+.Fn archive_entry_copy_hardlink_w "struct archive_entry *a" "const wchar_t *path"
 .Ft int
 .Fn archive_entry_update_hardlink_utf8 "struct archive_entry *a" "const char *path"
 .Ft void


### PR DESCRIPTION
I'm working on a little mdoc parser and it tripped over this invalid quoting.