### PR TITLE
pax: Remove uid/gid cast in value range check

### DIFF
--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1062,7 +1062,7 @@ archive_write_pax_header(struct archive_write *a,
 	}
 
 	/* If numeric GID is too large, add 'gid' to pax extended attrs. */
-	if ((unsigned int)archive_entry_gid(entry_main) >= (1 << 18)) {
+	if (archive_entry_gid(entry_main) >= (1 << 18)) {
 		add_pax_attr_int(&(pax->pax_header), "gid",
 		    archive_entry_gid(entry_main));
 		need_extension = 1;
@@ -1078,7 +1078,7 @@ archive_write_pax_header(struct archive_write *a,
 	}
 
 	/* If numeric UID is too large, add 'uid' to pax extended attrs. */
-	if ((unsigned int)archive_entry_uid(entry_main) >= (1 << 18)) {
+	if (archive_entry_uid(entry_main) >= (1 << 18)) {
 		add_pax_attr_int(&(pax->pax_header), "uid",
 		    archive_entry_uid(entry_main));
 		need_extension = 1;


### PR DESCRIPTION
The API allows to set int64_t uid/gid values. When writing pax archives, such large values are properly set in the USTAR header of actual data in base256, i.e. everything works.

The pax header entries might be missing though because the check truncates these values to unsigned int. Larger values could be truncated in a way that they seem smaller than (1 << 18).

The check in line 1427 which sets the uid/gid values into the PAX header block is correct, truncating the actual value to max. octal representation.

This is a purely defensive change to support parsers which actually allow such large uid/gid values but do not understand base256 encoding.