### PR TITLE
7zip: Verify that Codec ID fits into 63 bit

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -175,7 +175,7 @@ struct _7z_digests {
 struct _7z_folder {
 	uint64_t		 numCoders;
 	struct _7z_coder {
-		unsigned long	 codec;
+		uint64_t	 codec;
 		uint64_t	 numInStreams;
 		uint64_t	 numOutStreams;
 		uint64_t	 propertiesSize;
@@ -409,7 +409,7 @@ static int	archive_read_format_7zip_read_data_skip(struct archive_read *);
 static int	archive_read_format_7zip_read_header(struct archive_read *,
 		    struct archive_entry *);
 static int	check_7zip_header_in_sfx(const unsigned char *);
-static unsigned long decode_codec_id(const unsigned char *, size_t);
+static int	decode_codec_id(const unsigned char *, size_t, uint64_t *);
 static int	decode_encoded_header_info(struct archive_read *,
 		    struct _7z_stream_info *);
 static int	decompress(struct archive_read *, struct _7zip *,
@@ -1289,17 +1289,20 @@ set_error(struct archive_read *a, int ret)
 
 #endif
 
-static unsigned long
-decode_codec_id(const unsigned char *codecId, size_t id_size)
+static int
+decode_codec_id(const unsigned char *codecId, size_t id_size, uint64_t *id)
 {
 	unsigned i;
-	unsigned long id = 0;
+	uint64_t v = 0;
 
 	for (i = 0; i < id_size; i++) {
-		id <<= 8;
-		id += codecId[i];
+		if (v > (uint64_t)INT64_MAX / 256)
+			return (-1);
+		v <<= 8;
+		v += codecId[i];
 	}
-	return (id);
+	*id = v;
+	return (0);
 }
 
 static Byte
@@ -2287,7 +2290,8 @@ read_Folder(struct archive_read *a, struct _7z_folder *f)
 		if ((p = header_bytes(a, codec_size)) == NULL)
 			return (-1);
 
-		f->coders[i].codec = decode_codec_id(p, codec_size);
+		if (decode_codec_id(p, codec_size, &f->coders[i].codec) < 0)
+			return (-1);
 
 		if (simple) {
 			f->coders[i].numInStreams = 1;


### PR DESCRIPTION
According to 7zip standard, up to 15 bytes can be used for the Codec ID, but not more than 63 bit shall be used (by today):

- Switch to uint64_t to avoid 32 bit unsigned long on Windows
- Verify that Codec ID parser does not overflow the integer

If the Codec ID does not fit, treat it as a file format error.

Link to relevant spec: https://github.com/ip7z/7zip/blob/main/DOC/Methods.txt#L8

This implementation is quite benevolent: If the ID is larger in bytes but value fits into 63 bit, we still accept it.