### PR TITLE
Use pointer to size_t, not pointer to void.

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -402,7 +402,7 @@ static int cdeque_init(struct cdeque* d, int max_capacity_power_of_2) {
 		return CDE_PARAM;
 
 	cdeque_clear(d);
-	d->arr = malloc(sizeof(void*) * max_capacity_power_of_2);
+	d->arr = malloc(sizeof(size_t*) * max_capacity_power_of_2);
 
 	return d->arr ? CDE_OK : CDE_ALLOC;
 }


### PR DESCRIPTION
I don't think it matters but since d->arr is a size_t pointer, perhaps it should be a size_t pointer. Also silences an annoying clang-tidy warning.