### PR TITLE
Add Swift support to contrib

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,0 +1,66 @@
+name: Swift CI
+
+on:
+  push:
+    branches: [ '*' ]
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package on Linux"
+        run: swift test -c release --parallel
+      - name: "Test expected build failure without dependencies"
+        run: '! swift test --enable-all-traits'
+      - name: "Install dependencies for additional traits"
+        run: sudo apt install -y liblzma-dev libbz2-dev
+      - name: "Test Swift Package on Linux with all traits"
+        run: swift test -c release --parallel --enable-all-traits
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@v2
+        with:
+          swift-version: nightly-6.3
+          swift-configuration: debug
+          free-disk-space: true
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package on macOS"
+        run: swift test -c release --parallel
+      - name: "Test Swift Package on macOS with all traits"
+        run: swift test -c release --parallel --enable-all-traits
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "List available simulators"
+        run: |
+          echo "::group::Available simulators"
+          xcrun simctl list devices available
+          echo "::endgroup::"
+      - name: "Test Swift Package on iOS"
+        run: xcodebuild test -sdk "iphonesimulator" -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" -scheme "Archive"
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          swift-version: swift-6.2-release
+          swift-build: 6.2-RELEASE
+      - uses: actions/checkout@v6
+      - run: swift test -c release
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,83 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Archive",
+    platforms: [.macOS(.v13), .iOS(.v15), .tvOS(.v15), .watchOS(.v10)],
+    products: [
+        .library(name: "Archive", targets: ["Archive"]),
+    ],
+    traits: [
+        // On macOS, zlib and bzip2 are in the SDK. On Linux, dev packages
+        // (liblzma-dev, libbz2-dev) must be installed separately, so compression
+        // traits are not enabled by default.
+        .trait(name: "GzipSupport", description: "Enable gzip compression (zlib)"),
+        .trait(name: "Bzip2Support", description: "Enable bzip2 compression"),
+        .trait(name: "LZMASupport", description: "Enable lzma compression (requires liblzma)"),
+        .trait(name: "ZstdSupport", description: "Enable Zstandard compression (requires libzstd)"),
+        .default(enabledTraits: [/*"GzipSupport"*/]),
+    ],
+    targets: [
+        .target(
+            name: "CArchive",
+            dependencies: [
+                .target(name: "Cliblzma", condition: .when(platforms: [.macOS, .linux, .android], traits: ["LZMASupport"])),
+                .target(name: "Clibzstd", condition: .when(platforms: [.macOS, .linux, .android], traits: ["ZstdSupport"])),
+            ],
+            path: "libarchive",
+            exclude: [ "test" ],
+            publicHeadersPath: ".",
+            cSettings: [
+                .headerSearchPath("../contrib/android/include", .when(platforms: [.android])),
+                .define("PLATFORM_CONFIG_H", to: "\"config_spm.h\""),
+                .define("HAVE_ZLIB_H", .when(traits: ["GzipSupport"])),
+                .define("HAVE_LIBZ", .when(traits: ["GzipSupport"])),
+                .define("HAVE_BZLIB_H", .when(traits: ["Bzip2Support"])),
+                .define("HAVE_LIBBZ2", .when(traits: ["Bzip2Support"])),
+                .define("HAVE_LZMA_H", .when(traits: ["LZMASupport"])),
+                .define("HAVE_LIBLZMA", .when(traits: ["LZMASupport"])),
+                .define("HAVE_LZMA_STREAM_ENCODER_MT", .when(traits: ["LZMASupport"])),
+                .define("HAVE_ZSTD_H", .when(traits: ["ZstdSupport"])),
+                .define("HAVE_LIBZSTD", .when(traits: ["ZstdSupport"])),
+                .define("HAVE_ZSTD_compressStream", .when(traits: ["ZstdSupport"])),
+            ],
+            linkerSettings: [
+                .linkedLibrary("z", .when(traits: ["GzipSupport"])),
+                .linkedLibrary("bz2", .when(traits: ["Bzip2Support"])),
+                .linkedLibrary("lzma", .when(platforms: [.macOS, .linux, .android], traits: ["LZMASupport"])),
+                .linkedLibrary("zstd", .when(platforms: [.macOS, .linux, .android], traits: ["ZstdSupport"])),
+                .linkedLibrary("iconv", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS])),
+                .linkedLibrary("crypto", .when(platforms: [.linux])),
+            ]
+        ),
+        .systemLibrary(
+            name: "Cliblzma",
+            path: "contrib/Swift/Sources/Cliblzma",
+            pkgConfig: "liblzma",
+            providers: [
+                .brew(["xz"]),
+                .apt(["liblzma-dev"])
+            ]
+        ),
+        .systemLibrary(
+            name: "Clibzstd",
+            path: "contrib/Swift/Sources/Clibzstd",
+            pkgConfig: "libzstd",
+            providers: [
+                .brew(["zstd"]),
+                .apt(["libzstd-dev"])
+            ]
+        ),
+        .target(
+            name: "Archive",
+            dependencies: ["CArchive"],
+            path: "contrib/Swift/Sources/Archive"
+        ),
+        .testTarget(
+            name: "ArchiveTests",
+            dependencies: ["Archive"],
+            path: "contrib/Swift/Tests/ArchiveTests"
+        ),
+    ]
+)

--- a/contrib/README
+++ b/contrib/README
@@ -6,6 +6,15 @@ I do not support or use any of these; but if you can use them, enjoy!
 
 ======================================================================
 
+From: Marc Prud'hommeaux <marc@prux.org>
+
+Swift
+
+A Swift 6.1 package that provides an idiomatic API atop libarchive
+and offers customizable traits in the Package.swift
+
+======================================================================
+
 From: Andre Stechert <andre@splunk.com>
 
 libarchive_autodetect-st_lib_archive.m4

