### PR TITLE
Fix retaining const qualifier from pointer -Wdiscarded-qualifiers

### DIFF
--- a/libarchive/archive_options.c
+++ b/libarchive/archive_options.c
@@ -31,9 +31,9 @@
 
 #include "archive_options_private.h"
 
-static const char *
-parse_option(const char **str,
-    const char **mod, const char **opt, const char **val);
+static char *
+parse_option(char **str,
+    char **mod, char **opt, char **val);
 
 int
 _archive_set_option(struct archive *a,
@@ -101,7 +101,7 @@ _archive_set_options(struct archive *a, const char *options,
 {
 	int allok = 1, anyok = 0, ignore_mod_err = 0, r;
 	char *data;
-	const char *s, *mod, *opt, *val;
+	char *s, *mod, *opt, *val;
 
 	archive_check_magic(a, magic, ARCHIVE_STATE_NEW, fn);
 
@@ -113,7 +113,7 @@ _archive_set_options(struct archive *a, const char *options,
 		    ENOMEM, "Out of memory adding file to list");
 		return (ARCHIVE_FATAL);
 	}
-	s = (const char *)data;
+	s = data;
 
 	do {
 		mod = opt = val = NULL;
@@ -165,10 +165,10 @@ _archive_set_options(struct archive *a, const char *options,
 	return allok ? ARCHIVE_OK : anyok ? ARCHIVE_WARN : ARCHIVE_FAILED;
 }
 
-static const char *
-parse_option(const char **s, const char **m, const char **o, const char **v)
+static char *
+parse_option(char **s, char **m, char **o, char **v)
 {
-	const char *end, *mod, *opt, *val;
+	char *end, *mod, *opt, *val;
 	char *p;
 
 	end = NULL;
@@ -180,7 +180,7 @@ parse_option(const char **s, const char **m, const char **o, const char **v)
 
 	if (p != NULL) {
 		*p = '\0';
-		end = ((const char *)p) + 1;
+		end = p + 1;
 	}
 
 	if (0 == strlen(opt)) {

--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -319,7 +319,7 @@ compare_format(const void *key, const void *element)
 pack_t *
 pack_find(const char *name)
 {
-	struct format	*format;
+	const struct format	*format;
 
 	format = bsearch(name, formats,
 	    sizeof(formats)/sizeof(formats[0]),

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -2095,8 +2095,7 @@ readline(struct archive_read *a, struct mtree *mtree, char **start,
 	ssize_t bytes_read;
 	ssize_t total_size = 0;
 	ssize_t find_off = 0;
-	const void *t;
-	void *nl;
+	const void *nl, *t;
 	char *u;
 
 	/* Accumulate line in a line buffer. */

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -3534,9 +3534,8 @@ readline(struct archive_read *a, struct tar *tar, const char **start,
 {
 	ssize_t bytes_read;
 	ssize_t total_size = 0;
-	const void *t;
+	const void *p, *t;
 	const char *s;
-	void *p;
 
 	if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
 		return (ARCHIVE_FATAL);

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -5526,7 +5526,7 @@ isoent_setup_file_location(struct iso9660 *iso9660, int location)
 static int
 get_path_component(char *name, size_t n, const char *fn)
 {
-	char *p;
+	const char *p;
 	size_t l;
 
 	p = strchr(fn, '/');

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -2041,7 +2041,7 @@ mtree_entry_find_child(struct mtree_entry *parent, const char *child_name)
 static int
 get_path_component(char *name, size_t n, const char *fn)
 {
-	char *p;
+	const char *p;
 	size_t l;
 
 	p = strchr(fn, '/');

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -371,7 +371,7 @@ _popul_ehdr(struct archive_string *tgt, size_t tsz, warc_essential_hdr_t hdr)
 		static const char _uri[] = "";
 		static const char _fil[] = "file://";
 		const char *u;
-		char *chk = strchr(hdr.tgturi, ':');
+		const char *chk = strchr(hdr.tgturi, ':');
 
 		if (chk != NULL && chk[1U] == '/' && chk[2U] == '/') {
 			/* yep, it's definitely a URI */


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes:
```c

../libarchive/archive_options.c: In function 'parse_option':
../libarchive/archive_options.c:179:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  179 |         p = strchr(opt, ',');
      |           ^
../libarchive/archive_options.c:194:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  194 |         p = strchr(opt, ':');
      |           ^
../libarchive/archive_options.c:201:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  201 |         p = strchr(opt, '=');
      |           ^
../libarchive/archive_pack_dev.c: In function 'pack_find':
../libarchive/archive_pack_dev.c:324:16: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  324 |         format = bsearch(name, formats,
      |                ^
../libarchive/archive_read_support_format_mtree.c: In function 'readline':
../libarchive/archive_read_support_format_mtree.c:2110:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2110 |                 nl = memchr(t, '\n', bytes_read);
      |                    ^
../libarchive/archive_read_support_format_tar.c: In function 'readline':
../libarchive/archive_read_support_format_tar.c:3549:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3549 |         p = memchr(t, '\n', bytes_read);
      |           ^
../libarchive/archive_read_support_format_tar.c:3590:19: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3590 |                 p = memchr(t, '\n', bytes_read);
      |                   ^
../libarchive/archive_write_set_format_iso9660.c: In function 'get_path_component':
../libarchive/archive_write_set_format_iso9660.c:5532:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 5532 |         p = strchr(fn, '/');
      |           ^
../libarchive/archive_write_set_format_mtree.c: In function 'get_path_component':
../libarchive/archive_write_set_format_mtree.c:2047:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2047 |         p = strchr(fn, '/');
      |           ^
../libarchive/archive_write_set_format_warc.c: In function '_popul_ehdr':
../libarchive/archive_write_set_format_warc.c:374:29: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  374 |                 char *chk = strchr(hdr.tgturi, ':');
      |                             ^~~~~~

``` 