### PR TITLE
libarchive/archive_util.c: Uninitialized variable

### DIFF
--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -427,7 +427,7 @@ __archive_issetugid(void)
 		return (-1);
 	if (ruid != euid || ruid != suid)
 		return (1);
-	if (getresgid(&ruid, &egid, &sgid) != 0)
+	if (getresgid(&rgid, &egid, &sgid) != 0)
 		return (-1);
 	if (rgid != egid || rgid != sgid)
 		return (1);


### PR DESCRIPTION
There is an uninitialized variable in archive_util.c (most probably due to a c&p typo):

```
libarchive/archive_util.c: In function '__archive_issetugid':
libarchive/archive_util.c:461:12: warning: 'rgid' may be used uninitialized [-Wmaybe-uninitialized]
  461 |         if (rgid != egid || rgid != sgid)
      |            ^
libarchive/archive_util.c:454:15: note: 'rgid' was declared here
  454 |         gid_t rgid, egid, sgid;
      |               ^~~~
```

This message is from 3.8.3, the fix is for the master branch.