### PR TITLE
[tar] Bounds check newdir_len

### DIFF
--- a/tar/util.c
+++ b/tar/util.c
@@ -314,7 +314,10 @@ set_chdir(struct bsdtar *bsdtar, const char *newdir)
 		/* The -C /foo -C bar case; concatenate */
 		char *old_pending = bsdtar->pending_chdir;
 		size_t old_len = strlen(old_pending);
-        size_t new_len = old_len + strlen(newdir) + 2;
+		size_t newdir_len = strlen(newdir);
+		size_t new_len = old_len + newdir_len + 2;
+		if (old_len > SIZE_MAX - newdir_len - 2)
+		    lafe_errc(1, errno, "Path too long");
 		bsdtar->pending_chdir = malloc(new_len);
 		if (old_pending[old_len - 1] == '/')
 			old_pending[old_len - 1] = '\0';


### PR DESCRIPTION
Honestly, this is of little consequence; if old_len is too big the program will crash anyway. However, an error exists just in case.