### PR TITLE
rar: fix LZSS window size mismatch after PPMd block

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2548,7 +2548,8 @@ parse_codes(struct archive_read *a)
       return (r);
   }
 
-  if (!rar->dictionary_size || !rar->lzss.window)
+  if (!rar->dictionary_size || !rar->lzss.window ||
+      (rar->lzss.mask + 1) < rar->dictionary_size)
   {
     /* Seems as though dictionary sizes are not used. Even so, minimize
      * memory usage as much as possible.
@@ -3149,6 +3150,11 @@ copy_from_lzss_window(struct archive_read *a, uint8_t *buffer,
 
   windowoffs = lzss_offset_for_position(&rar->lzss, startpos);
   firstpart = lzss_size(&rar->lzss) - windowoffs;
+  if (length > lzss_size(&rar->lzss)) {
+    archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+                      "Bad RAR file data");
+    return (ARCHIVE_FATAL);
+  }
   if (firstpart < 0) {
     archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
                       "Bad RAR file data");
@@ -3315,7 +3321,8 @@ parse_filter(struct archive_read *a, const uint8_t *bytes, uint16_t length, uint
   else
     blocklength = prog ? prog->oldfilterlength : 0;
 
-  if (blocklength > rar->dictionary_size)
+  if (blocklength > rar->dictionary_size ||
+      blocklength > (uint32_t)(rar->lzss.mask + 1))
     return 0;
 
   registers[3] = PROGRAM_SYSTEM_GLOBAL_ADDRESS;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2549,7 +2549,7 @@ parse_codes(struct archive_read *a)
   }
 
   if (!rar->dictionary_size || !rar->lzss.window ||
-      (rar->lzss.mask + 1) < rar->dictionary_size)
+      (unsigned int)(rar->lzss.mask + 1) < rar->dictionary_size)
   {
     /* Seems as though dictionary sizes are not used. Even so, minimize
      * memory usage as much as possible.


### PR DESCRIPTION
## What happens

A 170-byte RAR3 archive leaks 257 bytes of heap memory when extracted through libarchive. The data comes back through the normal `archive_read_data()` API - the application sees it as regular file content and will happily serve it, log it, write it to disk, whatever. The CRC check that would catch the corruption doesn't run until *after* the data is already returned to the caller.

This isn't a single bug. It's a chain of five that have to fire in sequence. Any one of them alone wouldn't be exploitable, but together they give you a reliable heap read primitive.

## The chain

I'll walk through each bug in the order they fire.

### Bug A: PPMd block inflates dictionary_size

In `parse_codes()` around line 2342, when a PPMd-compressed block shows up after an LZSS block, it does:

```c
rar->dictionary_size = (rar_br_bits(br, 8) + 1) << 20;
```

So now `dictionary_size` jumps to 1 MB. But the LZSS sliding window - allocated at only 8 bytes for the first block's tiny 3-bit dictionary - is untouched. PPMd doesn't use the LZSS window, so nobody thinks to reallocate.

### Bug B: Conflated allocation guard

When Block 3 starts LZSS decoding again, `parse_codes()` (line ~2554) checks whether it needs to allocate the window:

```c
if (!rar->dictionary_size || !rar->lzss.window)
```

After Bug A, `dictionary_size = 1MB` (truthy) and `window` points to the old 8-byte buffer (also truthy). Both non-zero → the allocation branch is skipped entirely. The code now thinks it has a 1 MB window but it's still 8 bytes.

This is the core design flaw: the guard conflates "is there a dictionary size configured?" with "is the window actually big enough?" Those are different questions and need separate checks.

### Bug C: OOB read in copy_from_lzss_window()

Around line 3158:

```c
firstpart = lzss_size(ds) - windowoffs;
if (firstpart < length) {
    memcpy(buffer, &(ds->window[windowoffs]), firstpart);
    memcpy(buffer + firstpart, &(ds->window[0]), length - firstpart);
}
```

`lzss_size()` returns `mask + 1 = 8` (from the original allocation). With `windowoffs=1` and `length=256`:

- `firstpart = 8 - 1 = 7`
- Second memcpy: `memcpy(buf+7, &window[0], 249)` - reads 249 bytes out of an 8-byte buffer

That's 241 bytes of whatever sits next to the window on the heap.

### Bug D: Filter path passes validation but shouldn't

The filter code calls `copy_from_lzss_window()` to fill a VM buffer with `blocklength` bytes. But validation in `parse_filter()` checks `blocklength` against `dictionary_size` (1 MB), not the actual window allocation (8 bytes). 256 < 1MB passes just fine. The filter happily requests 256 bytes from an 8-byte window.

### Bug E: CRC runs too late

`read_data_compressed()` (around line 2100) does the CRC32 check after `archive_read_data()` has already handed data to the caller. In a web service doing upload-then-extract-then-download, the leaked heap bytes are already in the HTTP response body before anyone notices the CRC is wrong.

```
archive_read_data() → returns 257 bytes (including leaked heap) → app sends to client
next call → CRC mismatch → ARCHIVE_WARN ... but the data's already gone
```

## How it looks in practice

The archive layout is: LZSS block (tiny dict) → PPMd block (big dict) → LZSS block with delta filter. When extracted:

```
[+] Entry: A (size=4)
    read #1: ARCHIVE_OK - received 257 bytes at offset 0
    >>> LEAKED DATA (first 64 bytes): 00b1833c...
    >>> 257 bytes returned BEFORE any CRC error!
    read #2: ERROR (r=-25) - Bad RAR file
    >>> CRC error detected NOW (too late)

    Total bytes leaked: 257
    Non-zero bytes: 233 / 257 (90.7%)
```

Worth noting: the leaked bytes don't come back raw - they go through a delta filter first, which stores differences between consecutive bytes. So what you get back looks like `output[0] = heap[0], output[1] = heap[1] - heap[0], output[2] = heap[2] - heap[1], ...` But this is trivially reversible: just add each byte to the previous one (`heap[i] = output[i] + heap[i-1]`) and you reconstruct the original heap contents byte-for-byte. The filter doesn't obscure anything.

## ASAN confirms it

```
==XXXXX==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xYYYYYYYY
READ of size 249 at 0xYYYYYYYY thread T0
    #0 memcpy
    #1 copy_from_lzss_window  archive_read_support_format_rar.c:3160
    #2 run_filters             archive_read_support_format_rar.c:2766
    #3 expand                  archive_read_support_format_rar.c:2700
    #4 read_data_compressed    archive_read_support_format_rar.c:2094
    #5 archive_read_data       archive_read.c
```

## Fix

Three changes, in order of importance:

**1. `parse_codes()` - primary fix**

Also check if the existing window (`mask + 1`) is smaller than `dictionary_size`. If so, reallocate.


**2. `copy_from_lzss_window()` - defense in depth**

Reject requests where `length` exceeds the window size.

**3. `parse_filter()` - defense in depth**

Validate `blocklength` against the actual window allocation, not just `dictionary_size`.


## Testing

Built with `-fsanitize=address,undefined -fno-sanitize-recover=all`. The PoC RAR (170 bytes) now produces `"Bad RAR file data"` and exits cleanly - zero ASAN reports. Normal RAR3 archives (with and without filters, with and without PPMd blocks) still extract correctly.