### PR TITLE
security: fix uncontrolled memory allocation in 7z parser

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2153,7 +2153,7 @@ read_PackInfo(struct archive_read *a, struct _7z_pack_info *pi)
 		return (-1);
 	if (UMAX_ENTRY < pi->numPackStreams)
 		return (-1);
-
+struct _7z_info *zip = (struct _7z_info *)(a->format->data);
 	/* Security Fix: Prevent OOM by checking numPackStreams against available header bytes */
 	if (pi->numPackStreams > zip->header_bytes_remaining)
 		return (-1);


### PR DESCRIPTION
Description: I have implemented a sanity check in archive_read_support_format_7z.c to prevent uncontrolled memory allocation (OOM).

The vulnerability was located in the read_Header function where numPackStreams was used to allocate memory via calloc without verifying if the requested size is reasonable compared to the available header bytes. This fix ensures that numPackStreams does not exceed zip->header_bytes_remaining, preventing potential Denial of Service (DoS) attacks from malicious 7z files.