### PR TITLE
pathmatch: Treat anchors not special without flags

### DIFF
--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -387,7 +387,7 @@ __archive_pathmatch(const char *p, const char *s, int flags)
 		return (0);
 
 	/* Leading '^' anchors the start of the pattern. */
-	if (*p == '^') {
+	if ((flags & PATHMATCH_NO_ANCHOR_START) && *p == '^') {
 		++p;
 		flags &= ~PATHMATCH_NO_ANCHOR_START;
 	}
@@ -429,7 +429,7 @@ __archive_pathmatch_w(const wchar_t *p, const wchar_t *s, int flags)
 		return (0);
 
 	/* Leading '^' anchors the start of the pattern. */
-	if (*p == L'^') {
+	if ((flags & PATHMATCH_NO_ANCHOR_START) && *p == L'^') {
 		++p;
 		flags &= ~PATHMATCH_NO_ANCHOR_START;
 	}

--- a/libarchive/test/test_archive_match_path.c
+++ b/libarchive/test/test_archive_match_path.c
@@ -233,8 +233,8 @@ test_inclusion_mbs(void)
 		return;
 	}
 
-	/* Test for pattern "^aa*" */
-	assertEqualIntA(m, 0, archive_match_include_pattern(m, "^aa*"));
+	/* Test for pattern "aa*" */
+	assertEqualIntA(m, 0, archive_match_include_pattern(m, "aa*"));
 
 	/* Test with 'aa1234', which should not be excluded. */
 	archive_entry_copy_pathname(ae, "aa1234");
@@ -282,8 +282,8 @@ test_inclusion_wcs(void)
 		return;
 	}
 
-	/* Test for pattern "^aa*" */
-	assertEqualIntA(m, 0, archive_match_include_pattern_w(m, L"^aa*"));
+	/* Test for pattern "aa*" */
+	assertEqualIntA(m, 0, archive_match_include_pattern_w(m, L"aa*"));
 
 	/* Test with 'aa1234', which should not be excluded. */
 	archive_entry_copy_pathname(ae, "aa1234");
@@ -383,8 +383,8 @@ test_exclusion_and_inclusion(void)
 	}
 
 	assertEqualIntA(m, 0, archive_match_exclude_pattern(m, "^aaa*"));
-	assertEqualIntA(m, 0, archive_match_include_pattern_w(m, L"^aa*"));
-	assertEqualIntA(m, 0, archive_match_include_pattern(m, "^a1*"));
+	assertEqualIntA(m, 0, archive_match_include_pattern_w(m, L"aa*"));
+	assertEqualIntA(m, 0, archive_match_include_pattern(m, "a1*"));
 
 	/* Test with 'aa1234', which should not be excluded. */
 	archive_entry_copy_pathname(ae, "aa1234");
@@ -413,13 +413,13 @@ test_exclusion_and_inclusion(void)
 	/* Verify unmatched inclusion patterns. */
 	assertEqualIntA(m, ARCHIVE_OK,
 	    archive_match_path_unmatched_inclusions_next(m, &mp));
-	assertEqualString("^a1*", mp);
+	assertEqualString("a1*", mp);
 	assertEqualIntA(m, ARCHIVE_EOF,
 	    archive_match_path_unmatched_inclusions_next(m, &mp));
 	/* Verify unmatched inclusion patterns again in Wide-Char. */
 	assertEqualIntA(m, ARCHIVE_OK,
 	    archive_match_path_unmatched_inclusions_next_w(m, &wp));
-	assertEqualWString(L"^a1*", wp);
+	assertEqualWString(L"a1*", wp);
 	assertEqualIntA(m, ARCHIVE_EOF,
 	    archive_match_path_unmatched_inclusions_next_w(m, &wp));
 

--- a/libarchive/test/test_archive_pathmatch.c
+++ b/libarchive/test/test_archive_pathmatch.c
@@ -209,6 +209,14 @@ DEFINE_TEST(test_archive_pathmatch)
 	failure("Trailing '/.' is still the same directory.");
 	assertEqualInt(1, archive_pathmatch("./abc*/./def", "abc/def/.", 0));
 
+	/* Anchor characters without flags not special. */
+	assertEqualInt(0, archive_pathmatch("^abc", "abc", 0));
+	assertEqualInt(1, archive_pathmatch("^abc", "^abc", 0));
+	assertEqualInt(0, archive_pathmatch("abc$", "abc", 0));
+	assertEqualInt(1, archive_pathmatch("abc$", "abc$", 0));
+	assertEqualInt(0, archive_pathmatch("^abc$", "abc", 0));
+	assertEqualInt(1, archive_pathmatch("^abc$", "^abc$", 0));
+
 	/* Matches not anchored at beginning. */
 	assertEqualInt(0,
 	    archive_pathmatch("bcd", "abcd", PATHMATCH_NO_ANCHOR_START));