--- a/contrib/Swift/README.md
+++ b/contrib/Swift/README.md
@@ -1,0 +1,174 @@
+# Swift libarchive Wrapper
+
+A Swift Package that compiles [libarchive](https://libarchive.org) from source and provides an idiomatic Swift API for reading and writing archive files.
+
+## Installation
+
+Add to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/libarchive/libarchive", from: "3.8.5")
+]
+```
+
+Then add `"Archive"` to your target's dependencies.
+
+## Quick Start
+
+### Reading an archive
+
+```swift
+import Archive
+
+// From a file
+let reader = try ArchiveReader(path: "/path/to/archive.tar.gz")
+try reader.forEachEntry { entry, reader in
+    print(entry.pathname)
+    let data = try reader.readData()
+}
+
+// From in-memory data
+let reader = try ArchiveReader(data: archiveData)
+let entries = try reader.listEntries()
+```
+
+### Writing an archive
+
+```swift
+import Archive
+
+// In-memory tar.gz
+let writer = try ArchiveWriter(format: .tar, filters: [.gzip])
+try writer.writeEntry(
+    ArchiveEntry(pathname: "hello.txt", size: Int64(data.count)),
+    data: data
+)
+let archiveData = try writer.finish()
+
+// Write to file
+let writer = try ArchiveWriter(path: "/tmp/out.zip", format: .zip)
+try writer.writeEntry(
+    ArchiveEntry(pathname: "file.txt", size: Int64(data.count)),
+    data: data
+)
+try writer.close()
+```
+
+### Extracting to disk
+
+```swift
+let reader = try ArchiveReader(data: archiveData)
+try reader.extractAll(to: "/tmp/output", options: .default)
+```
+
+### Data extensions
+
+```swift
+// Compress data into an archive
+let compressed = try myData.compress(as: "file.txt", format: .tar, filters: [.gzip])
+
+// Decompress archive data
+let files = try compressed.decompressArchive()  // [String: Data]
+
+// List entries
+let entries = try archiveData.archiveEntries()
+```
+
+## Supported Formats
+
+| Format | Read | Write |
+|--------|------|-------|
+| tar (pax, gnutar, ustar, v7) | Yes | Yes |
+| zip | Yes | Yes |
+| 7-Zip | Yes | Yes |
+| cpio | Yes | Yes |
+| ar | Yes | Yes |
+| xar | Yes | Yes |
+| ISO 9660 | Yes | Yes |
+| shar | No | Yes |
+| mtree | Yes | Yes |
+| WARC | Yes | Yes |
+| RAW | Yes | Yes |
+| RAR, LHA, CAB | Yes | No |
+
+## Compression Filters
+
+| Filter | Read | Write | Trait |
+|--------|------|-------|-------|
+| gzip | Yes | Yes | `GzipSupport` (default) |
+| bzip2 | Yes | Yes | `Bzip2Support` (default) |
+| compress | Yes | Yes | Always available |
+| xz/lzma | Yes | Yes | `LZMASupport` (requires liblzma) |
+| zstd | Yes | Yes | `ZstdSupport` (requires libzstd) |
+| lz4 | Yes | Yes | Always available |
+
+### Filter composition
+
+Combine format and filters for common archive types:
+
+```swift
+// .tar.gz
+try ArchiveWriter(format: .tar, filters: [.gzip])
+
+// .tar.bz2
+try ArchiveWriter(format: .tar, filters: [.bzip2])
+
+// .tar.xz (requires LZMASupport trait)
+try ArchiveWriter(format: .tar, filters: [.xz])
+```
+
+## Traits Configuration
+
+The package uses Swift Package Manager traits to control optional compression library support:
+
+| Trait | Default | Description |
+|-------|---------|-------------|
+| `GzipSupport` | Enabled | zlib (available in macOS SDK) |
+| `Bzip2Support` | Enabled | bzip2 (available in macOS SDK) |
+| `LZMASupport` | Disabled | Requires liblzma (e.g., `brew install xz`) |
+| `ZstdSupport` | Disabled | Requires libzstd (e.g., `brew install zstd`) |
+
+Enable additional traits:
+
+```bash
+swift build --traits LZMASupport,ZstdSupport
+```
+
+## Error Handling
+
+All operations throw `ArchiveError` on failure:
+
+```swift
+do {
+    let reader = try ArchiveReader(data: corruptData)
+    _ = try reader.listEntries()
+} catch let error as ArchiveError {
+    print(error.code)     // libarchive errno
+    print(error.message)  // Human-readable description
+}
+```
+
+## Extract Options
+
+Control extraction behavior with `ExtractOptions`:
+
+```swift
+let reader = try ArchiveReader(data: archiveData)
+try reader.extractAll(to: "/tmp/out", options: [.permissions, .time, .secure])
+```
+
+Available options: `.permissions`, `.time`, `.owner`, `.acl`, `.xattr`, `.fflags`, `.noOverwrite`, `.noOverwriteNewer`, `.secure`.
+
+## Concurrency
+
+- `ArchiveEntry`, `ArchiveError`, `ArchiveFormat`, `ArchiveFilter`, `FileType`, and `ExtractOptions` are all `Sendable`
+- `ArchiveReader` and `ArchiveWriter` are reference types (classes) that should not be shared across threads
+
+## Architecture
+
+The package has three targets:
+
+1. **CArchive** — C target that compiles libarchive sources directly
+2. **Archive** — Swift wrapper with idiomatic API
+3. **ArchiveTests** — Tests using Swift Testing framework

--- a/contrib/Swift/Sources/Archive/Archive.swift
+++ b/contrib/Swift/Sources/Archive/Archive.swift
@@ -1,0 +1,14 @@
+@_exported import CArchive
+
+/// Namespace for libarchive Swift wrapper.
+public enum Archive {
+    /// The version of the underlying libarchive C library.
+    public static var version: String {
+        String(cString: archive_version_string())
+    }
+
+    /// The detailed version of the underlying libarchive C library.
+    public static var versionDetails: String {
+        String(cString: archive_version_details())
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveEntry.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveEntry.swift
@@ -1,0 +1,132 @@
+import CArchive
+import Foundation
+
+// AE_IF* macros use C type casts that Swift can't import directly.
+// Define them as Swift constants.
+private let AE_IFREG: UInt32  = 0o100000
+private let AE_IFDIR: UInt32  = 0o040000
+private let AE_IFLNK: UInt32  = 0o120000
+private let AE_IFBLK: UInt32  = 0o060000
+private let AE_IFCHR: UInt32  = 0o020000
+private let AE_IFIFO: UInt32  = 0o010000
+private let AE_IFSOCK: UInt32 = 0o140000
+
+/// The type of an archive entry.
+public enum FileType: Sendable {
+    case regular
+    case directory
+    case symbolicLink
+    case hardLink
+    case blockDevice
+    case characterDevice
+    case fifo
+    case socket
+
+    internal var cValue: UInt32 {
+        switch self {
+        case .regular: return AE_IFREG
+        case .directory: return AE_IFDIR
+        case .symbolicLink: return AE_IFLNK
+        case .hardLink: return 0
+        case .blockDevice: return AE_IFBLK
+        case .characterDevice: return AE_IFCHR
+        case .fifo: return AE_IFIFO
+        case .socket: return AE_IFSOCK
+        }
+    }
+
+    internal init?(cValue: UInt32) {
+        switch cValue {
+        case AE_IFREG: self = .regular
+        case AE_IFDIR: self = .directory
+        case AE_IFLNK: self = .symbolicLink
+        case AE_IFBLK: self = .blockDevice
+        case AE_IFCHR: self = .characterDevice
+        case AE_IFIFO: self = .fifo
+        case AE_IFSOCK: self = .socket
+        default: return nil
+        }
+    }
+}
+
+/// A value type representing an entry (file/directory) in an archive.
+public struct ArchiveEntry: Sendable {
+    public var pathname: String
+    public var size: Int64
+    public var fileType: FileType
+    /// POSIX permissions (e.g. 0o644).
+    public var permissions: UInt16
+    public var modificationDate: Date
+    public var uid: UInt32
+    public var gid: UInt32
+    public var symlinkTarget: String?
+    public var hardlinkTarget: String?
+
+    public init(
+        pathname: String,
+        size: Int64 = 0,
+        fileType: FileType = .regular,
+        permissions: UInt16 = 0o644,
+        modificationDate: Date = Date(),
+        uid: UInt32 = 0,
+        gid: UInt32 = 0,
+        symlinkTarget: String? = nil,
+        hardlinkTarget: String? = nil
+    ) {
+        self.pathname = pathname
+        self.size = size
+        self.fileType = fileType
+        self.permissions = permissions
+        self.modificationDate = modificationDate
+        self.uid = uid
+        self.gid = gid
+        self.symlinkTarget = symlinkTarget
+        self.hardlinkTarget = hardlinkTarget
+    }
+
+    /// Creates from a libarchive entry pointer.
+    internal init?(entry: OpaquePointer?) {
+        guard let entry = entry else { return nil }
+        guard let pathPtr = archive_entry_pathname(entry) else { return nil }
+        self.pathname = String(cString: pathPtr)
+        self.size = archive_entry_size(entry)
+        let ft = UInt32(archive_entry_filetype(entry))
+        if let symTarget = archive_entry_symlink(entry), ft == AE_IFLNK {
+            self.fileType = .symbolicLink
+            self.symlinkTarget = String(cString: symTarget)
+        } else if let hlTarget = archive_entry_hardlink(entry) {
+            self.fileType = .hardLink
+            self.hardlinkTarget = String(cString: hlTarget)
+        } else {
+            self.fileType = FileType(cValue: ft) ?? .regular
+            self.symlinkTarget = nil
+            self.hardlinkTarget = nil
+        }
+        self.permissions = UInt16(archive_entry_perm(entry))
+        let mtime = archive_entry_mtime(entry)
+        self.modificationDate = Date(timeIntervalSince1970: TimeInterval(mtime))
+        self.uid = UInt32(archive_entry_uid(entry))
+        self.gid = UInt32(archive_entry_gid(entry))
+    }
+
+    /// Applies this entry's metadata to a libarchive entry pointer.
+    internal func apply(to entry: OpaquePointer) {
+        archive_entry_set_pathname(entry, pathname)
+        archive_entry_set_size(entry, size)
+        archive_entry_set_filetype(entry, UInt32(fileType.cValue))
+        #if os(Windows)
+        archive_entry_set_perm(entry, UInt16(permissions))
+        #else
+        archive_entry_set_perm(entry, mode_t(permissions))
+        #endif
+        archive_entry_set_mtime(entry, time_t(modificationDate.timeIntervalSince1970), 0)
+        archive_entry_set_uid(entry, Int64(uid))
+        archive_entry_set_gid(entry, Int64(gid))
+        if let target = symlinkTarget {
+            archive_entry_set_symlink(entry, target)
+        }
+        if let target = hardlinkTarget {
+            archive_entry_set_hardlink(entry, target)
+        }
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveError.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveError.swift
@@ -1,0 +1,29 @@
+import CArchive
+
+/// An error from libarchive operations.
+public struct ArchiveError: Error, Sendable, CustomStringConvertible {
+    /// The libarchive error code.
+    public let code: Int32
+    /// The human-readable error message.
+    public let message: String
+
+    public var description: String {
+        "ArchiveError(\(code)): \(message)"
+    }
+
+    /// Creates an error from a libarchive archive pointer.
+    internal init(archive: OpaquePointer) {
+        self.code = Int32(archive_errno(archive))
+        if let msg = archive_error_string(archive) {
+            self.message = String(cString: msg)
+        } else {
+            self.message = "Unknown archive error"
+        }
+    }
+
+    /// Creates an error with a custom message.
+    internal init(code: Int32 = -1, message: String) {
+        self.code = code
+        self.message = message
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveExtractOptions.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveExtractOptions.swift
@@ -1,0 +1,32 @@
+import CArchive
+
+/// Options controlling archive extraction behavior.
+public struct ExtractOptions: OptionSet, Sendable {
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    /// Restore file permissions.
+    public static let permissions = ExtractOptions(rawValue: ARCHIVE_EXTRACT_PERM)
+    /// Restore file modification time.
+    public static let time = ExtractOptions(rawValue: ARCHIVE_EXTRACT_TIME)
+    /// Restore file ownership.
+    public static let owner = ExtractOptions(rawValue: ARCHIVE_EXTRACT_OWNER)
+    /// Restore ACLs.
+    public static let acl = ExtractOptions(rawValue: ARCHIVE_EXTRACT_ACL)
+    /// Restore extended attributes.
+    public static let xattr = ExtractOptions(rawValue: ARCHIVE_EXTRACT_XATTR)
+    /// Restore file flags (macOS/BSD).
+    public static let fflags = ExtractOptions(rawValue: ARCHIVE_EXTRACT_FFLAGS)
+    /// Do not overwrite existing files.
+    public static let noOverwrite = ExtractOptions(rawValue: ARCHIVE_EXTRACT_NO_OVERWRITE)
+    /// Do not overwrite newer files.
+    public static let noOverwriteNewer = ExtractOptions(rawValue: ARCHIVE_EXTRACT_NO_OVERWRITE_NEWER)
+    /// Refuse to extract absolute paths or paths with `..` components.
+    public static let secure = ExtractOptions(rawValue: ARCHIVE_EXTRACT_SECURE_NODOTDOT | ARCHIVE_EXTRACT_SECURE_SYMLINKS | ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS)
+
+    /// A reasonable default: permissions + time + security.
+    public static let `default`: ExtractOptions = [.permissions, .time, .secure]
+}

--- a/contrib/Swift/Sources/Archive/ArchiveFilter.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveFilter.swift
@@ -1,0 +1,43 @@
+import CArchive
+
+/// Supported archive compression filters.
+public enum ArchiveFilter: Sendable {
+    case none
+	case compress
+	case lz4
+    #if GzipSupport
+    case gzip
+    #endif
+    #if Bzip2Support
+    case bzip2
+    #endif
+    #if LZMASupport
+    case lzma
+    case xz
+    #endif
+    #if ZstdSupport
+    case zstd
+    #endif
+
+    /// Adds this filter to an archive write handle.
+    internal func addWriteFilter(_ a: OpaquePointer) -> Int32 {
+        switch self {
+        case .none: return archive_write_add_filter_none(a)
+		case .compress: return archive_write_add_filter_compress(a)
+		case .lz4: return archive_write_add_filter_lz4(a)
+        #if GzipSupport
+        case .gzip: return archive_write_add_filter_gzip(a)
+        #endif
+        #if Bzip2Support
+        case .bzip2: return archive_write_add_filter_bzip2(a)
+        #endif
+        #if LZMASupport
+        case .lzma: return archive_write_add_filter_lzma(a)
+        case .xz: return archive_write_add_filter_xz(a)
+        #endif
+        #if ZstdSupport
+        case .zstd: return archive_write_add_filter_zstd(a)
+        #endif
+        }
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveFormat.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveFormat.swift
@@ -1,0 +1,68 @@
+import CArchive
+
+/// Supported archive formats.
+public enum ArchiveFormat: Sendable {
+    case tar
+    case zip
+    case sevenZip
+    case cpio
+    case ar
+    case iso9660
+    case xar
+    case raw
+    case shar
+    case mtree
+    case warc
+
+    /// The libarchive format code for writing.
+    internal var writeFormatCode: Int32 {
+        switch self {
+        case .tar: return ARCHIVE_FORMAT_TAR
+        case .zip: return ARCHIVE_FORMAT_ZIP
+        case .sevenZip: return ARCHIVE_FORMAT_7ZIP
+        case .cpio: return ARCHIVE_FORMAT_CPIO
+        case .ar: return ARCHIVE_FORMAT_AR
+        case .iso9660: return ARCHIVE_FORMAT_ISO9660
+        case .xar: return ARCHIVE_FORMAT_XAR
+        case .raw: return ARCHIVE_FORMAT_RAW
+        case .shar: return ARCHIVE_FORMAT_SHAR
+        case .mtree: return ARCHIVE_FORMAT_MTREE
+        case .warc: return ARCHIVE_FORMAT_WARC
+        }
+    }
+
+    /// Creates from a libarchive format code (masking sub-format bits).
+    internal init?(rawFormat: Int32) {
+        switch rawFormat & ARCHIVE_FORMAT_BASE_MASK {
+        case ARCHIVE_FORMAT_TAR: self = .tar
+        case ARCHIVE_FORMAT_ZIP: self = .zip
+        case ARCHIVE_FORMAT_7ZIP: self = .sevenZip
+        case ARCHIVE_FORMAT_CPIO: self = .cpio
+        case ARCHIVE_FORMAT_AR: self = .ar
+        case ARCHIVE_FORMAT_ISO9660: self = .iso9660
+        case ARCHIVE_FORMAT_XAR: self = .xar
+        case ARCHIVE_FORMAT_RAW: self = .raw
+        case ARCHIVE_FORMAT_SHAR: self = .shar
+        case ARCHIVE_FORMAT_MTREE: self = .mtree
+        case ARCHIVE_FORMAT_WARC: self = .warc
+        default: return nil
+        }
+    }
+
+    /// Sets up the write format on an archive pointer.
+    internal func setWriteFormat(_ a: OpaquePointer) -> Int32 {
+        switch self {
+        case .tar: return archive_write_set_format_pax_restricted(a)
+        case .zip: return archive_write_set_format_zip(a)
+        case .sevenZip: return archive_write_set_format_7zip(a)
+        case .cpio: return archive_write_set_format_cpio_newc(a)
+        case .ar: return archive_write_set_format_ar_svr4(a)
+        case .iso9660: return archive_write_set_format_iso9660(a)
+        case .xar: return archive_write_set_format_xar(a)
+        case .raw: return archive_write_set_format_raw(a)
+        case .shar: return archive_write_set_format_shar_dump(a)
+        case .mtree: return archive_write_set_format_mtree(a)
+        case .warc: return archive_write_set_format_warc(a)
+        }
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveReader.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveReader.swift
@@ -1,0 +1,152 @@
+import CArchive
+import Foundation
+
+/// Reads entries and data from an archive.
+public final class ArchiveReader {
+    private let archive: OpaquePointer
+    /// Using NSData for a stable .bytes pointer that outlives withUnsafeBytes.
+    private let retainedData: NSData?
+
+    /// Opens an archive from a file path.
+    public init(path: String) throws {
+        guard let a = archive_read_new() else {
+            throw ArchiveError(message: "Failed to create archive reader")
+        }
+        self.archive = a
+        self.retainedData = nil
+        archive_read_support_filter_all(a)
+        archive_read_support_format_all(a)
+        let r = archive_read_open_filename(a, path, 10240)
+        if r != ARCHIVE_OK {
+            throw ArchiveError(archive: a)
+            // deinit will call archive_read_free
+        }
+    }
+
+    /// Opens an archive from in-memory data.
+    public init(data: Data) throws {
+        guard let a = archive_read_new() else {
+            throw ArchiveError(message: "Failed to create archive reader")
+        }
+        self.archive = a
+        let nsData = data as NSData
+        self.retainedData = nsData
+        archive_read_support_filter_all(a)
+        archive_read_support_format_all(a)
+        let r = archive_read_open_memory(a, nsData.bytes, nsData.length)
+        if r != ARCHIVE_OK {
+            throw ArchiveError(archive: a)
+        }
+    }
+
+    deinit {
+        archive_read_free(archive)
+    }
+
+    /// The detected archive format, available after reading the first header.
+    public var format: ArchiveFormat? {
+        ArchiveFormat(rawFormat: archive_format(archive))
+    }
+
+    private func nextHeader() throws -> OpaquePointer? {
+        var entryPtr: OpaquePointer?
+        let r = archive_read_next_header(archive, &entryPtr)
+        if r == ARCHIVE_EOF { return nil }
+        if r != ARCHIVE_OK && r != ARCHIVE_WARN {
+            throw ArchiveError(archive: archive)
+        }
+        return entryPtr
+    }
+
+    /// Iterates over all entries in the archive.
+    ///
+    /// Call `readData()` within the closure to get the entry's contents.
+    public func forEachEntry(_ body: (ArchiveEntry, ArchiveReader) throws -> Void) throws {
+        while let ep = try nextHeader() {
+            guard let entry = ArchiveEntry(entry: ep) else { continue }
+            try body(entry, self)
+        }
+    }
+
+    /// Reads the data for the current entry.
+    public func readData() throws -> Data {
+        var result = Data()
+        var buffer: UnsafeRawPointer?
+        var size: Int = 0
+        var offset: Int64 = 0
+        while true {
+            let r = archive_read_data_block(archive, &buffer, &size, &offset)
+            if r == ARCHIVE_EOF { break }
+            if r != ARCHIVE_OK {
+                throw ArchiveError(archive: archive)
+            }
+            if let buffer = buffer, size > 0 {
+                result.append(UnsafeBufferPointer(
+                    start: buffer.assumingMemoryBound(to: UInt8.self),
+                    count: size
+                ))
+            }
+        }
+        return result
+    }
+
+    /// Extracts the entire archive to the specified directory.
+    public func extractAll(to directory: String, options: ExtractOptions = .default) throws {
+        guard let disk = archive_write_disk_new() else {
+            throw ArchiveError(message: "Failed to create disk writer")
+        }
+        defer { archive_write_free(disk) }
+        // Remove security flags that conflict with our path rewriting:
+        // - SECURE_NOABSOLUTEPATHS: we prepend the directory ourselves
+        // - SECURE_SYMLINKS: macOS /var is a symlink to /private/var
+        let conflictFlags = ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS | ARCHIVE_EXTRACT_SECURE_SYMLINKS
+        archive_write_disk_set_options(disk, options.rawValue & ~conflictFlags)
+        archive_write_disk_set_standard_lookup(disk)
+
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        if !fm.fileExists(atPath: directory, isDirectory: &isDir) {
+            try fm.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        }
+
+        while let ep = try nextHeader() {
+            if let origPath = archive_entry_pathname(ep) {
+                let fullPath = (directory as NSString).appendingPathComponent(String(cString: origPath))
+                archive_entry_set_pathname(ep, fullPath)
+            }
+            let wh = archive_write_header(disk, ep)
+            if wh != ARCHIVE_OK && wh != ARCHIVE_WARN {
+                throw ArchiveError(archive: disk)
+            }
+            var buf: UnsafeRawPointer?
+            var size: Int = 0
+            var offset: Int64 = 0
+            while true {
+                let dr = archive_read_data_block(archive, &buf, &size, &offset)
+                if dr == ARCHIVE_EOF { break }
+                if dr != ARCHIVE_OK {
+                    throw ArchiveError(archive: archive)
+                }
+                let wr = archive_write_data_block(disk, buf, size, offset)
+                if wr != ARCHIVE_OK {
+                    throw ArchiveError(archive: disk)
+                }
+            }
+            let fe = archive_write_finish_entry(disk)
+            if fe != ARCHIVE_OK && fe != ARCHIVE_WARN {
+                throw ArchiveError(archive: disk)
+            }
+        }
+    }
+
+    /// Lists all entries in the archive without reading data.
+    public func listEntries() throws -> [ArchiveEntry] {
+        var entries: [ArchiveEntry] = []
+        while let ep = try nextHeader() {
+            if let entry = ArchiveEntry(entry: ep) {
+                entries.append(entry)
+            }
+        }
+        return entries
+    }
+}

--- a/contrib/Swift/Sources/Archive/ArchiveWriter.swift
+++ b/contrib/Swift/Sources/Archive/ArchiveWriter.swift
@@ -1,0 +1,126 @@
+import CArchive
+import Foundation
+
+/// Writes entries and data to an archive.
+public final class ArchiveWriter {
+    private let archive: OpaquePointer
+    private let entry: OpaquePointer
+    private let tempPath: String?
+    private var closed = false
+
+    /// Creates a writer that writes to a temporary file (for in-memory use).
+    ///
+    /// Call `finish()` to get the resulting `Data`.
+    public init(format: ArchiveFormat, filters: [ArchiveFilter] = [.none]) throws {
+        guard let a = archive_write_new() else {
+            throw ArchiveError(message: "Failed to create archive writer")
+        }
+        guard let e = archive_entry_new() else {
+            archive_write_free(a)
+            throw ArchiveError(message: "Failed to create archive entry")
+        }
+        self.archive = a
+        self.entry = e
+        let tmp = NSTemporaryDirectory() + "archive_\(ProcessInfo.processInfo.globallyUniqueString)"
+        self.tempPath = tmp
+
+        // After all stored properties are set, deinit handles cleanup on throw.
+        let fr = format.setWriteFormat(a)
+        if fr != ARCHIVE_OK && fr != ARCHIVE_WARN {
+            throw ArchiveError(archive: a)
+        }
+        for filter in filters {
+            let flr = filter.addWriteFilter(a)
+            if flr != ARCHIVE_OK && flr != ARCHIVE_WARN {
+                throw ArchiveError(archive: a)
+            }
+        }
+        let r = archive_write_open_filename(a, tmp)
+        if r != ARCHIVE_OK {
+            throw ArchiveError(archive: a)
+        }
+    }
+
+    /// Creates a writer that writes directly to a file path.
+    public init(path: String, format: ArchiveFormat, filters: [ArchiveFilter] = [.none]) throws {
+        guard let a = archive_write_new() else {
+            throw ArchiveError(message: "Failed to create archive writer")
+        }
+        guard let e = archive_entry_new() else {
+            archive_write_free(a)
+            throw ArchiveError(message: "Failed to create archive entry")
+        }
+        self.archive = a
+        self.entry = e
+        self.tempPath = nil
+
+        let fr = format.setWriteFormat(a)
+        if fr != ARCHIVE_OK && fr != ARCHIVE_WARN {
+            throw ArchiveError(archive: a)
+        }
+        for filter in filters {
+            let flr = filter.addWriteFilter(a)
+            if flr != ARCHIVE_OK && flr != ARCHIVE_WARN {
+                throw ArchiveError(archive: a)
+            }
+        }
+        let r = archive_write_open_filename(a, path)
+        if r != ARCHIVE_OK {
+            throw ArchiveError(archive: a)
+        }
+    }
+
+    deinit {
+        if !closed {
+            archive_write_close(archive)
+        }
+        archive_entry_free(entry)
+        archive_write_free(archive)
+        if let tmp = tempPath {
+            try? FileManager.default.removeItem(atPath: tmp)
+        }
+    }
+
+    /// Writes an entry with optional data to the archive.
+    public func writeEntry(_ archiveEntry: ArchiveEntry, data: Data? = nil) throws {
+        archive_entry_clear(entry)
+        archiveEntry.apply(to: entry)
+        if let data = data {
+            archive_entry_set_size(entry, Int64(data.count))
+        }
+        let r = archive_write_header(archive, entry)
+        if r != ARCHIVE_OK && r != ARCHIVE_WARN {
+            throw ArchiveError(archive: archive)
+        }
+        if let data = data, !data.isEmpty {
+            let written = data.withUnsafeBytes { buf in
+                archive_write_data(archive, buf.baseAddress, buf.count)
+            }
+            if written < 0 {
+                throw ArchiveError(archive: archive)
+            }
+        }
+    }
+
+    /// Finishes writing and returns the archive data (for in-memory writers).
+    public func finish() throws -> Data {
+        let r = archive_write_close(archive)
+        closed = true
+        if r != ARCHIVE_OK && r != ARCHIVE_WARN {
+            throw ArchiveError(archive: archive)
+        }
+        guard let tmp = tempPath else {
+            throw ArchiveError(message: "finish() called on file-based writer; use close() instead")
+        }
+        return try Data(contentsOf: URL(fileURLWithPath: tmp))
+    }
+
+    /// Closes a file-based archive writer.
+    public func close() throws {
+        let r = archive_write_close(archive)
+        closed = true
+        if r != ARCHIVE_OK && r != ARCHIVE_WARN {
+            throw ArchiveError(archive: archive)
+        }
+    }
+}

--- a/contrib/Swift/Sources/Archive/Data+Archive.swift
+++ b/contrib/Swift/Sources/Archive/Data+Archive.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension Data {
+    /// Lists the entries in this archive data.
+    public func archiveEntries() throws -> [ArchiveEntry] {
+        let reader = try ArchiveReader(data: self)
+        return try reader.listEntries()
+    }
+
+    /// Decompresses/extracts this archive data, returning a dictionary of
+    /// pathname to file data for each regular file entry.
+    public func decompressArchive() throws -> [String: Data] {
+        let reader = try ArchiveReader(data: self)
+        var result: [String: Data] = [:]
+        try reader.forEachEntry { entry, reader in
+            if entry.fileType == .regular {
+                let data = try reader.readData()
+                result[entry.pathname] = data
+            }
+        }
+        return result
+    }
+
+    /// Creates an archive from this data with the given filename.
+    public func compress(as filename: String, format: ArchiveFormat, filters: [ArchiveFilter] = []) throws -> Data {
+        let writer = try ArchiveWriter(format: format, filters: filters)
+        let entry = ArchiveEntry(pathname: filename, size: Int64(self.count))
+        try writer.writeEntry(entry, data: self)
+        return try writer.finish()
+    }
+}

--- a/contrib/Swift/Sources/Cliblzma/module.modulemap
+++ b/contrib/Swift/Sources/Cliblzma/module.modulemap
@@ -1,0 +1,4 @@
+module Cliblzma [system] {
+    link "lzma"
+    export *
+}

--- a/contrib/Swift/Sources/Clibzstd/module.modulemap
+++ b/contrib/Swift/Sources/Clibzstd/module.modulemap
@@ -1,0 +1,4 @@
+module Clibzstd [system] {
+    link "zstd"
+    export *
+}

--- a/contrib/Swift/Tests/ArchiveTests/ArchiveTests.swift
+++ b/contrib/Swift/Tests/ArchiveTests/ArchiveTests.swift
@@ -1,0 +1,1131 @@
+import Testing
+import Foundation
+@testable import Archive
+
+/// When the `GzipSupport` trait is enabled we will run the `.gzip` tests
+let gzipSupport: ArchiveFilter? = {
+    #if GzipSupport
+    .gzip
+    #else
+    nil
+    #endif
+}()
+
+/// When the `Bzip2Support` trait is enabled we will run the `.bzip2` tests
+let bzip2Support: ArchiveFilter? = {
+    #if Bzip2Support
+    .bzip2
+    #else
+    nil
+    #endif
+}()
+
+/// When the `LZMASupport` trait is enabled we will run the `.xz` tests
+let xzSupport: ArchiveFilter? = {
+    #if LZMASupport
+    .xz
+    #else
+    nil
+    #endif
+}()
+
+/// When the `LZMASupport` trait is enabled we will run the `.xz` tests
+let lzmaSupport: ArchiveFilter? = {
+    #if LZMASupport
+    .lzma
+    #else
+    nil
+    #endif
+}()
+
+/// When the `ZstdSupport` trait is enabled we will run the `.zstd` tests
+let zstdSupport: ArchiveFilter? = {
+    #if ZstdSupport
+    .zstd
+    #else
+    nil
+    #endif
+}()
+
+// MARK: - Version Tests
+
+@Test func versionInfo() {
+    let version = Archive.version
+    #expect(version.contains("libarchive"))
+}
+
+// MARK: - Format Round-Trip Tests
+
+@Suite("Format Round-Trips")
+struct FormatRoundTripTests {
+
+    @Test func tarRoundTrip() throws {
+        try roundTrip(format: .tar)
+    }
+
+    @Test func zipRoundTrip() throws {
+        try roundTrip(format: .zip)
+    }
+
+    @Test func sevenZipRoundTrip() throws {
+        try roundTrip(format: .sevenZip)
+    }
+
+    @Test func cpioRoundTrip() throws {
+        try roundTrip(format: .cpio)
+    }
+
+    @Test func arRoundTrip() throws {
+        let data = Data("ar file content".utf8)
+        let writer = try ArchiveWriter(format: .ar)
+        let entry = ArchiveEntry(pathname: "test.txt", size: Int64(data.count))
+        try writer.writeEntry(entry, data: data)
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        var found = false
+        try reader.forEachEntry { entry, reader in
+            let readData = try reader.readData()
+            #expect(readData == data)
+            found = true
+        }
+        #expect(found)
+    }
+
+    @Test(.disabled(if: true))
+    func xarRoundTrip() throws {
+        try roundTrip(format: .xar)
+    }
+
+    private func roundTrip(format: ArchiveFormat) throws {
+        let file1Data = Data("Hello, World!".utf8)
+        let file2Data = Data("Second file content with more data here.".utf8)
+
+        let writer = try ArchiveWriter(format: format)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file1.txt", size: Int64(file1Data.count)),
+            data: file1Data
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file2.txt", size: Int64(file2Data.count)),
+            data: file2Data
+        )
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        var files: [String: Data] = [:]
+        try reader.forEachEntry { entry, reader in
+            let data = try reader.readData()
+            files[entry.pathname] = data
+        }
+
+        #expect(files["file1.txt"] == file1Data)
+        #expect(files["file2.txt"] == file2Data)
+    }
+}
+
+// MARK: - Filter Round-Trip Tests
+
+@Suite("Filter Round-Trips")
+struct FilterRoundTripTests {
+
+    @Test
+    func compressFilter() throws {
+        try filterRoundTrip(filter: .compress)
+    }
+
+    @Test(.disabled(if: gzipSupport == nil))
+    func gzipFilter() throws {
+        try filterRoundTrip(filter: gzipSupport!)
+    }
+
+    @Test(.disabled(if: bzip2Support == nil))
+    func bzip2Filter() throws {
+        try filterRoundTrip(filter: bzip2Support!)
+    }
+
+    @Test(.disabled(if: xzSupport == nil))
+    func xzFilter() throws {
+        try filterRoundTrip(filter: xzSupport!)
+    }
+
+    @Test(.disabled(if: lzmaSupport == nil))
+    func lzmaFilter() throws {
+        try filterRoundTrip(filter: lzmaSupport!)
+    }
+
+    @Test(.disabled(if: zstdSupport == nil))
+    func zstdFilter() throws {
+        try filterRoundTrip(filter: zstdSupport!)
+    }
+
+    private func filterRoundTrip(filter: ArchiveFilter) throws {
+        let fileData = Data("This is test data for filter round-trip testing. Repeating content for compression: abcabcabcabc.".utf8)
+
+        let writer = try ArchiveWriter(format: .tar, filters: [filter])
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "compressed.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        var readBack: Data?
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "compressed.txt")
+            readBack = try reader.readData()
+        }
+        #expect(readBack == fileData)
+    }
+}
+
+// MARK: - Filter Composition Tests
+
+@Suite("Filter Composition")
+struct FilterCompositionTests {
+
+    @Test(.disabled(if: gzipSupport == nil))
+    func tarGzip() throws {
+        try compositionRoundTrip(filters: [gzipSupport!])
+    }
+
+    @Test(.disabled(if: bzip2Support == nil))
+    func tarBzip2() throws {
+        try compositionRoundTrip(filters: [bzip2Support!])
+    }
+
+    @Test(.disabled(if: xzSupport == nil))
+    func tarXz() throws {
+        try compositionRoundTrip(filters: [xzSupport!])
+    }
+
+    @Test(.disabled(if: zstdSupport == nil))
+    func tarZstd() throws {
+        try compositionRoundTrip(filters: [zstdSupport!])
+    }
+
+    private func compositionRoundTrip(filters: [ArchiveFilter]) throws {
+        let fileData = Data("Composition test data with repetition: xyzxyzxyzxyz.".utf8)
+
+        let writer = try ArchiveWriter(format: .tar, filters: filters)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "composed.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "composed.txt")
+            let data = try reader.readData()
+            #expect(data == fileData)
+        }
+    }
+}
+
+// MARK: - Write/Read Tests
+
+@Suite("Write and Read")
+struct WriteReadTests {
+
+    @Test func multipleEntries() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        for i in 0..<10 {
+            let data = Data("Content of file \(i)".utf8)
+            try writer.writeEntry(
+                ArchiveEntry(pathname: "dir/file\(i).txt", size: Int64(data.count)),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        let entries = try reader.listEntries()
+        #expect(entries.count == 10)
+    }
+
+    @Test func directoryEntries() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "mydir/", fileType: .directory, permissions: 0o755)
+        )
+        let fileData = Data("file in dir".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "mydir/file.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        #expect(entries.count == 2)
+        #expect(entries[0].fileType == .directory)
+        #expect(entries[1].fileType == .regular)
+    }
+
+    @Test func unicodePathnames() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let data = Data("unicode content".utf8)
+        let name = "日本語/ファイル.txt"
+        try writer.writeEntry(
+            ArchiveEntry(pathname: name, size: Int64(data.count)),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, _ in
+            #expect(entry.pathname == name)
+        }
+    }
+
+    @Test func emptyArchive() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        let entries = try reader.listEntries()
+        #expect(entries.isEmpty)
+    }
+
+    @Test func largeEntry() throws {
+        let size = 1024 * 1024
+        var largeData = Data(count: size)
+        for i in 0..<size {
+            largeData[i] = UInt8(i & 0xFF)
+        }
+
+        let writer = try ArchiveWriter(format: .tar)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "large.bin", size: Int64(size)),
+            data: largeData
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            let readData = try reader.readData()
+            #expect(readData.count == size)
+            #expect(readData == largeData)
+        }
+    }
+
+    @Test func permissionsPreserved() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let data = Data("test".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "exec.sh", size: Int64(data.count), permissions: 0o755),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, _ in
+            #expect(entry.permissions == 0o755)
+        }
+    }
+
+    @Test func symlinkEntry() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let data = Data("target file".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "target.txt", size: Int64(data.count)),
+            data: data
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "link.txt", fileType: .symbolicLink, symlinkTarget: "target.txt")
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        #expect(entries.count == 2)
+        #expect(entries[1].fileType == .symbolicLink)
+        #expect(entries[1].symlinkTarget == "target.txt")
+    }
+}
+
+// MARK: - Extract Tests
+
+@Suite("Extract")
+struct ExtractTests {
+
+    @Test func extractToDirectory() throws {
+        let fileData = Data("extracted content".utf8)
+        let writer = try ArchiveWriter(format: .tar)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "extracted.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        let archiveData = try writer.finish()
+
+        let tmpDir = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString)"
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.extractAll(to: tmpDir)
+
+        let extractedPath = (tmpDir as NSString).appendingPathComponent("extracted.txt")
+        let extractedData = try Data(contentsOf: URL(fileURLWithPath: extractedPath))
+        #expect(extractedData == fileData)
+    }
+}
+
+// MARK: - Data Extension Tests
+
+@Suite("Data Extensions")
+struct DataExtensionTests {
+
+    @Test(.disabled(if: gzipSupport == nil))
+    func compressDecompressGzip() throws {
+        let original = Data("Hello, gzip compression round-trip!".utf8)
+        let compressed = try original.compress(as: "test.txt", format: .tar, filters: [gzipSupport!])
+        #expect(!compressed.isEmpty)
+
+        let decompressed = try compressed.decompressArchive()
+        #expect(decompressed["test.txt"] == original)
+    }
+
+    @Test(.disabled(if: bzip2Support == nil))
+    func compressDecompressBzip2() throws {
+        let original = Data("Hello, bzip2 compression round-trip!".utf8)
+        let compressed = try original.compress(as: "test.txt", format: .tar, filters: [bzip2Support!])
+        #expect(!compressed.isEmpty)
+
+        let decompressed = try compressed.decompressArchive()
+        #expect(decompressed["test.txt"] == original)
+    }
+
+    @Test(.disabled(if: xzSupport == nil))
+    func compressDecompressXz() throws {
+        let original = Data("Hello, xz compression round-trip!".utf8)
+        let compressed = try original.compress(as: "test.txt", format: .tar, filters: [xzSupport!])
+        #expect(!compressed.isEmpty)
+
+        let decompressed = try compressed.decompressArchive()
+        #expect(decompressed["test.txt"] == original)
+    }
+
+    @Test(.disabled(if: zstdSupport == nil))
+    func compressDecompressZstd() throws {
+        let original = Data("Hello, zstd compression round-trip!".utf8)
+        let compressed = try original.compress(as: "test.txt", format: .tar, filters: [zstdSupport!])
+        #expect(!compressed.isEmpty)
+
+        let decompressed = try compressed.decompressArchive()
+        #expect(decompressed["test.txt"] == original)
+    }
+
+    @Test func compressDecompressNoFilter() throws {
+        let original = Data("Hello, no-filter round-trip!".utf8)
+        let compressed = try original.compress(as: "test.txt", format: .tar, filters: [.none])
+        #expect(!compressed.isEmpty)
+
+        let decompressed = try compressed.decompressArchive()
+        #expect(decompressed["test.txt"] == original)
+    }
+
+    @Test func archiveEntries() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let data1 = Data("one".utf8)
+        let data2 = Data("two".utf8)
+        try writer.writeEntry(ArchiveEntry(pathname: "a.txt", size: Int64(data1.count)), data: data1)
+        try writer.writeEntry(ArchiveEntry(pathname: "b.txt", size: Int64(data2.count)), data: data2)
+        let archiveData = try writer.finish()
+
+        let entries = try archiveData.archiveEntries()
+        #expect(entries.count == 2)
+        #expect(entries[0].pathname == "a.txt")
+        #expect(entries[1].pathname == "b.txt")
+    }
+}
+
+// MARK: - Error Handling Tests
+
+@Suite("Error Handling")
+struct ErrorHandlingTests {
+
+    @Test func corruptData() {
+        let garbage = Data([0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE])
+        #expect(throws: ArchiveError.self) {
+            let reader = try ArchiveReader(data: garbage)
+            _ = try reader.listEntries()
+        }
+    }
+
+    @Test func finishOnFileWriter() throws {
+        let tmpPath = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString).tar"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let writer = try ArchiveWriter(path: tmpPath, format: .tar)
+        let data = Data("test".utf8)
+        try writer.writeEntry(ArchiveEntry(pathname: "f.txt", size: Int64(data.count)), data: data)
+        #expect(throws: ArchiveError.self) {
+            _ = try writer.finish()
+        }
+    }
+}
+
+// MARK: - Concurrency Tests
+
+@Suite("Concurrency")
+struct ConcurrencyTests {
+
+    @Test func entryIsSendable() async {
+        let entry = ArchiveEntry(pathname: "test.txt", size: 42)
+        let task = Task { @Sendable in
+            return entry.pathname
+        }
+        let result = await task.value
+        #expect(result == "test.txt")
+    }
+}
+
+// MARK: - File-Based Writer Tests
+
+@Suite("File-Based Writing")
+struct FileBasedWriterTests {
+
+    @Test(.disabled(if: gzipSupport == nil))
+    func writeToFileAndReadBackGzip() throws {
+        let tmpPath = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString).tar.gz"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let fileData = Data("file-based gzip writing test".utf8)
+        let writer = try ArchiveWriter(path: tmpPath, format: .tar, filters: [gzipSupport!])
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        try writer.close()
+
+        let reader = try ArchiveReader(path: tmpPath)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "file.txt")
+            let data = try reader.readData()
+            #expect(data == fileData)
+        }
+    }
+
+    @Test(.disabled(if: xzSupport == nil))
+    func writeToFileAndReadBackXz() throws {
+        let tmpPath = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString).tar.xz"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let fileData = Data("file-based xz writing test".utf8)
+        let writer = try ArchiveWriter(path: tmpPath, format: .tar, filters: [xzSupport!])
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        try writer.close()
+
+        let reader = try ArchiveReader(path: tmpPath)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "file.txt")
+            let data = try reader.readData()
+            #expect(data == fileData)
+        }
+    }
+
+    @Test(.disabled(if: zstdSupport == nil))
+        func writeToFileAndReadBackZstd() throws {
+        let tmpPath = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString).tar.zst"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let fileData = Data("file-based zstd writing test".utf8)
+        let writer = try ArchiveWriter(path: tmpPath, format: .tar, filters: [zstdSupport!])
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        try writer.close()
+
+        let reader = try ArchiveReader(path: tmpPath)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "file.txt")
+            let data = try reader.readData()
+            #expect(data == fileData)
+        }
+    }
+
+    @Test func writeToFileAndReadBackUncompressed() throws {
+        let tmpPath = NSTemporaryDirectory() + "archive_test_\(ProcessInfo.processInfo.globallyUniqueString).tar"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let fileData = Data("file-based uncompressed writing test".utf8)
+        let writer = try ArchiveWriter(path: tmpPath, format: .tar)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "file.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        try writer.close()
+
+        let reader = try ArchiveReader(path: tmpPath)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "file.txt")
+            let data = try reader.readData()
+            #expect(data == fileData)
+        }
+    }
+}
+
+// MARK: - Format Detection Tests
+
+@Suite("Format Detection")
+struct FormatDetectionTests {
+
+    @Test func detectTarFormat() throws {
+        let writer = try ArchiveWriter(format: .tar)
+        let data = Data("detect me".utf8)
+        try writer.writeEntry(ArchiveEntry(pathname: "d.txt", size: Int64(data.count)), data: data)
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        _ = try reader.listEntries()
+        #expect(reader.format == .tar)
+    }
+
+    @Test func detectZipFormat() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        let data = Data("detect me".utf8)
+        try writer.writeEntry(ArchiveEntry(pathname: "d.txt", size: Int64(data.count)), data: data)
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        _ = try reader.listEntries()
+        #expect(reader.format == .zip)
+    }
+}
+
+// MARK: - Zip Edge Cases
+
+@Suite("Zip Edge Cases")
+struct ZipEdgeCaseTests {
+
+    @Test func zipEmptyFile() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "empty.txt", size: 0),
+            data: Data()
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "empty.txt")
+            #expect(entry.size == 0)
+            let data = try reader.readData()
+            #expect(data.isEmpty)
+        }
+    }
+
+    @Test func zipEmptyArchive() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        let archiveData = try writer.finish()
+        #expect(!archiveData.isEmpty)
+
+        let reader = try ArchiveReader(data: archiveData)
+        let entries = try reader.listEntries()
+        #expect(entries.isEmpty)
+    }
+
+    @Test func zipDirectoryHierarchy() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        // Create nested directory structure
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "a/", fileType: .directory, permissions: 0o755)
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "a/b/", fileType: .directory, permissions: 0o755)
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "a/b/c/", fileType: .directory, permissions: 0o755)
+        )
+        let data = Data("deep file".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "a/b/c/deep.txt", size: Int64(data.count)),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        var fileData: Data?
+        try reader.forEachEntry { entry, reader in
+            entries.append(entry)
+            if entry.fileType == .regular {
+                fileData = try reader.readData()
+            }
+        }
+        #expect(entries.count == 4)
+        #expect(entries[0].fileType == .directory)
+        #expect(entries[0].pathname == "a/")
+        #expect(entries[1].pathname == "a/b/")
+        #expect(entries[2].pathname == "a/b/c/")
+        #expect(entries[3].pathname == "a/b/c/deep.txt")
+        #expect(fileData == data)
+    }
+
+    @Test func zipSymlink() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        let targetData = Data("symlink target content".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "target.txt", size: Int64(targetData.count)),
+            data: targetData
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "link.txt", fileType: .symbolicLink, symlinkTarget: "target.txt")
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        #expect(entries.count == 2)
+        #expect(entries[0].pathname == "target.txt")
+        #expect(entries[0].fileType == .regular)
+        #expect(entries[1].pathname == "link.txt")
+        #expect(entries[1].fileType == .symbolicLink)
+        #expect(entries[1].symlinkTarget == "target.txt")
+    }
+
+    @Test func zipSymlinkToDirectory() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "realdir/", fileType: .directory, permissions: 0o755)
+        )
+        let data = Data("in real dir".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "realdir/file.txt", size: Int64(data.count)),
+            data: data
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "linkdir", fileType: .symbolicLink, symlinkTarget: "realdir")
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        let linkEntry = entries.first { $0.pathname == "linkdir" }
+        #expect(linkEntry != nil)
+        #expect(linkEntry?.fileType == .symbolicLink)
+        #expect(linkEntry?.symlinkTarget == "realdir")
+    }
+
+    @Test func zipUnicodeFilenames() throws {
+        let names = [
+            "café/résumé.txt",
+            "日本語/テスト.txt",
+            "Ünïcödé/fîlé.txt",
+            "emoji_🎉/party.txt",
+        ]
+        let writer = try ArchiveWriter(format: .zip)
+        for name in names {
+            let data = Data("content of \(name)".utf8)
+            try writer.writeEntry(
+                ArchiveEntry(pathname: name, size: Int64(data.count)),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var readNames: [String] = []
+        try reader.forEachEntry { entry, _ in
+            readNames.append(entry.pathname)
+        }
+        #expect(readNames == names)
+    }
+
+    @Test func zipLongFilename() throws {
+        // 255-char filename (typical max for many filesystems)
+        let longName = String(repeating: "a", count: 200) + ".txt"
+        let data = Data("long name content".utf8)
+
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: longName, size: Int64(data.count)),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == longName)
+            let readData = try reader.readData()
+            #expect(readData == data)
+        }
+    }
+
+    @Test func zipDeeplyNestedPath() throws {
+        // path with many directory components
+        let components = (0..<20).map { "d\($0)" }
+        let dirPath = components.joined(separator: "/") + "/"
+        let filePath = components.joined(separator: "/") + "/file.txt"
+        let data = Data("deeply nested".utf8)
+
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: dirPath, fileType: .directory, permissions: 0o755)
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: filePath, size: Int64(data.count)),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var foundFile = false
+        try reader.forEachEntry { entry, reader in
+            if entry.fileType == .regular {
+                #expect(entry.pathname == filePath)
+                let readData = try reader.readData()
+                #expect(readData == data)
+                foundFile = true
+            }
+        }
+        #expect(foundFile)
+    }
+
+    @Test func zipManySmallFiles() throws {
+        let count = 100
+        var expected: [String: Data] = [:]
+        let writer = try ArchiveWriter(format: .zip)
+        for i in 0..<count {
+            let name = "file_\(String(format: "%04d", i)).txt"
+            let data = Data("content #\(i)".utf8)
+            expected[name] = data
+            try writer.writeEntry(
+                ArchiveEntry(pathname: name, size: Int64(data.count)),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var actual: [String: Data] = [:]
+        try reader.forEachEntry { entry, reader in
+            actual[entry.pathname] = try reader.readData()
+        }
+        #expect(actual.count == count)
+        for (name, data) in expected {
+            #expect(actual[name] == data)
+        }
+    }
+
+    @Test func zipPermissionsPreserved() throws {
+        let perms: [UInt16] = [0o644, 0o755, 0o600, 0o444, 0o700]
+        let writer = try ArchiveWriter(format: .zip)
+        for (i, perm) in perms.enumerated() {
+            let data = Data("file \(i)".utf8)
+            try writer.writeEntry(
+                ArchiveEntry(pathname: "f\(i).txt", size: Int64(data.count), permissions: perm),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var readPerms: [UInt16] = []
+        try reader.forEachEntry { entry, _ in
+            readPerms.append(entry.permissions)
+        }
+        #expect(readPerms == perms)
+    }
+
+    @Test func zipMixedEntryTypes() throws {
+        let writer = try ArchiveWriter(format: .zip)
+
+        // Directory
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "project/", fileType: .directory, permissions: 0o755)
+        )
+        // Regular file
+        let srcData = Data("print('hello')".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "project/main.py", size: Int64(srcData.count), permissions: 0o644),
+            data: srcData
+        )
+        // Executable
+        let scriptData = Data("#!/bin/sh\necho hi".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "project/run.sh", size: Int64(scriptData.count), permissions: 0o755),
+            data: scriptData
+        )
+        // Symlink
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "project/link.py", fileType: .symbolicLink, symlinkTarget: "main.py")
+        )
+        // Empty file
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "project/.gitkeep", size: 0),
+            data: Data()
+        )
+
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        var fileContents: [String: Data] = [:]
+        try reader.forEachEntry { entry, reader in
+            entries.append(entry)
+            if entry.fileType == .regular {
+                fileContents[entry.pathname] = try reader.readData()
+            }
+        }
+
+        #expect(entries.count == 5)
+
+        let dir = entries[0]
+        #expect(dir.pathname == "project/")
+        #expect(dir.fileType == .directory)
+
+        let src = entries[1]
+        #expect(src.pathname == "project/main.py")
+        #expect(src.permissions == 0o644)
+        #expect(fileContents["project/main.py"] == srcData)
+
+        let script = entries[2]
+        #expect(script.pathname == "project/run.sh")
+        #expect(script.permissions == 0o755)
+        #expect(fileContents["project/run.sh"] == scriptData)
+
+        let link = entries[3]
+        #expect(link.pathname == "project/link.py")
+        #expect(link.fileType == .symbolicLink)
+        #expect(link.symlinkTarget == "main.py")
+
+        let empty = entries[4]
+        #expect(empty.pathname == "project/.gitkeep")
+        #expect(fileContents["project/.gitkeep"]?.isEmpty == true)
+    }
+
+    @Test func zipBinaryContent() throws {
+        // File with all possible byte values
+        var binaryData = Data(count: 256)
+        for i in 0..<256 {
+            binaryData[i] = UInt8(i)
+        }
+
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "binary.bin", size: Int64(binaryData.count)),
+            data: binaryData
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            let readData = try reader.readData()
+            #expect(readData == binaryData)
+        }
+    }
+
+    @Test func zipFilenameWithSpaces() throws {
+        let name = "path with spaces/file name.txt"
+        let data = Data("spaced content".utf8)
+
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: name, size: Int64(data.count)),
+            data: data
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == name)
+            let readData = try reader.readData()
+            #expect(readData == data)
+        }
+    }
+
+    @Test func zipFilenameWithSpecialCharacters() throws {
+        let names = [
+            "file (1).txt",
+            "file [2].txt",
+            "file {3}.txt",
+            "file #4.txt",
+            "file @5.txt",
+            "file & 6.txt",
+        ]
+        let writer = try ArchiveWriter(format: .zip)
+        for name in names {
+            let data = Data(name.utf8)
+            try writer.writeEntry(
+                ArchiveEntry(pathname: name, size: Int64(data.count)),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var readNames: [String] = []
+        try reader.forEachEntry { entry, _ in
+            readNames.append(entry.pathname)
+        }
+        #expect(readNames == names)
+    }
+
+    @Test func zipExtractWithSymlinks() throws {
+        let writer = try ArchiveWriter(format: .zip)
+
+        let fileData = Data("real file content".utf8)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "original.txt", size: Int64(fileData.count)),
+            data: fileData
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "symlink.txt", fileType: .symbolicLink, symlinkTarget: "original.txt")
+        )
+        let archiveData = try writer.finish()
+
+        let tmpDir = NSTemporaryDirectory() + "archive_zip_symlink_\(ProcessInfo.processInfo.globallyUniqueString)"
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.extractAll(to: tmpDir)
+
+        let fm = FileManager.default
+        let originalPath = (tmpDir as NSString).appendingPathComponent("original.txt")
+        let symlinkPath = (tmpDir as NSString).appendingPathComponent("symlink.txt")
+
+        // Original file should exist with correct content
+        let readOriginal = try Data(contentsOf: URL(fileURLWithPath: originalPath))
+        #expect(readOriginal == fileData)
+
+        // Symlink should exist and resolve to the same content
+        var isDir: ObjCBool = false
+        #expect(fm.fileExists(atPath: symlinkPath, isDirectory: &isDir))
+
+        let attrs = try fm.attributesOfItem(atPath: symlinkPath)
+        let type = attrs[.type] as? FileAttributeType
+        #expect(type == .typeSymbolicLink)
+
+        let dest = try fm.destinationOfSymbolicLink(atPath: symlinkPath)
+        #expect(dest == "original.txt")
+    }
+
+    @Test func zipLargeFile() throws {
+        // 2MB file to test zip with larger data
+        let size = 2 * 1024 * 1024
+        var largeData = Data(count: size)
+        // Fill with a repeating pattern for compressibility
+        for i in 0..<size {
+            largeData[i] = UInt8((i * 7 + 13) & 0xFF)
+        }
+
+        let writer = try ArchiveWriter(format: .zip)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "large.bin", size: Int64(size)),
+            data: largeData
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        try reader.forEachEntry { entry, reader in
+            #expect(entry.pathname == "large.bin")
+            let readData = try reader.readData()
+            #expect(readData.count == size)
+            #expect(readData == largeData)
+        }
+    }
+
+    @Test func zipMultipleSymlinksChain() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        let data = Data("base content".utf8)
+
+        // file -> link1 -> link2 (chain of symlinks)
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "base.txt", size: Int64(data.count)),
+            data: data
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "link1.txt", fileType: .symbolicLink, symlinkTarget: "base.txt")
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "link2.txt", fileType: .symbolicLink, symlinkTarget: "link1.txt")
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        #expect(entries.count == 3)
+        #expect(entries[0].fileType == .regular)
+        #expect(entries[1].fileType == .symbolicLink)
+        #expect(entries[1].symlinkTarget == "base.txt")
+        #expect(entries[2].fileType == .symbolicLink)
+        #expect(entries[2].symlinkTarget == "link1.txt")
+    }
+
+    @Test func zipRelativeSymlink() throws {
+        let writer = try ArchiveWriter(format: .zip)
+        let data = Data("nested content".utf8)
+
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "dir/", fileType: .directory, permissions: 0o755)
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "dir/subdir/", fileType: .directory, permissions: 0o755)
+        )
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "dir/real.txt", size: Int64(data.count)),
+            data: data
+        )
+        // Symlink from subdir back up to parent's file
+        try writer.writeEntry(
+            ArchiveEntry(pathname: "dir/subdir/uplink.txt", fileType: .symbolicLink, symlinkTarget: "../real.txt")
+        )
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var entries: [ArchiveEntry] = []
+        try reader.forEachEntry { entry, _ in
+            entries.append(entry)
+        }
+        let uplink = entries.first { $0.pathname == "dir/subdir/uplink.txt" }
+        #expect(uplink != nil)
+        #expect(uplink?.fileType == .symbolicLink)
+        #expect(uplink?.symlinkTarget == "../real.txt")
+    }
+
+    @Test func zipDotFiles() throws {
+        let dotFiles = [".hidden", ".gitignore", ".DS_Store", "dir/.env"]
+        let writer = try ArchiveWriter(format: .zip)
+        for name in dotFiles {
+            let data = Data("dotfile \(name)".utf8)
+            try writer.writeEntry(
+                ArchiveEntry(pathname: name, size: Int64(data.count)),
+                data: data
+            )
+        }
+        let archiveData = try writer.finish()
+
+        let reader = try ArchiveReader(data: archiveData)
+        var readNames: [String] = []
+        try reader.forEachEntry { entry, _ in
+            readNames.append(entry.pathname)
+        }
+        #expect(readNames == dotFiles)
+    }
+}

--- a/libarchive/config_spm.h
+++ b/libarchive/config_spm.h
@@ -1,0 +1,448 @@
+/*
+ * Hand-built configuration for building libarchive via Swift Package Manager.
+ * Supports macOS (Apple platforms), Android, Linux, and Windows.
+ *
+ * Compression library defines (HAVE_ZLIB_H, HAVE_BZLIB_H, etc.) are NOT
+ * defined here -- they come from trait-controlled cSettings in Package.swift.
+ */
+
+#define __LIBARCHIVE_CONFIG_H_INCLUDED 1
+
+/* ============================================================ */
+/* Windows platform configuration                               */
+/* ============================================================ */
+#if defined(_WIN32) && !defined(__CYGWIN__)
+
+/* Require at least Windows 7 for BCryptDeriveKeyPBKDF2 */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+#endif
+#ifndef NTDDI_VERSION
+#define NTDDI_VERSION 0x06010000
+#endif
+
+#include <stdint.h>
+
+/* POSIX types not provided by Windows */
+typedef unsigned short uid_t;
+typedef unsigned short gid_t;
+
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+
+typedef int pid_t;
+typedef unsigned short mode_t;
+typedef unsigned int id_t;
+
+#endif /* _WIN32 */
+
+/* ============================================================ */
+/* macOS / Apple platform configuration                         */
+/* ============================================================ */
+#if defined(__APPLE__)
+
+/* ACL support via macOS APIs */
+#define ARCHIVE_ACL_DARWIN 1
+#define HAVE_ACL_GET_PERM_NP 1
+#define HAVE_ACL_GET_LINK_NP 1
+#define HAVE_ACL_IS_TRIVIAL_NP 1
+#define HAVE_ACL_SET_LINK_NP 1
+#define HAVE_SYS_ACL_H 1
+#define HAVE_MEMBERSHIP_H 1
+
+/* Extended attributes via macOS APIs */
+#define ARCHIVE_XATTR_DARWIN 1
+#define HAVE_SYS_XATTR_H 1
+
+/* Crypto via CommonCrypto / libSystem */
+#define ARCHIVE_CRYPTO_MD5_LIBSYSTEM 1
+#define ARCHIVE_CRYPTO_SHA1_LIBSYSTEM 1
+#define ARCHIVE_CRYPTO_SHA256_LIBSYSTEM 1
+#define ARCHIVE_CRYPTO_SHA384_LIBSYSTEM 1
+#define ARCHIVE_CRYPTO_SHA512_LIBSYSTEM 1
+
+/* macOS-specific features */
+#define HAVE_COPYFILE_H 1
+#define HAVE_CHFLAGS 1
+#define HAVE_FCHFLAGS 1
+#define HAVE_LCHFLAGS 1
+#define HAVE_STRUCT_STAT_ST_FLAGS 1
+#define HAVE_STRUCT_STAT_ST_BIRTHTIME 1
+#define HAVE_STRUCT_STAT_ST_BIRTHTIMESPEC_TV_NSEC 1
+#define HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC 1
+#define HAVE_ARC4RANDOM_BUF 1
+#define HAVE_GETVFSBYNAME 1
+#define HAVE_STATFS 1
+#define HAVE_FSTATFS 1
+#define HAVE_STRUCT_STATFS_F_NAMEMAX 1
+#define HAVE_SYS_MOUNT_H 1
+#define HAVE_D_MD_ORDER 1
+#define HAVE_EFTYPE 1
+#define HAVE_READPASSPHRASE 1
+#define HAVE_READPASSPHRASE_H 1
+#define HAVE_LCHMOD 1
+
+/* macOS has iconv in libc */
+#define HAVE_ICONV 1
+#define HAVE_ICONV_H 1
+
+/* macOS has libxml2 in SDK */
+#define HAVE_LIBXML_XMLREADER_H 1
+#define HAVE_LIBXML_XMLWRITER_H 1
+
+/* ============================================================ */
+/* Linux platform configuration                                 */
+/* ============================================================ */
+#elif defined(__linux__)
+
+/* ACL support via POSIX ACL (requires libacl-dev) */
+#if __has_include(<sys/acl.h>)
+#define ARCHIVE_ACL_LIBACL 1
+#define HAVE_ACL_GET_PERM 1
+#define HAVE_SYS_ACL_H 1
+#endif
+
+/* Extended attributes via Linux APIs (sys/xattr.h is in glibc) */
+#if __has_include(<sys/xattr.h>)
+#define ARCHIVE_XATTR_LINUX 1
+#define HAVE_SYS_XATTR_H 1
+#endif
+#if __has_include(<attr/xattr.h>)
+#define HAVE_ATTR_XATTR_H 1
+#endif
+
+/* Crypto via OpenSSL (requires libssl-dev) */
+#if __has_include(<openssl/evp.h>)
+#define HAVE_LIBCRYPTO 1
+#define HAVE_OPENSSL_EVP_H 1
+#define HAVE_OPENSSL_MD5_H 1
+#define HAVE_OPENSSL_RIPEMD_H 1
+#define HAVE_OPENSSL_SHA_H 1
+#define HAVE_OPENSSL_SHA256_INIT 1
+#define HAVE_OPENSSL_SHA384_INIT 1
+#define HAVE_OPENSSL_SHA512_INIT 1
+#define HAVE_PKCS5_PBKDF2_HMAC_SHA1 1
+#define ARCHIVE_CRYPTO_MD5_OPENSSL 1
+#define ARCHIVE_CRYPTO_RMD160_OPENSSL 1
+#define ARCHIVE_CRYPTO_SHA1_OPENSSL 1
+#define ARCHIVE_CRYPTO_SHA256_OPENSSL 1
+#define ARCHIVE_CRYPTO_SHA384_OPENSSL 1
+#define ARCHIVE_CRYPTO_SHA512_OPENSSL 1
+#endif
+
+/* Linux-specific features */
+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+#define HAVE_FUTIMENS 1
+#define HAVE_UTIMENSAT 1
+#define HAVE_LINUX_FIEMAP_H 1
+#define HAVE_LINUX_FS_H 1
+#define HAVE_LINUX_TYPES_H 1
+#define HAVE_LINUX_MAGIC_H 1
+#define HAVE_SYS_STATFS_H 1
+#define HAVE_STATFS 1
+#define HAVE_FSTATFS 1
+
+/* iconv */
+#define HAVE_ICONV 1
+#define HAVE_ICONV_H 1
+
+/* libxml2 - may or may not be available */
+/* #define HAVE_LIBXML_XMLREADER_H 1 */
+
+#endif /* platform */
+
+/* ============================================================ */
+/* Common POSIX defines (shared across macOS and Linux)         */
+/* ============================================================ */
+
+#define HAVE_CHOWN 1
+#define HAVE_CHROOT 1
+#define HAVE_CTIME_R 1
+#define HAVE_CTYPE_H 1
+#define HAVE_DECL_INT32_MAX 1
+#define HAVE_DECL_INT32_MIN 1
+#define HAVE_DECL_INT64_MAX 1
+#define HAVE_DECL_INT64_MIN 1
+#define HAVE_DECL_INTMAX_MAX 1
+#define HAVE_DECL_INTMAX_MIN 1
+#define HAVE_DECL_SIZE_MAX 1
+#define HAVE_DECL_SSIZE_MAX 1
+#define HAVE_DECL_STRERROR_R 1
+#define HAVE_DECL_UINT32_MAX 1
+#define HAVE_DECL_UINT64_MAX 1
+#define HAVE_DECL_UINTMAX_MAX 1
+#define HAVE_DIRENT_H 1
+#define HAVE_DLFCN_H 1
+#define HAVE_EILSEQ 1
+#define HAVE_ERRNO_H 1
+#define HAVE_FCHDIR 1
+#define HAVE_FCHMOD 1
+#define HAVE_FCHOWN 1
+#define HAVE_FCNTL 1
+#define HAVE_FCNTL_H 1
+#define HAVE_FDOPENDIR 1
+#define HAVE_FNMATCH 1
+#define HAVE_FNMATCH_H 1
+#define HAVE_FORK 1
+#define HAVE_FSEEKO 1
+#define HAVE_FSTAT 1
+#define HAVE_FSTATAT 1
+#define HAVE_FSTATVFS 1
+#define HAVE_FTRUNCATE 1
+#define HAVE_FUTIMES 1
+#define HAVE_GETEUID 1
+#define HAVE_GETGRGID_R 1
+#define HAVE_GETGRNAM_R 1
+#define HAVE_GETLINE 1
+#define HAVE_GETPID 1
+#define HAVE_GETPWNAM_R 1
+#define HAVE_GETPWUID_R 1
+#define HAVE_GMTIME_R 1
+#define HAVE_GRP_H 1
+#define HAVE_INTMAX_T 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LANGINFO_H 1
+#define HAVE_LCHOWN 1
+#define HAVE_LIMITS_H 1
+#define HAVE_LINK 1
+#define HAVE_LINKAT 1
+#define HAVE_LOCALE_H 1
+#define HAVE_LOCALTIME_R 1
+#define HAVE_LONG_LONG_INT 1
+#define HAVE_LSTAT 1
+#define HAVE_LUTIMES 1
+#define HAVE_MBRTOWC 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMORY_H 1
+#define HAVE_MEMSET 1
+#define HAVE_MKDIR 1
+#define HAVE_MKFIFO 1
+#define HAVE_MKNOD 1
+#define HAVE_MKSTEMP 1
+#define HAVE_NL_LANGINFO 1
+#define HAVE_OPENAT 1
+#define HAVE_PATHS_H 1
+#define HAVE_PIPE 1
+#define HAVE_POLL 1
+#define HAVE_POLL_H 1
+#define HAVE_POSIX_SPAWNP 1
+#define HAVE_PTHREAD_H 1
+#define HAVE_PWD_H 1
+#define HAVE_READDIR_R 1
+#define HAVE_READLINK 1
+#define HAVE_READLINKAT 1
+#define HAVE_REGEX_H 1
+#define HAVE_SELECT 1
+#define HAVE_SETENV 1
+#define HAVE_SETLOCALE 1
+#define HAVE_SIGACTION 1
+#define HAVE_SIGNAL_H 1
+#define HAVE_SPAWN_H 1
+#define HAVE_STATVFS 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRCHR 1
+#define HAVE_STRDUP 1
+#define HAVE_STRERROR 1
+#define HAVE_STRERROR_R 1
+#define HAVE_STRFTIME 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRNLEN 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRUCT_STAT_ST_BLKSIZE 1
+#define HAVE_STRUCT_TM_TM_GMTOFF 1
+#define HAVE_SYMLINK 1
+#define HAVE_SYS_CDEFS_H 1
+#define HAVE_SYS_IOCTL_H 1
+#define HAVE_SYS_PARAM_H 1
+#define HAVE_SYS_POLL_H 1
+#define HAVE_SYS_SELECT_H 1
+#define HAVE_SYS_STATVFS_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TIME_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_SYS_UTSNAME_H 1
+#define HAVE_SYS_WAIT_H 1
+#define HAVE_TIMEGM 1
+#define HAVE_TIME_H 1
+#define HAVE_TZSET 1
+#define HAVE_UINTMAX_T 1
+#define HAVE_UNISTD_H 1
+#define HAVE_UNLINKAT 1
+#define HAVE_UNSETENV 1
+#define HAVE_UNSIGNED_LONG_LONG 1
+#define HAVE_UNSIGNED_LONG_LONG_INT 1
+#define HAVE_UTIME 1
+#define HAVE_UTIMES 1
+#define HAVE_UTIME_H 1
+#define HAVE_VFORK 1
+#define HAVE_VPRINTF 1
+#define HAVE_WCHAR_H 1
+#define HAVE_WCHAR_T 1
+#define HAVE_WCRTOMB 1
+#define HAVE_WCSCMP 1
+#define HAVE_WCSCPY 1
+#define HAVE_WCSLEN 1
+#define HAVE_WCTOMB 1
+#define HAVE_WCTYPE_H 1
+#define HAVE_WMEMCMP 1
+#define HAVE_WMEMCPY 1
+#define HAVE_WMEMMOVE 1
+
+/* iconv const qualifier (empty on macOS and glibc) */
+#define ICONV_CONST
+
+/* Hash support flags */
+#define HAVE_SHA256 1
+#define HAVE_SHA384 1
+#define HAVE_SHA512 1
+
+/* ============================================================ */
+/* Windows (MSVC / clang-cl) overrides                           */
+/* Windows lacks most POSIX headers and functions; undef them.   */
+/* ============================================================ */
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#undef HAVE_CHOWN
+#undef HAVE_CHROOT
+#undef HAVE_CTIME_R
+#undef HAVE_DECL_SSIZE_MAX
+#undef HAVE_DECL_STRERROR_R
+#undef HAVE_DIRENT_H
+#undef HAVE_DLFCN_H
+#undef HAVE_FCHDIR
+#undef HAVE_FCHMOD
+#undef HAVE_FCHOWN
+#undef HAVE_FCNTL
+#undef HAVE_FDOPENDIR
+#undef HAVE_FNMATCH
+#undef HAVE_FNMATCH_H
+#undef HAVE_FORK
+#undef HAVE_FSEEKO
+#undef HAVE_FSTATAT
+#undef HAVE_FSTATVFS
+#undef HAVE_FTRUNCATE
+#undef HAVE_FUTIMES
+#undef HAVE_GETEUID
+#undef HAVE_GETGRGID_R
+#undef HAVE_GETGRNAM_R
+#undef HAVE_GETLINE
+#undef HAVE_GETPWNAM_R
+#undef HAVE_GETPWUID_R
+#undef HAVE_GMTIME_R
+#undef HAVE_GRP_H
+#undef HAVE_LANGINFO_H
+#undef HAVE_LCHOWN
+#undef HAVE_LINK
+#undef HAVE_LINKAT
+#undef HAVE_LOCALTIME_R
+#undef HAVE_LSTAT
+#undef HAVE_LUTIMES
+#undef HAVE_MKFIFO
+#undef HAVE_MKNOD
+#undef HAVE_MKSTEMP
+#undef HAVE_NL_LANGINFO
+#undef HAVE_OPENAT
+#undef HAVE_PATHS_H
+#undef HAVE_PIPE
+#undef HAVE_POLL
+#undef HAVE_POLL_H
+#undef HAVE_POSIX_SPAWNP
+#undef HAVE_PTHREAD_H
+#undef HAVE_PWD_H
+#undef HAVE_READDIR_R
+#undef HAVE_READLINK
+#undef HAVE_READLINKAT
+#undef HAVE_REGEX_H
+#undef HAVE_SIGACTION
+#undef HAVE_SPAWN_H
+#undef HAVE_STATVFS
+#undef HAVE_STRERROR_R
+#undef HAVE_STRINGS_H
+#undef HAVE_STRUCT_STAT_ST_BLKSIZE
+#undef HAVE_STRUCT_TM_TM_GMTOFF
+#undef HAVE_SYMLINK
+#undef HAVE_SYS_CDEFS_H
+#undef HAVE_SYS_IOCTL_H
+#undef HAVE_SYS_PARAM_H
+#undef HAVE_SYS_POLL_H
+#undef HAVE_SYS_SELECT_H
+#undef HAVE_SYS_STATVFS_H
+#undef HAVE_SYS_TIME_H
+#undef HAVE_SYS_UTSNAME_H
+#undef HAVE_SYS_WAIT_H
+#undef HAVE_TIMEGM
+#undef HAVE_UNISTD_H
+#undef HAVE_UNLINKAT
+#undef HAVE_UNSETENV
+#undef HAVE_UTIMES
+#undef HAVE_UTIME_H
+#undef HAVE_VFORK
+#undef HAVE_ICONV
+#undef HAVE_ICONV_H
+#undef ICONV_CONST
+/* Windows UCRT provides _get_timezone() instead of the POSIX timezone global */
+#define HAVE__GET_TIMEZONE 1
+/* Windows BCrypt API for random number generation */
+#define HAVE_BCRYPT_H 1
+/* Crypto via Windows CNG (BCrypt) */
+#define ARCHIVE_CRYPTO_MD5_WIN 1
+#define ARCHIVE_CRYPTO_SHA1_WIN 1
+#define ARCHIVE_CRYPTO_SHA256_WIN 1
+#define ARCHIVE_CRYPTO_SHA384_WIN 1
+#define ARCHIVE_CRYPTO_SHA512_WIN 1
+#endif /* _WIN32 */
+
+/* ============================================================ */
+/* Android (Bionic libc) overrides                               */
+/* Bionic lacks several POSIX/BSD functions that glibc provides. */
+/* ============================================================ */
+#if defined(__ANDROID__)
+#undef HAVE_CHROOT
+#undef HAVE_FUTIMES
+#undef HAVE_LANGINFO_H
+#undef HAVE_LUTIMES
+#undef HAVE_MKFIFO
+#undef HAVE_MKNOD
+#undef HAVE_NL_LANGINFO
+#undef HAVE_PATHS_H
+#undef HAVE_READDIR_R
+#undef HAVE_READPASSPHRASE
+#undef HAVE_READPASSPHRASE_H
+#undef HAVE_SYS_CDEFS_H
+#undef HAVE_VFORK
+/* Android iconv may not be available */
+#if !__has_include(<iconv.h>)
+#undef HAVE_ICONV
+#undef HAVE_ICONV_H
+#endif
+#endif /* __ANDROID__ */
+
+/* ============================================================ */
+/* Validate compression headers actually exist.                  */
+/* SPM traits are package-level, so defines like HAVE_BZLIB_H    */
+/* may be set even when cross-compiling to platforms that lack    */
+/* the headers. Undef them if the header is not actually present. */
+/* ============================================================ */
+#if defined(HAVE_ZLIB_H) && !__has_include(<zlib.h>)
+#undef HAVE_ZLIB_H
+#undef HAVE_LIBZ
+#endif
+
+#if defined(HAVE_BZLIB_H) && !__has_include(<bzlib.h>)
+#undef HAVE_BZLIB_H
+#undef HAVE_LIBBZ2
+#endif
+
+#if defined(HAVE_LZMA_H) && !__has_include(<lzma.h>)
+#undef HAVE_LZMA_H
+#undef HAVE_LIBLZMA
+#undef HAVE_LZMA_STREAM_ENCODER_MT
+#endif
+
+#if defined(HAVE_ZSTD_H) && !__has_include(<zstd.h>)
+#undef HAVE_ZSTD_H
+#undef HAVE_LIBZSTD
+#undef HAVE_ZSTD_compressStream
+#endif


### PR DESCRIPTION
This PR adds a Swift package in `contrib/Swift/` and an implementation that wraps libarchive in an idiomatic Swift API. A GitHub action is added to test the Swift implementation on Linux, macOS, Android, iOS, and Windows. Everything lives in `contrib/Swift/` except the top-level `Package.swift`, which is needed in order to be able to reference this project directly as a Swift dependency.