### PR TITLE
Avoid magic numbers in zip support code

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -82,7 +82,7 @@
 #define ZIP_LOCHDR_LEN		30U
 
 /* maximum length of Mac metadata in MiB */
-#define ZIP_MAX_METADATA	4U
+#define ZIP_MAX_METADATA	10U
 
 struct zip_entry {
 	struct archive_rb_node	node;


### PR DESCRIPTION
* zip: Avoid magic numbers

  Provide preprocessor macros for two recurring magic numbers in the zip
  support code: the length of the local file header (30 bytes) and the
  maximum allowable size for Mac metadata (4 MiB).

* zip: Increase max size of Mac metadata

  Raise the maximum size of Mac metadata from 4 MiB to 10 MiB, as that is
  the value used by Apple themselves in the version of libarchive included
  in Darwin.