### PR TITLE
Add option to list tests

### DIFF
--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3681,10 +3681,18 @@ test_run(int i, const char *tmpdir)
  */
 
 static void
-usage(const char *program)
+list_tests(void)
 {
 	static const int limit = nitems(tests);
 	int i;
+
+	for (i = 0; i < limit; i++)
+		printf("  %d: %s\n", i, tests[i].name);
+}
+
+static void
+usage(const char *program)
+{
 
 	printf("Usage: %s [options] <test> <test> ...\n", program);
 	printf("Default is to run all tests.\n");
@@ -3693,6 +3701,8 @@ usage(const char *program)
 	printf("  -d  Dump core after any failure, for debugging.\n");
 	printf("  -k  Keep all temp files.\n");
 	printf("      Default: temp files for successful tests deleted.\n");
+	printf("  -l  List available tests and exit, ignoring all other.\n");
+	printf("      options and arguments.\n");
 #ifdef PROGRAM
 	printf("  -p <path>  Path to executable to be tested.\n");
 	printf("      Default: path taken from " ENVBASE " environment variable.\n");
@@ -3704,8 +3714,7 @@ usage(const char *program)
 	printf("  -u  Keep running specified tests until one fails.\n");
 	printf("  -v  Verbose.\n");
 	printf("Available tests:\n");
-	for (i = 0; i < limit; i++)
-		printf("  %d: %s\n", i, tests[i].name);
+	list_tests();
 	exit(1);
 }
 
@@ -4078,6 +4087,10 @@ main(int argc, char **argv)
 				break;
 			case 'k':
 				keep_temp_files = 1;
+				break;
+			case 'l':
+				list_tests();
+				exit(0);
 				break;
 			case 'p':
 #ifdef PROGRAM


### PR DESCRIPTION
The test runner already lists available tests if it fails to parse the command line, but add a `-l` option to explicitly do this without also printing an error message and a summary of options.