--- a/libarchive/test/test_archive_pathmatch.c
+++ b/libarchive/test/test_archive_pathmatch.c
@@ -56,6 +56,10 @@ DEFINE_TEST(test_archive_pathmatch)
 	assertEqualInt(0, archive_pathmatch_w(L"a/b/c", NULL, 0));
 
 	/* Empty pattern only matches empty string. */
+	assertEqualInt(1, archive_pathmatch(NULL,NULL, 0));
+	assertEqualInt(1, archive_pathmatch(NULL,"", 0));
+	assertEqualInt(0, archive_pathmatch(NULL,"a", 0));
+	assertEqualInt(1, archive_pathmatch("",NULL, 0));
 	assertEqualInt(1, archive_pathmatch("","", 0));
 	assertEqualInt(0, archive_pathmatch("","a", 0));
 	assertEqualInt(1, archive_pathmatch("*","", 0));
@@ -76,11 +80,15 @@ DEFINE_TEST(test_archive_pathmatch)
 	assertEqualInt(0, archive_pathmatch("a", "ab", 0));
 	assertEqualInt(0, archive_pathmatch("a", "ab", 0));
 	assertEqualInt(1, archive_pathmatch("a?c", "abc", 0));
+	assertEqualInt(1, archive_pathmatch("*a", "/a", 0));
+	assertEqualInt(1, archive_pathmatch("*a", "a", 0));
 	/* SUSv2: ? matches / */
 	assertEqualInt(1, archive_pathmatch("a?c", "a/c", 0));
 	assertEqualInt(1, archive_pathmatch("a?*c*", "a/c", 0));
 	assertEqualInt(1, archive_pathmatch("*a*", "a/c", 0));
 	assertEqualInt(1, archive_pathmatch("*a*", "/a/c", 0));
+	assertEqualInt(0, archive_pathmatch("*a", "/a/c", 0));
+	assertEqualInt(0, archive_pathmatch("*a", "a/c", 0));
 	assertEqualInt(1, archive_pathmatch("*a*", "defaaaaaaa", 0));
 	assertEqualInt(0, archive_pathmatch("a*", "defghi", 0));
 	assertEqualInt(0, archive_pathmatch("*a*", "defghi", 0));


### PR DESCRIPTION
If no flags are supplied, anchor flags are supposed to be not special. This means that ^ at the beginning of a pattern should be treated as a regular character.

This breaks current behavior, but complies with comments in code, i.e. archive_pathmatch.h line 41/42.

It was introduced 15 years ago with https://github.com/libarchive/libarchive/commit/3b14daeb93a81cb840947e85a2e91a629e325cd6 and is "wrong" since then.

So, alternatively we could adjust the comment and document the pattern, since it's not as close to tcsh's globbing as the document suggests (`^/b*` in tcsh would revert `/b*` and won't anchor like libarchive does). It's more like a combination between regular expression (^$) and globbing.

Consequence of this change is that `bsdtar --include` starts treating `^` as a character, but `--exclude` does not. It's just as the "quirkiness" of gtar is supposed to be according to comments, but hard to say if this feels in any way natural to a bsdtar user:

Whatever the choice is, it would be nice if comments match code. If it's not this code change, I'll adjust comments. :)

Without this PR:
```
$ bsdtar -cf null.tar /dev/null
$ bsdtar --include ^dev -tf null.tar
dev/null
$ bsdtar --exclude ^dev -tf null.tar
$ _
```

With this PR:
```
$ bsdtar -cf null.tar /dev/null
$ bsdtar --include ^dev -tf null.tar
bsdtar: ^dev: Not found in archive
bsdtar: Error exit delayed from previous errors.
$ bsdtar --exclude ^dev -tf null.tar
$ _
```

Further reading:
https://github.com/libarchive/libarchive/blob/8b978a03685c88ef0583ded5e7a1df0b1f262dd7/libarchive/archive_match.c#L204-L209
https://github.com/libarchive/libarchive/blob/8b978a03685c88ef0583ded5e7a1df0b1f262dd7/libarchive/archive_match.c#L778-L784
https://github.com/libarchive/libarchive/blob/8b978a03685c88ef0583ded5e7a1df0b1f262dd7/libarchive/archive_match.c#L807-L812