### PR TITLE
Partially revert "Merge pull request #2679 from AZero13/error"

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1254,7 +1254,7 @@ parse_file(struct archive_read *a, struct archive_entry *entry,
 				archive_entry_filetype(entry) == AE_IFDIR) {
 			mtree->fd = open(path, O_RDONLY | O_BINARY | O_CLOEXEC);
 			__archive_ensure_cloexec_flag(mtree->fd);
-			if (mtree->fd < 0 && (
+			if (mtree->fd == -1 && (
 #if defined(_WIN32) && !defined(__CYGWIN__)
         /*
          * On Windows, attempting to open a file with an

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2561,9 +2561,9 @@ _archive_write_disk_close(struct archive *_a)
 			 * for directories. For other file types
 			 * we need to verify via fstat() or lstat()
 			 */
-			if (fd < 0 || p->filetype != AE_IFDIR) {
+			if (fd == -1 || p->filetype != AE_IFDIR) {
 #if HAVE_FSTAT
-				if (fd >= 0 && (
+				if (fd > 0 && (
 				    fstat(fd, &st) != 0 ||
 				    la_verify_filetype(st.st_mode,
 				    p->filetype) == 0)) {
@@ -4447,7 +4447,7 @@ fixup_appledouble(struct archive_write_disk *a, const char *pathname)
 	 */
 	fd = open(pathname, O_RDONLY | O_BINARY | O_CLOEXEC);
 	__archive_ensure_cloexec_flag(fd);
-	if (fd < 0) {
+	if (fd == -1) {
 		archive_set_error(&a->archive, errno,
 		    "Failed to open a restoring file");
 		ret = ARCHIVE_WARN;


### PR DESCRIPTION
This reverts commit d8aaf88c9feab047139df4cae60d845764a2480a, reversing changes made to ee49ac81068f93754f004368f2cc72c95a8bf056.

tree_reopen() and tree_dup() return NULL only of they are unable to allocate memory. Otherwise libarchive enters ARCHIVE_FATAL if trying to walk an enterable but unreadable directory.

__archive_ensure_cloexec_flag() operates only on fd >= 0 so there is no need to skip it

I have reimplemented the check around fdopendir()

Reported by:	Christian Weisgerber from OpenBSD