### PR TITLE
Use INVALID_SET_FILE_POINTER, as it is a DWORD

### DIFF
--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -76,7 +76,7 @@ static BOOL SetFilePointerEx_perso(HANDLE hFile,
 	if(lpNewFilePointer) {
 		lpNewFilePointer->QuadPart = li.QuadPart;
 	}
-	return li.LowPart != -1 || GetLastError() == NO_ERROR;
+	return li.LowPart != INVALID_SET_FILE_POINTER || GetLastError() == NO_ERROR;
 }
 #endif
 


### PR DESCRIPTION
INVALID_SET_FILE_POINTER also explains why -1 is an error.