### PR TITLE
Fix RAR5 solid_window_size check bypass (CWE-665)

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -873,10 +873,16 @@ static void free_filters(struct rar5* rar) {
 }
 
 static void reset_file_context(struct rar5* rar) {
+	/* Preserve solid_window_size across the memset so the consistency
+	 * check in process_head_file() can detect window size changes
+	 * between solid archive entries. */
+	ssize_t saved_solid_window_size = rar->file.solid_window_size;
+
 	memset(&rar->file, 0, sizeof(rar->file));
 	blake2sp_init(&rar->file.b2state, 32);
 
 	if(rar->main.solid) {
+		rar->file.solid_window_size = saved_solid_window_size;
 		rar->cstate.solid_offset += rar->cstate.write_ptr;
 	} else {
 		rar->cstate.solid_offset = 0;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1304,6 +1304,49 @@ DEFINE_TEST(test_read_format_rar5_different_solid_window_size)
 	EPILOGUE();
 }
 
+/*
+ * Regression test for solid_window_size check bypass (CWE-665).
+ *
+ * Bug: reset_file_context() in archive_read_support_format_rar5.c
+ * calls memset(&rar->file, 0, ...) which zeros solid_window_size.
+ * This defeats the consistency check in process_head_file() that
+ * prevents changing window sizes between solid archive entries.
+ *
+ * Test archive layout (crafted):
+ *   Entry 1: non-solid, stored, window=256KB
+ *   Entry 2: solid, stored, window=256KB (sets solid_window_size)
+ *   Entry 3: solid, stored, window=1MB   (should trigger mismatch)
+ *
+ * Without fix: all 3 headers return ARCHIVE_OK (bypass)
+ * With fix: entry 3 returns ARCHIVE_FATAL (mismatch detected)
+ */
+DEFINE_TEST(test_read_format_rar5_solid_window_bypass)
+{
+	char buf[4096];
+	int r;
+	PROLOGUE("test_read_format_rar5_solid_window_bypass.rar");
+
+	/* Entry 1: non-solid, should succeed. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	while(0 < archive_read_data(a, buf, sizeof(buf))) {}
+
+	/* Entry 2: first solid entry, sets solid_window_size=256KB. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	while(0 < archive_read_data(a, buf, sizeof(buf))) {}
+
+	/* Entry 3: solid with window=1MB. The consistency check should
+	 * detect the mismatch and return ARCHIVE_FATAL.
+	 *
+	 * Without fix: reset_file_context() zeros solid_window_size,
+	 * the check at line 1871 sees 0 > 0 == false, returns ARCHIVE_OK.
+	 * With fix: solid_window_size is preserved, check fires. */
+	r = archive_read_next_header(a, &ae);
+	assertEqualIntA(a, ARCHIVE_FATAL, r);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_read_format_rar5_different_winsize_on_merge)
 {
 	char buf[4096];

--- a/libarchive/test/test_read_format_rar5_solid_window_bypass.rar.uu
+++ b/libarchive/test/test_read_format_rar5_solid_window_bypass.rar.uu
@@ -1,0 +1,8 @@
+begin 644 test_read_format_rar5_solid_window_bypass.rar
+M4F%R(1H' 0#<WEXU P$ !/VLDX8@ @,"$@82I(,"    8"G8P': " $)9FEL
+M93$N='AT 0%(96QL;R!F<F]M(&9I;&4Q(0I.KWMA'0("$@82I(,"    8'!F
+MAG3 " $)9FEL93(N='AT2&5L;&\@9G)O;2!F:6QE,B$*1%!D-1T" A(&$J2#
+M @   &!'#$1UP!@!"69I;&4S+G1X=$AE;&QO(&9R;VT@9FEL93,A"CGYLH$"
+"!0  
+ 
+end


### PR DESCRIPTION
reset_file_context() calls memset(&rar->file, 0, sizeof(rar->file)) which zeros solid_window_size. This defeats the consistency check in process_head_file() (line 1871) that is supposed to prevent window size changes between solid archive entries. The check condition (solid_window_size > 0) can never be true after the memset, making it dead code for all solid archives after the first entry.

Fix: save and restore solid_window_size across the memset when processing a solid archive.

Impact: data corruption in solid archives with mismatched window sizes (not memory corruption — window_mask constrains all accesses).

Add regression test with a crafted 3-entry solid RAR5 archive:
  Entry 1: non-solid, stored, window=256KB
  Entry 2: solid, stored, window=256KB (sets solid_window_size)
  Entry 3: solid, stored, window=1MB (triggers mismatch)

Without fix: test fails (all headers return ARCHIVE_OK, bypass).
With fix: test passes (entry 3 returns ARCHIVE_FATAL).