### PR TITLE
Fix Windows test regression

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2119,7 +2119,7 @@ restore_entry(struct archive_write_disk *a)
 
 	if ((en == ENOENT) && (archive_entry_hardlink(a->entry) != NULL)) {
 		archive_set_error(&a->archive, en,
-		    "Hard-link target '%s' does not exist.",
+		    "Hard-link target '%s' does not exist",
 		    archive_entry_hardlink(a->entry));
 		return (ARCHIVE_FAILED);
 	}
@@ -4019,7 +4019,7 @@ set_fflags_platform(struct archive_write_disk *a, int fd, const char *name,
 #elif defined(HAVE_CHFLAGS)
 	if (S_ISLNK(a->st.st_mode)) {
 		archive_set_error(&a->archive, errno,
-		    "Can't set file flags on symlink.");
+		    "Can't set file flags on symlink");
 		return (ARCHIVE_WARN);
 	}
 	if (chflags(name, a->st.st_flags) == 0)
@@ -4578,7 +4578,7 @@ set_xattrs(struct archive_write_disk *a)
 		} else
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Cannot restore extended "
-			    "attributes on this file system.");
+			    "attributes on this file system");
 	}
 
 	archive_string_free(&errlist);
@@ -4680,7 +4680,7 @@ set_xattrs(struct archive_write_disk *a)
 		} else
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Cannot restore extended "
-			    "attributes on this file system.");
+			    "attributes on this file system");
 	}
 
 	archive_string_free(&errlist);

--- a/libarchive/test/test_warn_missing_hardlink_target.c
+++ b/libarchive/test/test_warn_missing_hardlink_target.c
@@ -37,7 +37,7 @@ DEFINE_TEST(test_warn_missing_hardlink_target)
 
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	assertEqualInt(ENOENT, archive_errno(a));
-	assertEqualString("Hard-link target 'hardlink-target' does not exist.",
+	assertEqualString("Hard-link target 'hardlink-target' does not exist",
 	    archive_error_string(a));
 
 	archive_entry_free(ae);


### PR DESCRIPTION
By only removing periods from error messages in Windows specific code, but not adjusting its POSIX counterpart, the test fails on Windows but not on POSIX systems.

Fix this by removing the period in test and in POSIX error messages.

Fixes: 3e0819b59e ("libarchive: Remove period from error messages")