### PR TITLE
Revert "Wait for the process instead of busy wait loop"

### DIFF
--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -779,18 +779,16 @@ pid_t
 __la_waitpid(HANDLE child, int *status, int option)
 {
 	DWORD cs;
-	DWORD wait_result;
 
-	(void)option; /* UNUSED */
-	wait_result = WaitForSingleObject(child, INFINITE);
-	if (wait_result != WAIT_OBJECT_0 ||
-	    GetExitCodeProcess(child, &cs) == 0)
-	{
-		la_dosmaperr(GetLastError());
-		CloseHandle(child);
-		*status = 0;
-		return (-1);
-	}
+	(void)option;/* UNUSED */
+	do {
+		if (GetExitCodeProcess(child, &cs) == 0) {
+			la_dosmaperr(GetLastError());
+			CloseHandle(child);
+			*status = 0;
+			return (-1);
+		}
+	} while (cs == STILL_ACTIVE);
 
 	CloseHandle(child);
 	*status = (int)(cs & 0xff);


### PR DESCRIPTION
Reverts libarchive/libarchive#2826

It was causing Windows test failures.