### PR TITLE
pathmatch: Anchors within pattern not special

### DIFF
--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -202,7 +202,7 @@ pm(const char *p, const char *s, int flags)
 			if (*p == '\0')
 				return (1);
 			while (*s) {
-				if (archive_pathmatch(p, s, flags))
+				if (pm(p, s, flags))
 					return (1);
 				++s;
 			}
@@ -307,7 +307,7 @@ pm_w(const wchar_t *p, const wchar_t *s, int flags)
 			if (*p == L'\0')
 				return (1);
 			while (*s) {
-				if (archive_pathmatch_w(p, s, flags))
+				if (pm_w(p, s, flags))
 					return (1);
 				++s;
 			}

--- a/libarchive/test/test_archive_pathmatch.c
+++ b/libarchive/test/test_archive_pathmatch.c
@@ -285,4 +285,22 @@ DEFINE_TEST(test_archive_pathmatch)
 	    archive_pathmatch("a/b/c$", "a/b/c/d", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
 	assertEqualInt(1,
 	    archive_pathmatch("b/c/d$", "a/b/c/d", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+
+	/* Anchor characters within pattern not special. */
+	assertEqualInt(0,
+	    archive_pathmatch("*^*", "a/b/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(1,
+	    archive_pathmatch("*^*", "a^b", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(0,
+	    archive_pathmatch("*$*", "a/b/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(1,
+	    archive_pathmatch("*$*", "a$b", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(0,
+	    archive_pathmatch("a*/^b/c", "a/b/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(1,
+	    archive_pathmatch("a*/^b/c", "a/^b/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(0,
+	    archive_pathmatch("a*/b$/c", "a/b/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
+	assertEqualInt(1,
+	    archive_pathmatch("a*/b$/c", "a/b$/c", PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END));
 }


### PR DESCRIPTION
The anchor characters `^` and `$` have only special meanings if they are located at the beginning (`^`) or at the end (`$`) of the pattern. And even then they are supposed to be only special if flags are set.

If they are located within the pattern itself, they are regular characters regardless of flags.

Proof of Concept:
1. Create a tar archive with `/dev/null` in it
```
bsdtar -cf null.tar /dev/null
```
2. List content and exclude `dev/*^*`
```
bsdtar --exclude='dev/*^*' -tf null.tar
```
No output is shown.

For a change, I was able to add unit tests for this.