### PR TITLE
filter options: Use ARCHIVE_FAILED on errors

### DIFF
--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -127,8 +127,11 @@ archive_compressor_bzip2_options(struct archive_write_filter *f,
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression-level invalid");
+			return (ARCHIVE_FAILED);
+		}
 		data->compression_level = value[0] - '0';
 		/* Make '0' be a synonym for '1'. */
 		/* This way, bzip2 compressor supports the same 0..9

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -160,8 +160,11 @@ archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression-level invalid");
+			return (ARCHIVE_FAILED);
+		}
 		data->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -97,8 +97,11 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 	struct write_lrzip *data = (struct write_lrzip *)f->data;
 
 	if (strcmp(key, "compression") == 0) {
-		if (value == NULL)
-			return (ARCHIVE_WARN);
+		if (value == NULL) {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression option requires an argument");
+			return (ARCHIVE_FAILED);
+		}
 		else if (strcmp(value, "bzip2") == 0)
 			data->compression = bzip2;
 		else if (strcmp(value, "gzip") == 0)
@@ -109,13 +112,19 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 			data->compression = none;
 		else if (strcmp(value, "zpaq") == 0)
 			data->compression = zpaq;
-		else
-			return (ARCHIVE_WARN);
+		else {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression invalid");
+			return (ARCHIVE_FAILED);
+		}
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '1' && value[0] <= '9') ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression-level invalid");
+			return (ARCHIVE_FAILED);
+		}
 		data->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -160,8 +160,11 @@ archive_filter_lz4_options(struct archive_write_filter *f,
 	if (strcmp(key, "compression-level") == 0) {
 		int val;
 		if (value == NULL || !((val = value[0] - '0') >= 1 && val <= 9) ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression-level invalid");
+			return (ARCHIVE_FAILED);
+		}
 
 #ifndef HAVE_LZ4HC_H
 		if(val >= 3)
@@ -184,8 +187,11 @@ archive_filter_lz4_options(struct archive_write_filter *f,
 	}
 	if (strcmp(key, "block-size") == 0) {
 		if (value == NULL || !(value[0] >= '4' && value[0] <= '7') ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "block-size invalid");
+			return (ARCHIVE_FAILED);
+		}
 		data->block_maximum_size = value[0] - '0';
 		return (ARCHIVE_OK);
 	}

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -211,8 +211,11 @@ archive_write_lzop_options(struct archive_write_filter *f, const char *key,
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '1' && value[0] <= '9') ||
-		    value[1] != '\0')
-			return (ARCHIVE_WARN);
+		    value[1] != '\0') {
+			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
+			    "compression-level invalid");
+			return (ARCHIVE_FAILED);
+		}
 		data->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}


### PR DESCRIPTION
If a filter option is recognized but its value is invalid, return ARCHIVE_FAILED instead of ARCHIVE_WARN. The latter is used for unknown options, e.g. at the end of the option setter functions.

Proof of Concept:
```
$ bsdtar -acf null.tar.bz2 --options="bzip2:compression-level=A" /dev/null
bsdtar: Undefined option: `bzip2:compression-level'
```

The option itself is defined, but the value is incorrect. Return the correct error value (and text) instead.