### PR TITLE
Replace SetFilePointerEx_perso with NT kernel's SetFilePointerEx

### DIFF
--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -63,23 +63,6 @@
 #include <windows.h>
 #include <share.h>
 
-#if defined(__LA_LSEEK_NEEDED)
-static BOOL SetFilePointerEx_perso(HANDLE hFile,
-				   LARGE_INTEGER liDistanceToMove,
-				   PLARGE_INTEGER lpNewFilePointer,
-				   DWORD dwMoveMethod)
-{
-	LARGE_INTEGER li;
-	li.QuadPart = liDistanceToMove.QuadPart;
-	li.LowPart = SetFilePointer(
-		hFile, li.LowPart, &li.HighPart, dwMoveMethod);
-	if(lpNewFilePointer) {
-		lpNewFilePointer->QuadPart = li.QuadPart;
-	}
-	return li.LowPart != -1 || GetLastError() == NO_ERROR;
-}
-#endif
-
 struct ustat {
 	int64_t		st_atime;
 	uint32_t	st_atime_nsec;
@@ -285,7 +268,7 @@ __la_lseek(int fd, __int64 offset, int whence)
 		return (-1);
 	}
 	distance.QuadPart = offset;
-	if (!SetFilePointerEx_perso(handle, distance, &newpointer, whence)) {
+	if (!SetFilePointerEx(handle, distance, &newpointer, whence)) {
 		DWORD lasterr;
 
 		lasterr = GetLastError();

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -70,21 +70,6 @@
 #define	IO_REPARSE_TAG_SYMLINK 0xA000000CL
 #endif
 
-static BOOL SetFilePointerEx_perso(HANDLE hFile,
-                             LARGE_INTEGER liDistanceToMove,
-                             PLARGE_INTEGER lpNewFilePointer,
-                             DWORD dwMoveMethod)
-{
-	LARGE_INTEGER li;
-	li.QuadPart = liDistanceToMove.QuadPart;
-	li.LowPart = SetFilePointer(
-	    hFile, li.LowPart, &li.HighPart, dwMoveMethod);
-	if(lpNewFilePointer) {
-		lpNewFilePointer->QuadPart = li.QuadPart;
-	}
-	return li.LowPart != (DWORD)-1 || GetLastError() == NO_ERROR;
-}
-
 struct fixup_entry {
 	struct fixup_entry	*next;
 	struct archive_acl	 acl;
@@ -773,7 +758,7 @@ la_ftruncate(HANDLE handle, int64_t length)
 		return (-1);
 	}
 	distance.QuadPart = length;
-	if (!SetFilePointerEx_perso(handle, distance, NULL, FILE_BEGIN)) {
+	if (!SetFilePointerEx(handle, distance, NULL, FILE_BEGIN)) {
 		la_dosmaperr(GetLastError());
 		return (-1);
 	}


### PR DESCRIPTION
We do not support Windows XP anymore, we can go back to the NT kernel version instead of maintaining our own