### PR TITLE
fix `archive_entry_set_mode` & `archive_entry_set_perm`

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1239,7 +1239,7 @@ _archive_entry_copy_link_l(struct archive_entry *entry,
 }
 
 void
-archive_entry_set_mode(struct archive_entry *entry, mode_t m)
+archive_entry_set_mode(struct archive_entry *entry, __LA_MODE_T m)
 {
 	entry->stat_valid = 0;
 	entry->acl.mode = m;
@@ -1314,7 +1314,7 @@ _archive_entry_copy_pathname_l(struct archive_entry *entry,
 }
 
 void
-archive_entry_set_perm(struct archive_entry *entry, mode_t p)
+archive_entry_set_perm(struct archive_entry *entry, __LA_MODE_T p)
 {
 	entry->stat_valid = 0;
 	entry->acl.mode &= AE_IFMT;


### PR DESCRIPTION
Match the prototypes in `archive_entry.h`: use `__LA_MODE_T` (which is not always an alias for `mode_t`):

https://github.com/libarchive/libarchive/blob/8f6614c378743e9daa3ab36b4c036bebfdd111a4/libarchive/archive_entry.h#L384

https://github.com/libarchive/libarchive/blob/8f6614c378743e9daa3ab36b4c036bebfdd111a4/libarchive/archive_entry.h#L393

https://github.com/libarchive/libarchive/blob/8f6614c378743e9daa3ab36b4c036bebfdd111a4/libarchive/archive_entry.h#L95-L103