### PR TITLE
LZOP and GRZIP support

### DIFF
--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -104,6 +104,10 @@ archive_read_append_filter(struct archive *_a, int code)
       strcpy(str, "lrzip");
       r1 = archive_read_support_filter_lrzip(_a);
       break;
+    case ARCHIVE_FILTER_GRZIP:
+      strcpy(str, "grzip");
+      r1 = archive_read_support_filter_grzip(_a);
+      break;
     default:
       archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
           "Invalid filter code specified");

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -62,7 +62,7 @@ archive_read_support_filter_grzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "grzip",
 				&grzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -110,7 +110,7 @@ archive_read_support_filter_lzop(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "lzop",
 				&lzop_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -177,6 +177,40 @@ DEFINE_TEST(test_read_append_wrong_filter)
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 
+DEFINE_TEST(test_read_append_lzop_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
+  if (archive_liblzo2_version() != NULL) {
+    assertEqualIntA(a, ARCHIVE_OK, r);
+  } else if (canLzop()) {
+    // We're using an external program
+    assertEqualIntA(a, ARCHIVE_WARN, r);
+  }
+
+  archive_read_free(a);
+}
+
+DEFINE_TEST(test_read_append_grzip_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP);
+  // Grzip currently always uses an external program.
+  if (canGrzip()) {
+    assertEqualIntA(a, ARCHIVE_WARN, r);
+  }
+
+  archive_read_free(a);
+}
+
 DEFINE_TEST(test_read_append_filter_program)
 {
   struct archive_entry *ae;


### PR DESCRIPTION
Fix `archive_read_append_filter()` for LZOP and GRZIP.

These two filters failed to correctly set a name when being registered, which prevented them from working correctly with `archive_read_append_filter()`.

Also add a missing `case ARCHIVE_FILTER_GRZIP` statement to `archive_read_append_filter()`.
