### PR TITLE
Prune FreeBSD CI from 10 variations down to 3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ env:
 
 FreeBSD_task:
   matrix:
-    - name: 15.0-STABLE (UFS) cmake
+    - name: 15.0-RELEASE (UFS) cmake
       freebsd_instance:
         image_family: freebsd-15-0-amd64-ufs
       env:


### PR DESCRIPTION
Previously, we tested many combinations of FreeBSD version, build system, and filesystem. In practice, that's redundant, and we've started seeing these excessive requests get throttled by Cirrus. Cutting back to just 3 combinations should suffice and reduce the risk of throttling.