### PR TITLE
Fix OOB read in contrib/untar.c parseoct()

### DIFF
--- a/contrib/untar.c
+++ b/contrib/untar.c
@@ -60,11 +60,11 @@ parseoct(const char *p, size_t n)
 {
 	unsigned long i = 0;
 
-	while ((*p < '0' || *p > '7') && n > 0) {
+	while (n > 0 && (*p < '0' || *p > '7')) {
 		++p;
 		--n;
 	}
-	while (*p >= '0' && *p <= '7' && n > 0) {
+	while (n > 0 && *p >= '0' && *p <= '7') {
 		i *= 8;
 		i += *p - '0';
 		++p;


### PR DESCRIPTION
This PR fixes an out-of-bounds read in the standalone `contrib/untar.c` octal parser.

The bug is caused by the loop conditions in `parseoct()` dereferencing `*p` before checking whether `n > 0`. Because `&&` is evaluated left-to-right in C, an input that ends with octal digits at the final valid byte can advance `p` to one-past-the-end, set `n` to zero, and then still read `*p` on the next loop-condition evaluation. That makes this an attacker-controlled OOB read on malformed input, with crash / denial-of-service impact in affected consumers.

The fix is minimal and behavior-preserving: both loops now test `n > 0` before dereferencing `*p`.

I validated the change by rebuilding `contrib/untar.c` with `cc -Wall -Wextra -c contrib/untar.c -o /tmp/untar.o`. The file still has pre-existing unused-parameter warnings, but the patched code compiles successfully.

Reported-by: ZUENS2020

Please also consider requesting or assigning a CVE for this issue.
