### PR TITLE
cab: Add NULL check for memimage in cab_checksum_finish()

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1160,6 +1160,13 @@ cab_checksum_finish(struct archive_read *a)
 	if (cfdata->sum == 0)
 		return (ARCHIVE_OK);
 
+	/* Validate memimage before accessing. */
+	if (cfdata->memimage == NULL) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Invalid CAB data: missing CFDATA for checksum");
+		return (ARCHIVE_FATAL);
+	}
+
 	/*
 	 * Calculate the sum of remaining CFDATA.
 	 */

--- a/libarchive/test/test_fuzz_cab_null_deref.cab.uu
+++ b/libarchive/test/test_fuzz_cab_null_deref.cab.uu
@@ -1,0 +1,14 @@
+begin 644 test_fuzz_cab_null_deref.cab
+M35-#1@     ?BP@ N=-> #P      ! @#$4!  $    *0   9    &=9  !_
+M_P                  (            &0   !GB&X@ /____\         
+M  H   T  $E0BP@ N44!  $    *0   9 !,R$A$*B6CWKXFU2RK6=JL5D.%
+M"._,'V4 N/__!)P<"A\!^@ @W/TW>@ @3+!(1&<EH]Z^)D-O;75N8V&+FV5V
+M;6EN;W)E;1 W+5I'3E4N:7 @9I" FO+=G(LA?____QZX?,0$@7J+BL=90EIH
+M !=R13A0   ! '1D(&1E8V]M<')E<W-I;VX@9E+3!JWLQ\O]KY_^=[R-U$X 
+MN"+]_3=Z6'\!T2)DFL6P < *   -  !) F_3?H (VGSJ?=K_K5-YD9R7C6]N
+M;XISF[7MBG$^!@ "UO(BG(LA1 CA]!Z__'!!W0+OS.^:_T< 86%A8;K_N3]H
+M1$OEN("74&C#L!7*( OM!5 2TK,8 ( !? F0.-P$Q\O]KY^!A7R+QZ33!JWL
+MQ\O]KY_^=P   ^@ N)?]?P$5(M3'$.U5+FEP(&:0@)KRW9R+(7____\>N'S$
+A!(&%='__6<3>$#F"_#ZB3>AC[70ZG?_ -Q=0^-[_[P  
+`
+end


### PR DESCRIPTION
Validate cfdata->memimage is not NULL before accessing it during checksum calculation. This pointer can be uninitialized when processing certain malformed CAB files.