### PR TITLE
Fix NULL pointer increment in archive_acl_from_text_nl

### DIFF
--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -1755,13 +1755,14 @@ archive_acl_from_text_nl(struct archive_acl *acl, const char *text,
 
 			tag = 0;
 			s = field[n].start;
-			st = field[n].start + 1;
 			len = field[n].end - field[n].start;
 
 			if (len == 0) {
 				ret = ARCHIVE_WARN;
 				continue;
 			}
+
+			st = s + 1; 
 
 			switch (*s) {
 			case 'u':


### PR DESCRIPTION
### Summary
This PR fixes a NULL pointer ~dereference~ increment in `archive_acl_from_text_nl()` (located in `archive_acl.c`) that occurs when parsing malformed PAX tar archives containing a short "default" ACL prefix.

### Technical Details
This is a variant of the bug previously fixed in the wide-character version `archive_acl_from_text_w()` via commit 7a6549a6 (Issue #2744). 

The vulnerability exists because `st = field[n].start + 1` is calculated before verifying if the field length is zero. In cases of malformed entries, `field[n].start` can be NULL, leading to Undefined Behavior (SIGILL if running under UBSan). This patch applies the same logic from the wide-char fix: moving the pointer increment after the length guard.

### Validation
- **Environment:** Ubuntu 24.04, compiled with AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan).
- **Reproduction:** Verified that the minimized PAX tar archive provided in issue #2904 no longer triggers the ~crash~ undefined behavior.
- **Regression:** All existing library tests pass.

Closes #2904