### PR TITLE
cpio: Improve mode option handling

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -427,7 +427,7 @@ main(int argc, char *argv[])
 		break;
 	default:
 		lafe_errc(1, 0,
-		    "Must specify at least one of -i, -o, or -p");
+		    "Must specify one of -i, -o, or -p");
 	}
 
 	archive_match_free(cpio->matching);


### PR DESCRIPTION
Supplying a mode multiple times leads to funny error messages:
```
$ bsdcpio -o -o
bsdcpio: Cannot use both -o and -o
```

POSIX from 1997 does not explicitly state that it's invalid to supply the same mode multiple times. But since cpio has been removed since then, it wouldn't be that important to stay compatible, I guess. GNU cpio does not allow `-o -o` either but exits with exit code 2, while bsdcpio exits with 1. In short: I guess it's safe to allow the same mode multiple times.

While at it, do not confuse the user with following message:
```
$ bsdcpio
bsdcpio: Must specify at least one of -i, -o, or -p
```

It has to be exactly one mode, not at least one. :)