### PR TITLE
 Fix heap-buffer-overflow write in lzx_decode_blocks() for malformed CAB files

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -2828,6 +2828,8 @@ lzx_decode_blocks(struct lzx_stream *strm, int last)
 				w_buff[w_pos] = c;
 				w_pos = (w_pos + 1) & w_mask;
 				/* Store the decoded code to output buffer. */
+				if (noutp >= endp)
+					goto next_data;
 				*noutp++ = c;
 				block_bytes_avail--;
 			}


### PR DESCRIPTION
## Summary

Fix out-of-bounds heap write in `lzx_decode_blocks()` in `archive_read_support_format_cab.c` when processing a crafted CAB file with malformed LZX compressed data.

Fixes #2931 (replace with your issue number)

## Problem

When processing a malformed CAB file, `lzx_decode_blocks()` writes decoded literal bytes to the output buffer at line 2831 (`*noutp++ = c`) without checking whether `noutp` has reached the buffer boundary `endp`. The boundary check at line 2797 only runs at the top of the decode loop, but within the Huffman decode path, multiple iterations can occur before the check is re-evaluated, allowing writes past the end of the 32KB output buffer.

This causes a SIGSEGV crash in production builds and a heap-buffer-overflow write detected by AddressSanitizer.

## Fix

Add a boundary check before writing the decoded byte to the output buffer.

## Diff

```diff
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -2828,6 +2828,8 @@ lzx_decode_blocks(struct lzx_stream *strm, int last)
 				w_buff[w_pos] = c;
 				w_pos = (w_pos + 1) & w_mask;
 				/* Store the decoded code to output buffer. */
+				if (noutp >= endp)
+					goto next_data;
 				*noutp++ = c;
 				block_bytes_avail--;
 			}
```

## Testing

### Reproducer

```c
#include <stdio.h>
#include <stdlib.h>
#include <archive.h>
#include <archive_entry.h>

int main(int argc, char **argv) {
    if (argc < 2) return 1;
    FILE *f = fopen(argv[1], "rb");
    fseek(f, 0, SEEK_END);
    long len = ftell(f);
    fseek(f, 0, SEEK_SET);
    unsigned char *buf = malloc(len);
    fread(buf, 1, len, f);
    fclose(f);

    struct archive *a = archive_read_new();
    archive_read_support_format_cab(a);
    archive_read_support_filter_all(a);
    if (archive_read_open_memory(a, buf, len) == ARCHIVE_OK) {
        struct archive_entry *entry;
        while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
            const void *block;
            size_t block_size;
            la_int64_t offset;
            while (archive_read_data_block(a, &block, &block_size, &offset) == ARCHIVE_OK) {}
        }
    }
    archive_read_free(a);
    free(buf);
    return 0;
}
```

Compile with: `clang -fsanitize=address poc.c -larchive -o poc`

Run with a crafted 660-byte CAB file containing malformed LZX compressed data.

### ASAN output

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x52d000008400
WRITE of size 1 at 0x52d000008400 thread T0
    #0 in lzx_decode_blocks archive_read_support_format_cab.c:2831
    #1 in lzx_decode archive_read_support_format_cab.c:2417
    #2 in cab_read_ahead_cfdata_lzx archive_read_support_format_cab.c:1708
    #3 in cab_read_ahead_cfdata archive_read_support_format_cab.c:1365

0x52d000008400 is located 0 bytes after 32768-byte region
```

### Results

- **Without ASAN (production):** SIGSEGV, exit code 139
- **Before fix:** crashes
- **After fix:** returns cleanly