### PR TITLE
bsdunzip: Fix ISO week year and Gregorian year confusion

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -884,9 +884,9 @@ list(struct archive *a, struct archive_entry *e)
 	mtime = archive_entry_mtime(e);
 	tm = localtime(&mtime);
 	if (*y_str)
-		strftime(buf, sizeof(buf), "%m-%d-%G %R", tm);
+		strftime(buf, sizeof(buf), "%m-%d-%Y %R", tm);
 	else
-		strftime(buf, sizeof(buf), "%m-%d-%g %R", tm);
+		strftime(buf, sizeof(buf), "%m-%d-%y %R", tm);
 
 	pathname = archive_entry_pathname(e);
 	if (!pathname)


### PR DESCRIPTION
Tom Scott did [an explainer video](https://www.youtube.com/watch?v=D3jxx8Yyw1c) about this exact bug back in 2019.

**Test archive:**
```
$ touch -d "@1577731187" test.txt
$ zip test.zip test.txt
```

**Before this PR:**
```
$ ./bsdunzip -l test.zip
Archive:  test.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  12-30-20 19:39   test.txt
```

**After this PR:**
```
$ ./bsdunzip -l test.zip
Archive:  test.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  12-30-19 19:39   test.txt
```
