### PR TITLE
tar: When reading, open the file ourselves

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -70,8 +70,6 @@
 #endif
 #endif
 
-#define _PATH_STDIO "-"
-
 #ifdef __MINGW32__
 int _CRT_glob = 0; /* Disable broken CRT globbing. */
 #endif
@@ -220,9 +218,6 @@ main(int argc, char **argv)
 		}
 	}
 #endif
-	if (bsdtar->filename == NULL) {
-		bsdtar->filename = _PATH_STDIO;
-	}
 
 	/* Default block size settings. */
 	bsdtar->bytes_per_block = DEFAULT_BYTES_PER_BLOCK;
@@ -940,6 +935,7 @@ main(int argc, char **argv)
 		only_mode(bsdtar, "--check-links", "cr");
 
 	if ((bsdtar->flags & OPTFLAG_AUTO_COMPRESS) &&
+	    bsdtar->filename != NULL && *bsdtar->filename != '\0' &&
 	    cset_auto_compress(bsdtar->cset, bsdtar->filename)) {
 		/* Ignore specified compressions if auto-compress works. */
 		compression = '\0';
@@ -993,13 +989,14 @@ main(int argc, char **argv)
 	 * It is relevant for extraction or listing.
 	 */
 	archive_match_set_inclusion_recursion(bsdtar->matching,
-					      !(bsdtar->flags & OPTFLAG_NO_SUBDIRS));
+	    !(bsdtar->flags & OPTFLAG_NO_SUBDIRS));
 
 	/* Filename "-" implies stdio. */
-	if (strcmp(bsdtar->filename, "-") == 0)
+	if (bsdtar->filename != NULL &&
+	    (*bsdtar->filename == '\0' || strcmp(bsdtar->filename, "-") == 0))
 		bsdtar->filename = NULL;
 
-	switch(bsdtar->mode) {
+	switch (bsdtar->mode) {
 	case 'c':
 		tar_mode_c(bsdtar);
 		break;

--- a/tar/write.c
+++ b/tar/write.c
@@ -658,9 +658,6 @@ append_archive_filename(struct bsdtar *bsdtar, struct archive *a,
 	const char *filename = raw_filename;
 	int rc;
 
-	if (strcmp(filename, "-") == 0)
-		filename = NULL; /* Library uses NULL for stdio. */
-
 	ina = archive_read_new();
 	archive_read_support_format_all(ina);
 	archive_read_support_filter_all(ina);


### PR DESCRIPTION
See individual commits for details.

While working on this, I noticed that the manual page seems to suggest that `-a` defaults to bzip2. This does not appear to be the case. It defaults to no compression, just like I would expect. I'm not sure if the manual page is incorrect or if I'm just reading it wrong.

I didn't have the time to add tests, but ideally we should have test cases in `bsdtar_test` for the following:

* these all read any supported format from `stdin`:
  * `-t` without `-f`
  * `-t` with `-f ''`
  * `-t` with `-f -`
  * `-x` without `-f`
  * `-x` with `-f ''`
  * `-x` with `-f -`
* these all write an uncompressed pax archive to `stdout`:
  * `-c` without `-f`
  * `-c` with `-f ''`
  * `-c` with `-f -`
  * `-ca` without `-f`
  * `-ca` with `-f ''`
  * `-ca` with `-f -`

Some of these may already be covered, but I doubt they all are. This would be trivial to do with atf-sh; not so much with the current framework.