### PR TITLE
rar5: validate remaining compressed bytes before merging split blocks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -953,6 +953,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_leftshift1.rar.uu \
 	libarchive/test/test_read_format_rar5_leftshift2.rar.uu \
 	libarchive/test/test_read_format_rar5_loop_bug.rar.uu \
+	libarchive/test/test_read_format_rar5_zero_remaining_block_header.rar.uu \
 	libarchive/test/test_read_format_rar5_multiarchive.part01.rar.uu \
 	libarchive/test/test_read_format_rar5_multiarchive.part02.rar.uu \
 	libarchive/test/test_read_format_rar5_multiarchive.part03.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3521,13 +3521,18 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 	while(1) {
 		/* Get the size of current block chunk in this multivolume
 		 * archive file and read it. */
+		if(partial_offset > block_size || rar->file.bytes_remaining <= 0) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Invalid state when merging split RAR5 blocks");
+			return ARCHIVE_FATAL;
+		}
 		cur_block_size = rar5_min(rar->file.bytes_remaining,
 		    block_size - partial_offset);
 
-		if(cur_block_size == 0) {
+		if(cur_block_size <= 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
-			    "Encountered block size == 0 during block merge");
+			    "Encountered invalid block size during block merge");
 			return ARCHIVE_FATAL;
 		}
 
@@ -3602,6 +3607,12 @@ static int process_block(struct archive_read* a) {
 		ssize_t to_skip;
 		ssize_t cur_block_size;
 
+		if(rar->file.bytes_remaining <= 0) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+			    "No compressed data left for another RAR5 block");
+			return ARCHIVE_FATAL;
+		}
+
 		/* The header size won't be bigger than 6 bytes. */
 		if(!read_ahead(a, 6, &p)) {
 			/* Failed to prefetch data block header. */
@@ -3626,6 +3637,11 @@ static int process_block(struct archive_read* a) {
 		 * if present. */
 		to_skip = sizeof(struct compressed_block_header) +
 			bf_byte_count(&rar->last_block_hdr) + 1;
+		if(rar->file.bytes_remaining < to_skip) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+			    "RAR5 block header exceeds remaining compressed data");
+			return ARCHIVE_FATAL;
+		}
 
 		if(ARCHIVE_OK != consume(a, to_skip))
 			return ARCHIVE_EOF;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1494,3 +1494,25 @@ DEFINE_TEST(test_read_format_rar5_invalidhash_and_validhtime_exfld)
 
 	EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_zero_remaining_block_header)
+{
+	/* Malformed RAR5 block layout that used to drive bytes_remaining
+	 * negative and reach the oversized allocation path in merge_block(). */
+
+	char buf[4096];
+	la_ssize_t r;
+	PROLOGUE("test_read_format_rar5_zero_remaining_block_header.rar");
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("bin/2to3;1", archive_entry_pathname(ae));
+
+	do {
+		r = archive_read_data(a, buf, sizeof(buf));
+	} while (r > 0);
+
+	assertEqualIntA(a, ARCHIVE_FATAL, r);
+	assertA(archive_error_string(a) != NULL);
+
+	EPILOGUE();
+}

--- a/libarchive/test/test_read_format_rar5_zero_remaining_block_header.rar.uu
+++ b/libarchive/test/test_read_format_rar5_zero_remaining_block_header.rar.uu
@@ -1,0 +1,7 @@
+begin 644 test_read_format_rar5_zero_remaining_block_header.rar
+M4F%R(1H' 0"BNGU4(0(#!%D&7^V# I?:-URW@4'R@ ,!"&)I;B\R=&\S P0 
+M <7)5B550C]U!#WY13&:5TJ$=$IZ(*3 CFVN#YI-_Q &5:6-!8((VD*21_V.
+MCF2X\:/J9V >ID+B 0!08  !"^ "E]HW7+>!0?*  P$(8FEN__]/P   K-,!
+&Q<E6)4)"
+ `
+end


### PR DESCRIPTION
  ## Summary

  Fix a RAR5 signed-length validation bug in compressed block processing.

  A malformed archive can drive `file.bytes_remaining` negative after parsing an
  additional compressed block header. That negative value then reaches the
  split-block merge path and is passed to `read_ahead(size_t)`, which turns it
  into an oversized allocation request.

  Local verification indicates the issue affects official releases from `v3.4.0`
  through `v3.8.6`.

  ## Fix

  - reject `bytes_remaining <= 0` before parsing another compressed block
  - reject compressed block headers that do not fit in the remaining compressed data
  - reject invalid split-block merge state before computing the next chunk size
  - reject non-positive merged chunk sizes before calling `read_ahead`

  These checks keep malformed RAR5 data on a deterministic file-format failure
  path instead of letting a negative signed length reach the read-ahead allocator.

  ## Tests

  - add `test_read_format_rar5_zero_remaining_block_header`
  - add `test_read_format_rar5_zero_remaining_block_header.rar.uu`
  - verify the new regression and adjacent RAR5 negative tests under ASan

  ## Verification

  - `ninja -C build libarchive_test`
  - `ninja -C build-asan libarchive_test`
  - `ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build-asan -R 'libarchive_test_read_format_rar5_(data_ready_pointer_leak|
  only_crypt_exfld|only_unsupported_exfld|invalidhash_and_validhtime_exfld|zero_remaining_block_header|loop_bug)' --output-on-failure`