### PR TITLE
libarchive: Correctly handle option failures

### DIFF
--- a/libarchive/archive_options.c
+++ b/libarchive/archive_options.c
@@ -90,7 +90,9 @@ _archive_set_either_option(struct archive *a, const char *m, const char *o, cons
 	if (r2 == ARCHIVE_FATAL)
 		return (ARCHIVE_FATAL);
 
-	if (r2 == ARCHIVE_WARN - 1)
+	if (r1 == ARCHIVE_WARN - 1)
+		return r2;
+	if (r2 == ARCHIVE_WARN -1)
 		return r1;
 	return r1 > r2 ? r1 : r2;
 }


### PR DESCRIPTION
If an incorrect option value has been passed to a filter, it is possible that library operations continue without even printing a warning.

This can happen because the special value `ARCHIVE_WARN - 1` is only checked for filter issues, not format issues. Since this special value is larger than `ARCHIVE_FAILED`, such failures are silently discarded.

Fix this by checking for this magic value for formats as well.

Proof of Concepts:

1. Trigger `ARCHIVE_FAILED` in `archive_filter_b64encode_options`
```
$ TAR_WRITER_OPTIONS='b64encode:!mode' bsdtar -cf null.tar.b64encode --b64encode /dev/null
bsdtar: Removing leading '/' from member names
```

2. Trigger `ARCHIVE_FAILED` in `archive_filter_b64encode_options` through `--options`
```
$ bsdtar -cf null.tar.b64encode --b64encode --options='b64encode:!mode' /dev/null
bsdtar: Unknown module name: `b64encode'
```

Explanation: Since `ARCHIVE_WARN - 1` for format options is larger than `ARCHIVE_FAILED` for filter options, it is preferred in variant 2, even falsely pretending that module b64encode is unknown. In variant 1, the error is silently ignored because environment variable parsing ignores "unknown formats/filters".