### PR TITLE
Have cab_strnlen behave like strnlen

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -543,11 +543,11 @@ cab_strnlen(const unsigned char *p, size_t maxlen)
 {
 	size_t i;
 
-	for (i = 0; i <= maxlen; i++) {
+	for (i = 0; i < maxlen; i++) {
 		if (p[i] == 0)
 			break;
 	}
-	if (i > maxlen)
+	if (i >= maxlen)
 		return (-1);/* invalid */
 	return ((ssize_t)i);
 }
@@ -691,13 +691,13 @@ cab_read_header(struct archive_read *a)
 		/* How many bytes are used for szCabinetPrev. */
 		if ((p = __archive_read_ahead(a, used+256, NULL)) == NULL)
 			return (truncated_error(a));
-		if ((len = cab_strnlen(p + used, 255)) <= 0)
+		if ((len = cab_strnlen(p + used, 256)) <= 0)
 			goto invalid;
 		used += len + 1;
 		/* How many bytes are used for szDiskPrev. */
 		if ((p = __archive_read_ahead(a, used+256, NULL)) == NULL)
 			return (truncated_error(a));
-		if ((len = cab_strnlen(p + used, 255)) <= 0)
+		if ((len = cab_strnlen(p + used, 256)) <= 0)
 			goto invalid;
 		used += len + 1;
 	}
@@ -705,13 +705,13 @@ cab_read_header(struct archive_read *a)
 		/* How many bytes are used for szCabinetNext. */
 		if ((p = __archive_read_ahead(a, used+256, NULL)) == NULL)
 			return (truncated_error(a));
-		if ((len = cab_strnlen(p + used, 255)) <= 0)
+		if ((len = cab_strnlen(p + used, 256)) <= 0)
 			goto invalid;
 		used += len + 1;
 		/* How many bytes are used for szDiskNext. */
 		if ((p = __archive_read_ahead(a, used+256, NULL)) == NULL)
 			return (truncated_error(a));
-		if ((len = cab_strnlen(p + used, 255)) <= 0)
+		if ((len = cab_strnlen(p + used, 256)) <= 0)
 			goto invalid;
 		used += len + 1;
 	}
@@ -807,7 +807,7 @@ cab_read_header(struct archive_read *a)
 		cab->cab_offset += 16;
 		if ((p = cab_read_ahead_remaining(a, 256, &avail)) == NULL)
 			return (truncated_error(a));
-		if ((len = cab_strnlen(p, avail-1)) <= 0)
+		if ((len = cab_strnlen(p, avail)) <= 0)
 			goto invalid;
 
 		/* Copy a pathname.  */

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -198,11 +198,11 @@ mtree_strnlen(const char *p, size_t maxlen)
 {
 	size_t i;
 
-	for (i = 0; i <= maxlen; i++) {
+	for (i = 0; i < maxlen; i++) {
 		if (p[i] == 0)
 			break;
 	}
-	if (i > maxlen)
+	if (i >= maxlen)
 		return (-1);/* invalid */
 	return (i);
 }

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -136,9 +136,6 @@ static int	skip(struct archive_read *a);
 static int	read_header(struct archive_read *,
 		    struct archive_entry *);
 static int64_t	mtree_atol(char **, int base);
-#ifndef HAVE_STRNLEN
-static size_t	mtree_strnlen(const char *, size_t);
-#endif
 
 /*
  * There's no standard for TIME_T_MAX/TIME_T_MIN.  So we compute them
@@ -202,8 +199,6 @@ mtree_strnlen(const char *p, size_t maxlen)
 		if (p[i] == 0)
 			break;
 	}
-	if (i >= maxlen)
-		return (-1);/* invalid */
 	return (i);
 }
 #endif

--- a/libarchive/test/test_read_data_large.c
+++ b/libarchive/test/test_read_data_large.c
@@ -96,7 +96,7 @@ DEFINE_TEST(test_read_data_large)
 #else
 	tmpfilefd = open(tmpfilename, O_WRONLY | O_CREAT | O_BINARY, 0777);
 #endif
-	assert(tmpfilefd != 0);
+	assert(tmpfilefd >= 0);
 	assertEqualIntA(a, 0, archive_read_data_into_fd(a, tmpfilefd));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));


### PR DESCRIPTION
Instead of subtracting 1, we should return -1 if we reach maxlen, since we start at 0.