### PR TITLE
Fix incompatibility with Nettle 4.x

### DIFF
--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -109,6 +109,10 @@ typedef struct {
 #include <nettle/version.h>
 #define	ARCHIVE_CRYPTOR_USE_NETTLE 1
 
+#ifndef AES_MAX_KEY_SIZE
+#define AES_MAX_KEY_SIZE AES256_KEY_SIZE
+#endif
+
 typedef struct {
 #if NETTLE_VERSION_MAJOR < 3
 	struct aes_ctx	ctx;

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -198,6 +198,7 @@ static void __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 }
 
 #elif defined(HAVE_LIBNETTLE) && defined(HAVE_NETTLE_HMAC_H)
+#include <nettle/version.h>
 
 static int
 __hmac_sha1_init(archive_hmac_sha1_ctx *ctx, const uint8_t *key, size_t key_len)
@@ -216,7 +217,12 @@ __hmac_sha1_update(archive_hmac_sha1_ctx *ctx, const uint8_t *data,
 static void
 __hmac_sha1_final(archive_hmac_sha1_ctx *ctx, uint8_t *out, size_t *out_len)
 {
+#if NETTLE_VERSION_MAJOR < 4
 	hmac_sha1_digest(ctx, (unsigned)*out_len, out);
+#else
+	hmac_sha1_digest(ctx, out);
+	*out_len = SHA1_DIGEST_SIZE;
+#endif
 }
 
 static void


### PR DESCRIPTION
Nettle 4.x no longer defines `AES_MAX_KEY_SIZE`[^1] and removed the length argument from hash functions[^2].

[^1]: https://git.lysator.liu.se/nettle/nettle/-/blob/nettle_4.0_release_20260205/NEWS?ref_type=tags#L67
[^2]: https://git.lysator.liu.se/nettle/nettle/-/blob/nettle_4.0_release_20260205/NEWS?ref_type=tags#L31
