### PR TITLE
tools: Remove `Error : ` prefix in lafe_errc calls

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -222,7 +222,7 @@ main(int argc, char *argv[])
 			if (archive_match_include_pattern_from_file(
 			    cpio->matching, cpio->argument,
 			    cpio->option_null) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(cpio->matching));
 			break;
 		case 'F': /* NetBSD/OpenBSD/GNU cpio */
@@ -231,7 +231,7 @@ main(int argc, char *argv[])
 		case 'f': /* POSIX 1997 */
 			if (archive_match_exclude_pattern(cpio->matching,
 			    cpio->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(cpio->matching));
 			break;
 		case OPTION_GRZIP:
@@ -409,7 +409,7 @@ main(int argc, char *argv[])
 		while (*cpio->argv != NULL) {
 			if (archive_match_include_pattern(cpio->matching,
 			    *cpio->argv) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(cpio->matching));
 			--cpio->argc;
 			++cpio->argv;

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -525,28 +525,28 @@ main(int argc, char **argv)
 			if (archive_match_include_date(bsdtar->matching,
 			    ARCHIVE_MATCH_CTIME | ARCHIVE_MATCH_NEWER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_NEWER_CTIME_THAN:
 			if (archive_match_include_file_time(bsdtar->matching,
 			    ARCHIVE_MATCH_CTIME | ARCHIVE_MATCH_NEWER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_NEWER_MTIME: /* GNU tar */
 			if (archive_match_include_date(bsdtar->matching,
 			    ARCHIVE_MATCH_MTIME | ARCHIVE_MATCH_NEWER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_NEWER_MTIME_THAN:
 			if (archive_match_include_file_time(bsdtar->matching,
 			    ARCHIVE_MATCH_MTIME | ARCHIVE_MATCH_NEWER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_NODUMP: /* star */
@@ -618,28 +618,28 @@ main(int argc, char **argv)
 			if (archive_match_include_date(bsdtar->matching,
 			    ARCHIVE_MATCH_CTIME | ARCHIVE_MATCH_OLDER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_OLDER_CTIME_THAN:
 			if (archive_match_include_file_time(bsdtar->matching,
 			    ARCHIVE_MATCH_CTIME | ARCHIVE_MATCH_OLDER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_OLDER_MTIME:
 			if (archive_match_include_date(bsdtar->matching,
 			    ARCHIVE_MATCH_MTIME | ARCHIVE_MATCH_OLDER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_OLDER_MTIME_THAN:
 			if (archive_match_include_file_time(bsdtar->matching,
 			    ARCHIVE_MATCH_MTIME | ARCHIVE_MATCH_OLDER,
 			    bsdtar->argument) != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case OPTION_ONE_FILE_SYSTEM: /* GNU tar */
@@ -819,7 +819,7 @@ main(int argc, char **argv)
 			if (archive_match_exclude_pattern_from_file(
 			    bsdtar->matching, bsdtar->argument, 0)
 			    != ARCHIVE_OK)
-				lafe_errc(1, 0, "Error : %s",
+				lafe_errc(1, 0, "%s",
 				    archive_error_string(bsdtar->matching));
 			break;
 		case 'x': /* SUSv2 */

--- a/tar/write.c
+++ b/tar/write.c
@@ -399,7 +399,7 @@ tar_mode_u(struct bsdtar *bsdtar)
 		if (archive_match_exclude_entry(bsdtar->matching,
 		    ARCHIVE_MATCH_MTIME | ARCHIVE_MATCH_OLDER |
 		    ARCHIVE_MATCH_EQUAL, entry) != ARCHIVE_OK)
-			lafe_errc(1, 0, "Error : %s",
+			lafe_errc(1, 0, "%s",
 			    archive_error_string(bsdtar->matching));
 		/* Record the last format determination we see */
 		format = archive_format(a);


### PR DESCRIPTION
Only a minority of calls to lafe_errc state explicitly that an error occurred. Remove these few cases for a more unified argument handling.

Example of differences:
```
$ bsdtar -t --owner x:
bsdtar: Invalid argument to --owner (missing id after :)
```
```
$ bsdtar -t --newer 'never'
bsdtar: Error : invalid date string
```

And no, I won't challenge the fact that sometimes error messages start with capital letters and sometimes not ... ;)