### PR TITLE
Fix heap-buffer-overflow in ISO9660 Joliet identifier generation

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -6334,6 +6334,8 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 			noff = ext_off - 2;
 		else
 			noff = ext_off;
+		if (noff < 0)
+			noff = 0;
 		/* Register entry to the identifier resolver. */
 		idr_register(idr, np, weight, noff);
 	}


### PR DESCRIPTION
## Summary
- Fix a heap-based out-of-bounds write in `isoent_gen_joliet_identifier()` in `archive_write_set_format_iso9660.c`
- Root cause: the `noff` calculation (`ext_off - 6/4/2`) can produce a negative value when `ext_off` is smaller than the subtracted constant, causing `idr_set_num_beutf16()` to write UTF-16 characters before the start of the allocated identifier buffer
- Fix: clamp `noff` to 0 after computation, before passing it to `idr_register()`
- Validated with AddressSanitizer: no sanitizer errors after patch

## Reproduction
Build with `-fsanitize=address` and run the PoC from #2938.
Before: `AddressSanitizer: heap-buffer-overflow` in `archive_be16enc`. After: clean exit.

Fixes #2938