### PR TITLE
tests: Build on older Darwin systems as well

### DIFF
--- a/tar/test/test_option_acls.c
+++ b/tar/test/test_option_acls.c
@@ -26,7 +26,9 @@ static const acl_perm_t acl_perms[] = {
     ACL_READ_SECURITY,
     ACL_WRITE_SECURITY,
     ACL_CHANGE_OWNER,
-    ACL_SYNCHRONIZE
+#if HAVE_DECL_ACL_SYNCHRONIZE
+	ACL_SYNCHRONIZE
+#endif
 #else /* !ARCHIVE_ACL_DARWIN */
     ACL_EXECUTE,
     ACL_WRITE,


### PR DESCRIPTION
Some Darwin systems lack ACL_SYNCHRONIZE. Copy the check from test_main.c into test_option_acls.c to support these as well.

Fixes libarchive/libarchive#2870