### PR TITLE
Fix for an out-of-bounds buffer overrun when using p[H_LEVEL_OFFSET]

### DIFF
--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -689,7 +689,7 @@ archive_read_format_lha_read_header(struct archive_read *a,
 	 * a pathname and a symlink has '\' character, a directory
 	 * separator in DOS/Windows. So we should convert it to '/'.
 	 */
-	if (p[H_LEVEL_OFFSET] == 0)
+	if (lha->level == 0)
 		lha_replace_path_separator(lha, entry);
 
 	archive_entry_set_mode(entry, lha->mode);


### PR DESCRIPTION
This change fixes an error that occurs when attempting to read data from an invalid index in the p[] array, which can lead to a buffer overrun. The error occurs when checking p[H_LEVEL_OFFSET] when the buffer size is less than H_LEVEL_OFFSET.

Changes:
Replaced access to the p[] array with the existing lha->level field, which is initialized earlier during the archive header reading process.