### PR TITLE
Unchecked malloc result in archive_read_support_filter_program_signature()

### DIFF
--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -149,6 +149,8 @@ archive_read_support_filter_program_signature(struct archive *_a,
 	if (signature != NULL && signature_len > 0) {
 		state->signature_len = signature_len;
 		state->signature = malloc(signature_len);
+		if (state->signature == NULL)
+			goto memerr;
 		memcpy(state->signature, signature, signature_len);
 	}
 


### PR DESCRIPTION
If malloc() returns NULL (e.g., under memory pressure, container memory limits, or constrained embedded environments), the subsequent memcpy(NULL, ...) produces a SIGSEGV.
This is inconsistent with the error-handling pattern used elsewhere in the same function, which uses a `goto memerr` for all other allocations.
The bug was confirmed on libarchive 3.7.2 (Ubuntu 24.04) via two independent methods:

1. Self-contained ASAN build - NULL injection into a faithful code replica:

   AddressSanitizer: SEGV on unknown address 0x0 (WRITE)
     #0  __memmove_avx_unaligned_erms
     #1  vulnerable_signature_alloc ← crash site (line 152)
     #2  main

2. Real libarchive API call under ulimit memory constraint:

   archive_read_support_filter_program_signature(
     a, "bzip2 -d", sig, 256MB ← forces malloc failure
   )
   → SIGSEGV: write to 0x0000000000000000