### PR TITLE
Fix double-free in LZ4 filter on reallocation failure (CWE-415)

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -304,13 +304,15 @@ lz4_allocate_out_block(struct archive_read_filter *self)
 		out_block_size += 64 * 1024;
 	if (state->out_block_size < out_block_size) {
 		free(state->out_block);
+		state->out_block = NULL;
 		out_block = malloc(out_block_size);
-		state->out_block_size = out_block_size;
 		if (out_block == NULL) {
+			state->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
+		state->out_block_size = out_block_size;
 		state->out_block = out_block;
 	}
 	if (!state->flags.block_independence)
@@ -327,13 +329,15 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 
 	if (state->out_block_size < out_block_size) {
 		free(state->out_block);
+		state->out_block = NULL;
 		out_block = malloc(out_block_size);
-		state->out_block_size = out_block_size;
 		if (out_block == NULL) {
+			state->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
+		state->out_block_size = out_block_size;
 		state->out_block = out_block;
 	}
 	return (ARCHIVE_OK);

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -98,6 +98,7 @@ IF(ENABLE_TEST)
     test_read_filter_grzip.c
     test_read_filter_gzip_recursive.c
     test_read_filter_lrzip.c
+    test_read_filter_lz4_doublefree.c
     test_read_filter_lzop.c
     test_read_filter_lzop_multiple_parts.c
     test_read_filter_program.c

--- a/libarchive/test/test_read_filter_lz4_doublefree.c
+++ b/libarchive/test/test_read_filter_lz4_doublefree.c
@@ -1,0 +1,76 @@
+#include "test.h"
+
+/*
+ * Regression test for double-free in LZ4 filter (CWE-415).
+ *
+ * Bug: lz4_allocate_out_block() in archive_read_support_filter_lz4.c
+ * frees state->out_block without NULLing the pointer, then updates
+ * state->out_block_size before checking if the subsequent malloc
+ * succeeded. If malloc fails:
+ *   1. state->out_block is a dangling pointer (freed but not NULLed)
+ *   2. state->out_block_size is already inflated to the new size
+ *   3. lz4_filter_close() calls free(state->out_block) again
+ *      -> double-free
+ *
+ * Test data: Two concatenated LZ4 frames with different block sizes
+ *   Frame 1: block_maximum_size = 64KB  (BD=0x40)
+ *   Frame 2: block_maximum_size = 4MB   (BD=0x70)
+ * This forces the reallocation path in lz4_allocate_out_block().
+ *
+ * To trigger the double-free, malloc must fail on the 4MB allocation.
+ * Run with: LD_PRELOAD=failmalloc.so (fail allocations >= 3MB)
+ *
+ * Without fix + ASAN + failmalloc:
+ *   ASAN detects double-free in lz4_filter_close() -> test crashes
+ * With fix + ASAN + failmalloc:
+ *   state->out_block is NULLed after free, free(NULL) is safe
+ *   -> test passes with ARCHIVE_OK from archive_read_free()
+ *
+ * Without failmalloc, this test exercises the reallocation path
+ * and verifies cleanup does not cause memory safety issues.
+ */
+DEFINE_TEST(test_read_filter_lz4_doublefree)
+{
+	const char *refname = "test_read_filter_lz4_doublefree.lz4";
+	struct archive *a;
+	struct archive_entry *ae;
+	int r;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	r = archive_read_support_filter_lz4(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("lz4 reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, r);
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_format_raw(a));
+
+	/*
+	 * Open the crafted two-frame LZ4 file. The second frame has
+	 * a larger block_maximum_size, triggering reallocation of
+	 * the output buffer via lz4_allocate_out_block().
+	 *
+	 * Under normal conditions, the 4MB malloc succeeds and the
+	 * test verifies basic correctness. Under failmalloc, the
+	 * malloc fails and the double-free path is exercised.
+	 */
+	r = archive_read_open_filename(a, refname, 10240);
+	if (r == ARCHIVE_OK) {
+		if (archive_read_next_header(a, &ae) == ARCHIVE_OK) {
+			char buf[1024];
+			while (archive_read_data(a, buf, sizeof(buf)) > 0) {}
+		}
+	}
+
+	/*
+	 * archive_read_free triggers lz4_filter_close() which calls
+	 * free(state->out_block). Without the fix, if frame 2's
+	 * malloc failed, state->out_block is a dangling pointer
+	 * and this is a double-free.
+	 */
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_filter_lz4_doublefree.lz4.uu
+++ b/libarchive/test/test_read_filter_lz4_doublefree.lz4.uu
@@ -1,0 +1,4 @@
+begin 664 test_read_filter_lz4_doublefree.lz4
+F!")-&&!   0  (!415-4      0B31A@<  $  " 5$535       
+ 
+end


### PR DESCRIPTION
lz4_allocate_out_block() frees state->out_block without NULLing the pointer. If the subsequent malloc fails, the function returns ARCHIVE_FATAL with a dangling pointer. lz4_filter_close() later calls free(state->out_block) again, triggering a double-free.

Also, state->out_block_size was updated before checking if malloc succeeded, leaving inconsistent metadata on failure.

Fix both lz4_allocate_out_block() and lz4_allocate_out_block_for_legacy():
- NULL the pointer immediately after free
- Move size update to after malloc succeeds
- Reset size to 0 on allocation failure

Add regression test with a crafted two-frame LZ4 file (64KB then 4MB block sizes) that exercises the reallocation path.