### PR TITLE
Fix heap-buffer-overflow in write_path() and copy_path() for empty pathname

### DIFF
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -2295,7 +2295,7 @@ write_path(struct archive_entry *entry, struct archive_write *archive)
 	type = archive_entry_filetype(entry);
 	written_bytes = 0;
 
-	if (path == NULL)
+	if (path == NULL || path[0] == '\0')
 		return (ARCHIVE_FATAL);
 
 	ret = __archive_write_output(archive, path, strlen(path));
@@ -2328,7 +2328,7 @@ copy_path(struct archive_entry *entry, unsigned char *p)
 	memcpy(p, path, pathlen);
 
 	/* Folders are recognized by a trailing slash. */
-	if ((type == AE_IFDIR) && (path[pathlen - 1] != '/'))
+	if ((type == AE_IFDIR) && pathlen > 0 && (path[pathlen - 1] != '/'))
 		p[pathlen] = '/';
 }
 


### PR DESCRIPTION
## Summary

Fix out-of-bounds heap read in `write_path()` and `copy_path()` in `archive_write_set_format_zip.c` when the archive entry has an empty pathname.

Fixes #2925

## Problem

When `archive_write_header()` is called with an entry that has an empty pathname (`""`) and `AE_IFDIR` filetype, `strlen(path)` returns 0, and the expression `strlen(path) - 1` underflows to `SIZE_MAX` (since `size_t` is unsigned). This causes `path[SIZE_MAX]` to read far out of bounds.

Two locations are affected:
- `write_path()` line 2307: `path[strlen(path) - 1]`
- `copy_path()` line 2331: `path[pathlen - 1]`

## Fix

Extend the existing NULL check to also reject empty strings in `write_path()`, and add a length guard to the trailing-slash check in `copy_path()`.

## Diff

```diff
--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -2295,7 +2295,7 @@ write_path(struct archive_entry *entry, struct archive_write *archive)
 	type = archive_entry_filetype(entry);
 	written_bytes = 0;

-	if (path == NULL)
+	if (path == NULL || path[0] == '\0')
 		return (ARCHIVE_FATAL);

 	ret = __archive_write_output(archive, path, strlen(path));
@@ -2328,7 +2328,7 @@ copy_path(struct archive_entry *entry, unsigned char *p)
 	memcpy(p, path, pathlen);

 	/* Folders are recognized by a trailing slash. */
-	if ((type == AE_IFDIR) && (path[pathlen - 1] != '/'))
+	if ((type == AE_IFDIR) && pathlen > 0 && (path[pathlen - 1] != '/'))
 		p[pathlen] = '/';
 }
```

## Testing

Reproducer:

```c
struct archive *a = archive_write_new();
archive_write_set_format_zip(a);
archive_write_add_filter_none(a);
char outbuf[4096];
size_t used = 0;
archive_write_open_memory(a, outbuf, sizeof(outbuf), &used);

struct archive_entry *entry = archive_entry_new();
archive_entry_set_pathname(entry, "");
archive_entry_set_filetype(entry, AE_IFDIR);
archive_write_header(a, entry);  // OOB read before fix, ARCHIVE_FATAL after fix
```

Before fix: AddressSanitizer reports heap-buffer-overflow.
After fix: `archive_write_header` returns `ARCHIVE_FATAL` cleanly.