### PR TITLE
Fix NULL pointer dereference in cab_checksum_finish()

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1157,7 +1157,7 @@ cab_checksum_finish(struct archive_read *a)
 	int l;
 
 	/* Do not need to compute a sum. */
-	if (cfdata->sum == 0)
+	if (cfdata->sum == 0 || cfdata->memimage == NULL)
 		return (ARCHIVE_OK);
 
 	/*


### PR DESCRIPTION
cab_checksum_finish() dereferences cfdata->memimage without a NULL check. When a crafted CAB archive triggers the data-skip path after partial data consumption, memimage can be NULL, causing a SEGV at archive_le32dec.

Add a NULL guard for cfdata->memimage alongside the existing sum == 0 early return.

Fixes #2861

Without this patch:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==1==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000007 (pc 0x70c2523f4622 bp 0x7fffbac50510 sp 0x7fffbac504e0 T0)
==1==The signal is caused by a READ memory access.
==1==Hint: address points to the zero page.
    #0 0x70c2523f4622 in archive_le32dec /fuzz/src/libarchive/archive_endian.h:119
    #1 0x70c2523f8de8 in cab_checksum_cfdata_4 /fuzz/src/libarchive/archive_read_support_format_cab.c:1077
    #2 0x70c2523f8e2c in cab_checksum_cfdata /fuzz/src/libarchive/archive_read_support_format_cab.c:1090
    #3 0x70c2523f9792 in cab_checksum_finish /fuzz/src/libarchive/archive_read_support_format_cab.c:1176
    #4 0x70c2523fe9e0 in cab_minimum_consume_cfdata /fuzz/src/libarchive/archive_read_support_format_cab.c:1904
    #5 0x70c2523fe3ef in cab_consume_cfdata /fuzz/src/libarchive/archive_read_support_format_cab.c:1848
    #6 0x70c2523ff545 in archive_read_format_cab_read_data_skip /fuzz/src/libarchive/archive_read_support_format_cab.c:2003
    #7 0x70c2523ad7b5 in archive_read_data_skip /fuzz/src/libarchive/archive_read.c:926
    #8 0x70c2523ac279 in _archive_read_next_header2 /fuzz/src/libarchive/archive_read.c:625
    #9 0x70c2523ac6ff in _archive_read_next_header /fuzz/src/libarchive/archive_read.c:677
    #10 0x70c2524b3c79 in archive_read_next_header /fuzz/src/libarchive/archive_virtual.c:148
    #11 0x6517b37637dd in main /fuzz/harness.c:34
    #12 0x70c252113d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #13 0x70c252113e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #14 0x6517b3763384 in _start (/fuzz/harness+0x1384)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /fuzz/src/libarchive/archive_endian.h:119 in archive_le32dec
```

With this patch:
`Found entry: seed`


_This patch is generated by ASKRepair, an agentic automated vulnerability repair framework_