### PR TITLE
tar: Use UTF-8 by default

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -552,7 +552,7 @@ archive_read_format_tar_read_header(struct archive_read *a,
 	if (tar->sconv == NULL) {
 		if (!tar->init_default_conversion) {
 			tar->sconv_default =
-			    archive_string_default_conversion_for_read(&(a->archive));
+				archive_string_conversion_from_charset(&a->archive, "UTF-8", 1);
 			tar->init_default_conversion = 1;
 		}
 		tar->sconv = tar->sconv_default;


### PR DESCRIPTION
On Windows with ja-JP locale `pathname` was incorrectly converted to wide string using CP932 instead of CP65001.

https://github.com/microsoft/vcpkg/issues/43176#issuecomment-2585612872
https://github.com/microsoft/vcpkg/issues/48699#issuecomment-3680018230

To verify without changing system locale, use [activeCodePage](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#activecodepage) manifest property.

Not sure about performance implication of the change.