### PR TITLE
Fix file descriptor leak in mtree parser cleanup (CWE-775)

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -300,7 +300,12 @@ cleanup(struct archive_read *a)
 	struct mtree_entry *p, *q;
 
 	mtree = (struct mtree *)(a->format->data);
-
+	
+	/* Close any dangling file descriptor before freeing */
+    if (mtree->fd >= 0) {
+        close(mtree->fd);
+        mtree->fd = -1;
+    }
 	p = mtree->entries;
 	while (p != NULL) {
 		q = p->next;


### PR DESCRIPTION
### Description
This PR fixes a file descriptor leak in the `mtree` format parser that occurs when the `checkfs` option is enabled and the archive reading loop is aborted early.

*(Note: This issue was previously reported and discussed via the security mailing list, and I was advised by the maintainers to submit this PR.)*

### Root Cause
When parsing an `mtree` entry with physical file references (e.g., using the `contents=` keyword), the parser opens the file and assigns the descriptor to `mtree->fd`. 

If the client application breaks the `archive_read_next_header()` loop early (for example, upon finding a target file, or encountering an `ARCHIVE_WARN` due to an attribute mismatch), the format's `skip()` function is bypassed. Subsequently, when `archive_read_free()` is called, the format-specific `cleanup()` function is invoked. 

Currently, `cleanup()` frees allocated strings and resolvers but fails to check and close the dangling `mtree->fd`. In long-running processes or server-side automated scanning environments, this can lead to File Descriptor exhaustion (`-1 EMFILE`) and a Denial of Service (DoS).

### Proposed Fix
Added a check in `cleanup()` (`libarchive/archive_read_support_format_mtree.c`) to properly `close(mtree->fd)` and set it to `-1` before freeing the `mtree` structure.

### Testing
- Verified locally that the file descriptor is properly closed when `archive_read_free()` is called after an early loop break.
- Confirmed that resource exhaustion (EMFILE) no longer occurs when parsing crafted files in a continuous loop.