### PR TITLE
Fix double-free in libarchive_linkify_fuzzer

### DIFF
--- a/contrib/oss-fuzz/libarchive_linkify_fuzzer.cc
+++ b/contrib/oss-fuzz/libarchive_linkify_fuzzer.cc
@@ -76,14 +76,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
     // This is the main function we want to fuzz (zero coverage)
     archive_entry_linkify(resolver, &entry, &spare);
 
-    // entry and spare may be modified by linkify
-    // We still need to free the original entries we allocated
+    // Update entries[i] to reflect ownership changes from linkify.
+    // If linkify cached the entry internally, entry is now NULL and the
+    // resolver owns the object. If linkify swapped it with a previously
+    // cached entry, entry points to that other object.
+    entries[i] = entry;
+
+    // Free any entry returned via spare (complete hardlink pair)
     if (spare != NULL) {
       archive_entry_free(spare);
     }
   }
 
-  // Free remaining entries from the resolver
+  // Free remaining entries from the resolver (drain loop)
   struct archive_entry *entry = NULL;
   struct archive_entry *spare = NULL;
   while (1) {
@@ -98,7 +103,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len) {
     }
   }
 
-  // Free all our created entries
+  // Free all our created entries that were NOT consumed by the resolver
   for (int i = 0; i < num_entries; i++) {
     if (entries[i] != NULL) {
       archive_entry_free(entries[i]);


### PR DESCRIPTION
## Summary

This is **not** a bug in libarchive. It is a bug in the fuzz harness `libarchive_linkify_fuzzer.cc` that causes a **heap-use-after-free (double-free)** detectable by AddressSanitizer.

The `archive_entry_linkify()` API works correctly — it properly manages entry ownership per its documented contract. The bug is that the harness fails to update `entries[i]` after `linkify` modifies the pointer (caching or swapping entries), causing the cleanup loop to free entries that were already freed.

### False Positive Impact

If left unfixed, any crash report from this fuzzer will be a **false positive** — the crash originates in the harness, not in libarchive. This can lead to:

- **Wasted developer time**: Maintainers investigating crashes that are not real libarchive bugs
- **Noise in OSS-Fuzz dashboards**: Persistent unfixed "bugs" that are actually harness defects
- **Amplified impact in the AI era**: AI-assisted fuzzing tools increasingly reference existing OSS-Fuzz harnesses as ground truth. A buggy harness pattern can be copied and propagated by LLM-based harness generators, multiplying false positives across downstream projects

### ASan Report

```
==13==ERROR: AddressSanitizer: heap-use-after-free on address 0x7ce9277e1980
WRITE of size 16 at 0x7ce9277e1980 thread T0
SCARINESS: 55 (multi-byte-write-heap-use-after-free)
    #0 __asan_memset
    #1 archive_wstring_free (archive_string.c:282)
    #2 archive_mstring_clean (archive_string.c:3912)
    #3 archive_entry_clear (archive_entry.c:158)
    #4 archive_entry_free (archive_entry.c:251)
    #5 LLVMFuzzerTestOneInput (libarchive_linkify_fuzzer.cc:104)

freed by thread T0 here:
    #0 free
    #1 LLVMFuzzerTestOneInput (libarchive_linkify_fuzzer.cc:93)

previously allocated by thread T0 here:
    #0 calloc
    #1 archive_entry_new (archive_entry.c:258)
    #2 LLVMFuzzerTestOneInput (libarchive_linkify_fuzzer.cc:48)

SUMMARY: AddressSanitizer: heap-use-after-free archive_string.c:282 in archive_wstring_free
```

### PoC

Crash input (23 bytes): `AygA1f8A5gAA/yoq////J3An/yEq//8=` (Base64)

### Root Cause

The harness creates entries in `entries[]`, passes each to `archive_entry_linkify()` via a local variable, but never updates `entries[i]` with the (possibly modified) pointer. When `linkify` caches an entry (sets pointer to NULL) or swaps it, `entries[i]` still holds the original pointer. The drain loop later frees the cached entry, and then the cleanup loop frees `entries[i]` again — double-free.

### Fix

Add `entries[i] = entry;` after the `linkify` call to track ownership changes. If the entry was cached, `entries[i]` becomes NULL and the cleanup loop skips it.