### PR TITLE
Support legacy Zip compression formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ ENDIF()
 OPTION(ENABLE_XATTR "Enable extended attribute support" ON)
 OPTION(ENABLE_ACL "Enable ACL support" ON)
 OPTION(ENABLE_ICONV "Enable iconv support" ON)
+OPTION(ENABLE_LEGACY "Enable legacy compression formats" ON)
 OPTION(ENABLE_TEST "Enable unit and regression tests" ON)
 OPTION(ENABLE_COVERAGE "Enable code coverage (GCC only, automatically sets ENABLE_TEST to ON)" FALSE)
 OPTION(ENABLE_INSTALL "Enable installing of libraries" ON)
@@ -1147,6 +1148,12 @@ ELSE(ENABLE_ICONV)
   UNSET(LIBCHARSET_DLL CACHE)
   UNSET(LIBCHARSET_STATIC CACHE)
 ENDIF(ENABLE_ICONV)
+
+IF(ENABLE_LEGACY)
+  SET(HAVE_LEGACY 1)
+ELSE(ENABLE_LEGACY)
+  UNSET(HAVE_LEGACY)
+ENDIF(ENABLE_LEGACY)
 
 #
 # Find Libxml2

--- a/Makefile.am
+++ b/Makefile.am
@@ -258,6 +258,7 @@ libarchive_la_SOURCES= \
 	libarchive/archive_zip_legacy_shrink.c \
 	libarchive/archive_zip_legacy_reduce.c \
 	libarchive/archive_zip_legacy_implode.c \
+	libarchive/archive_zip_legacy_common.c \
 	libarchive/filter_fork_posix.c \
 	libarchive/xxhash.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -131,6 +131,7 @@ noinst_HEADERS= \
 	libarchive/archive_write_private.h \
 	libarchive/archive_write_set_format_private.h \
 	libarchive/archive_xxhash.h \
+	libarchive/archive_zip_legacy.h \
 	libarchive/config_freebsd.h \
 	libarchive/filter_fork.h
 
@@ -254,6 +255,9 @@ libarchive_la_SOURCES= \
 	libarchive/archive_write_set_format_zip.c \
 	libarchive/archive_write_set_options.c \
 	libarchive/archive_write_set_passphrase.c \
+	libarchive/archive_zip_legacy_shrink.c \
+	libarchive/archive_zip_legacy_reduce.c \
+	libarchive/archive_zip_legacy_implode.c \
 	libarchive/filter_fork_posix.c \
 	libarchive/xxhash.c
 

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -1399,6 +1399,9 @@ typedef uint64_t uintmax_t;
 /* Define for large files, on AIX-style hosts. */
 #cmakedefine _LARGE_FILES @_LARGE_FILES@
 
+/* Define to 1 to include support for legacy compression formats */
+#cmakedefine HAVE_LEGACY 1
+
 /* Define to control Windows SDK version */
 #ifndef NTDDI_VERSION
 #cmakedefine NTDDI_VERSION @NTDDI_VERSION@

--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,27 @@ esac
 
 AM_CONDITIONAL([BUILD_BSDUNZIP], [ test "$build_bsdunzip" = yes ])
 AM_CONDITIONAL([STATIC_BSDUNZIP], [ test "$static_bsdunzip" = yes ])
+#
+# Options for building legacy compression formats.
+#
+# Default is to build these formats, but that can be overridden.
+#
+AC_ARG_ENABLE([legacy],
+	[AS_HELP_STRING([--enable-legacy], [enable build of legacy compression formats (default)])
+AS_HELP_STRING([--disable-legacy], [disable build of legacy compression formats])],
+	[], [enable_legacy=yes])
+
+case "$enable_legacy" in
+yes)
+	AC_DEFINE([HAVE_LEGACY], [1], [Define to 1 to build legacy compression formats.])
+	;;
+
+no)
+	;;
+*)
+	AC_MSG_FAILURE([Unsupported value for --enable-legacy])
+	;;
+esac
 
 # Checks for header files.
 AC_HEADER_DIRENT

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -173,6 +173,7 @@ SET(libarchive_SOURCES
   archive_zip_legacy_implode.c
   archive_zip_legacy_reduce.c
   archive_zip_legacy_shrink.c
+  archive_zip_legacy_common.c
   archive_zip_legacy.h
   filter_fork_posix.c
   filter_fork.h

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -170,6 +170,10 @@ SET(libarchive_SOURCES
   archive_write_set_options.c
   archive_write_set_passphrase.c
   archive_xxhash.h
+  archive_zip_legacy_implode.c
+  archive_zip_legacy_reduce.c
+  archive_zip_legacy_shrink.c
+  archive_zip_legacy.h
   filter_fork_posix.c
   filter_fork.h
   xxhash.c

--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -104,6 +104,10 @@ archive_read_append_filter(struct archive *_a, int code)
       strcpy(str, "lrzip");
       r1 = archive_read_support_filter_lrzip(_a);
       break;
+    case ARCHIVE_FILTER_GRZIP:
+      strcpy(str, "grzip");
+      r1 = archive_read_support_filter_grzip(_a);
+      break;
     default:
       archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
           "Invalid filter code specified");

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -62,7 +62,7 @@ archive_read_support_filter_grzip(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "grzip",
 				&grzip_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -110,7 +110,7 @@ archive_read_support_filter_lzop(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
 
-	if (__archive_read_register_bidder(a, NULL, NULL,
+	if (__archive_read_register_bidder(a, NULL, "lzop",
 				&lzop_bidder_vtable) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -347,10 +347,7 @@ trad_enc_decrypt_byte(struct trad_enc_ctx *ctx)
 	return (uint8_t)((temp * (temp ^ 1)) >> 8) & 0xff;
 }
 
-#ifndef HAVE_LEGACY
-static
-#endif
-void
+static void
 trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
     size_t in_len, uint8_t *out, size_t out_len)
 {

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -286,6 +286,10 @@ static int
 zip_read_data_zipx_lzma_alone(struct archive_read *a, const void **buff,
 	size_t *size, int64_t *offset);
 #endif
+#if HAVE_LEGACY
+static int zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
+	int r, size_t cmp_size);
+#endif
 
 /* This function is used by Ppmd8_DecodeSymbol during decompression of Ppmd8
  * streams inside ZIP files. It has 2 purposes: one is to fetch the next
@@ -1766,20 +1770,7 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 
 	r = implode_read(zip->implode, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
-	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
-		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
-	}
-	zip->entry_compressed_bytes_read += cmp_size;
-	zip->entry_uncompressed_bytes_read += *size;
-	if (r == ARCHIVE_EOF) {
-		zip->end_of_entry = 1;
-	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
-		return (ARCHIVE_FATAL);
-	}
-
-	*buff = zip->uncompressed_buffer;
-	return ARCHIVE_OK;
+	return zip_read_wrapup(a, buff, size, r, cmp_size);
 }
 
 static int
@@ -1817,20 +1808,7 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 
 	r = shrink_read(zip->shrink, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
-	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
-		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
-	}
-	zip->entry_compressed_bytes_read += cmp_size;
-	zip->entry_uncompressed_bytes_read += *size;
-	if (r == ARCHIVE_EOF) {
-		zip->end_of_entry = 1;
-	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
-		return (ARCHIVE_FATAL);
-	}
-
-	*buff = zip->uncompressed_buffer;
-	return ARCHIVE_OK;
+	return zip_read_wrapup(a, buff, size, r, cmp_size);
 }
 
 static int
@@ -1869,6 +1847,16 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 
 	r = reduce_read(zip->reduce, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
+	return zip_read_wrapup(a, buff, size, r, cmp_size);
+}
+
+/* Common elements to legacy zip_read_* functions */
+static int
+zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
+	int r, size_t cmp_size)
+{
+	struct zip *zip = (struct zip *)(a->format->data);
+
 	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
 		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -340,7 +340,10 @@ trad_enc_decrypt_byte(struct trad_enc_ctx *ctx)
 	return (uint8_t)((temp * (temp ^ 1)) >> 8) & 0xff;
 }
 
-static void
+#ifndef HAVE_LEGACY
+static
+#endif
+void
 trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
     size_t in_len, uint8_t *out, size_t out_len)
 {
@@ -1740,7 +1743,9 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 	/* Initialize decompression context if we're here for the first time. */
 	if (!zip->decompress_init) {
 		r = implode_init(&zip->implode, a,
-			zip->entry->compressed_size, zip->entry->zip_flags,
+			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
+			zip->tctx_valid ? &zip->tctx : NULL,
+			zip->entry->zip_flags,
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
 		if(r != ARCHIVE_OK)
@@ -1790,7 +1795,8 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 	/* Initialize decompression context if we're here for the first time. */
 	if (!zip->decompress_init) {
 		r = shrink_init(&zip->shrink, a,
-			zip->entry->compressed_size,
+			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
+			zip->tctx_valid ? &zip->tctx : NULL,
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
 		if(r != ARCHIVE_OK)

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -286,6 +286,11 @@ static int
 zip_read_data_zipx_lzma_alone(struct archive_read *a, const void **buff,
 	size_t *size, int64_t *offset);
 #endif
+#if defined(HAVE_ZLIB_H) || defined(HAVE_LEGACY)
+static void zip_decrypt_data(struct zip *zip, ssize_t *bytes_avail,
+	const void **compressed_buff);
+static int zip_decrypt_update(struct archive_read *a, const void *sp, ssize_t to_consume);
+#endif
 #if HAVE_LEGACY
 static int zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
 	int r, uint64_t cmp_size);
@@ -1735,23 +1740,44 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 
 #if HAVE_LEGACY
 static int
-zip_read_data_implode(struct archive_read *a, const void **buff,
+zip_read_data_legacy(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip;
 	int r;
-	uint64_t cmp_size;
+	struct zip_legacy_io io;
+	const void *compressed_buff;
+	const void *sp;
+	ssize_t bytes_avail;
+	ssize_t to_consume;
+	const char *encoding = "implode";
 
 	(void)offset; /* UNUSED */
 
+	zip = (struct zip *)(a->format->data);
+
+	if (zip->entry->zip_flags & ZIP_LENGTH_AT_END) {
+		/* The legacy encodings don't have an end of file marker */
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+			"Invalid options flags set for %s", encoding);
+		return (ARCHIVE_FATAL);
+	}
+
+	/* If the buffer hasn't been allocated, allocate it now. */
+	if (zip->uncompressed_buffer == NULL) {
+		zip->uncompressed_buffer_size = 256 * 1024;
+		zip->uncompressed_buffer
+		    = malloc(zip->uncompressed_buffer_size);
+		if (zip->uncompressed_buffer == NULL) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "No memory for %s decompression", encoding);
+			return (ARCHIVE_FATAL);
+		}
+	}
+
 	/* Initialize decompression context if we're here for the first time. */
 	if (!zip->decompress_init) {
-		r = implode_init(&zip->implode, a,
-			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
-			zip->tctx_valid ? &zip->tctx : NULL,
-			zip->entry->zip_flags,
-			&cmp_size);
-		zip->entry_compressed_bytes_read += cmp_size;
+		r = implode_init(&zip->implode, zip->entry->zip_flags);
 		if(r != ARCHIVE_OK) {
 			archive_set_error(&a->archive, -1, "%s",
 				zip_legacy_error(r));
@@ -1759,21 +1785,64 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 		}
 		zip->decompress_init = 1;
 		zip->implode_valid = 1;
-
-		if (zip->uncompressed_buffer == NULL) {
-			zip->uncompressed_buffer_size = 256 * 1024;
-			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
-			if (zip->uncompressed_buffer == NULL) {
-				archive_set_error(&a->archive, ENOMEM,
-				    "No memory for implode decompression");
-				return (ARCHIVE_FATAL);
-			}
-		}
 	}
 
-	r = implode_read(zip->implode, zip->uncompressed_buffer,
-		zip->uncompressed_buffer_size, size, &cmp_size);
-	return zip_read_wrapup(a, buff, size, r, cmp_size);
+	/*
+	 * Note: '1' here is a performance optimization.
+	 * Recall that the decompression layer returns a count of
+	 * available bytes; asking for more than that forces the
+	 * decompressor to combine reads by copying data.
+	 */
+	compressed_buff = sp = __archive_read_ahead(a, 1, &bytes_avail);
+	if (bytes_avail < 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Truncated ZIP file body");
+		return (ARCHIVE_FATAL);
+	}
+	if (bytes_avail > zip->entry_bytes_remaining) {
+		bytes_avail = (ssize_t)zip->entry_bytes_remaining;
+	}
+
+	/* Decrypt if indicated */
+	zip_decrypt_data(zip, &bytes_avail, &compressed_buff);
+
+	io.next_in = compressed_buff;
+	io.avail_in = bytes_avail;
+	io.total_in = 0;
+	io.next_out = zip->uncompressed_buffer;
+	io.avail_out = zip->uncompressed_buffer_size;
+	io.total_out = 0;
+	if (io.avail_out > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
+		io.avail_out = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
+	}
+
+	r = implode_read(zip->implode, &io);
+
+	/* Consume as much as the compressor actually used */
+	to_consume = io.total_in;
+	__archive_read_consume(a, to_consume);
+	zip->entry_bytes_remaining -= to_consume;
+	zip->entry_compressed_bytes_read += to_consume;
+	zip->entry_uncompressed_bytes_read += io.total_out;
+
+	if (r == ARCHIVE_EOF) {
+		zip->end_of_entry = 1;
+	} else if (r != ARCHIVE_OK) {
+		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
+		return (ARCHIVE_FATAL);
+	} else if (zip->entry_uncompressed_bytes_read >= zip->entry->uncompressed_size) {
+		zip->end_of_entry = 1;
+	}
+
+	/* Update decryption state */
+	r = zip_decrypt_update(a, sp, to_consume);
+	if (r != ARCHIVE_OK) {
+		return (r);
+	}
+
+	*size = io.total_out;
+	*buff = zip->uncompressed_buffer;
+	return ARCHIVE_OK;
 }
 
 static int
@@ -2756,54 +2825,8 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 		return (ARCHIVE_FATAL);
 	}
 
-	if (zip->tctx_valid || zip->cctx_valid) {
-		if (zip->decrypted_bytes_remaining < (size_t)bytes_avail) {
-			size_t buff_remaining =
-			    (zip->decrypted_buffer +
-			    zip->decrypted_buffer_size)
-			    - (zip->decrypted_ptr +
-			    zip->decrypted_bytes_remaining);
-
-			if (buff_remaining > (size_t)bytes_avail)
-				buff_remaining = (size_t)bytes_avail;
-
-			if (0 == (zip->entry->zip_flags & ZIP_LENGTH_AT_END) &&
-			      zip->entry_bytes_remaining > 0) {
-				if ((int64_t)(zip->decrypted_bytes_remaining
-				    + buff_remaining)
-				      > zip->entry_bytes_remaining) {
-					if (zip->entry_bytes_remaining <
-					    (int64_t)zip->decrypted_bytes_remaining)
-						buff_remaining = 0;
-					else
-						buff_remaining =
-						    (size_t)zip->entry_bytes_remaining
-						    - zip->decrypted_bytes_remaining;
-				}
-			}
-			if (buff_remaining > 0) {
-				if (zip->tctx_valid) {
-					trad_enc_decrypt_update(&zip->tctx,
-					    compressed_buff, buff_remaining,
-					    zip->decrypted_ptr
-					      + zip->decrypted_bytes_remaining,
-					    buff_remaining);
-				} else {
-					size_t dsize = buff_remaining;
-					archive_decrypto_aes_ctr_update(
-					    &zip->cctx,
-					    compressed_buff, buff_remaining,
-					    zip->decrypted_ptr
-					      + zip->decrypted_bytes_remaining,
-					    &dsize);
-				}
-				zip->decrypted_bytes_remaining +=
-				    buff_remaining;
-			}
-		}
-		bytes_avail = zip->decrypted_bytes_remaining;
-		compressed_buff = (const char *)zip->decrypted_ptr;
-	}
+	/* Decrypt if indicated */
+	zip_decrypt_data(zip, &bytes_avail, &compressed_buff);
 
 	/*
 	 * A bug in zlib.h: stream.next_in should be marked 'const'
@@ -2842,6 +2865,80 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 	zip->entry_compressed_bytes_read += to_consume;
 	zip->entry_uncompressed_bytes_read += zip->stream.total_out;
 
+	/* Update decryption state */
+	r = zip_decrypt_update(a, sp, to_consume);
+	if (r != ARCHIVE_OK) {
+		return (r);
+	}
+
+	*size = zip->stream.total_out;
+	*buff = zip->uncompressed_buffer;
+
+	return (ARCHIVE_OK);
+}
+#endif
+
+#if defined(HAVE_ZLIB_H) || defined(HAVE_LEGACY)
+static void
+zip_decrypt_data(struct zip *zip, ssize_t *bytes_avail,
+	const void **compressed_buff)
+{
+	if (zip->tctx_valid || zip->cctx_valid) {
+		if (zip->decrypted_bytes_remaining < (size_t)*bytes_avail) {
+			size_t buff_remaining =
+			    (zip->decrypted_buffer +
+			    zip->decrypted_buffer_size)
+			    - (zip->decrypted_ptr +
+			    zip->decrypted_bytes_remaining);
+
+			if (buff_remaining > (size_t)*bytes_avail)
+				buff_remaining = (size_t)*bytes_avail;
+
+			if (0 == (zip->entry->zip_flags & ZIP_LENGTH_AT_END) &&
+			      zip->entry_bytes_remaining > 0) {
+				if ((int64_t)(zip->decrypted_bytes_remaining
+				    + buff_remaining)
+				      > zip->entry_bytes_remaining) {
+					if (zip->entry_bytes_remaining <
+					    (int64_t)zip->decrypted_bytes_remaining)
+						buff_remaining = 0;
+					else
+						buff_remaining =
+						    (size_t)zip->entry_bytes_remaining
+						    - zip->decrypted_bytes_remaining;
+				}
+			}
+			if (buff_remaining > 0) {
+				if (zip->tctx_valid) {
+					trad_enc_decrypt_update(&zip->tctx,
+					    *compressed_buff, buff_remaining,
+					    zip->decrypted_ptr
+					      + zip->decrypted_bytes_remaining,
+					    buff_remaining);
+				} else {
+					size_t dsize = buff_remaining;
+					archive_decrypto_aes_ctr_update(
+					    &zip->cctx,
+					    *compressed_buff, buff_remaining,
+					    zip->decrypted_ptr
+					      + zip->decrypted_bytes_remaining,
+					    &dsize);
+				}
+				zip->decrypted_bytes_remaining +=
+				    buff_remaining;
+			}
+		}
+		*bytes_avail = zip->decrypted_bytes_remaining;
+		*compressed_buff = (const char *)zip->decrypted_ptr;
+	}
+}
+
+static int
+zip_decrypt_update(struct archive_read *a, const void *sp, ssize_t to_consume)
+{
+	struct zip *zip = (struct zip *)(a->format->data);
+	int r = 0;
+
 	if (zip->tctx_valid || zip->cctx_valid) {
 		zip->decrypted_bytes_remaining -= to_consume;
 		if (zip->decrypted_bytes_remaining == 0)
@@ -2855,18 +2952,12 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 	if (zip->end_of_entry) {
 		if (zip->hctx_valid) {
 			r = check_authentication_code(a, NULL);
-			if (r != ARCHIVE_OK) {
-				return (r);
-			}
 		}
 	}
 
-	*size = zip->stream.total_out;
-	*buff = zip->uncompressed_buffer;
-
-	return (ARCHIVE_OK);
+	return r;
 }
-#endif
+#endif /* defined(HAVE_ZLIB_H) || defined(HAVE_LEGACY) */
 
 static int
 read_decryption_header(struct archive_read *a)
@@ -3301,7 +3392,7 @@ archive_read_format_zip_read_data(struct archive_read *a,
 		r = zip_read_data_reduce(a, buff, size, offset);
 		break;
 	case 6:	 /* Implode */
-		r = zip_read_data_implode(a, buff, size, offset);
+		r = zip_read_data_legacy(a, buff, size, offset);
 		break;
 #endif
 #ifdef HAVE_BZLIB_H

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -42,6 +42,8 @@
  * refactoring) was added in 2014.
  */
 
+#include <assert.h>
+
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
@@ -1750,11 +1752,25 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 	const void *sp;
 	ssize_t bytes_avail;
 	ssize_t to_consume;
-	const char *encoding = "implode";
+	const char *encoding = "";
 
 	(void)offset; /* UNUSED */
 
 	zip = (struct zip *)(a->format->data);
+
+	/* Name the compression method, for messages */
+	switch(zip->entry->compression) {
+	case 1:
+		encoding = "shrink";
+		break;
+
+	case 6:
+		encoding = "implode";
+		break;
+
+	default:
+		assert(0);
+	}
 
 	if (zip->entry->zip_flags & ZIP_LENGTH_AT_END) {
 		/* The legacy encodings don't have an end of file marker */
@@ -1777,7 +1793,18 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 
 	/* Initialize decompression context if we're here for the first time. */
 	if (!zip->decompress_init) {
-		r = implode_init(&zip->implode, zip->entry->zip_flags);
+		switch(zip->entry->compression) {
+		case 1:
+			r = shrink_init(&zip->shrink);
+			break;
+
+		case 6:
+			r = implode_init(&zip->implode, zip->entry->zip_flags);
+			break;
+
+		default:
+			assert(0);
+		}
 		if(r != ARCHIVE_OK) {
 			archive_set_error(&a->archive, -1, "%s",
 				zip_legacy_error(r));
@@ -1816,7 +1843,18 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 		io.avail_out = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}
 
-	r = implode_read(zip->implode, &io);
+	switch(zip->entry->compression) {
+	case 1:
+		r = shrink_read(zip->shrink, &io);
+		break;
+
+	case 6:
+		r = implode_read(zip->implode, &io);
+		break;
+
+	default:
+		assert(0);
+	}
 
 	/* Consume as much as the compressor actually used */
 	to_consume = io.total_in;
@@ -1843,47 +1881,6 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 	*size = io.total_out;
 	*buff = zip->uncompressed_buffer;
 	return ARCHIVE_OK;
-}
-
-static int
-zip_read_data_shrink(struct archive_read *a, const void **buff,
-    size_t *size, int64_t *offset)
-{
-	struct zip *zip = (struct zip *)(a->format->data);
-	int r;
-	uint64_t cmp_size;
-
-	(void)offset; /* UNUSED */
-
-	/* Initialize decompression context if we're here for the first time. */
-	if (!zip->decompress_init) {
-		r = shrink_init(&zip->shrink, a,
-			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
-			zip->tctx_valid ? &zip->tctx : NULL,
-			&cmp_size);
-		zip->entry_compressed_bytes_read += cmp_size;
-		if(r != ARCHIVE_OK) {
-			archive_set_error(&a->archive, -1, "%s",
-				zip_legacy_error(r));
-			return ARCHIVE_FATAL;
-		}
-		zip->decompress_init = 1;
-		zip->shrink_valid = 1;
-
-		if (zip->uncompressed_buffer == NULL) {
-			zip->uncompressed_buffer_size = 256 * 1024;
-			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
-			if (zip->uncompressed_buffer == NULL) {
-				archive_set_error(&a->archive, ENOMEM,
-				    "No memory for shrink decompression");
-				return (ARCHIVE_FATAL);
-			}
-		}
-	}
-
-	r = shrink_read(zip->shrink, zip->uncompressed_buffer,
-		zip->uncompressed_buffer_size, size, &cmp_size);
-	return zip_read_wrapup(a, buff, size, r, cmp_size);
 }
 
 static int
@@ -3383,7 +3380,7 @@ archive_read_format_zip_read_data(struct archive_read *a,
 		break;
 #if HAVE_LEGACY
 	case 1:	 /* Shrink */
-		r = zip_read_data_shrink(a, buff, size, offset);
+		r = zip_read_data_legacy(a, buff, size, offset);
 		break;
 	case 2:  /* Reduce */
 	case 3:

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -288,7 +288,7 @@ zip_read_data_zipx_lzma_alone(struct archive_read *a, const void **buff,
 #endif
 #if HAVE_LEGACY
 static int zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
-	int r, size_t cmp_size);
+	int r, uint64_t cmp_size);
 #endif
 
 /* This function is used by Ppmd8_DecodeSymbol during decompression of Ppmd8
@@ -1862,7 +1862,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 /* Common elements to legacy zip_read_* functions */
 static int
 zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
-	int r, size_t cmp_size)
+	int r, uint64_t cmp_size)
 {
 	struct zip *zip = (struct zip *)(a->format->data);
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1857,7 +1857,7 @@ zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
 {
 	struct zip *zip = (struct zip *)(a->format->data);
 
-	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
+	if (*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
 		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}
 	zip->entry_compressed_bytes_read += cmp_size;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1740,7 +1740,7 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 {
 	struct zip *zip = (struct zip *)(a->format->data);
 	int r;
-	size_t cmp_size;
+	uint64_t cmp_size;
 
 	(void)offset; /* UNUSED */
 
@@ -1782,7 +1782,7 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 {
 	struct zip *zip = (struct zip *)(a->format->data);
 	int r;
-	size_t cmp_size;
+	uint64_t cmp_size;
 
 	(void)offset; /* UNUSED */
 
@@ -1823,7 +1823,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 {
 	struct zip *zip = (struct zip *)(a->format->data);
 	int r;
-	size_t cmp_size;
+	uint64_t cmp_size;
 
 	(void)offset; /* UNUSED */
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1774,7 +1774,7 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
+		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 
@@ -1825,7 +1825,7 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
+		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 
@@ -1877,7 +1877,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
+		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1752,8 +1752,11 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 			zip->entry->zip_flags,
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
-		if(r != ARCHIVE_OK)
-			return r;
+		if(r != ARCHIVE_OK) {
+			archive_set_error(&a->archive, -1, "%s",
+				zip_legacy_error(r));
+			return ARCHIVE_FATAL;
+		}
 		zip->decompress_init = 1;
 		zip->implode_valid = 1;
 
@@ -1790,8 +1793,11 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 			zip->tctx_valid ? &zip->tctx : NULL,
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
-		if(r != ARCHIVE_OK)
-			return r;
+		if(r != ARCHIVE_OK) {
+			archive_set_error(&a->archive, -1, "%s",
+				zip_legacy_error(r));
+			return ARCHIVE_FATAL;
+		}
 		zip->decompress_init = 1;
 		zip->shrink_valid = 1;
 
@@ -1829,8 +1835,11 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 			zip->entry->compression - 1, /* level: 1, 2, 3, 4 */
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
-		if(r != ARCHIVE_OK)
-			return r;
+		if(r != ARCHIVE_OK) {
+			archive_set_error(&a->archive, -1, "%s",
+				zip_legacy_error(r));
+			return ARCHIVE_FATAL;
+		}
 		zip->decompress_init = 1;
 		zip->reduce_valid = 1;
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -74,9 +74,9 @@
 #include "archive_time_private.h"
 #include "archive_ppmd8_private.h"
 
-// #if HAVE_LEGACY
+#if HAVE_LEGACY
 #include "archive_zip_legacy.h"
-// #endif
+#endif
 
 #ifndef HAVE_ZLIB_H
 #include "archive_crc32.h"
@@ -209,7 +209,7 @@ struct zip {
 	char            zstdstream_valid;
 #endif
 
-// #if HAVE_LEGACY
+#if HAVE_LEGACY
 	struct implode_desc *implode;
 	char                implode_valid;
 
@@ -218,7 +218,7 @@ struct zip {
 
 	struct reduce_desc *reduce;
 	char                reduce_valid;
-// #endif
+#endif
 
 	IByteIn			zipx_ppmd_stream;
 	ssize_t			zipx_ppmd_read_compressed;
@@ -1726,7 +1726,7 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 	return (ARCHIVE_OK);
 }
 
-// #if HAVE_LEGACY
+#if HAVE_LEGACY
 static int
 zip_read_data_implode(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
@@ -1877,7 +1877,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 	*buff = zip->uncompressed_buffer;
 	return ARCHIVE_OK;
 }
-// #endif /* HAVE_LEGACY */
+#endif /* HAVE_LEGACY */
 
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 static int
@@ -3286,7 +3286,7 @@ archive_read_format_zip_read_data(struct archive_read *a,
 	case 0:  /* No compression. */
 		r =  zip_read_data_none(a, buff, size, offset);
 		break;
-// #if HAVE_LEGACY
+#if HAVE_LEGACY
 	case 1:	 /* Shrink */
 		r = zip_read_data_shrink(a, buff, size, offset);
 		break;
@@ -3299,7 +3299,7 @@ archive_read_format_zip_read_data(struct archive_read *a,
 	case 6:	 /* Implode */
 		r = zip_read_data_implode(a, buff, size, offset);
 		break;
-// #endif
+#endif
 #ifdef HAVE_BZLIB_H
 	case 12: /* ZIPx bzip2 compression. */
 		r = zip_read_data_zipx_bzip2(a, buff, size, offset);
@@ -3393,14 +3393,14 @@ archive_read_format_zip_cleanup(struct archive_read *a)
 
 	zip = (struct zip *)(a->format->data);
 
-// #if HAVE_LEGACY
+#if HAVE_LEGACY
 	if (zip->implode_valid)
 		implode_free(&zip->implode);
 	if (zip->shrink_valid)
 		shrink_free(&zip->shrink);
 	if (zip->reduce_valid)
 		reduce_free(&zip->reduce);
-// #endif
+#endif
 
 #ifdef HAVE_ZLIB_H
 	if (zip->stream_valid)

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1761,7 +1761,7 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 
 	r = implode_read(zip->implode, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
-	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
 		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}
 	zip->entry_compressed_bytes_read += cmp_size;
@@ -1811,7 +1811,7 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 
 	r = shrink_read(zip->shrink, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
-	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
 		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}
 	zip->entry_compressed_bytes_read += cmp_size;
@@ -1862,7 +1862,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 
 	r = reduce_read(zip->reduce, zip->uncompressed_buffer,
 		zip->uncompressed_buffer_size, size, &cmp_size);
-	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+	if ((uintmax_t)*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
 		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
 	}
 	zip->entry_compressed_bytes_read += cmp_size;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -293,10 +293,6 @@ static void zip_decrypt_data(struct zip *zip, ssize_t *bytes_avail,
 	const void **compressed_buff);
 static int zip_decrypt_update(struct archive_read *a, const void *sp, ssize_t to_consume);
 #endif
-#if HAVE_LEGACY
-static int zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
-	int r, uint64_t cmp_size);
-#endif
 
 /* This function is used by Ppmd8_DecodeSymbol during decompression of Ppmd8
  * streams inside ZIP files. It has 2 purposes: one is to fetch the next
@@ -1764,6 +1760,13 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 		encoding = "shrink";
 		break;
 
+	case 2:
+	case 3:
+	case 4:
+	case 5:
+		encoding = "reduce";
+		break;
+
 	case 6:
 		encoding = "implode";
 		break;
@@ -1796,6 +1799,13 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 		switch(zip->entry->compression) {
 		case 1:
 			r = shrink_init(&zip->shrink);
+			break;
+
+		case 2:
+		case 3:
+		case 4:
+		case 5:
+			r = reduce_init(&zip->reduce, zip->entry->compression - 1);
 			break;
 
 		case 6:
@@ -1848,6 +1858,13 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 		r = shrink_read(zip->shrink, &io);
 		break;
 
+	case 2:
+	case 3:
+	case 4:
+	case 5:
+		r = reduce_read(zip->reduce, &io);
+		break;
+
 	case 6:
 		r = implode_read(zip->implode, &io);
 		break;
@@ -1879,71 +1896,6 @@ zip_read_data_legacy(struct archive_read *a, const void **buff,
 	}
 
 	*size = io.total_out;
-	*buff = zip->uncompressed_buffer;
-	return ARCHIVE_OK;
-}
-
-static int
-zip_read_data_reduce(struct archive_read *a, const void **buff,
-    size_t *size, int64_t *offset)
-{
-	struct zip *zip = (struct zip *)(a->format->data);
-	int r;
-	uint64_t cmp_size;
-
-	(void)offset; /* UNUSED */
-
-	/* Initialize decompression context if we're here for the first time. */
-	if (!zip->decompress_init) {
-		r = reduce_init(&zip->reduce, a,
-			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
-			zip->tctx_valid ? &zip->tctx : NULL,
-			zip->entry->compression - 1, /* level: 1, 2, 3, 4 */
-			&cmp_size);
-		zip->entry_compressed_bytes_read += cmp_size;
-		if(r != ARCHIVE_OK) {
-			archive_set_error(&a->archive, -1, "%s",
-				zip_legacy_error(r));
-			return ARCHIVE_FATAL;
-		}
-		zip->decompress_init = 1;
-		zip->reduce_valid = 1;
-
-		if (zip->uncompressed_buffer == NULL) {
-			zip->uncompressed_buffer_size = 256 * 1024;
-			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
-			if (zip->uncompressed_buffer == NULL) {
-				archive_set_error(&a->archive, ENOMEM,
-				    "No memory for reduce decompression");
-				return (ARCHIVE_FATAL);
-			}
-		}
-	}
-
-	r = reduce_read(zip->reduce, zip->uncompressed_buffer,
-		zip->uncompressed_buffer_size, size, &cmp_size);
-	return zip_read_wrapup(a, buff, size, r, cmp_size);
-}
-
-/* Common elements to legacy zip_read_* functions */
-static int
-zip_read_wrapup(struct archive_read *a, const void **buff, size_t *size,
-	int r, uint64_t cmp_size)
-{
-	struct zip *zip = (struct zip *)(a->format->data);
-
-	if (*size > (uintmax_t)(zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read)) {
-		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
-	}
-	zip->entry_compressed_bytes_read += cmp_size;
-	zip->entry_uncompressed_bytes_read += *size;
-	if (r == ARCHIVE_EOF) {
-		zip->end_of_entry = 1;
-	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, -1, "%s", zip_legacy_error(r));
-		return (ARCHIVE_FATAL);
-	}
-
 	*buff = zip->uncompressed_buffer;
 	return ARCHIVE_OK;
 }
@@ -3380,14 +3332,10 @@ archive_read_format_zip_read_data(struct archive_read *a,
 		break;
 #if HAVE_LEGACY
 	case 1:	 /* Shrink */
-		r = zip_read_data_legacy(a, buff, size, offset);
-		break;
 	case 2:  /* Reduce */
 	case 3:
 	case 4:
 	case 5:
-		r = zip_read_data_reduce(a, buff, size, offset);
-		break;
 	case 6:	 /* Implode */
 		r = zip_read_data_legacy(a, buff, size, offset);
 		break;

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1774,7 +1774,7 @@ zip_read_data_implode(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", implode_error(r));
+		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 
@@ -1825,7 +1825,7 @@ zip_read_data_shrink(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", shrink_error(r));
+		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 
@@ -1846,7 +1846,8 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 	/* Initialize decompression context if we're here for the first time. */
 	if (!zip->decompress_init) {
 		r = reduce_init(&zip->reduce, a,
-			zip->entry->compressed_size,
+			zip->entry->compressed_size - zip->entry_compressed_bytes_read,
+			zip->tctx_valid ? &zip->tctx : NULL,
 			zip->entry->compression - 1, /* level: 1, 2, 3, 4 */
 			&cmp_size);
 		zip->entry_compressed_bytes_read += cmp_size;
@@ -1876,7 +1877,7 @@ zip_read_data_reduce(struct archive_read *a, const void **buff,
 	if (r == ARCHIVE_EOF) {
 		zip->end_of_entry = 1;
 	} else if (r != ARCHIVE_OK) {
-		archive_set_error(&a->archive, 0, "%s", reduce_error(r));
+		archive_set_error(&a->archive, 0, "%s", zip_legacy_error(r));
 		return (ARCHIVE_FATAL);
 	}
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -74,6 +74,10 @@
 #include "archive_time_private.h"
 #include "archive_ppmd8_private.h"
 
+// #if HAVE_LEGACY
+#include "archive_zip_legacy.h"
+// #endif
+
 #ifndef HAVE_ZLIB_H
 #include "archive_crc32.h"
 #endif
@@ -204,6 +208,17 @@ struct zip {
 	ZSTD_DStream	*zstdstream;
 	char            zstdstream_valid;
 #endif
+
+// #if HAVE_LEGACY
+	struct implode_desc *implode;
+	char                implode_valid;
+
+	struct shrink_desc *shrink;
+	char                shrink_valid;
+
+	struct reduce_desc *reduce;
+	char                reduce_valid;
+// #endif
 
 	IByteIn			zipx_ppmd_stream;
 	ssize_t			zipx_ppmd_read_compressed;
@@ -1711,6 +1726,159 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 	return (ARCHIVE_OK);
 }
 
+// #if HAVE_LEGACY
+static int
+zip_read_data_implode(struct archive_read *a, const void **buff,
+    size_t *size, int64_t *offset)
+{
+	struct zip *zip = (struct zip *)(a->format->data);
+	int r;
+	size_t cmp_size;
+
+	(void)offset; /* UNUSED */
+
+	/* Initialize decompression context if we're here for the first time. */
+	if (!zip->decompress_init) {
+		r = implode_init(&zip->implode, a,
+			zip->entry->compressed_size, zip->entry->zip_flags,
+			&cmp_size);
+		zip->entry_compressed_bytes_read += cmp_size;
+		if(r != ARCHIVE_OK)
+			return r;
+		zip->decompress_init = 1;
+		zip->implode_valid = 1;
+
+		if (zip->uncompressed_buffer == NULL) {
+			zip->uncompressed_buffer_size = 256 * 1024;
+			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
+			if (zip->uncompressed_buffer == NULL) {
+				archive_set_error(&a->archive, ENOMEM,
+				    "No memory for implode decompression");
+				return (ARCHIVE_FATAL);
+			}
+		}
+	}
+
+	r = implode_read(zip->implode, zip->uncompressed_buffer,
+		zip->uncompressed_buffer_size, size, &cmp_size);
+	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
+	}
+	zip->entry_compressed_bytes_read += cmp_size;
+	zip->entry_uncompressed_bytes_read += *size;
+	if (r == ARCHIVE_EOF) {
+		zip->end_of_entry = 1;
+	} else if (r != ARCHIVE_OK) {
+		archive_set_error(&a->archive, 0, "%s", implode_error(r));
+		return (ARCHIVE_FATAL);
+	}
+
+	*buff = zip->uncompressed_buffer;
+	return ARCHIVE_OK;
+}
+
+static int
+zip_read_data_shrink(struct archive_read *a, const void **buff,
+    size_t *size, int64_t *offset)
+{
+	struct zip *zip = (struct zip *)(a->format->data);
+	int r;
+	size_t cmp_size;
+
+	(void)offset; /* UNUSED */
+
+	/* Initialize decompression context if we're here for the first time. */
+	if (!zip->decompress_init) {
+		r = shrink_init(&zip->shrink, a,
+			zip->entry->compressed_size,
+			&cmp_size);
+		zip->entry_compressed_bytes_read += cmp_size;
+		if(r != ARCHIVE_OK)
+			return r;
+		zip->decompress_init = 1;
+		zip->shrink_valid = 1;
+
+		if (zip->uncompressed_buffer == NULL) {
+			zip->uncompressed_buffer_size = 256 * 1024;
+			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
+			if (zip->uncompressed_buffer == NULL) {
+				archive_set_error(&a->archive, ENOMEM,
+				    "No memory for shrink decompression");
+				return (ARCHIVE_FATAL);
+			}
+		}
+	}
+
+	r = shrink_read(zip->shrink, zip->uncompressed_buffer,
+		zip->uncompressed_buffer_size, size, &cmp_size);
+	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
+	}
+	zip->entry_compressed_bytes_read += cmp_size;
+	zip->entry_uncompressed_bytes_read += *size;
+	if (r == ARCHIVE_EOF) {
+		zip->end_of_entry = 1;
+	} else if (r != ARCHIVE_OK) {
+		archive_set_error(&a->archive, 0, "%s", shrink_error(r));
+		return (ARCHIVE_FATAL);
+	}
+
+	*buff = zip->uncompressed_buffer;
+	return ARCHIVE_OK;
+}
+
+static int
+zip_read_data_reduce(struct archive_read *a, const void **buff,
+    size_t *size, int64_t *offset)
+{
+	struct zip *zip = (struct zip *)(a->format->data);
+	int r;
+	size_t cmp_size;
+
+	(void)offset; /* UNUSED */
+
+	/* Initialize decompression context if we're here for the first time. */
+	if (!zip->decompress_init) {
+		r = reduce_init(&zip->reduce, a,
+			zip->entry->compressed_size,
+			zip->entry->compression - 1, /* level: 1, 2, 3, 4 */
+			&cmp_size);
+		zip->entry_compressed_bytes_read += cmp_size;
+		if(r != ARCHIVE_OK)
+			return r;
+		zip->decompress_init = 1;
+		zip->reduce_valid = 1;
+
+		if (zip->uncompressed_buffer == NULL) {
+			zip->uncompressed_buffer_size = 256 * 1024;
+			zip->uncompressed_buffer = malloc(zip->uncompressed_buffer_size);
+			if (zip->uncompressed_buffer == NULL) {
+				archive_set_error(&a->archive, ENOMEM,
+				    "No memory for reduce decompression");
+				return (ARCHIVE_FATAL);
+			}
+		}
+	}
+
+	r = reduce_read(zip->reduce, zip->uncompressed_buffer,
+		zip->uncompressed_buffer_size, size, &cmp_size);
+	if (*size > zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read) {
+		*size = zip->entry->uncompressed_size - zip->entry_uncompressed_bytes_read;
+	}
+	zip->entry_compressed_bytes_read += cmp_size;
+	zip->entry_uncompressed_bytes_read += *size;
+	if (r == ARCHIVE_EOF) {
+		zip->end_of_entry = 1;
+	} else if (r != ARCHIVE_OK) {
+		archive_set_error(&a->archive, 0, "%s", reduce_error(r));
+		return (ARCHIVE_FATAL);
+	}
+
+	*buff = zip->uncompressed_buffer;
+	return ARCHIVE_OK;
+}
+// #endif /* HAVE_LEGACY */
+
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 static int
 zipx_xz_init(struct archive_read *a, struct zip *zip)
@@ -3118,6 +3286,20 @@ archive_read_format_zip_read_data(struct archive_read *a,
 	case 0:  /* No compression. */
 		r =  zip_read_data_none(a, buff, size, offset);
 		break;
+// #if HAVE_LEGACY
+	case 1:	 /* Shrink */
+		r = zip_read_data_shrink(a, buff, size, offset);
+		break;
+	case 2:  /* Reduce */
+	case 3:
+	case 4:
+	case 5:
+		r = zip_read_data_reduce(a, buff, size, offset);
+		break;
+	case 6:	 /* Implode */
+		r = zip_read_data_implode(a, buff, size, offset);
+		break;
+// #endif
 #ifdef HAVE_BZLIB_H
 	case 12: /* ZIPx bzip2 compression. */
 		r = zip_read_data_zipx_bzip2(a, buff, size, offset);
@@ -3210,6 +3392,15 @@ archive_read_format_zip_cleanup(struct archive_read *a)
 	struct zip_entry *zip_entry, *next_zip_entry;
 
 	zip = (struct zip *)(a->format->data);
+
+// #if HAVE_LEGACY
+	if (zip->implode_valid)
+		implode_free(&zip->implode);
+	if (zip->shrink_valid)
+		shrink_free(&zip->shrink);
+	if (zip->reduce_valid)
+		reduce_free(&zip->reduce);
+// #endif
 
 #ifdef HAVE_ZLIB_H
 	if (zip->stream_valid)

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -1,0 +1,42 @@
+/* archive_zip_legacy.h */
+
+#ifndef ARCHIVE_ZIP_LEGACY_H_INCLUDED
+#define ARCHIVE_ZIP_LEGACY_H_INCLUDED
+
+// #ifdef HAVE_LEGACY
+
+#include "archive_read_private.h"
+
+/* Implode */
+struct implode_desc;
+
+int implode_init(struct implode_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, unsigned zip_flags, size_t *cmp_bytes_read);
+void implode_free(struct implode_desc **desc);
+int implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read);
+const char *implode_error(int err);
+
+/* Shrink */
+struct shrink_desc;
+
+int shrink_init(struct shrink_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, size_t *cmp_bytes_read);
+void shrink_free(struct shrink_desc **desc);
+int shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read);
+const char *shrink_error(int err);
+
+/* Reduce */
+struct reduce_desc;
+
+int reduce_init(struct reduce_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, unsigned level, size_t *cmp_bytes_read);
+void reduce_free(struct reduce_desc **desc);
+int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read);
+const char *reduce_error(int err);
+
+// #endif /* HAVE_LEGACY */
+
+#endif /* !ARCHIVE_ZIP_LEGACY_H_INCLUDED */

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -30,6 +30,15 @@
 
 #include "archive_read_private.h"
 
+/* Errors occurring within the ZIP format */
+enum {
+	end_of_data = -1,
+	file_truncated = -2,
+	file_inconsistent = -3
+};
+
+const char *zip_legacy_error(int err);
+
 /* To decrypt compressed data */
 struct trad_enc_ctx;
 void trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
@@ -44,7 +53,6 @@ int implode_init(struct implode_desc **desc, struct archive_read *a,
 void implode_free(struct implode_desc **desc);
 int implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);
-const char *implode_error(int err);
 
 /* Shrink */
 struct shrink_desc;
@@ -54,17 +62,48 @@ int shrink_init(struct shrink_desc **desc, struct archive_read *a,
 void shrink_free(struct shrink_desc **desc);
 int shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);
-const char *shrink_error(int err);
 
 /* Reduce */
 struct reduce_desc;
 
 int reduce_init(struct reduce_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, unsigned level, size_t *cmp_bytes_read);
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
+	size_t *cmp_bytes_read);
 void reduce_free(struct reduce_desc **desc);
 int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);
-const char *reduce_error(int err);
+
+/* Current state of sliding window */
+struct lz77_window {
+	uint8_t *window;
+	unsigned window_pos;
+	unsigned copy_pos;
+	unsigned copy_size;
+	unsigned window_mask;
+};
+
+int lz77_init(struct lz77_window *lz77, unsigned window_size);
+void lz77_free(struct lz77_window *lz77);
+size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
+void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
+void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
+
+/* Archive data, remaining bytes, decryption */
+struct arch_data {
+	/* Archive data from caller */
+	struct archive_read *arch;
+	/* Compressed bytes remaining */
+	uint64_t cmp_size;
+	/* To read bits not on a byte boundary */
+	uint32_t bits;
+	uint8_t num_bits;
+	/* Traditional PKZIP decryption */
+	struct trad_enc_ctx *decrypt;
+	uint8_t decrypt_buf[256];
+};
+
+int archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits);
+void const *archive_read_bytes(struct arch_data *arch, unsigned num_bytes);
 
 #endif /* HAVE_LEGACY */
 

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -49,11 +49,6 @@ struct zip_legacy_io {
 	size_t total_out;
 };
 
-/* To decrypt compressed data */
-struct trad_enc_ctx;
-void trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
-    size_t in_len, uint8_t *out, size_t out_len);
-
 /* Implode */
 struct implode_desc;
 
@@ -89,22 +84,14 @@ size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
 void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
 void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
 
-/* Archive data, remaining bytes, decryption */
-struct arch_data {
-	/* Archive data from caller */
-	struct archive_read *arch;
-	/* Compressed bytes remaining */
-	uint64_t cmp_size;
-	/* To read bits not on a byte boundary */
+/* To read bits not on a byte boundary */
+struct arch_bits {
 	uint32_t bits;
 	uint8_t num_bits;
-	/* Traditional PKZIP decryption */
-	struct trad_enc_ctx *decrypt;
-	uint8_t decrypt_buf[256];
 };
 
-int archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits);
-void const *archive_read_bytes(struct arch_data *arch, unsigned num_bytes);
+int archive_read_bits(struct arch_bits *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits);
 
 #endif /* HAVE_LEGACY */
 

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -30,11 +30,17 @@
 
 #include "archive_read_private.h"
 
+/* To decrypt compressed data */
+struct trad_enc_ctx;
+void trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
+    size_t in_len, uint8_t *out, size_t out_len);
+
 /* Implode */
 struct implode_desc;
 
 int implode_init(struct implode_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, unsigned zip_flags, size_t *cmp_bytes_read);
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
+	size_t *cmp_bytes_read);
 void implode_free(struct implode_desc **desc);
 int implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);
@@ -44,7 +50,7 @@ const char *implode_error(int err);
 struct shrink_desc;
 
 int shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, size_t *cmp_bytes_read);
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, size_t *cmp_bytes_read);
 void shrink_free(struct shrink_desc **desc);
 int shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -39,6 +39,16 @@ enum {
 
 const char *zip_legacy_error(int err);
 
+/* Input and output to decoders */
+struct zip_legacy_io {
+	const uint8_t *next_in;
+	size_t avail_in;
+	size_t total_in;
+	uint8_t *next_out;
+	size_t avail_out;
+	size_t total_out;
+};
+
 /* To decrypt compressed data */
 struct trad_enc_ctx;
 void trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
@@ -47,12 +57,9 @@ void trad_enc_decrypt_update(struct trad_enc_ctx *ctx, const uint8_t *in,
 /* Implode */
 struct implode_desc;
 
-int implode_init(struct implode_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
-	uint64_t *cmp_bytes_read);
+int implode_init(struct implode_desc **desc, unsigned zip_flags);
 void implode_free(struct implode_desc **desc);
-int implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read);
+int implode_read(struct implode_desc *desc, struct zip_legacy_io *io);
 
 /* Shrink */
 struct shrink_desc;

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -49,29 +49,29 @@ struct implode_desc;
 
 int implode_init(struct implode_desc **desc, struct archive_read *a,
 	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
-	size_t *cmp_bytes_read);
+	uint64_t *cmp_bytes_read);
 void implode_free(struct implode_desc **desc);
 int implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read);
+	size_t *bytes_read, uint64_t *cmp_bytes_read);
 
 /* Shrink */
 struct shrink_desc;
 
 int shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, size_t *cmp_bytes_read);
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, uint64_t *cmp_bytes_read);
 void shrink_free(struct shrink_desc **desc);
 int shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read);
+	size_t *bytes_read, uint64_t *cmp_bytes_read);
 
 /* Reduce */
 struct reduce_desc;
 
 int reduce_init(struct reduce_desc **desc, struct archive_read *a,
 	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
-	size_t *cmp_bytes_read);
+	uint64_t *cmp_bytes_read);
 void reduce_free(struct reduce_desc **desc);
 int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read);
+	size_t *bytes_read, uint64_t *cmp_bytes_read);
 
 /* Current state of sliding window */
 struct lz77_window {

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -1,4 +1,27 @@
-/* archive_zip_legacy.h */
+/*-
+ * Copyright (c) 2026 Ray Chason
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #ifndef ARCHIVE_ZIP_LEGACY_H_INCLUDED
 #define ARCHIVE_ZIP_LEGACY_H_INCLUDED

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -71,12 +71,9 @@ int shrink_read(struct shrink_desc *desc, struct zip_legacy_io *io);
 /* Reduce */
 struct reduce_desc;
 
-int reduce_init(struct reduce_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
-	uint64_t *cmp_bytes_read);
+int reduce_init(struct reduce_desc **desc, unsigned level);
 void reduce_free(struct reduce_desc **desc);
-int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read);
+int reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io);
 
 /* Current state of sliding window */
 struct lz77_window {

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -64,11 +64,9 @@ int implode_read(struct implode_desc *desc, struct zip_legacy_io *io);
 /* Shrink */
 struct shrink_desc;
 
-int shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, uint64_t *cmp_bytes_read);
+int shrink_init(struct shrink_desc **desc);
 void shrink_free(struct shrink_desc **desc);
-int shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read);
+int shrink_read(struct shrink_desc *desc, struct zip_legacy_io *io);
 
 /* Reduce */
 struct reduce_desc;

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -75,11 +75,10 @@ int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 /* Current state of sliding window */
 struct lz77_window {
-	uint8_t *window;
+	uint8_t window[8192*2];
 	unsigned window_pos;
 	unsigned copy_pos;
-	unsigned copy_size;
-	unsigned window_mask;
+	unsigned window_size;
 };
 
 int lz77_init(struct lz77_window *lz77, unsigned window_size);

--- a/libarchive/archive_zip_legacy.h
+++ b/libarchive/archive_zip_legacy.h
@@ -3,7 +3,7 @@
 #ifndef ARCHIVE_ZIP_LEGACY_H_INCLUDED
 #define ARCHIVE_ZIP_LEGACY_H_INCLUDED
 
-// #ifdef HAVE_LEGACY
+#ifdef HAVE_LEGACY
 
 #include "archive_read_private.h"
 
@@ -37,6 +37,6 @@ int reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read);
 const char *reduce_error(int err);
 
-// #endif /* HAVE_LEGACY */
+#endif /* HAVE_LEGACY */
 
 #endif /* !ARCHIVE_ZIP_LEGACY_H_INCLUDED */

--- a/libarchive/archive_zip_legacy_common.c
+++ b/libarchive/archive_zip_legacy_common.c
@@ -1,0 +1,169 @@
+/*-
+ * Copyright (c) 2026 Ray Chason
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "archive_platform.h"
+
+#if HAVE_LEGACY
+
+#if HAVE_ERRNO_H
+#  include <errno.h>
+#endif
+#if HAVE_STDINT_H
+#  include <stdint.h>
+#endif
+#if HAVE_STDLIB_H
+#  include <stdlib.h>
+#endif
+#if HAVE_STRING_H
+#  include <string.h>
+#endif
+
+#include "archive_read_private.h"
+#include "archive_zip_legacy.h"
+
+const char *
+zip_legacy_error(int err)
+{
+	switch (err) {
+	case end_of_data:
+		return "End of compressed data";
+
+	case file_truncated:
+		return "Truncated ZIP file data";
+
+	case file_inconsistent:
+		return "Corrupted ZIP file data";
+
+	default:
+		return strerror(err);
+	}
+}
+
+int
+lz77_init(struct lz77_window *lz77, unsigned window_size)
+{
+	free(lz77->window);
+	lz77->window = calloc(1, window_size);
+	if (lz77->window == NULL) {
+		return errno;
+	}
+	lz77->window_pos = 0;
+	lz77->copy_pos = 0;
+	lz77->copy_size = 0;
+	lz77->window_mask = window_size - 1;
+	return 0;
+}
+
+void
+lz77_free(struct lz77_window *lz77)
+{
+	free(lz77->window);
+	lz77->window = NULL;
+}
+
+/* Fulfill any pending copy */
+size_t
+lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
+{
+	size_t b_read = 0;
+
+	while (lz77->copy_size != 0 && b_read < num_bytes) {
+		uint8_t byte = lz77->window[lz77->copy_pos];
+		bytes[b_read++] = byte;
+		lz77_add_byte(lz77, byte);
+		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
+		--lz77->copy_size;
+	}
+
+	return b_read;
+}
+
+/* Add a byte to the sliding window */
+void
+lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
+{
+	lz77->window[lz77->window_pos] = byte;
+	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
+}
+
+/* Begin a copy */
+void
+lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
+{
+	lz77->copy_size = length;
+	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
+}
+
+/* Read one or more bits from the archive */
+int
+archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits)
+{
+	while (arch->num_bits < num_bits) {
+		const uint8_t *ptr;
+
+		if (arch->cmp_size == 0) {
+			return end_of_data;
+		}
+		ptr = archive_read_bytes(arch, 1);
+		if (ptr == NULL) {
+			return file_truncated;
+		}
+		arch->bits |= ptr[0] << arch->num_bits;
+		arch->num_bits += 8;
+	}
+
+	*bits = arch->bits;
+	arch->bits >>= num_bits;
+	arch->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
+	return 0;
+}
+
+/* Read and possibly decrypt one or more bytes */
+void const *
+archive_read_bytes(struct arch_data *arch, unsigned num_bytes)
+{
+	void const *ptr;
+	ssize_t avail;
+
+	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
+	if (ptr == NULL) {
+		return NULL;
+	}
+	__archive_read_consume(arch->arch, num_bytes);
+	arch->cmp_size -= num_bytes;
+
+	if (arch->decrypt) {
+		trad_enc_decrypt_update(arch->decrypt,
+			ptr, num_bytes,
+			arch->decrypt_buf, num_bytes);
+		ptr = arch->decrypt_buf;
+	}
+
+	return ptr;
+}
+
+#endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_common.c
+++ b/libarchive/archive_zip_legacy_common.c
@@ -153,57 +153,39 @@ lz77_copy_window(struct lz77_window *lz77)
     lz77->copy_pos -= start;
 }
 
-/* Read one or more bits from the archive */
+/* Read the given number of bits, possibly not byte aligned */
+/* Return -1 if end of data reached, else 0 */
 int
-archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits)
+archive_read_bits(struct arch_bits *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits)
 {
-	if (arch->num_bits < num_bits) {
-		unsigned num_bytes = (num_bits - arch->num_bits + 7) / 8;
-		const uint8_t *ptr;
+	if (desc->num_bits < num_bits) {
+		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
 
-		if (arch->cmp_size < num_bytes) {
-			return end_of_data;
-		}
-		ptr = archive_read_bytes(arch, num_bytes);
-		if (ptr == NULL) {
-			return file_truncated;
+		/*
+		 * If whole bytes are available, add them to desc->bits even if
+		 * we can't fulfill the request, so that the decoders don't
+		 * wrongly report end of data
+		 */
+		if (io->total_in + num_bytes > io->avail_in) {
+			num_bytes = (unsigned)(io->avail_in - io->total_in);
 		}
 		for (unsigned i = 0; i < num_bytes; ++i) {
-			arch->bits |= ptr[i] << arch->num_bits;
-			arch->num_bits += 8;
+			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
+			desc->num_bits += 8;
 		}
 	}
+	if (desc->num_bits < num_bits) {
+		/* End of data */
+		return -1;
+	}
 
-	*bits = arch->bits;
-	arch->bits >>= num_bits;
-	arch->num_bits -= num_bits;
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
 	*bits &= (1 << num_bits) - 1;
 
 	return 0;
-}
-
-/* Read and possibly decrypt one or more bytes */
-void const *
-archive_read_bytes(struct arch_data *arch, unsigned num_bytes)
-{
-	void const *ptr;
-	ssize_t avail;
-
-	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
-	if (ptr == NULL) {
-		return NULL;
-	}
-	__archive_read_consume(arch->arch, num_bytes);
-	arch->cmp_size -= num_bytes;
-
-	if (arch->decrypt) {
-		trad_enc_decrypt_update(arch->decrypt,
-			ptr, num_bytes,
-			arch->decrypt_buf, num_bytes);
-		ptr = arch->decrypt_buf;
-	}
-
-	return ptr;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_common.c
+++ b/libarchive/archive_zip_legacy_common.c
@@ -161,7 +161,7 @@ archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits)
 		unsigned num_bytes = (num_bits - arch->num_bits + 7) / 8;
 		const uint8_t *ptr;
 
-		if (arch->cmp_size == 0) {
+		if (arch->cmp_size < num_bytes) {
 			return end_of_data;
 		}
 		ptr = archive_read_bytes(arch, num_bytes);

--- a/libarchive/archive_zip_legacy_common.c
+++ b/libarchive/archive_zip_legacy_common.c
@@ -27,6 +27,8 @@
 
 #if HAVE_LEGACY
 
+#include <assert.h>
+
 #if HAVE_ERRNO_H
 #  include <errno.h>
 #endif
@@ -42,6 +44,8 @@
 
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"
+
+static void lz77_copy_window(struct lz77_window *lz77);
 
 const char *
 zip_legacy_error(int err)
@@ -64,38 +68,37 @@ zip_legacy_error(int err)
 int
 lz77_init(struct lz77_window *lz77, unsigned window_size)
 {
-	free(lz77->window);
-	lz77->window = calloc(1, window_size);
-	if (lz77->window == NULL) {
-		return errno;
-	}
-	lz77->window_pos = 0;
-	lz77->copy_pos = 0;
-	lz77->copy_size = 0;
-	lz77->window_mask = window_size - 1;
+	assert(window_size * 2 <= sizeof(lz77->window));
+
+	/* A copy from before the start of the uncompressed data is supposed
+	   to copy zero bytes */
+	memset(lz77->window, 0, window_size);
+	lz77->window_pos = window_size;
+	lz77->copy_pos = window_size;
+	lz77->window_size = window_size;
 	return 0;
 }
 
 void
 lz77_free(struct lz77_window *lz77)
 {
-	free(lz77->window);
-	lz77->window = NULL;
+	/* no op */
+	(void)lz77;
 }
 
 /* Fulfill any pending copy */
 size_t
 lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
 {
-	size_t b_read = 0;
+	unsigned pending = lz77->window_pos - lz77->copy_pos;
+	size_t b_read = num_bytes;
 
-	while (lz77->copy_size != 0 && b_read < num_bytes) {
-		uint8_t byte = lz77->window[lz77->copy_pos];
-		bytes[b_read++] = byte;
-		lz77_add_byte(lz77, byte);
-		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
-		--lz77->copy_size;
+	if (b_read > pending) {
+		b_read = pending;
 	}
+
+	memcpy(bytes, lz77->window + lz77->copy_pos, b_read);
+	lz77->copy_pos += b_read;
 
 	return b_read;
 }
@@ -104,16 +107,50 @@ lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
 void
 lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
 {
-	lz77->window[lz77->window_pos] = byte;
-	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
+	if (lz77->window_pos >= sizeof(lz77->window)) {
+		lz77_copy_window(lz77);
+	}
+	lz77->window[lz77->window_pos++] = byte;
+	/* lz77_copy will copy the byte to the final output */
 }
 
 /* Begin a copy */
 void
 lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
 {
-	lz77->copy_size = length;
-	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
+	/*
+	 * The source and destination are allowed to overlap. The desired
+	 * output is a repeating pattern. memmove does the wrong thing in this
+	 * case, and memcpy invokes undefined behavior.
+	 * Implement the repeating pattern with repeated calls to memcpy.
+	 */
+	while (length != 0) {
+		unsigned block = (length < distance) ? length : distance;
+
+		if (lz77->window_pos + block > sizeof(lz77->window)) {
+			lz77_copy_window(lz77);
+		}
+
+		assert(lz77->window_pos + block <= sizeof(lz77->window));
+		memcpy(lz77->window + lz77->window_pos,
+		       lz77->window + lz77->window_pos - distance,
+		       block);
+		lz77->window_pos += block;
+
+		length -= block;
+	}
+}
+
+/* Copy the sliding window back to the start */
+static void
+lz77_copy_window(struct lz77_window *lz77)
+{
+    assert(lz77->window_pos >= lz77->window_size);
+
+    unsigned start = lz77->window_pos - lz77->window_size;
+    memmove(lz77->window, lz77->window + start, lz77->window_size);
+    lz77->window_pos -= start;
+    lz77->copy_pos -= start;
 }
 
 /* Read one or more bits from the archive */

--- a/libarchive/archive_zip_legacy_common.c
+++ b/libarchive/archive_zip_legacy_common.c
@@ -120,18 +120,21 @@ lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
 int
 archive_read_bits(struct arch_data *arch, unsigned num_bits, unsigned *bits)
 {
-	while (arch->num_bits < num_bits) {
+	if (arch->num_bits < num_bits) {
+		unsigned num_bytes = (num_bits - arch->num_bits + 7) / 8;
 		const uint8_t *ptr;
 
 		if (arch->cmp_size == 0) {
 			return end_of_data;
 		}
-		ptr = archive_read_bytes(arch, 1);
+		ptr = archive_read_bytes(arch, num_bytes);
 		if (ptr == NULL) {
 			return file_truncated;
 		}
-		arch->bits |= ptr[0] << arch->num_bits;
-		arch->num_bits += 8;
+		for (unsigned i = 0; i < num_bytes; ++i) {
+			arch->bits |= ptr[i] << arch->num_bits;
+			arch->num_bits += 8;
+		}
 	}
 
 	*bits = arch->bits;

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -139,24 +139,22 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 {
 	int err = 0;
 	uint64_t cmp_size = desc->cmp_size;
+	size_t b_read;
 
-	*bytes_read = 0;
-	while (num_bytes != 0) {
+	b_read = 0;
+	while (b_read < num_bytes) {
 		uint8_t literal;
 
 		/* Fulfill any pending copy */
-		while (desc->copy_size != 0 && num_bytes != 0) {
+		while (desc->copy_size != 0 && b_read < num_bytes) {
 			uint8_t byte = desc->window[desc->copy_pos];
-			bytes[0] = byte;
-			++bytes;
-			--num_bytes;
-			++(*bytes_read);
+			bytes[b_read++] = byte;
 			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
 			--desc->copy_size;
 			add_byte(desc, byte);
 		}
 
-		if (num_bytes == 0) {
+		if (b_read >= num_bytes) {
 			break;
 		}
 
@@ -179,10 +177,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			if (err) {
 				goto fail;
 			}
-			bytes[0] = byte;
-			++bytes;
-			--num_bytes;
-			++(*bytes_read);
+			bytes[b_read++] = byte;
 			add_byte(desc, byte);
 		} else {
 			/* Copy marker found */
@@ -227,12 +222,14 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 		}
 	}
 
+	*bytes_read = b_read;
 	*cmp_bytes_read = cmp_size - desc->cmp_size;
 	return 0;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
+	*bytes_read = b_read;
 	*cmp_bytes_read = cmp_size - desc->cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
 }

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -614,12 +614,15 @@ archive_read_bits_2(struct implode_desc *desc, struct zip_legacy_io *io,
 		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
 
 		if (io->total_in + num_bytes > io->avail_in) {
-			return -1;
+			num_bytes = (unsigned)(io->avail_in - io->total_in);
 		}
 		for (unsigned i = 0; i < num_bytes; ++i) {
 			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
 			desc->num_bits += 8;
 		}
+	}
+	if (desc->num_bits < num_bits) {
+		return -1;
 	}
 
 	*bits = desc->bits;

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -175,8 +175,10 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* Copy marker found */
-			unsigned dist_low, dist_high;
-			unsigned length1, length2;
+			unsigned dist_low;
+			unsigned dist_high;
+			unsigned length1;
+			unsigned length2;
 			unsigned distance;
 			unsigned length;
 
@@ -235,8 +237,10 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	uint8_t tree_data[256];
 	uint8_t bit_lengths[256];
 	uint16_t codes[256];
-	unsigned next_code, bit;
-	unsigned i, j;
+	unsigned next_code;
+	unsigned bit;
+	unsigned i;
+	unsigned j;
 	unsigned tree_size;
 
 	/* Raw data for the tree (5.3.7): */
@@ -262,7 +266,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 
 	/* Set the bit lengths */
 	i = 0;
-	for (j = 0; j < (unsigned)tree_bytes; ++j) {
+	for (j = 0; j < tree_bytes; ++j) {
 		unsigned count = (tree_data[j] >> 4) + 1;
 		unsigned length = (tree_data[j] & 0x0F) + 1;
 		while (count != 0) {

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -145,6 +145,8 @@ implode_free(struct implode_desc **desc)
 	*desc = NULL;
 }
 
+static int read_copy_marker(struct implode_desc *desc);
+
 int
 implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
@@ -182,51 +184,16 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			} else {
 				err = archive_read_bits(&desc->arch, 8, &byte);
 			}
-			if (err) {
-				goto fail;
+			if (!err) {
+				bytes[b_read++] = byte;
+				lz77_add_byte(&desc->lz77, byte);
 			}
-			bytes[b_read++] = byte;
-			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* Copy marker found */
-			unsigned dist_low;
-			unsigned dist_high;
-			unsigned length1;
-			unsigned length2;
-			unsigned distance;
-			unsigned length;
-
-			/* Low bits of distance */
-			err = archive_read_bits(&desc->arch, desc->window_8k ? 7 : 6, &dist_low);
-			if (err) {
-				goto fail;
-			}
-			/* High bits of distance */
-			err = sf_decode(desc, desc->distance_tree, &dist_high);
-			if (err) {
-				goto fail;
-			}
-			/* Complete distance */
-			distance = (dist_high << (desc->window_8k ? 7 : 6))
-				 + dist_low + 1;
-
-			/* First part of length */
-			err = sf_decode(desc, desc->length_tree, &length1);
-			if (err) {
-				goto fail;
-			}
-			length = length1;
-			if (length1 == 63) {
-				/* Second part of length */
-				err = archive_read_bits(&desc->arch, 8, &length2);
-				if (err) {
-					goto fail;
-				}
-				length += length2;
-			}
-			length += desc->have_literal_tree ? 3 : 2;
-
-			lz77_set_copy(&desc->lz77, distance, length);
+			err = read_copy_marker(desc);
+		}
+		if (err) {
+			goto fail;
 		}
 	}
 
@@ -240,6 +207,52 @@ fail:
 	*bytes_read = b_read;
 	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
+}
+
+/* Read a copy marker and start the copy */
+static int
+read_copy_marker(struct implode_desc *desc)
+{
+	unsigned dist_low;
+	unsigned dist_high;
+	unsigned length1;
+	unsigned length2;
+	unsigned distance;
+	unsigned length;
+	int err;
+
+	/* Low bits of distance */
+	err = archive_read_bits(&desc->arch, desc->window_8k ? 7 : 6, &dist_low);
+	if (err) {
+		return err;
+	}
+	/* High bits of distance */
+	err = sf_decode(desc, desc->distance_tree, &dist_high);
+	if (err) {
+		return err;
+	}
+	/* Complete distance */
+	distance = (dist_high << (desc->window_8k ? 7 : 6))
+		 + dist_low + 1;
+
+	/* First part of length */
+	err = sf_decode(desc, desc->length_tree, &length1);
+	if (err) {
+		return err;
+	}
+	length = length1;
+	if (length1 == 63) {
+		/* Second part of length */
+		err = archive_read_bits(&desc->arch, 8, &length2);
+		if (err) {
+			return err;
+		}
+		length += length2;
+	}
+	length += desc->have_literal_tree ? 3 : 2;
+
+	lz77_set_copy(&desc->lz77, distance, length);
+	return 0;
 }
 
 /* Read one Shannon-Fano tree from the archive */

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -69,6 +69,20 @@ struct implode_desc {
 };
 
 static int read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[]);
+static int set_bit_lengths(
+	unsigned num_values,
+	uint8_t bit_lengths[256],
+	uint8_t const tree_data[256],
+	unsigned tree_bytes);
+static int build_codes(
+	unsigned num_values,
+	uint16_t codes[256],
+	uint8_t const bit_lengths[256]);
+static int build_tree(
+	unsigned num_values,
+	struct implode_tree tree[],
+	uint16_t const codes[256],
+	uint8_t const bit_lengths[256]);
 static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
 	unsigned *elem);
 
@@ -237,11 +251,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	uint8_t tree_data[256];
 	uint8_t bit_lengths[256];
 	uint16_t codes[256];
-	unsigned next_code;
-	unsigned bit;
-	unsigned i;
-	unsigned j;
-	unsigned tree_size;
+	int err;
 
 	/* Raw data for the tree (5.3.7): */
 	/* Number of bytes that encode the tree */
@@ -265,8 +275,41 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	memcpy(tree_data, ptr, tree_bytes);
 
 	/* Set the bit lengths */
-	i = 0;
-	for (j = 0; j < tree_bytes; ++j) {
+	err = set_bit_lengths(num_values, bit_lengths, tree_data, tree_bytes);
+	if (err) {
+		return err;
+	}
+
+	/* Construct the codes */
+	err = build_codes(num_values, codes, bit_lengths);
+	if (err) {
+		return err;
+	}
+
+	/* Build the tree */
+	err = build_tree(num_values, tree, codes, bit_lengths);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+/*
+ * Given the raw bytes for the Shannon-Fano tree as read from the compressed
+ * data, produce an array of bit lengths.
+ * The lengths are not sorted as described in APPNOTE.TXT; rather, build_codes
+ * and build_tree will scan the array multiple times to produce the codes.
+ */
+static int
+set_bit_lengths(
+	unsigned num_values,
+	uint8_t bit_lengths[256],
+	uint8_t const tree_data[256],
+	unsigned tree_bytes)
+{
+	unsigned i = 0;
+	for (unsigned j = 0; j < tree_bytes; ++j) {
 		unsigned count = (tree_data[j] >> 4) + 1;
 		unsigned length = (tree_data[j] & 0x0F) + 1;
 		while (count != 0) {
@@ -281,11 +324,23 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 		return file_inconsistent;
 	}
 
-	/* Construct the codes */
-	next_code = 0x10000;
-	bit = 0x8000;
-	for (i = 1; i <= 16; ++i) {
-		for (j = 0; j < num_values; ++j) {
+	return 0;
+}
+
+/*
+ * Given the bit lengths from set_bit_lengths, produce the corresponding codes.
+ * The codes are aligned at the left side of the 16 bit array elements.
+ */
+static int
+build_codes(
+	unsigned num_values,
+	uint16_t codes[256],
+	uint8_t const bit_lengths[256])
+{
+	unsigned next_code = 0x10000;
+	unsigned bit = 0x8000;
+	for (unsigned i = 1; i <= 16; ++i) {
+		for (unsigned j = 0; j < num_values; ++j) {
 			if (bit_lengths[j] == i) {
 				if (next_code < bit) {
 					return file_inconsistent;
@@ -297,17 +352,30 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 		bit >>= 1;
 	}
 
-	/* Build the tree */
-	for (i = 0; i < num_values; ++i) {
+	return 0;
+}
+
+/*
+ * Given the codes from build_codes and the bit lengths from set_bit_lengths,
+ * construct the final tree.
+ */
+static int
+build_tree(unsigned num_values, struct implode_tree tree[],
+	uint16_t const codes[256], uint8_t const bit_lengths[256])
+{
+	unsigned tree_size;
+	unsigned bit;
+
+	for (unsigned i = 0; i < num_values; ++i) {
 		tree[i].next[0] = 0xFFFF;
 		tree[i].next[1] = 0xFFFF;
 	}
 	tree_size = 1;
-	for (i = 0; i < num_values; ++i) {
+	for (unsigned i = 0; i < num_values; ++i) {
 		uint16_t code = codes[i];
 		uint8_t length = bit_lengths[i];
 		unsigned node = 0;
-		for (j = 0; j + 1 < length; ++j) {
+		for (unsigned j = 0; j + 1 < length; ++j) {
 			bit = (code >> (15 - j)) & 1;
 			if (tree[node].next[bit] == 0xFFFF) {
 				if (tree_size >= num_values - 1) {

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -335,7 +335,7 @@ implode_setup(struct implode_desc *desc, struct zip_legacy_io *io)
 		default:
 			assert(0);
 			break;
-		};
+		}
 
 		if (err) {
 			return err;

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -185,7 +185,6 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 				err = archive_read_bits(&desc->arch, 8, &byte);
 			}
 			if (!err) {
-				bytes[b_read++] = byte;
 				lz77_add_byte(&desc->lz77, byte);
 			}
 		} else {

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -15,12 +15,12 @@
 /* 5.3.7 and 5.3.8 */
 struct implode_tree {
 	/*
-     * Each bit indexes this array
+	 * Each bit indexes this array
 	 * The value is 0-255 for a terminal value and 256-511 for an index
 	 * to another node in the tree
 	 * For 256-511, subtract 256 for the actual index
-     * 0xFFFF marks an invalid entry
-     */
+	 * 0xFFFF marks an invalid entry
+	 */
 	uint16_t next[2];
 };
 
@@ -34,9 +34,9 @@ struct implode_desc {
 	/* Current state of Shannon-Fano decoder */
 	unsigned bits;
 	uint8_t num_bits;
-	struct implode_tree literal_tree[255];
-	struct implode_tree length_tree[63];
-	struct implode_tree distance_tree[63];
+	struct implode_tree literal_tree[256];
+	struct implode_tree length_tree[64];
+	struct implode_tree distance_tree[64];
 	/* Current state of sliding window */
 	uint8_t window[8192];
 	uint16_t window_pos;
@@ -66,9 +66,11 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 {
 	int err = 0;
 
-	*desc = calloc(1, sizeof(**desc));
 	if (*desc == NULL) {
-		return errno;
+		*desc = calloc(1, sizeof(**desc));
+		if (*desc == NULL) {
+			return errno;
+		}
 	}
 
 	(*desc)->arch = a;
@@ -308,7 +310,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	}
 
 	/* Build the tree */
-	for (i = 0; i < num_values+1; ++i) {
+	for (i = 0; i < num_values; ++i) {
 		tree[i].next[0] = 0xFFFF;
 		tree[i].next[1] = 0xFFFF;
 	}

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -27,10 +27,18 @@
 
 #if HAVE_LEGACY
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
+#if HAVE_ERRNO_H
+#  include <errno.h>
+#endif
+#if HAVE_STDINT_H
+#  include <stdint.h>
+#endif
+#if HAVE_STDLIB_H
+#  include <stdlib.h>
+#endif
+#if HAVE_STRING_H
+#  include <string.h>
+#endif
 
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -1,8 +1,8 @@
 /* implode */
 
-// #if HAVE_LEGACY
-
 #include "archive_platform.h"
+
+#if HAVE_LEGACY
 
 #include <errno.h>
 #include <stdint.h>
@@ -402,3 +402,5 @@ read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
 
 	return 0;
 }
+
+#endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -1,0 +1,406 @@
+/* implode */
+
+// #if HAVE_LEGACY
+
+#include "archive_platform.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "archive_read_private.h"
+#include "archive_zip_legacy.h"
+
+/* 5.3.7 and 5.3.8 */
+struct implode_tree {
+	/*
+     * Each bit indexes this array
+	 * The value is 0-255 for a terminal value and 256-511 for an index
+	 * to another node in the tree
+	 * For 256-511, subtract 256 for the actual index
+     * 0xFFFF marks an invalid entry
+     */
+	uint16_t next[2];
+};
+
+struct implode_desc {
+	/* Source of bytes */
+	struct archive_read *arch;
+	uint64_t cmp_size;
+	/* Flags set in the Zip structure */
+	uint8_t window_8k;
+	uint8_t have_literal_tree;
+	/* Current state of Shannon-Fano decoder */
+	unsigned bits;
+	uint8_t num_bits;
+	struct implode_tree literal_tree[255];
+	struct implode_tree length_tree[63];
+	struct implode_tree distance_tree[63];
+	/* Current state of sliding window */
+	uint8_t window[8192];
+	uint16_t window_pos;
+	uint16_t copy_pos;
+	uint16_t copy_size;
+	uint16_t window_mask;
+};
+
+/* Errors occurring within the ZIP format */
+enum {
+	end_of_data = -1,
+	file_truncated = -2,
+	file_inconsistent = -3
+};
+
+static int read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[]);
+static void add_byte(struct implode_desc *desc, uint8_t byte);
+static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
+	uint8_t *elem);
+static int read_bits(struct implode_desc *desc, unsigned num_bits,
+	uint8_t *bits);
+
+/* Initialize the implode_desc structure and read the Shannon-Fano trees */
+int
+implode_init(struct implode_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, unsigned zip_flags, size_t *cmp_bytes_read)
+{
+	int err = 0;
+
+	*desc = calloc(1, sizeof(**desc));
+	if (*desc == NULL) {
+		return errno;
+	}
+
+	(*desc)->arch = a;
+	(*desc)->cmp_size = cmp_size;
+	(*desc)->window_8k = (zip_flags & 0x02) != 0;
+	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
+	(*desc)->window_pos = 0;
+	(*desc)->copy_pos = 0;
+	(*desc)->copy_size = 0;
+	(*desc)->window_mask = (*desc)->window_8k ? 0x1FFF : 0x0FFF;
+
+	if ((*desc)->have_literal_tree) {
+		err = read_tree((*desc), 256, (*desc)->literal_tree);
+		if (err) {
+			goto fail;
+		}
+	}
+	err = read_tree((*desc), 64, (*desc)->length_tree);
+	if (err) {
+		goto fail;
+	}
+	err = read_tree((*desc), 64, (*desc)->distance_tree);
+	if (err) {
+		goto fail;
+	}
+	memset((*desc)->window, 0, sizeof((*desc)->window));
+
+	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	return 0;
+
+fail:
+	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	return err;
+}
+
+void
+implode_free(struct implode_desc **desc)
+{
+	free(*desc);
+	*desc = NULL;
+}
+
+const char *
+implode_error(int err)
+{
+	switch (err) {
+	case end_of_data:
+		return "End of compressed data";
+
+	case file_truncated:
+		return "Truncated ZIP file data";
+
+	case file_inconsistent:
+		return "Corrupted ZIP file data";
+
+	default:
+		return strerror(err);
+	}
+}
+
+int
+implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read)
+{
+	int err = 0;
+	uint64_t cmp_size = desc->cmp_size;
+
+	*bytes_read = 0;
+	while (num_bytes != 0) {
+		uint8_t literal;
+
+		/* Fulfill any pending copy */
+		while (desc->copy_size != 0 && num_bytes != 0) {
+			uint8_t byte = desc->window[desc->copy_pos];
+			bytes[0] = byte;
+			++bytes;
+			--num_bytes;
+			++(*bytes_read);
+			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
+			--desc->copy_size;
+			add_byte(desc, byte);
+		}
+
+		if (num_bytes == 0) {
+			break;
+		}
+
+		/* desc->copy_size is 0 at this point */
+		/* Read one bit: literal or copy marker? */
+		err = read_bits(desc, 1, &literal);
+		if (err) {
+			goto fail;
+		}
+
+		if (literal) {
+			/* Literal byte found */
+			int err;
+			uint8_t byte;
+
+			if (desc->have_literal_tree) {
+				err = sf_decode(desc, desc->literal_tree, &byte);
+			} else {
+				err = read_bits(desc, 8, &byte);
+			}
+			if (err) {
+				goto fail;
+			}
+			bytes[0] = byte;
+			++bytes;
+			--num_bytes;
+			++(*bytes_read);
+			add_byte(desc, byte);
+		} else {
+			/* Copy marker found */
+			uint8_t dist_low, dist_high;
+			uint8_t length1, length2;
+			unsigned distance;
+			unsigned length;
+
+			/* Low bits of distance */
+			err = read_bits(desc, desc->window_8k ? 7 : 6, &dist_low);
+			if (err) {
+				goto fail;
+			}
+			/* High bits of distance */
+			err = sf_decode(desc, desc->distance_tree, &dist_high);
+			if (err) {
+				goto fail;
+			}
+			/* Complete distance */
+			distance = (dist_high << (desc->window_8k ? 7 : 6))
+				 + dist_low + 1;
+
+			/* First part of length */
+			err = sf_decode(desc, desc->length_tree, &length1);
+			if (err) {
+				goto fail;
+			}
+			length = length1;
+			if (length1 == 63) {
+				/* Second part of length */
+				err = read_bits(desc, 8, &length2);
+				if (err) {
+					goto fail;
+				}
+				length += length2;
+			}
+			length += desc->have_literal_tree ? 3 : 2;
+
+			desc->copy_size = length;
+			desc->copy_pos = (desc->window_pos - distance)
+				       & desc->window_mask;
+		}
+	}
+
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return 0;
+
+fail:
+	/* If we reach the end of the compressed data, return success with the
+	   number of bytes read so far */
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return err == end_of_data ? ARCHIVE_EOF : err;
+}
+
+/* Read one Shannon-Fano tree from the archive */
+static int
+read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[])
+{
+	const uint8_t *ptr;
+	ssize_t avail;
+	int tree_bytes;
+	uint8_t tree_data[256];
+	uint8_t bit_lengths[256];
+	uint16_t codes[256];
+	unsigned next_code, bit;
+	unsigned i, j;
+	unsigned tree_size;
+
+	/* Raw data for the tree (5.3.7): */
+	/* Number of bytes that encode the tree */
+	if (desc->cmp_size == 0) {
+		return file_inconsistent;
+	}
+	ptr = __archive_read_ahead(desc->arch, 1, &avail);
+	if (ptr == NULL) {
+		return file_truncated;
+	}
+	tree_bytes = ptr[0] + 1;
+	__archive_read_consume(desc->arch, 1);
+	--desc->cmp_size;
+
+	/* The code counts and bit lengths */
+	if (desc->cmp_size < tree_bytes) {
+		return file_inconsistent;
+	}
+	ptr = __archive_read_ahead(desc->arch, tree_bytes, &avail);
+	if (ptr == NULL) {
+		return file_truncated;
+	}
+	desc->cmp_size -= tree_bytes;
+	memcpy(tree_data, ptr, tree_bytes);
+	__archive_read_consume(desc->arch, tree_bytes);
+
+	/* Set the bit lengths */
+	i = 0;
+	for (j = 0; j < (unsigned)tree_bytes; ++j) {
+		unsigned count = (tree_data[j] >> 4) + 1;
+		unsigned length = (tree_data[j] & 0x0F) + 1;
+		while (count != 0) {
+			if (i >= num_values) {
+				return file_inconsistent;
+			}
+			bit_lengths[i++] = length;
+			--count;
+		}
+	}
+	if (i != num_values) {
+		return file_inconsistent;
+	}
+
+	/* Construct the codes */
+	next_code = 0x10000;
+	bit = 0x8000;
+	for (i = 1; i <= 16; ++i) {
+		for (j = 0; j < num_values; ++j) {
+			if (bit_lengths[j] == i) {
+				if (next_code < bit) {
+					return file_inconsistent;
+				}
+				next_code -= bit;
+				codes[j] = (uint16_t)next_code;
+			}
+		}
+		bit >>= 1;
+	}
+
+	/* Build the tree */
+	for (i = 0; i < num_values+1; ++i) {
+		tree[i].next[0] = 0xFFFF;
+		tree[i].next[1] = 0xFFFF;
+	}
+	tree_size = 1;
+	for (i = 0; i < num_values; ++i) {
+		uint16_t code = codes[i];
+		uint8_t length = bit_lengths[i];
+		unsigned node = 0;
+		unsigned bit;
+		for (j = 0; j + 1 < length; ++j) {
+			bit = (code >> (15 - j)) & 1;
+			if (tree[node].next[bit] == 0xFFFF) {
+				if (tree_size >= num_values - 1) {
+					return file_inconsistent;
+				}
+				tree[node].next[bit] = tree_size + 0x100;
+				++tree_size;
+			}
+			if (tree[node].next[bit] < 0x100) {
+				return file_inconsistent;
+			}
+			node = tree[node].next[bit] - 0x100;
+		}
+		bit = (code >> (16 - length)) & 1;
+		tree[node].next[bit] = i;
+	}
+
+	return 0;
+}
+
+/* Add a byte to the sliding window */
+static void
+add_byte(struct implode_desc *desc, uint8_t byte)
+{
+	desc->window[desc->window_pos] = byte;
+	desc->window_pos = (desc->window_pos + 1) & desc->window_mask;
+}
+
+/* Decode an element through a Shannon-Fano tree */
+/* Return 0 on success, -1 on end of data, positive on file error */
+static int
+sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
+	uint8_t *elem)
+{
+	unsigned node = 0;
+	uint8_t bit;
+	int err;
+
+	while (1) {
+		unsigned node2;
+		err = read_bits(desc, 1, &bit);
+		if (err) {
+			return err;
+		}
+		node2 = tree[node].next[bit];
+		if (node2 < 0x100) {
+			*elem = node2;
+			return 0;
+		}
+		if (node2 == 0xFFFF) {
+			return file_inconsistent;
+		}
+		node = node2 - 0x100;
+	}
+}
+
+/* Read one or more bits from the archive */
+static int
+read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
+{
+	while (desc->num_bits < num_bits) {
+		const uint8_t *ptr;
+		ssize_t avail;
+
+		if (desc->cmp_size == 0) {
+			return end_of_data;
+		}
+		ptr = __archive_read_ahead(desc->arch, 1, &avail);
+		if (ptr == NULL) {
+			return file_truncated;
+		}
+		desc->bits |= ptr[0] << desc->num_bits;
+		desc->num_bits += 8;
+		--desc->cmp_size;
+		__archive_read_consume(desc->arch, 1);
+	}
+
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
+	return 0;
+}

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -1,4 +1,27 @@
-/* implode */
+/*-
+ * Copyright (c) 2026 Ray Chason
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "archive_platform.h"
 

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -78,8 +78,7 @@ enum implode_state {
 
 struct implode_desc {
 	/* To read bits not on a byte boundary */
-	uint64_t bits;
-	uint8_t num_bits;
+	struct arch_bits bits;
 	/* Current state of sliding window */
 	struct lz77_window lz77;
 	/* Flags set in the Zip structure */
@@ -128,8 +127,6 @@ static int read_length_first(struct implode_desc *desc, struct zip_legacy_io *io
 static int read_length_second(struct implode_desc *desc, struct zip_legacy_io *io);
 static int sf_decode(struct implode_desc *desc, struct zip_legacy_io *io,
 	struct implode_tree const tree[], unsigned *elem);
-static int archive_read_bits_2(struct implode_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits);
 
 /* Initialize the implode_desc structure and read the Shannon-Fano trees */
 int
@@ -144,8 +141,8 @@ implode_init(struct implode_desc **desc, unsigned zip_flags)
 		}
 	}
 
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
+	(*desc)->bits.bits = 0;
+	(*desc)->bits.num_bits = 0;
 	(*desc)->window_8k = (zip_flags & 0x02) != 0;
 	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
 	err = lz77_init(&(*desc)->lz77, (*desc)->window_8k ? 0x2000 : 0x1000);
@@ -172,7 +169,7 @@ implode_read(struct implode_desc *desc, struct zip_legacy_io *io)
 	int eodata = 0;
 	size_t total_in = io->total_in;
 	size_t total_out = io->total_out;
-	unsigned num_bits = desc->num_bits;
+	unsigned num_bits = desc->bits.num_bits;
 
 	/* Set up the Shannon-Fano trees at the start */
 	if (desc->state < UNIMPLODE) {
@@ -247,7 +244,7 @@ implode_read(struct implode_desc *desc, struct zip_legacy_io *io)
 	}
 
 	if (total_in == io->total_in && total_out == io->total_out
-	&&  num_bits == desc->num_bits) {
+	&&  num_bits == desc->bits.num_bits) {
 		return ARCHIVE_EOF;
 	}
 	return ARCHIVE_OK;
@@ -482,7 +479,7 @@ read_literal_flag(struct implode_desc *desc, struct zip_legacy_io *io)
 {
 	unsigned literal;
 
-	int eodata = archive_read_bits_2(desc, io, 1, &literal);
+	int eodata = archive_read_bits(&desc->bits, io, 1, &literal);
 	if (!eodata) {
 		if (literal) {
 			/* Read a literal */
@@ -508,7 +505,7 @@ read_literal(struct implode_desc *desc, struct zip_legacy_io *io)
 	if (desc->have_literal_tree) {
 		eodata = sf_decode(desc, io, desc->literal_tree, &byte);
 	} else {
-		eodata = archive_read_bits_2(desc, io, 8, &byte);
+		eodata = archive_read_bits(&desc->bits, io, 8, &byte);
 	}
 	if (!eodata) {
 		lz77_add_byte(&desc->lz77, byte);
@@ -521,7 +518,7 @@ read_literal(struct implode_desc *desc, struct zip_legacy_io *io)
 static int
 read_distance_low(struct implode_desc *desc, struct zip_legacy_io *io)
 {
-	int eodata = archive_read_bits_2(desc, io, desc->window_8k ? 7 : 6, &desc->distance);
+	int eodata = archive_read_bits(&desc->bits, io, desc->window_8k ? 7 : 6, &desc->distance);
 	if (!eodata) {
 		desc->state = READ_DISTANCE_HIGH;
 		/* Next state will use the Shannon-Fano tree for distance */
@@ -564,7 +561,7 @@ read_length_second(struct implode_desc *desc, struct zip_legacy_io *io)
 {
 	if (desc->length == 63) {
 		unsigned length2;
-		int eodata = archive_read_bits_2(desc, io, 8, &length2);
+		int eodata = archive_read_bits(&desc->bits, io, 8, &length2);
 		if (eodata) {
 			return eodata;
 		}
@@ -588,7 +585,7 @@ sf_decode(struct implode_desc *desc, struct zip_legacy_io *io,
 
 	while (1) {
 		unsigned node2;
-		int eodata = archive_read_bits_2(desc, io, 1, &bit);
+		int eodata = archive_read_bits(&desc->bits, io, 1, &bit);
 		if (eodata) {
 			return eodata;
 		}
@@ -602,35 +599,6 @@ sf_decode(struct implode_desc *desc, struct zip_legacy_io *io,
 		}
 		desc->tree_index = node2 - 0x100;
 	}
-}
-
-/* Read the given number of bits, possibly not byte aligned */
-/* Return -1 if end of data reached, else 0 */
-static int
-archive_read_bits_2(struct implode_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits)
-{
-	if (desc->num_bits < num_bits) {
-		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
-
-		if (io->total_in + num_bytes > io->avail_in) {
-			num_bytes = (unsigned)(io->avail_in - io->total_in);
-		}
-		for (unsigned i = 0; i < num_bytes; ++i) {
-			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
-			desc->num_bits += 8;
-		}
-	}
-	if (desc->num_bits < num_bits) {
-		return -1;
-	}
-
-	*bits = desc->bits;
-	desc->bits >>= num_bits;
-	desc->num_bits -= num_bits;
-	*bits &= (1 << num_bits) - 1;
-
-	return 0;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -40,28 +40,7 @@
 #  include <string.h>
 #endif
 
-#include "archive_read_private.h"
 #include "archive_zip_legacy.h"
-
-/* Archive data, remaining bytes, decryption */
-struct arch_data {
-	/* Archive data from caller */
-	struct archive_read *arch;
-	/* Compressed bytes remaining */
-	uint64_t cmp_size;
-	/* Traditional PKZIP decryption */
-	struct trad_enc_ctx *decrypt;
-	uint8_t decrypt_buf[256];
-};
-
-/* Current state of sliding window */
-struct lz77_window {
-	uint8_t *window;
-	unsigned window_pos;
-	unsigned copy_pos;
-	unsigned copy_size;
-	unsigned window_mask;
-};
 
 /* 5.3.7 and 5.3.8 */
 struct implode_tree {
@@ -78,9 +57,6 @@ struct implode_tree {
 struct implode_desc {
 	/* Source of bytes */
 	struct arch_data arch;
-	/* For reading individual bits */
-	unsigned bits;
-	uint8_t num_bits;
 	/* Current state of sliding window */
 	struct lz77_window lz77;
 	/* Flags set in the Zip structure */
@@ -92,25 +68,9 @@ struct implode_desc {
 	struct implode_tree distance_tree[64];
 };
 
-/* Errors occurring within the ZIP format */
-enum {
-	end_of_data = -1,
-	file_truncated = -2,
-	file_inconsistent = -3
-};
-
 static int read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[]);
 static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
-	uint8_t *elem);
-static int read_bits(struct implode_desc *desc, unsigned num_bits,
-	uint8_t *bits);
-static void const *read_bytes(struct arch_data *arch, unsigned num_bytes);
-
-static int lz77_init(struct lz77_window *lz77, unsigned window_size);
-static void lz77_free(struct lz77_window *lz77);
-static size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
-static void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
-static void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
+	unsigned *elem);
 
 /* Initialize the implode_desc structure and read the Shannon-Fano trees */
 int
@@ -130,10 +90,10 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 	(*desc)->arch.arch = a;
 	(*desc)->arch.cmp_size = cmp_size;
 	(*desc)->arch.decrypt = decrypt;
+	(*desc)->arch.bits = 0;
+	(*desc)->arch.num_bits = 0;
 	(*desc)->window_8k = (zip_flags & 0x02) != 0;
 	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
 	err = lz77_init(&(*desc)->lz77, (*desc)->window_8k ? 0x2000 : 0x1000);
 	if (err) {
 		implode_free(desc);
@@ -171,24 +131,6 @@ implode_free(struct implode_desc **desc)
 	*desc = NULL;
 }
 
-const char *
-implode_error(int err)
-{
-	switch (err) {
-	case end_of_data:
-		return "End of compressed data";
-
-	case file_truncated:
-		return "Truncated ZIP file data";
-
-	case file_inconsistent:
-		return "Corrupted ZIP file data";
-
-	default:
-		return strerror(err);
-	}
-}
-
 int
 implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
@@ -199,7 +141,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 	b_read = 0;
 	while (b_read < num_bytes) {
-		uint8_t literal;
+		unsigned literal;
 		size_t count;
 
 		/* Fulfill any pending copy */
@@ -212,19 +154,19 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 		/* desc->copy_size is 0 at this point */
 		/* Read one bit: literal or copy marker? */
-		err = read_bits(desc, 1, &literal);
+		err = archive_read_bits(&desc->arch, 1, &literal);
 		if (err) {
 			goto fail;
 		}
 
 		if (literal) {
 			/* Literal byte found */
-			uint8_t byte;
+			unsigned byte;
 
 			if (desc->have_literal_tree) {
 				err = sf_decode(desc, desc->literal_tree, &byte);
 			} else {
-				err = read_bits(desc, 8, &byte);
+				err = archive_read_bits(&desc->arch, 8, &byte);
 			}
 			if (err) {
 				goto fail;
@@ -233,13 +175,13 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* Copy marker found */
-			uint8_t dist_low, dist_high;
-			uint8_t length1, length2;
+			unsigned dist_low, dist_high;
+			unsigned length1, length2;
 			unsigned distance;
 			unsigned length;
 
 			/* Low bits of distance */
-			err = read_bits(desc, desc->window_8k ? 7 : 6, &dist_low);
+			err = archive_read_bits(&desc->arch, desc->window_8k ? 7 : 6, &dist_low);
 			if (err) {
 				goto fail;
 			}
@@ -260,7 +202,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			length = length1;
 			if (length1 == 63) {
 				/* Second part of length */
-				err = read_bits(desc, 8, &length2);
+				err = archive_read_bits(&desc->arch, 8, &length2);
 				if (err) {
 					goto fail;
 				}
@@ -302,7 +244,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	if (desc->arch.cmp_size == 0) {
 		return file_inconsistent;
 	}
-	ptr = read_bytes(&desc->arch, 1);
+	ptr = archive_read_bytes(&desc->arch, 1);
 	if (ptr == NULL) {
 		return file_truncated;
 	}
@@ -312,7 +254,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	if (desc->arch.cmp_size < tree_bytes) {
 		return file_inconsistent;
 	}
-	ptr = read_bytes(&desc->arch, tree_bytes);
+	ptr = archive_read_bytes(&desc->arch, tree_bytes);
 	if (ptr == NULL) {
 		return file_truncated;
 	}
@@ -386,15 +328,15 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 /* Return 0 on success, -1 on end of data, positive on file error */
 static int
 sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
-	uint8_t *elem)
+	unsigned *elem)
 {
 	unsigned node = 0;
-	uint8_t bit;
+	unsigned bit;
 	int err;
 
 	while (1) {
 		unsigned node2;
-		err = read_bits(desc, 1, &bit);
+		err = archive_read_bits(&desc->arch, 1, &bit);
 		if (err) {
 			return err;
 		}
@@ -408,111 +350,6 @@ sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
 		}
 		node = node2 - 0x100;
 	}
-}
-
-/* Read one or more bits from the archive */
-static int
-read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
-{
-	while (desc->num_bits < num_bits) {
-		const uint8_t *ptr;
-
-		if (desc->arch.cmp_size == 0) {
-			return end_of_data;
-		}
-		ptr = read_bytes(&desc->arch, 1);
-		if (ptr == NULL) {
-			return file_truncated;
-		}
-		desc->bits |= ptr[0] << desc->num_bits;
-		desc->num_bits += 8;
-	}
-
-	*bits = desc->bits;
-	desc->bits >>= num_bits;
-	desc->num_bits -= num_bits;
-	*bits &= (1 << num_bits) - 1;
-
-	return 0;
-}
-
-/* Read and possibly decrypt one or more bytes */
-static void const *
-read_bytes(struct arch_data *arch, unsigned num_bytes)
-{
-	void const *ptr;
-	ssize_t avail;
-
-	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
-	if (ptr == NULL) {
-		return NULL;
-	}
-	__archive_read_consume(arch->arch, num_bytes);
-	arch->cmp_size -= num_bytes;
-
-	if (arch->decrypt) {
-		trad_enc_decrypt_update(arch->decrypt,
-			ptr, num_bytes,
-			arch->decrypt_buf, num_bytes);
-		ptr = arch->decrypt_buf;
-	}
-
-	return ptr;
-}
-
-static int
-lz77_init(struct lz77_window *lz77, unsigned window_size)
-{
-	free(lz77->window);
-	lz77->window = calloc(1, window_size);
-	if (lz77->window == NULL) {
-		return errno;
-	}
-	lz77->window_pos = 0;
-	lz77->copy_pos = 0;
-	lz77->copy_size = 0;
-	lz77->window_mask = window_size - 1;
-	return 0;
-}
-
-static void
-lz77_free(struct lz77_window *lz77)
-{
-	free(lz77->window);
-	lz77->window = NULL;
-}
-
-/* Fulfill any pending copy */
-static size_t
-lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
-{
-	size_t b_read = 0;
-
-	while (lz77->copy_size != 0 && b_read < num_bytes) {
-		uint8_t byte = lz77->window[lz77->copy_pos];
-		bytes[b_read++] = byte;
-		lz77_add_byte(lz77, byte);
-		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
-		--lz77->copy_size;
-	}
-
-	return b_read;
-}
-
-/* Add a byte to the sliding window */
-static void
-lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
-{
-	lz77->window[lz77->window_pos] = byte;
-	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
-}
-
-/* Begin a copy */
-static void
-lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
-{
-	lz77->copy_size = length;
-	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -172,7 +172,7 @@ implode_read(struct implode_desc *desc, struct zip_legacy_io *io)
 	int eodata = 0;
 	size_t total_in = io->total_in;
 	size_t total_out = io->total_out;
-	size_t num_bits = desc->num_bits;
+	unsigned num_bits = desc->num_bits;
 
 	/* Set up the Shannon-Fano trees at the start */
 	if (desc->state < UNIMPLODE) {

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -43,6 +43,17 @@
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"
 
+/* Archive data, remaining bytes, decryption */
+struct arch_data {
+	/* Archive data from caller */
+	struct archive_read *arch;
+	/* Compressed bytes remaining */
+	uint64_t cmp_size;
+	/* Traditional PKZIP decryption */
+	struct trad_enc_ctx *decrypt;
+	uint8_t decrypt_buf[256];
+};
+
 /* Current state of sliding window */
 struct lz77_window {
 	uint8_t *window;
@@ -66,8 +77,8 @@ struct implode_tree {
 
 struct implode_desc {
 	/* Source of bytes */
-	struct archive_read *arch;
-	uint64_t cmp_size;
+	struct arch_data arch;
+	/* For reading individual bits */
 	unsigned bits;
 	uint8_t num_bits;
 	/* Current state of sliding window */
@@ -93,6 +104,7 @@ static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[]
 	uint8_t *elem);
 static int read_bits(struct implode_desc *desc, unsigned num_bits,
 	uint8_t *bits);
+static void const *read_bytes(struct arch_data *arch, unsigned num_bytes);
 
 static int lz77_init(struct lz77_window *lz77, unsigned window_size);
 static void lz77_free(struct lz77_window *lz77);
@@ -103,7 +115,8 @@ static void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned 
 /* Initialize the implode_desc structure and read the Shannon-Fano trees */
 int
 implode_init(struct implode_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, unsigned zip_flags, size_t *cmp_bytes_read)
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
+	size_t *cmp_bytes_read)
 {
 	int err = 0;
 
@@ -114,8 +127,9 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch = a;
-	(*desc)->cmp_size = cmp_size;
+	(*desc)->arch.arch = a;
+	(*desc)->arch.cmp_size = cmp_size;
+	(*desc)->arch.decrypt = decrypt;
 	(*desc)->window_8k = (zip_flags & 0x02) != 0;
 	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
 	(*desc)->bits = 0;
@@ -141,11 +155,11 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 		goto fail;
 	}
 
-	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return 0;
 
 fail:
-	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return err;
 }
 
@@ -180,7 +194,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
 {
 	int err = 0;
-	uint64_t cmp_size = desc->cmp_size;
+	uint64_t cmp_size = desc->arch.cmp_size;
 	size_t b_read;
 
 	b_read = 0;
@@ -259,14 +273,14 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	}
 
 	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return 0;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
 	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
 }
 
@@ -275,7 +289,6 @@ static int
 read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[])
 {
 	const uint8_t *ptr;
-	ssize_t avail;
 	unsigned tree_bytes;
 	uint8_t tree_data[256];
 	uint8_t bit_lengths[256];
@@ -286,28 +299,24 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 
 	/* Raw data for the tree (5.3.7): */
 	/* Number of bytes that encode the tree */
-	if (desc->cmp_size == 0) {
+	if (desc->arch.cmp_size == 0) {
 		return file_inconsistent;
 	}
-	ptr = __archive_read_ahead(desc->arch, 1, &avail);
+	ptr = read_bytes(&desc->arch, 1);
 	if (ptr == NULL) {
 		return file_truncated;
 	}
 	tree_bytes = ptr[0] + 1;
-	__archive_read_consume(desc->arch, 1);
-	--desc->cmp_size;
 
 	/* The code counts and bit lengths */
-	if (desc->cmp_size < tree_bytes) {
+	if (desc->arch.cmp_size < tree_bytes) {
 		return file_inconsistent;
 	}
-	ptr = __archive_read_ahead(desc->arch, tree_bytes, &avail);
+	ptr = read_bytes(&desc->arch, tree_bytes);
 	if (ptr == NULL) {
 		return file_truncated;
 	}
-	desc->cmp_size -= tree_bytes;
 	memcpy(tree_data, ptr, tree_bytes);
-	__archive_read_consume(desc->arch, tree_bytes);
 
 	/* Set the bit lengths */
 	i = 0;
@@ -407,19 +416,16 @@ read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
 {
 	while (desc->num_bits < num_bits) {
 		const uint8_t *ptr;
-		ssize_t avail;
 
-		if (desc->cmp_size == 0) {
+		if (desc->arch.cmp_size == 0) {
 			return end_of_data;
 		}
-		ptr = __archive_read_ahead(desc->arch, 1, &avail);
+		ptr = read_bytes(&desc->arch, 1);
 		if (ptr == NULL) {
 			return file_truncated;
 		}
 		desc->bits |= ptr[0] << desc->num_bits;
 		desc->num_bits += 8;
-		--desc->cmp_size;
-		__archive_read_consume(desc->arch, 1);
 	}
 
 	*bits = desc->bits;
@@ -428,6 +434,30 @@ read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
 	*bits &= (1 << num_bits) - 1;
 
 	return 0;
+}
+
+/* Read and possibly decrypt one or more bytes */
+static void const *
+read_bytes(struct arch_data *arch, unsigned num_bytes)
+{
+	void const *ptr;
+	ssize_t avail;
+
+	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
+	if (ptr == NULL) {
+		return NULL;
+	}
+	__archive_read_consume(arch->arch, num_bytes);
+	arch->cmp_size -= num_bytes;
+
+	if (arch->decrypt) {
+		trad_enc_decrypt_update(arch->decrypt,
+			ptr, num_bytes,
+			arch->decrypt_buf, num_bytes);
+		ptr = arch->decrypt_buf;
+	}
+
+	return ptr;
 }
 
 static int

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -27,6 +27,8 @@
 
 #if HAVE_LEGACY
 
+#include <assert.h>
+
 #if HAVE_ERRNO_H
 #  include <errno.h>
 #endif
@@ -42,6 +44,8 @@
 
 #include "archive_zip_legacy.h"
 
+#define SIZE(x) (sizeof(x)/sizeof((x)[0]))
+
 /* 5.3.7 and 5.3.8 */
 struct implode_tree {
 	/*
@@ -54,9 +58,28 @@ struct implode_tree {
 	uint16_t next[2];
 };
 
+/* State of the decoder */
+enum implode_state {
+	LITERAL_SIZE,  /* Expecting size of literal tree */
+	LITERAL_DATA,  /* Expecting bytes of literal tree */
+	LENGTH_SIZE,   /* Expecting size of length tree */
+	LENGTH_DATA,   /* Expecting bytes of length tree */
+	DISTANCE_SIZE, /* Expecting size of distance tree */
+	DISTANCE_DATA, /* Expecting bytes of distance tree */
+	/* Once we get to the UNIMPLODE state, we don't go back to
+	   the above states */
+	UNIMPLODE,          /* Expecting literal flag */
+	READ_LITERAL,       /* Expecting literal */
+	READ_DISTANCE_LOW,  /* Expecting low part of copy distance */
+	READ_DISTANCE_HIGH, /* Expecting high part of copy distance */
+	READ_LENGTH_FIRST,  /* Expecting first part of copy length */
+	READ_LENGTH_SECOND  /* Expecting second part of copy length */
+};
+
 struct implode_desc {
-	/* Source of bytes */
-	struct arch_data arch;
+	/* To read bits not on a byte boundary */
+	uint64_t bits;
+	uint8_t num_bits;
 	/* Current state of sliding window */
 	struct lz77_window lz77;
 	/* Flags set in the Zip structure */
@@ -66,9 +89,23 @@ struct implode_desc {
 	struct implode_tree literal_tree[256];
 	struct implode_tree length_tree[64];
 	struct implode_tree distance_tree[64];
+	/* State of the decoder */
+	enum implode_state state;
+	/* For reading the Shannon-Fano trees */
+	unsigned tree_size;
+	unsigned tree_read;
+	uint8_t tree_data[256];
+	/* For reading literals and copy markers */
+	unsigned tree_index;
+	/* A copy marker */
+	unsigned distance;
+	unsigned length;
 };
 
-static int read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[]);
+static int implode_setup(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_tree(
+	struct implode_tree tree[], unsigned num_values,
+	uint8_t const tree_data[], unsigned tree_bytes);
 static int set_bit_lengths(
 	unsigned num_values,
 	uint8_t bit_lengths[256],
@@ -83,14 +120,20 @@ static int build_tree(
 	struct implode_tree tree[],
 	uint16_t const codes[256],
 	uint8_t const bit_lengths[256]);
-static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
-	unsigned *elem);
+static int read_literal_flag(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_literal(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_distance_low(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_distance_high(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_length_first(struct implode_desc *desc, struct zip_legacy_io *io);
+static int read_length_second(struct implode_desc *desc, struct zip_legacy_io *io);
+static int sf_decode(struct implode_desc *desc, struct zip_legacy_io *io,
+	struct implode_tree const tree[], unsigned *elem);
+static int archive_read_bits_2(struct implode_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits);
 
 /* Initialize the implode_desc structure and read the Shannon-Fano trees */
 int
-implode_init(struct implode_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
-	uint64_t *cmp_bytes_read)
+implode_init(struct implode_desc **desc, unsigned zip_flags)
 {
 	int err = 0;
 
@@ -101,11 +144,8 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch.arch = a;
-	(*desc)->arch.cmp_size = cmp_size;
-	(*desc)->arch.decrypt = decrypt;
-	(*desc)->arch.bits = 0;
-	(*desc)->arch.num_bits = 0;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
 	(*desc)->window_8k = (zip_flags & 0x02) != 0;
 	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
 	err = lz77_init(&(*desc)->lz77, (*desc)->window_8k ? 0x2000 : 0x1000);
@@ -113,28 +153,9 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 		implode_free(desc);
 		return err;
 	}
+	(*desc)->state = (*desc)->have_literal_tree ? LITERAL_SIZE : LENGTH_SIZE;
 
-	if ((*desc)->have_literal_tree) {
-		err = read_tree((*desc), 256, (*desc)->literal_tree);
-		if (err) {
-			goto fail;
-		}
-	}
-	err = read_tree((*desc), 64, (*desc)->length_tree);
-	if (err) {
-		goto fail;
-	}
-	err = read_tree((*desc), 64, (*desc)->distance_tree);
-	if (err) {
-		goto fail;
-	}
-
-	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return 0;
-
-fail:
-	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
-	return err;
 }
 
 void
@@ -145,146 +166,193 @@ implode_free(struct implode_desc **desc)
 	*desc = NULL;
 }
 
-static int read_copy_marker(struct implode_desc *desc);
-
 int
-implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read)
+implode_read(struct implode_desc *desc, struct zip_legacy_io *io)
 {
-	int err = 0;
-	uint64_t cmp_size = desc->arch.cmp_size;
-	size_t b_read;
+	int eodata = 0;
+	size_t total_in = io->total_in;
+	size_t total_out = io->total_out;
+	size_t num_bits = desc->num_bits;
 
-	b_read = 0;
-	while (b_read < num_bytes) {
-		unsigned literal;
-		size_t count;
-
-		/* Fulfill any pending copy */
-		count = lz77_copy(&desc->lz77, bytes + b_read, num_bytes - b_read);
-		b_read += count;
-
-		if (b_read >= num_bytes) {
-			break;
-		}
-
-		/* desc->copy_size is 0 at this point */
-		/* Read one bit: literal or copy marker? */
-		err = archive_read_bits(&desc->arch, 1, &literal);
-		if (err) {
-			goto fail;
-		}
-
-		if (literal) {
-			/* Literal byte found */
-			unsigned byte;
-
-			if (desc->have_literal_tree) {
-				err = sf_decode(desc, desc->literal_tree, &byte);
-			} else {
-				err = archive_read_bits(&desc->arch, 8, &byte);
-			}
-			if (!err) {
-				lz77_add_byte(&desc->lz77, byte);
-			}
-		} else {
-			/* Copy marker found */
-			err = read_copy_marker(desc);
-		}
-		if (err) {
-			goto fail;
-		}
-	}
-
-	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
-	return 0;
-
-fail:
-	/* If we reach the end of the compressed data, return success with the
-	   number of bytes read so far */
-	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
-	return err == end_of_data ? ARCHIVE_EOF : err;
-}
-
-/* Read a copy marker and start the copy */
-static int
-read_copy_marker(struct implode_desc *desc)
-{
-	unsigned dist_low;
-	unsigned dist_high;
-	unsigned length1;
-	unsigned length2;
-	unsigned distance;
-	unsigned length;
-	int err;
-
-	/* Low bits of distance */
-	err = archive_read_bits(&desc->arch, desc->window_8k ? 7 : 6, &dist_low);
-	if (err) {
-		return err;
-	}
-	/* High bits of distance */
-	err = sf_decode(desc, desc->distance_tree, &dist_high);
-	if (err) {
-		return err;
-	}
-	/* Complete distance */
-	distance = (dist_high << (desc->window_8k ? 7 : 6))
-		 + dist_low + 1;
-
-	/* First part of length */
-	err = sf_decode(desc, desc->length_tree, &length1);
-	if (err) {
-		return err;
-	}
-	length = length1;
-	if (length1 == 63) {
-		/* Second part of length */
-		err = archive_read_bits(&desc->arch, 8, &length2);
+	/* Set up the Shannon-Fano trees at the start */
+	if (desc->state < UNIMPLODE) {
+		int err = implode_setup(desc, io);
 		if (err) {
 			return err;
 		}
-		length += length2;
 	}
-	length += desc->have_literal_tree ? 3 : 2;
+	if (desc->state < UNIMPLODE) {
+		/* We're out of input but the trees are not complete */
+		eodata = 1;
+	}
 
-	lz77_set_copy(&desc->lz77, distance, length);
+	/* If we get here with eodata = 0, the Shannon-Fano trees are read and
+	   we are ready to decompress */
+
+	while (!eodata && io->total_out < io->avail_out) {
+		size_t count;
+
+		/* Fulfill any pending copy */
+		count = lz77_copy(&desc->lz77, io->next_out + io->total_out,
+			io->avail_out - io->total_out);
+		io->total_out += count;
+
+		if (io->total_out >= io->avail_out) {
+			break;
+		}
+
+		switch (desc->state) {
+		/* "Ground state" of the decoder */
+		/* Read a single bit: 1 indicates a literal, 0 a copy marker */
+		case UNIMPLODE:
+			eodata = read_literal_flag(desc, io);
+			/* May go to READ_LITERAL or READ_DISTANCE_LOW */
+			break;
+
+		/* Read a literal */
+		case READ_LITERAL:
+			eodata = read_literal(desc, io);
+			/* Produces output and returns to UNIMPLODE */
+			break;
+
+		/* The remaining states read a copy marker */
+		/* Read the low bits of the distance */
+		case READ_DISTANCE_LOW:
+			eodata = read_distance_low(desc, io);
+			/* Goes to READ_DISTANCE_HIGH */
+			break;
+
+		/* Read the high bits of the distance */
+		case READ_DISTANCE_HIGH:
+			eodata = read_distance_high(desc, io);
+			/* Goes to READ_LENGTH_FIRST */
+			break;
+
+		/* Read the first part of the distance */
+		case READ_LENGTH_FIRST:
+			eodata = read_length_first(desc, io);
+			/* Goes to READ_LENGTH_SECOND */
+			break;
+
+		/* Read the second part of the distance */
+		case READ_LENGTH_SECOND:
+			eodata = read_length_second(desc, io);
+			/* Produces output and returns to UNIMPLODE */
+			break;
+
+		default:
+			assert(0);
+			break;
+		}
+	}
+
+	if (total_in == io->total_in && total_out == io->total_out
+	&&  num_bits == desc->num_bits) {
+		return ARCHIVE_EOF;
+	}
+	return ARCHIVE_OK;
+}
+
+/* All states less than UNIMPLODE: Read the Shannon-Fano trees */
+static int
+implode_setup(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	while (desc->state < UNIMPLODE && io->total_in < io->avail_in) {
+		size_t avail;
+		int err = 0;
+
+		/* Read the tree data */
+		switch (desc->state) {
+		case LITERAL_SIZE:
+		case LENGTH_SIZE:
+		case DISTANCE_SIZE:
+			/* Read byte count for current tree */
+			desc->tree_size = io->next_in[io->total_in++] + 1;
+			desc->tree_read = 0;
+			break;
+
+		case LITERAL_DATA:
+		case LENGTH_DATA:
+		case DISTANCE_DATA:
+			/* Read bytes for current tree */
+			avail = io->avail_in - io->total_in;
+			if (avail > desc->tree_size - desc->tree_read) {
+				avail = desc->tree_size - desc->tree_read;
+			}
+			memcpy(desc->tree_data + desc->tree_read,
+			       io->next_in + io->total_in,
+			       avail);
+			io->total_in += avail;
+			desc->tree_read += avail;
+			break;
+
+		default:
+			assert(0);
+			break;
+		}
+
+		/* Change the state if warranted */
+		switch (desc->state) {
+		case LITERAL_SIZE:
+			desc->state = LITERAL_DATA;
+			break;
+
+		case LITERAL_DATA:
+			if (desc->tree_read >= desc->tree_size) {
+				err = read_tree(
+					desc->literal_tree, SIZE(desc->literal_tree),
+					desc->tree_data, desc->tree_size);
+				desc->state = LENGTH_SIZE;
+			}
+			break;
+
+		case LENGTH_SIZE:
+			desc->state = LENGTH_DATA;
+			break;
+
+		case LENGTH_DATA:
+			if (desc->tree_read >= desc->tree_size) {
+				err = read_tree(
+					desc->length_tree, SIZE(desc->length_tree),
+					desc->tree_data, desc->tree_size);
+				desc->state = DISTANCE_SIZE;
+			}
+			break;
+
+		case DISTANCE_SIZE:
+			desc->state = DISTANCE_DATA;
+			break;
+
+		case DISTANCE_DATA:
+			if (desc->tree_read >= desc->tree_size) {
+				err = read_tree(
+					desc->distance_tree, SIZE(desc->distance_tree),
+					desc->tree_data, desc->tree_size);
+				desc->state = UNIMPLODE;
+			}
+			break;
+
+		default:
+			assert(0);
+			break;
+		};
+
+		if (err) {
+			return err;
+		}
+	}
+
 	return 0;
 }
 
 /* Read one Shannon-Fano tree from the archive */
 static int
-read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[])
+read_tree(struct implode_tree tree[], unsigned num_values,
+	  uint8_t const tree_data[], unsigned tree_bytes)
 {
-	const uint8_t *ptr;
-	unsigned tree_bytes;
-	uint8_t tree_data[256];
 	uint8_t bit_lengths[256];
 	uint16_t codes[256];
 	int err;
-
-	/* Raw data for the tree (5.3.7): */
-	/* Number of bytes that encode the tree */
-	if (desc->arch.cmp_size == 0) {
-		return file_inconsistent;
-	}
-	ptr = archive_read_bytes(&desc->arch, 1);
-	if (ptr == NULL) {
-		return file_truncated;
-	}
-	tree_bytes = ptr[0] + 1;
-
-	/* The code counts and bit lengths */
-	if (desc->arch.cmp_size < tree_bytes) {
-		return file_inconsistent;
-	}
-	ptr = archive_read_bytes(&desc->arch, tree_bytes);
-	if (ptr == NULL) {
-		return file_truncated;
-	}
-	memcpy(tree_data, ptr, tree_bytes);
 
 	/* Set the bit lengths */
 	err = set_bit_lengths(num_values, bit_lengths, tree_data, tree_bytes);
@@ -408,23 +476,123 @@ build_tree(unsigned num_values, struct implode_tree tree[],
 	return 0;
 }
 
+/* UNIMPLODE state: read the literal flag */
+static int
+read_literal_flag(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	unsigned literal;
+
+	int eodata = archive_read_bits_2(desc, io, 1, &literal);
+	if (!eodata) {
+		if (literal) {
+			/* Read a literal */
+			desc->state = READ_LITERAL;
+		} else {
+			/* Read a copy marker */
+			desc->state = READ_DISTANCE_LOW;
+		}
+		/* Either way, we may need to use a Shannon-Fano tree */
+		desc->tree_index = 0;
+	}
+
+	return eodata;
+}
+
+/* READ_LITERAL state: read a literal */
+static int
+read_literal(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	int eodata;
+	unsigned byte;
+
+	if (desc->have_literal_tree) {
+		eodata = sf_decode(desc, io, desc->literal_tree, &byte);
+	} else {
+		eodata = archive_read_bits_2(desc, io, 8, &byte);
+	}
+	if (!eodata) {
+		lz77_add_byte(&desc->lz77, byte);
+		desc->state = UNIMPLODE;
+	}
+	return eodata;
+}
+
+/* READ_DISTANCE_LOW state: read the low bits of the distance */
+static int
+read_distance_low(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	int eodata = archive_read_bits_2(desc, io, desc->window_8k ? 7 : 6, &desc->distance);
+	if (!eodata) {
+		desc->state = READ_DISTANCE_HIGH;
+		/* Next state will use the Shannon-Fano tree for distance */
+		desc->tree_index = 0;
+	}
+	return eodata;
+}
+
+/* READ_DISTANCE_HIGH state: read the high bits of the distance */
+static int
+read_distance_high(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	unsigned dist_high;
+	int eodata = sf_decode(desc, io, desc->distance_tree, &dist_high);
+	if (!eodata) {
+		/* Complete distance */
+		desc->distance = (dist_high << (desc->window_8k ? 7 : 6))
+			       + desc->distance + 1;
+		desc->state = READ_LENGTH_FIRST;
+		/* Next state will use the Shannon-Fano tree for length */
+		desc->tree_index = 0;
+	}
+	return eodata;
+}
+
+/* READ_LENGTH_FIRST state: read the first part of the length */
+static int
+read_length_first(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	int eodata = sf_decode(desc, io, desc->length_tree, &desc->length);
+	if (!eodata) {
+		desc->state = READ_LENGTH_SECOND;
+	}
+	return eodata;
+}
+
+/* READ_LENGTH_SECOND state: read the second part of the length, and set the copy */
+static int
+read_length_second(struct implode_desc *desc, struct zip_legacy_io *io)
+{
+	if (desc->length == 63) {
+		unsigned length2;
+		int eodata = archive_read_bits_2(desc, io, 8, &length2);
+		if (eodata) {
+			return eodata;
+		}
+		desc->length += length2;
+	}
+	/* otherwise consumes no input */
+
+	desc->length += desc->have_literal_tree ? 3 : 2;
+	lz77_set_copy(&desc->lz77, desc->distance, desc->length);
+	desc->state = UNIMPLODE;
+	return 0;
+}
+
 /* Decode an element through a Shannon-Fano tree */
 /* Return 0 on success, -1 on end of data, positive on file error */
 static int
-sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
-	unsigned *elem)
+sf_decode(struct implode_desc *desc, struct zip_legacy_io *io,
+	struct implode_tree const tree[], unsigned *elem)
 {
-	unsigned node = 0;
 	unsigned bit;
-	int err;
 
 	while (1) {
 		unsigned node2;
-		err = archive_read_bits(&desc->arch, 1, &bit);
-		if (err) {
-			return err;
+		int eodata = archive_read_bits_2(desc, io, 1, &bit);
+		if (eodata) {
+			return eodata;
 		}
-		node2 = tree[node].next[bit];
+		node2 = tree[desc->tree_index].next[bit];
 		if (node2 < 0x100) {
 			*elem = node2;
 			return 0;
@@ -432,8 +600,34 @@ sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
 		if (node2 == 0xFFFF) {
 			return file_inconsistent;
 		}
-		node = node2 - 0x100;
+		desc->tree_index = node2 - 0x100;
 	}
+}
+
+/* Read the given number of bits, possibly not byte aligned */
+/* Return -1 if end of data reached, else 0 */
+static int
+archive_read_bits_2(struct implode_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits)
+{
+	if (desc->num_bits < num_bits) {
+		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
+
+		if (io->total_in + num_bytes > io->avail_in) {
+			return -1;
+		}
+		for (unsigned i = 0; i < num_bytes; ++i) {
+			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
+			desc->num_bits += 8;
+		}
+	}
+
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
+	return 0;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -167,7 +167,6 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 		if (literal) {
 			/* Literal byte found */
-			int err;
 			uint8_t byte;
 
 			if (desc->have_literal_tree) {
@@ -242,7 +241,7 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 {
 	const uint8_t *ptr;
 	ssize_t avail;
-	int tree_bytes;
+	unsigned tree_bytes;
 	uint8_t tree_data[256];
 	uint8_t bit_lengths[256];
 	uint16_t codes[256];
@@ -318,7 +317,6 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 		uint16_t code = codes[i];
 		uint8_t length = bit_lengths[i];
 		unsigned node = 0;
-		unsigned bit;
 		for (j = 0; j + 1 < length; ++j) {
 			bit = (code >> (15 - j)) & 1;
 			if (tree[node].next[bit] == 0xFFFF) {

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -90,7 +90,7 @@ static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[]
 int
 implode_init(struct implode_desc **desc, struct archive_read *a,
 	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned zip_flags,
-	size_t *cmp_bytes_read)
+	uint64_t *cmp_bytes_read)
 {
 	int err = 0;
 
@@ -149,7 +149,7 @@ static int read_copy_marker(struct implode_desc *desc);
 
 int
 implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read)
+	size_t *bytes_read, uint64_t *cmp_bytes_read)
 {
 	int err = 0;
 	uint64_t cmp_size = desc->arch.cmp_size;

--- a/libarchive/archive_zip_legacy_implode.c
+++ b/libarchive/archive_zip_legacy_implode.c
@@ -12,6 +12,15 @@
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"
 
+/* Current state of sliding window */
+struct lz77_window {
+	uint8_t *window;
+	unsigned window_pos;
+	unsigned copy_pos;
+	unsigned copy_size;
+	unsigned window_mask;
+};
+
 /* 5.3.7 and 5.3.8 */
 struct implode_tree {
 	/*
@@ -28,21 +37,17 @@ struct implode_desc {
 	/* Source of bytes */
 	struct archive_read *arch;
 	uint64_t cmp_size;
+	unsigned bits;
+	uint8_t num_bits;
+	/* Current state of sliding window */
+	struct lz77_window lz77;
 	/* Flags set in the Zip structure */
 	uint8_t window_8k;
 	uint8_t have_literal_tree;
 	/* Current state of Shannon-Fano decoder */
-	unsigned bits;
-	uint8_t num_bits;
 	struct implode_tree literal_tree[256];
 	struct implode_tree length_tree[64];
 	struct implode_tree distance_tree[64];
-	/* Current state of sliding window */
-	uint8_t window[8192];
-	uint16_t window_pos;
-	uint16_t copy_pos;
-	uint16_t copy_size;
-	uint16_t window_mask;
 };
 
 /* Errors occurring within the ZIP format */
@@ -53,11 +58,16 @@ enum {
 };
 
 static int read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tree[]);
-static void add_byte(struct implode_desc *desc, uint8_t byte);
 static int sf_decode(struct implode_desc *desc, struct implode_tree const tree[],
 	uint8_t *elem);
 static int read_bits(struct implode_desc *desc, unsigned num_bits,
 	uint8_t *bits);
+
+static int lz77_init(struct lz77_window *lz77, unsigned window_size);
+static void lz77_free(struct lz77_window *lz77);
+static size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
+static void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
+static void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
 
 /* Initialize the implode_desc structure and read the Shannon-Fano trees */
 int
@@ -79,10 +89,11 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 	(*desc)->have_literal_tree = (zip_flags & 0x04) != 0;
 	(*desc)->bits = 0;
 	(*desc)->num_bits = 0;
-	(*desc)->window_pos = 0;
-	(*desc)->copy_pos = 0;
-	(*desc)->copy_size = 0;
-	(*desc)->window_mask = (*desc)->window_8k ? 0x1FFF : 0x0FFF;
+	err = lz77_init(&(*desc)->lz77, (*desc)->window_8k ? 0x2000 : 0x1000);
+	if (err) {
+		implode_free(desc);
+		return err;
+	}
 
 	if ((*desc)->have_literal_tree) {
 		err = read_tree((*desc), 256, (*desc)->literal_tree);
@@ -98,7 +109,6 @@ implode_init(struct implode_desc **desc, struct archive_read *a,
 	if (err) {
 		goto fail;
 	}
-	memset((*desc)->window, 0, sizeof((*desc)->window));
 
 	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
 	return 0;
@@ -111,6 +121,7 @@ fail:
 void
 implode_free(struct implode_desc **desc)
 {
+	lz77_free(&(*desc)->lz77);
 	free(*desc);
 	*desc = NULL;
 }
@@ -144,15 +155,11 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 	b_read = 0;
 	while (b_read < num_bytes) {
 		uint8_t literal;
+		size_t count;
 
 		/* Fulfill any pending copy */
-		while (desc->copy_size != 0 && b_read < num_bytes) {
-			uint8_t byte = desc->window[desc->copy_pos];
-			bytes[b_read++] = byte;
-			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
-			--desc->copy_size;
-			add_byte(desc, byte);
-		}
+		count = lz77_copy(&desc->lz77, bytes + b_read, num_bytes - b_read);
+		b_read += count;
 
 		if (b_read >= num_bytes) {
 			break;
@@ -178,7 +185,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 				goto fail;
 			}
 			bytes[b_read++] = byte;
-			add_byte(desc, byte);
+			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* Copy marker found */
 			uint8_t dist_low, dist_high;
@@ -216,9 +223,7 @@ implode_read(struct implode_desc *desc, uint8_t bytes[], size_t num_bytes,
 			}
 			length += desc->have_literal_tree ? 3 : 2;
 
-			desc->copy_size = length;
-			desc->copy_pos = (desc->window_pos - distance)
-				       & desc->window_mask;
+			lz77_set_copy(&desc->lz77, distance, length);
 		}
 	}
 
@@ -337,14 +342,6 @@ read_tree(struct implode_desc *desc, unsigned num_values, struct implode_tree tr
 	return 0;
 }
 
-/* Add a byte to the sliding window */
-static void
-add_byte(struct implode_desc *desc, uint8_t byte)
-{
-	desc->window[desc->window_pos] = byte;
-	desc->window_pos = (desc->window_pos + 1) & desc->window_mask;
-}
-
 /* Decode an element through a Shannon-Fano tree */
 /* Return 0 on success, -1 on end of data, positive on file error */
 static int
@@ -400,6 +397,61 @@ read_bits(struct implode_desc *desc, unsigned num_bits, uint8_t *bits)
 	*bits &= (1 << num_bits) - 1;
 
 	return 0;
+}
+
+static int
+lz77_init(struct lz77_window *lz77, unsigned window_size)
+{
+	free(lz77->window);
+	lz77->window = calloc(1, window_size);
+	if (lz77->window == NULL) {
+		return errno;
+	}
+	lz77->window_pos = 0;
+	lz77->copy_pos = 0;
+	lz77->copy_size = 0;
+	lz77->window_mask = window_size - 1;
+	return 0;
+}
+
+static void
+lz77_free(struct lz77_window *lz77)
+{
+	free(lz77->window);
+	lz77->window = NULL;
+}
+
+/* Fulfill any pending copy */
+static size_t
+lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
+{
+	size_t b_read = 0;
+
+	while (lz77->copy_size != 0 && b_read < num_bytes) {
+		uint8_t byte = lz77->window[lz77->copy_pos];
+		bytes[b_read++] = byte;
+		lz77_add_byte(lz77, byte);
+		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
+		--lz77->copy_size;
+	}
+
+	return b_read;
+}
+
+/* Add a byte to the sliding window */
+static void
+lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
+{
+	lz77->window[lz77->window_pos] = byte;
+	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
+}
+
+/* Begin a copy */
+static void
+lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
+{
+	lz77->copy_size = length;
+	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -69,7 +69,7 @@ struct reduce_desc {
 
 static int read_follower_set(struct reduce_desc *desc,
 	struct follower_set *folset);
-static int reduce_read_byte(struct reduce_desc *desc, unsigned *byte);
+static int reduce_read_byte(struct reduce_desc *desc, uint8_t *byte);
 
 int
 reduce_init(struct reduce_desc **desc, struct archive_read *a,
@@ -135,7 +135,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 	b_read = 0;
 	while (b_read < num_bytes) {
-		unsigned byte;
+		uint8_t byte;
 		size_t count;
 
 		/* Fulfill any pending copy */
@@ -236,7 +236,7 @@ read_follower_set(struct reduce_desc *desc,
 
 /* Read one byte from the follower set encoding */
 static int
-reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
+reduce_read_byte(struct reduce_desc *desc, uint8_t *byte)
 {
 	unsigned literal;
 	int err;
@@ -253,10 +253,13 @@ reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
 		}
 	}
 	if (literal) {
-		err = archive_read_bits(&desc->arch, 8, byte);
+		unsigned bits;
+		err = archive_read_bits(&desc->arch, 8, &bits);
 		if (err) {
 			return err;
 		}
+		assert(bits <= 255);
+		*byte = (uint8_t)bits;
 	} else {
 		unsigned index;
 		err = archive_read_bits(&desc->arch, desc->folset[desc->last_ch].bits, &index);

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -60,6 +60,7 @@ enum {
 static void add_byte(struct reduce_desc *desc, uint8_t byte);
 static int read_follower_set(struct reduce_desc *desc,
 	struct follower_set *folset);
+static int reduce_read_byte(struct reduce_desc *desc, unsigned *byte);
 static int read_bits(struct reduce_desc *desc, unsigned num_bits,
 	unsigned *bits);
 
@@ -121,114 +122,79 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 {
 	int err = 0;
 	uint64_t cmp_size = desc->cmp_size;
+	size_t b_read;
 
-	*bytes_read = 0;
-	while (num_bytes != 0) {
+	b_read = 0;
+	while (b_read < num_bytes) {
 		unsigned byte;
-		unsigned literal;
-		unsigned length, distance;
 
 		/* Fulfill any pending copy */
-		while (desc->copy_size != 0 && num_bytes != 0) {
+		while (desc->copy_size != 0 && b_read < num_bytes) {
 			byte = desc->window[desc->copy_pos];
-			bytes[0] = byte;
-			++bytes;
-			--num_bytes;
-			++(*bytes_read);
+			bytes[b_read++] = byte;
 			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
 			--desc->copy_size;
 			add_byte(desc, byte);
 		}
 
-		if (num_bytes == 0) {
+		if (b_read >= num_bytes) {
 			break;
 		}
 
 		/* desc->copy_size is 0 at this point */
 		/* Decode one byte from the follower set encoding */
-		if (desc->folset[desc->last_ch].size == 0) {
-			/* Always literal if the follower set is empty */
-			literal = 1;
-		} else {
-			/* If the follower set is empty, the next bit determines
-			   whether a literal follows */
-			err = read_bits(desc, 1, &literal);
-			if (err) {
-				goto fail;
-			}
+		err = reduce_read_byte(desc, &byte);
+		if (err) {
+			goto fail;
 		}
-		if (literal) {
-			err = read_bits(desc, 8, &byte);
-			if (err) {
-				goto fail;
-			}
+
+		if (byte != 0x90) {
+			/* Literal byte */
+			bytes[b_read++] = byte;
+			add_byte(desc, byte);
 		} else {
-			unsigned index;
-			err = read_bits(desc, desc->folset[desc->last_ch].bits, &index);
+			/* May be a copy marker or a literal 0x90 */
+			err = reduce_read_byte(desc, &byte);
 			if (err) {
 				goto fail;
 			}
-			byte = desc->folset[desc->last_ch].chr[index];
-		}
-		desc->last_ch = byte;
-
-		/* State machine according to 5.2.5 */
-		switch (desc->state) {
-		case 0: /* Normal state */
-			if (byte == 0x90) {
-				desc->state = 1;
-			} else {
-				bytes[0] = byte;
-				++bytes;
-				--num_bytes;
-				++(*bytes_read);
-				add_byte(desc, byte);
-			}
-			break;
-
-		case 1: /* Escape byte received */
-			if (byte != 0) {
-				/* let V <- C */
-				desc->distance = byte >> (8 - desc->level);
-				/* let len <- L(V) */
-				desc->length = byte & desc->length_mask;
-				/* let state <- F(len) */
-				desc->state = (desc->length == desc->length_mask)
-					    ? 2 : 3;
-			} else {
+			if (byte == 0x00) {
 				/* Literal 0x90 */
-				bytes[0] = 0x90;
-				++bytes;
-				--num_bytes;
-				++(*bytes_read);
+				bytes[b_read++] = 0x90;
 				add_byte(desc, 0x90);
-				desc->state = 0;
+			} else {
+				/* Copy marker */
+				unsigned distance = byte >> (8 - desc->level);
+				unsigned length = byte & desc->length_mask;
+				if (length == desc->length_mask) {
+					/* Need another length byte */
+					err = reduce_read_byte(desc, &byte);
+					if (err) {
+						goto fail;
+					}
+					length += byte;
+				}
+				length += 3;
+				err = reduce_read_byte(desc, &byte);
+				if (err) {
+					goto fail;
+				}
+				distance = (distance << 8) + byte + 1;
+				desc->copy_size = length;
+				desc->copy_pos = (desc->window_pos - distance)
+					       & desc->window_mask;
 			}
-			break;
-
-		case 2: /* Additional length */
-			desc->length += byte;
-			desc->state = 3;
-			break;
-
-		case 3: /* Additional distance */
-			/* Copy marker is complete */
-			distance = (desc->distance << 8) + byte + 1;
-			length = desc->length + 3;
-			desc->copy_size = length;
-			desc->copy_pos = (desc->window_pos - distance)
-				       & desc->window_mask;
-			desc->state = 0;
-			break;
 		}
 	}
 
+	*bytes_read = b_read;
 	*cmp_bytes_read = cmp_size - desc->cmp_size;
 	return 0;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
+	*bytes_read = b_read;
 	*cmp_bytes_read = cmp_size - desc->cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
 }
@@ -288,6 +254,41 @@ read_follower_set(struct reduce_desc *desc,
 		folset->chr[i] = byte;
 	}
 
+	return 0;
+}
+
+/* Read one byte from the follower set encoding */
+static int
+reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
+{
+	unsigned literal;
+	int err;
+
+	if (desc->folset[desc->last_ch].size == 0) {
+		/* Always literal if the follower set is empty */
+		literal = 1;
+	} else {
+		/* If the follower set is empty, the next bit determines
+		   whether a literal follows */
+		err = read_bits(desc, 1, &literal);
+		if (err) {
+			return err;
+		}
+	}
+	if (literal) {
+		err = read_bits(desc, 8, byte);
+		if (err) {
+			return err;
+		}
+	} else {
+		unsigned index;
+		err = read_bits(desc, desc->folset[desc->last_ch].bits, &index);
+		if (err) {
+			return err;
+		}
+		*byte = desc->folset[desc->last_ch].chr[index];
+	}
+	desc->last_ch = *byte;
 	return 0;
 }
 

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -40,10 +40,7 @@
 #  include <string.h>
 #endif
 
-#include "archive_read_private.h"
 #include "archive_zip_legacy.h"
-
-struct reduce_desc;
 
 /* Decompressor state */
 struct follower_set {
@@ -52,21 +49,9 @@ struct follower_set {
 	uint8_t chr[63];
 };
 
-/* Current state of sliding window */
-struct lz77_window {
-	uint8_t *window;
-	unsigned window_pos;
-	unsigned copy_pos;
-	unsigned copy_size;
-	unsigned window_mask;
-};
-
 struct reduce_desc {
 	/* Source of bytes */
-	struct archive_read *arch;
-	uint64_t cmp_size;
-	unsigned bits;
-	uint8_t num_bits;
+	struct arch_data arch;
 
 	/* Current state of sliding window */
 	struct lz77_window lz77;
@@ -80,28 +65,14 @@ struct reduce_desc {
 	uint8_t last_ch;
 };
 
-/* Errors occurring within the ZIP format */
-enum {
-	end_of_data = -1,
-	file_truncated = -2,
-	file_inconsistent = -3
-};
-
 static int read_follower_set(struct reduce_desc *desc,
 	struct follower_set *folset);
 static int reduce_read_byte(struct reduce_desc *desc, unsigned *byte);
-static int read_bits(struct reduce_desc *desc, unsigned num_bits,
-	unsigned *bits);
-
-static int lz77_init(struct lz77_window *lz77, unsigned window_size);
-static void lz77_free(struct lz77_window *lz77);
-static size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
-static void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
-static void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
 
 int
 reduce_init(struct reduce_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, unsigned level, size_t *cmp_bytes_read)
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
+	size_t *cmp_bytes_read)
 {
 	int err = 0;
 
@@ -112,10 +83,11 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch = a;
-	(*desc)->cmp_size = cmp_size;
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
+	(*desc)->arch.arch = a;
+	(*desc)->arch.cmp_size = cmp_size;
+	(*desc)->arch.decrypt = decrypt;
+	(*desc)->arch.bits = 0;
+	(*desc)->arch.num_bits = 0;
 	(*desc)->level = level;
 	(*desc)->length_mask = 255 >> level;
 	(*desc)->last_ch = 0;
@@ -133,11 +105,11 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 		}
 	}
 
-	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return 0;
 
 fail:
-	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return err;
 }
 
@@ -154,7 +126,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
 {
 	int err = 0;
-	uint64_t cmp_size = desc->cmp_size;
+	uint64_t cmp_size = desc->arch.cmp_size;
 	size_t b_read;
 
 	b_read = 0;
@@ -215,33 +187,15 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 	}
 
 	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return 0;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
 	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
-}
-
-const char *
-reduce_error(int err)
-{
-	switch (err) {
-	case end_of_data:
-		return "End of compressed data";
-
-	case file_truncated:
-		return "Truncated ZIP file data";
-
-	case file_inconsistent:
-		return "Corrupted ZIP file data";
-
-	default:
-		return strerror(err);
-	}
 }
 
 static int
@@ -253,7 +207,7 @@ read_follower_set(struct reduce_desc *desc,
 	unsigned i;
 
 	/* Size of follower set */
-	err = read_bits(desc, 6, &size);
+	err = archive_read_bits(&desc->arch, 6, &size);
 	if (err) {
 		return err;
 	}
@@ -266,7 +220,7 @@ read_follower_set(struct reduce_desc *desc,
 	/* Read the set of bytes */
 	for (i = 0; i < size; ++i) {
 		unsigned byte;
-		err = read_bits(desc, 8, &byte);
+		err = archive_read_bits(&desc->arch, 8, &byte);
 		if (err) {
 			return err;
 		}
@@ -289,19 +243,19 @@ reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
 	} else {
 		/* If the follower set is empty, the next bit determines
 		   whether a literal follows */
-		err = read_bits(desc, 1, &literal);
+		err = archive_read_bits(&desc->arch, 1, &literal);
 		if (err) {
 			return err;
 		}
 	}
 	if (literal) {
-		err = read_bits(desc, 8, byte);
+		err = archive_read_bits(&desc->arch, 8, byte);
 		if (err) {
 			return err;
 		}
 	} else {
 		unsigned index;
-		err = read_bits(desc, desc->folset[desc->last_ch].bits, &index);
+		err = archive_read_bits(&desc->arch, desc->folset[desc->last_ch].bits, &index);
 		if (err) {
 			return err;
 		}
@@ -309,90 +263,6 @@ reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
 	}
 	desc->last_ch = *byte;
 	return 0;
-}
-
-/* Read one or more bits from the archive */
-static int
-read_bits(struct reduce_desc *desc, unsigned num_bits, unsigned *bits)
-{
-	while (desc->num_bits < num_bits) {
-		const uint8_t *ptr;
-		ssize_t avail;
-
-		if (desc->cmp_size == 0) {
-			return end_of_data;
-		}
-		ptr = __archive_read_ahead(desc->arch, 1, &avail);
-		if (ptr == NULL) {
-			return file_truncated;
-		}
-		desc->bits |= ptr[0] << desc->num_bits;
-		desc->num_bits += 8;
-		--desc->cmp_size;
-		__archive_read_consume(desc->arch, 1);
-	}
-
-	*bits = desc->bits;
-	desc->bits >>= num_bits;
-	desc->num_bits -= num_bits;
-	*bits &= (1 << num_bits) - 1;
-
-	return 0;
-}
-
-static int
-lz77_init(struct lz77_window *lz77, unsigned window_size)
-{
-	free(lz77->window);
-	lz77->window = calloc(1, window_size);
-	if (lz77->window == NULL) {
-		return errno;
-	}
-	lz77->window_pos = 0;
-	lz77->copy_pos = 0;
-	lz77->copy_size = 0;
-	lz77->window_mask = window_size - 1;
-	return 0;
-}
-
-static void
-lz77_free(struct lz77_window *lz77)
-{
-	free(lz77->window);
-	lz77->window = NULL;
-}
-
-/* Fulfill any pending copy */
-static size_t
-lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
-{
-	size_t b_read = 0;
-
-	while (lz77->copy_size != 0 && b_read < num_bytes) {
-		uint8_t byte = lz77->window[lz77->copy_pos];
-		bytes[b_read++] = byte;
-		lz77_add_byte(lz77, byte);
-		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
-		--lz77->copy_size;
-	}
-
-	return b_read;
-}
-
-/* Add a byte to the sliding window */
-static void
-lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
-{
-	lz77->window[lz77->window_pos] = byte;
-	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
-}
-
-/* Begin a copy */
-static void
-lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
-{
-	lz77->copy_size = length;
-	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -128,7 +128,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 		/* Fulfill any pending copy */
 		while (desc->copy_size != 0 && num_bytes != 0) {
-			uint8_t byte = desc->window[desc->copy_pos];
+			byte = desc->window[desc->copy_pos];
 			bytes[0] = byte;
 			++bytes;
 			--num_bytes;
@@ -273,7 +273,7 @@ read_follower_set(struct reduce_desc *desc,
 	folset->size = size;
 
 	/* Size in terms of bits (e.g. 64 -> 6 bits) */
-	for (i = 1; (1 << i) < size; ++i) {}
+	for (i = 1; (1U << i) < size; ++i) {}
 	folset->bits = i;
 
 	/* Read the set of bytes */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -259,6 +259,9 @@ reduce_read_byte(struct reduce_desc *desc, unsigned *byte)
 		if (err) {
 			return err;
 		}
+		if (index >= desc->folset[desc->last_ch].size) {
+			return file_inconsistent;
+		}
 		*byte = desc->folset[desc->last_ch].chr[index];
 	}
 	desc->last_ch = *byte;

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -31,16 +31,11 @@ struct reduce_desc {
 
 	/* Compression level */
 	uint8_t level;
+	uint8_t length_mask;
 
 	/* Follower set encoding */
 	struct follower_set folset[256];
 	uint8_t last_ch;
-
-	/* State machine according to 5.2.5 */
-	uint8_t state;
-	uint8_t length_mask;
-	uint8_t distance;
-	uint16_t length;
 
 	/* Current state of sliding window */
 	uint8_t window[4096];
@@ -82,11 +77,8 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 	(*desc)->bits = 0;
 	(*desc)->num_bits = 0;
 	(*desc)->level = level;
-	(*desc)->last_ch = 0;
-	(*desc)->state = 0;
-	(*desc)->length = 0;
 	(*desc)->length_mask = 255 >> level;
-	(*desc)->distance = 0;
+	(*desc)->last_ch = 0;
 	(*desc)->window_pos = 0;
 	(*desc)->copy_pos = 0;
 	(*desc)->copy_size = 0;

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -21,13 +21,24 @@ struct follower_set {
 	uint8_t chr[63];
 };
 
+/* Current state of sliding window */
+struct lz77_window {
+	uint8_t *window;
+	unsigned window_pos;
+	unsigned copy_pos;
+	unsigned copy_size;
+	unsigned window_mask;
+};
+
 struct reduce_desc {
 	/* Source of bytes */
 	struct archive_read *arch;
 	uint64_t cmp_size;
-
 	unsigned bits;
 	uint8_t num_bits;
+
+	/* Current state of sliding window */
+	struct lz77_window lz77;
 
 	/* Compression level */
 	uint8_t level;
@@ -36,13 +47,6 @@ struct reduce_desc {
 	/* Follower set encoding */
 	struct follower_set folset[256];
 	uint8_t last_ch;
-
-	/* Current state of sliding window */
-	uint8_t window[4096];
-	uint16_t window_pos;
-	uint16_t copy_pos;
-	uint16_t copy_size;
-	uint16_t window_mask;
 };
 
 /* Errors occurring within the ZIP format */
@@ -52,12 +56,17 @@ enum {
 	file_inconsistent = -3
 };
 
-static void add_byte(struct reduce_desc *desc, uint8_t byte);
 static int read_follower_set(struct reduce_desc *desc,
 	struct follower_set *folset);
 static int reduce_read_byte(struct reduce_desc *desc, unsigned *byte);
 static int read_bits(struct reduce_desc *desc, unsigned num_bits,
 	unsigned *bits);
+
+static int lz77_init(struct lz77_window *lz77, unsigned window_size);
+static void lz77_free(struct lz77_window *lz77);
+static size_t lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes);
+static void lz77_add_byte(struct lz77_window *lz77, uint8_t byte);
+static void lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length);
 
 int
 reduce_init(struct reduce_desc **desc, struct archive_read *a,
@@ -79,11 +88,11 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 	(*desc)->level = level;
 	(*desc)->length_mask = 255 >> level;
 	(*desc)->last_ch = 0;
-	(*desc)->window_pos = 0;
-	(*desc)->copy_pos = 0;
-	(*desc)->copy_size = 0;
-	(*desc)->window_mask = (256 << level) - 1;
-	memset((*desc)->window, 0, sizeof((*desc)->window));
+	err = lz77_init(&(*desc)->lz77, 0x100 << level);
+	if (err) {
+		reduce_free(desc);
+		return err;
+	}
 
 	/* Read the follower sets */
 	for (unsigned j = 256; j-- != 0; ) {
@@ -104,6 +113,7 @@ fail:
 void
 reduce_free(struct reduce_desc **desc)
 {
+	lz77_free(&(*desc)->lz77);
 	free(*desc);
 	*desc = NULL;
 }
@@ -119,15 +129,11 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 	b_read = 0;
 	while (b_read < num_bytes) {
 		unsigned byte;
+		size_t count;
 
 		/* Fulfill any pending copy */
-		while (desc->copy_size != 0 && b_read < num_bytes) {
-			byte = desc->window[desc->copy_pos];
-			bytes[b_read++] = byte;
-			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
-			--desc->copy_size;
-			add_byte(desc, byte);
-		}
+		count = lz77_copy(&desc->lz77, bytes + b_read, num_bytes - b_read);
+		b_read += count;
 
 		if (b_read >= num_bytes) {
 			break;
@@ -143,7 +149,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 		if (byte != 0x90) {
 			/* Literal byte */
 			bytes[b_read++] = byte;
-			add_byte(desc, byte);
+			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* May be a copy marker or a literal 0x90 */
 			err = reduce_read_byte(desc, &byte);
@@ -153,7 +159,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 			if (byte == 0x00) {
 				/* Literal 0x90 */
 				bytes[b_read++] = 0x90;
-				add_byte(desc, 0x90);
+				lz77_add_byte(&desc->lz77, 0x90);
 			} else {
 				/* Copy marker */
 				unsigned distance = byte >> (8 - desc->level);
@@ -172,9 +178,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 					goto fail;
 				}
 				distance = (distance << 8) + byte + 1;
-				desc->copy_size = length;
-				desc->copy_pos = (desc->window_pos - distance)
-					       & desc->window_mask;
+				lz77_set_copy(&desc->lz77, distance, length);
 			}
 		}
 	}
@@ -207,14 +211,6 @@ reduce_error(int err)
 	default:
 		return strerror(err);
 	}
-}
-
-/* Add a byte to the sliding window */
-static void
-add_byte(struct reduce_desc *desc, uint8_t byte)
-{
-	desc->window[desc->window_pos] = byte;
-	desc->window_pos = (desc->window_pos + 1) & desc->window_mask;
 }
 
 static int
@@ -311,6 +307,61 @@ read_bits(struct reduce_desc *desc, unsigned num_bits, unsigned *bits)
 	*bits &= (1 << num_bits) - 1;
 
 	return 0;
+}
+
+static int
+lz77_init(struct lz77_window *lz77, unsigned window_size)
+{
+	free(lz77->window);
+	lz77->window = calloc(1, window_size);
+	if (lz77->window == NULL) {
+		return errno;
+	}
+	lz77->window_pos = 0;
+	lz77->copy_pos = 0;
+	lz77->copy_size = 0;
+	lz77->window_mask = window_size - 1;
+	return 0;
+}
+
+static void
+lz77_free(struct lz77_window *lz77)
+{
+	free(lz77->window);
+	lz77->window = NULL;
+}
+
+/* Fulfill any pending copy */
+static size_t
+lz77_copy(struct lz77_window *lz77, uint8_t bytes[], size_t num_bytes)
+{
+	size_t b_read = 0;
+
+	while (lz77->copy_size != 0 && b_read < num_bytes) {
+		uint8_t byte = lz77->window[lz77->copy_pos];
+		bytes[b_read++] = byte;
+		lz77_add_byte(lz77, byte);
+		lz77->copy_pos = (lz77->copy_pos + 1) & lz77->window_mask;
+		--lz77->copy_size;
+	}
+
+	return b_read;
+}
+
+/* Add a byte to the sliding window */
+static void
+lz77_add_byte(struct lz77_window *lz77, uint8_t byte)
+{
+	lz77->window[lz77->window_pos] = byte;
+	lz77->window_pos = (lz77->window_pos + 1) & lz77->window_mask;
+}
+
+/* Begin a copy */
+static void
+lz77_set_copy(struct lz77_window *lz77, unsigned distance, unsigned length)
+{
+	lz77->copy_size = length;
+	lz77->copy_pos = (lz77->window_pos - distance) & lz77->window_mask;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -27,10 +27,18 @@
 
 #if HAVE_LEGACY
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
+#if HAVE_ERRNO_H
+#  include <errno.h>
+#endif
+#if HAVE_STDINT_H
+#  include <stdint.h>
+#endif
+#if HAVE_STDLIB_H
+#  include <stdlib.h>
+#endif
+#if HAVE_STRING_H
+#  include <string.h>
+#endif
 
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -71,8 +71,7 @@ enum byte_state {
 
 struct reduce_desc {
 	/* To read bits not on a byte boundary */
-	uint64_t bits;
-	uint8_t num_bits;
+	struct arch_bits bits;
 
 	/* Current state of sliding window */
 	struct lz77_window lz77;
@@ -94,8 +93,6 @@ struct reduce_desc {
 
 static int reduce_setup(struct reduce_desc *desc, struct zip_legacy_io *io);
 static void process_byte(struct reduce_desc *desc);
-static int archive_read_bits_2(struct reduce_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits);
 
 int
 reduce_init(struct reduce_desc **desc, unsigned level)
@@ -111,8 +108,8 @@ reduce_init(struct reduce_desc **desc, unsigned level)
 		}
 	}
 
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
+	(*desc)->bits.bits = 0;
+	(*desc)->bits.num_bits = 0;
 	(*desc)->level = level - 1;
 	(*desc)->length_mask = 255 >> level;
 	(*desc)->last_ch = 0xFF;
@@ -142,7 +139,7 @@ reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 	int eodata = 0;
 	size_t total_in = io->total_in;
 	size_t total_out = io->total_out;
-	unsigned num_bits = desc->num_bits;
+	unsigned num_bits = desc->bits.num_bits;
 
 	/* Set up the follower sets at the start */
 	if (desc->f_state < READ_LITERAL_FLAG) {
@@ -180,7 +177,7 @@ reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 			} else {
 				unsigned literal;
 
-				eodata = archive_read_bits_2(desc, io, 1, &literal);
+				eodata = archive_read_bits(&desc->bits, io, 1, &literal);
 				if (eodata) {
 					break;
 				}
@@ -197,7 +194,7 @@ reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 			{
 				unsigned byte;
 
-				eodata = archive_read_bits_2(desc, io, 8, &byte);
+				eodata = archive_read_bits(&desc->bits, io, 8, &byte);
 				if (eodata) {
 					break;
 				}
@@ -210,7 +207,7 @@ reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 			{
 				unsigned byte;
 
-				eodata = archive_read_bits_2(desc, io, desc->folset[desc->last_ch].bits, &byte);
+				eodata = archive_read_bits(&desc->bits, io, desc->folset[desc->last_ch].bits, &byte);
 				if (eodata) {
 					break;
 				}
@@ -233,7 +230,7 @@ reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 	}
 
 	if (total_in == io->total_in && total_out == io->total_out
-	&&  num_bits == desc->num_bits) {
+	&&  num_bits == desc->bits.num_bits) {
 		return ARCHIVE_EOF;
 	}
 	return ARCHIVE_OK;
@@ -251,7 +248,7 @@ reduce_setup(struct reduce_desc *desc, struct zip_legacy_io *io)
 				unsigned i;
 				unsigned size;
 
-				eodata = archive_read_bits_2(desc, io, 6, &size);
+				eodata = archive_read_bits(&desc->bits, io, 6, &size);
 				if (eodata) {
 					return eodata;
 				}
@@ -267,7 +264,7 @@ reduce_setup(struct reduce_desc *desc, struct zip_legacy_io *io)
 			if (desc->folset[desc->last_ch].size != 0) {
 				unsigned byte;
 
-				eodata = archive_read_bits_2(desc, io, 8, &byte);
+				eodata = archive_read_bits(&desc->bits, io, 8, &byte);
 				if (eodata) {
 					return eodata;
 				}
@@ -338,35 +335,6 @@ process_byte(struct reduce_desc *desc)
 		desc->b_state = BYTE_LITERAL;
 		break;
 	}
-}
-
-/* Read the given number of bits, possibly not byte aligned */
-/* Return -1 if end of data reached, else 0 */
-static int
-archive_read_bits_2(struct reduce_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits)
-{
-	if (desc->num_bits < num_bits) {
-		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
-
-		if (io->total_in + num_bytes > io->avail_in) {
-			num_bytes = (unsigned)(io->avail_in - io->total_in);
-		}
-		for (unsigned i = 0; i < num_bytes; ++i) {
-			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
-			desc->num_bits += 8;
-		}
-	}
-	if (desc->num_bits < num_bits) {
-		return -1;
-	}
-
-	*bits = desc->bits;
-	desc->bits >>= num_bits;
-	desc->num_bits -= num_bits;
-	*bits &= (1 << num_bits) - 1;
-
-	return 0;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -214,7 +214,7 @@ read_follower_set(struct reduce_desc *desc,
 	folset->size = size;
 
 	/* Size in terms of bits (e.g. 64 -> 6 bits) */
-	for (i = 1; (1U << i) < size; ++i) {}
+	for (i = 1; (1U << i) < size; ++i) { /*nothing needed here*/ }
 	folset->bits = i;
 
 	/* Read the set of bytes */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -1,0 +1,321 @@
+/* reduce */
+
+// #if HAVE_LEGACY
+
+#include "archive_platform.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "archive_read_private.h"
+#include "archive_zip_legacy.h"
+
+struct reduce_desc;
+
+/* Decompressor state */
+struct follower_set {
+    uint8_t size;
+    uint8_t bits;
+    uint8_t chr[63];
+};
+
+struct reduce_desc {
+	/* Source of bytes */
+	struct archive_read *arch;
+	uint64_t cmp_size;
+
+	unsigned bits;
+	uint8_t num_bits;
+
+	/* Compression level */
+	uint8_t level;
+
+	/* Follower set encoding */
+	struct follower_set folset[256];
+	uint8_t last_ch;
+
+	/* State machine according to 5.2.5 */
+	uint8_t state;
+	uint8_t length_mask;
+	uint8_t distance;
+	uint16_t length;
+
+	/* Current state of sliding window */
+	uint8_t window[4096];
+	uint16_t window_pos;
+	uint16_t copy_pos;
+	uint16_t copy_size;
+	uint16_t window_mask;
+};
+
+/* Errors occurring within the ZIP format */
+enum {
+	end_of_data = -1,
+	file_truncated = -2,
+	file_inconsistent = -3
+};
+
+static void add_byte(struct reduce_desc *desc, uint8_t byte);
+static int read_follower_set(struct reduce_desc *desc,
+	struct follower_set *folset);
+static int read_bits(struct reduce_desc *desc, unsigned num_bits,
+	unsigned *bits);
+
+int
+reduce_init(struct reduce_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, unsigned level, size_t *cmp_bytes_read)
+{
+	int err = 0;
+
+	*desc = calloc(1, sizeof(**desc));
+	if (*desc == NULL) {
+		return errno;
+	}
+
+	(*desc)->arch = a;
+	(*desc)->cmp_size = cmp_size;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
+	(*desc)->level = level;
+	(*desc)->last_ch = 0;
+	(*desc)->state = 0;
+	(*desc)->length = 0;
+	(*desc)->length_mask = 255 >> level;
+	(*desc)->distance = 0;
+	(*desc)->window_pos = 0;
+	(*desc)->copy_pos = 0;
+	(*desc)->copy_size = 0;
+	(*desc)->window_mask = (256 << level) - 1;
+	memset((*desc)->window, 0, sizeof((*desc)->window));
+
+	/* Read the follower sets */
+	for (unsigned j = 256; j-- != 0; ) {
+		err = read_follower_set(*desc, &(*desc)->folset[j]);
+		if (err) {
+			goto fail;
+		}
+	}
+
+	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	return 0;
+
+fail:
+	*cmp_bytes_read = cmp_size - (*desc)->cmp_size;
+	return err;
+}
+
+void
+reduce_free(struct reduce_desc **desc)
+{
+	free(*desc);
+	*desc = NULL;
+}
+
+int
+reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read)
+{
+	int err = 0;
+	uint64_t cmp_size = desc->cmp_size;
+
+	*bytes_read = 0;
+	while (num_bytes != 0) {
+		unsigned byte;
+		unsigned literal;
+		unsigned length, distance;
+
+		/* Fulfill any pending copy */
+		while (desc->copy_size != 0 && num_bytes != 0) {
+			uint8_t byte = desc->window[desc->copy_pos];
+			bytes[0] = byte;
+			++bytes;
+			--num_bytes;
+			++(*bytes_read);
+			desc->copy_pos = (desc->copy_pos + 1) & desc->window_mask;
+			--desc->copy_size;
+			add_byte(desc, byte);
+		}
+
+		if (num_bytes == 0) {
+			break;
+		}
+
+		/* desc->copy_size is 0 at this point */
+		/* Decode one byte from the follower set encoding */
+		if (desc->folset[desc->last_ch].size == 0) {
+			/* Always literal if the follower set is empty */
+			literal = 1;
+		} else {
+			/* If the follower set is empty, the next bit determines
+			   whether a literal follows */
+			err = read_bits(desc, 1, &literal);
+			if (err) {
+				goto fail;
+			}
+		}
+		if (literal) {
+			err = read_bits(desc, 8, &byte);
+			if (err) {
+				goto fail;
+			}
+		} else {
+			unsigned index;
+			err = read_bits(desc, desc->folset[desc->last_ch].bits, &index);
+			if (err) {
+				goto fail;
+			}
+			byte = desc->folset[desc->last_ch].chr[index];
+		}
+		desc->last_ch = byte;
+
+		/* State machine according to 5.2.5 */
+		switch (desc->state) {
+		case 0: /* Normal state */
+			if (byte == 0x90) {
+				desc->state = 1;
+			} else {
+				bytes[0] = byte;
+				++bytes;
+				--num_bytes;
+				++(*bytes_read);
+				add_byte(desc, byte);
+			}
+			break;
+
+		case 1: /* Escape byte received */
+			if (byte != 0) {
+				/* let V <- C */
+				desc->distance = byte >> (8 - desc->level);
+				/* let len <- L(V) */
+				desc->length = byte & desc->length_mask;
+				/* let state <- F(len) */
+				desc->state = (desc->length == desc->length_mask)
+					    ? 2 : 3;
+			} else {
+				/* Literal 0x90 */
+				bytes[0] = 0x90;
+				++bytes;
+				--num_bytes;
+				++(*bytes_read);
+				add_byte(desc, 0x90);
+				desc->state = 0;
+			}
+			break;
+
+		case 2: /* Additional length */
+			desc->length += byte;
+			desc->state = 3;
+			break;
+
+		case 3: /* Additional distance */
+			/* Copy marker is complete */
+			distance = (desc->distance << 8) + byte + 1;
+			length = desc->length + 3;
+			desc->copy_size = length;
+			desc->copy_pos = (desc->window_pos - distance)
+				       & desc->window_mask;
+			desc->state = 0;
+			break;
+		}
+	}
+
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return 0;
+
+fail:
+	/* If we reach the end of the compressed data, return success with the
+	   number of bytes read so far */
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return err == end_of_data ? ARCHIVE_EOF : err;
+}
+
+const char *
+reduce_error(int err)
+{
+	switch (err) {
+	case end_of_data:
+		return "End of compressed data";
+
+	case file_truncated:
+		return "Truncated ZIP file data";
+
+	case file_inconsistent:
+		return "Corrupted ZIP file data";
+
+	default:
+		return strerror(err);
+	}
+}
+
+/* Add a byte to the sliding window */
+static void
+add_byte(struct reduce_desc *desc, uint8_t byte)
+{
+	desc->window[desc->window_pos] = byte;
+	desc->window_pos = (desc->window_pos + 1) & desc->window_mask;
+}
+
+static int
+read_follower_set(struct reduce_desc *desc,
+	struct follower_set *folset)
+{
+	unsigned size;
+	int err;
+	unsigned i;
+
+	/* Size of follower set */
+	err = read_bits(desc, 6, &size);
+	if (err) {
+		return err;
+	}
+	folset->size = size;
+
+	/* Size in terms of bits (e.g. 64 -> 6 bits) */
+	for (i = 1; (1 << i) < size; ++i) {}
+	folset->bits = i;
+
+	/* Read the set of bytes */
+	for (i = 0; i < size; ++i) {
+		unsigned byte;
+		err = read_bits(desc, 8, &byte);
+		if (err) {
+			return err;
+		}
+		folset->chr[i] = byte;
+	}
+
+	return 0;
+}
+
+/* Read one or more bits from the archive */
+static int
+read_bits(struct reduce_desc *desc, unsigned num_bits, unsigned *bits)
+{
+	while (desc->num_bits < num_bits) {
+		const uint8_t *ptr;
+		ssize_t avail;
+
+		if (desc->cmp_size == 0) {
+			return end_of_data;
+		}
+		ptr = __archive_read_ahead(desc->arch, 1, &avail);
+		if (ptr == NULL) {
+			return file_truncated;
+		}
+		desc->bits |= ptr[0] << desc->num_bits;
+		desc->num_bits += 8;
+		--desc->cmp_size;
+		__archive_read_consume(desc->arch, 1);
+	}
+
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
+	return 0;
+}
+
+// #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -16,9 +16,9 @@ struct reduce_desc;
 
 /* Decompressor state */
 struct follower_set {
-    uint8_t size;
-    uint8_t bits;
-    uint8_t chr[63];
+	uint8_t size;
+	uint8_t bits;
+	uint8_t chr[63];
 };
 
 struct reduce_desc {
@@ -69,9 +69,11 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 {
 	int err = 0;
 
-	*desc = calloc(1, sizeof(**desc));
 	if (*desc == NULL) {
-		return errno;
+		*desc = calloc(1, sizeof(**desc));
+		if (*desc == NULL) {
+			return errno;
+		}
 	}
 
 	(*desc)->arch = a;

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -72,7 +72,7 @@ static int reduce_read_byte(struct reduce_desc *desc, unsigned *byte);
 int
 reduce_init(struct reduce_desc **desc, struct archive_read *a,
 	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
-	size_t *cmp_bytes_read)
+	uint64_t *cmp_bytes_read)
 {
 	int err = 0;
 
@@ -123,7 +123,7 @@ reduce_free(struct reduce_desc **desc)
 
 int
 reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read)
+	size_t *bytes_read, uint64_t *cmp_bytes_read)
 {
 	int err = 0;
 	uint64_t cmp_size = desc->arch.cmp_size;

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -27,6 +27,8 @@
 
 #if HAVE_LEGACY
 
+#include <assert.h>
+
 #if HAVE_ERRNO_H
 #  include <errno.h>
 #endif
@@ -57,7 +59,7 @@ struct reduce_desc {
 	struct lz77_window lz77;
 
 	/* Compression level */
-	uint8_t level;
+	unsigned level:2; /* 0-3 for level 1-4 */
 	uint8_t length_mask;
 
 	/* Follower set encoding */
@@ -76,6 +78,8 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 {
 	int err = 0;
 
+	assert(1 <= level && level <= 4);
+
 	if (*desc == NULL) {
 		*desc = calloc(1, sizeof(**desc));
 		if (*desc == NULL) {
@@ -88,7 +92,7 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 	(*desc)->arch.decrypt = decrypt;
 	(*desc)->arch.bits = 0;
 	(*desc)->arch.num_bits = 0;
-	(*desc)->level = level;
+	(*desc)->level = level - 1;
 	(*desc)->length_mask = 255 >> level;
 	(*desc)->last_ch = 0;
 	err = lz77_init(&(*desc)->lz77, 0x100 << level);
@@ -165,7 +169,7 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 				lz77_add_byte(&desc->lz77, 0x90);
 			} else {
 				/* Copy marker */
-				unsigned distance = byte >> (8 - desc->level);
+				unsigned distance = byte >> (7 - desc->level);
 				unsigned length = byte & desc->length_mask;
 				if (length == desc->length_mask) {
 					/* Need another length byte */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -1,8 +1,8 @@
 /* reduce */
 
-// #if HAVE_LEGACY
-
 #include "archive_platform.h"
+
+#if HAVE_LEGACY
 
 #include <errno.h>
 #include <stdint.h>
@@ -318,4 +318,4 @@ read_bits(struct reduce_desc *desc, unsigned num_bits, unsigned *bits)
 	return 0;
 }
 
-// #endif /* HAVE_LEGACY */
+#endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -51,9 +51,28 @@ struct follower_set {
 	uint8_t chr[63];
 };
 
+enum folset_state {
+	READ_FOLSET_SIZE,  /* Read size of follower set */
+	READ_FOLSET_DATA,  /* Read contents of follower set */
+	/* Once we get to the READ_LITERAL_FLAG state, we don't go back to
+	   the above states */
+	READ_LITERAL_FLAG, /* Read bit: 1 for literal, 0 to use follower set */
+	READ_BYTE,         /* Read 8 bits for literal byte */
+	READ_INDEX,        /* Read 1-6 bits for follower set index */
+	PROCESS_BYTE       /* Process byte according to b_state */
+};
+
+enum byte_state {
+	BYTE_LITERAL,      /* Byte is literal unless equal to 0x90 */
+	BYTE_COPY1,        /* First byte of copy marker, or 0 for literal 0x90 */
+	BYTE_COPY2,        /* Second byte of copy marker */
+	BYTE_COPY3         /* Third byte of copy marker */
+};
+
 struct reduce_desc {
-	/* Source of bytes */
-	struct arch_data arch;
+	/* To read bits not on a byte boundary */
+	uint64_t bits;
+	uint8_t num_bits;
 
 	/* Current state of sliding window */
 	struct lz77_window lz77;
@@ -65,16 +84,21 @@ struct reduce_desc {
 	/* Follower set encoding */
 	struct follower_set folset[256];
 	uint8_t last_ch;
+	uint8_t bytes_read;
+
+	enum folset_state f_state;
+	enum byte_state b_state;
+	unsigned distance;
+	unsigned length;
 };
 
-static int read_follower_set(struct reduce_desc *desc,
-	struct follower_set *folset);
-static int reduce_read_byte(struct reduce_desc *desc, uint8_t *byte);
+static int reduce_setup(struct reduce_desc *desc, struct zip_legacy_io *io);
+static void process_byte(struct reduce_desc *desc);
+static int archive_read_bits_2(struct reduce_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits);
 
 int
-reduce_init(struct reduce_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, unsigned level,
-	uint64_t *cmp_bytes_read)
+reduce_init(struct reduce_desc **desc, unsigned level)
 {
 	int err = 0;
 
@@ -87,34 +111,21 @@ reduce_init(struct reduce_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch.arch = a;
-	(*desc)->arch.cmp_size = cmp_size;
-	(*desc)->arch.decrypt = decrypt;
-	(*desc)->arch.bits = 0;
-	(*desc)->arch.num_bits = 0;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
 	(*desc)->level = level - 1;
 	(*desc)->length_mask = 255 >> level;
-	(*desc)->last_ch = 0;
+	(*desc)->last_ch = 0xFF;
+	(*desc)->f_state = READ_FOLSET_SIZE;
+	(*desc)->b_state = BYTE_LITERAL;
 	err = lz77_init(&(*desc)->lz77, 0x100 << level);
 	if (err) {
 		reduce_free(desc);
-		return err;
 	}
 
-	/* Read the follower sets */
-	for (unsigned j = 256; j-- != 0; ) {
-		err = read_follower_set(*desc, &(*desc)->folset[j]);
-		if (err) {
-			goto fail;
-		}
-	}
-
-	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
-	return 0;
-
-fail:
-	*cmp_bytes_read = cmp_size - (*desc)->arch.cmp_size;
 	return err;
+
+	return 0;
 }
 
 void
@@ -126,150 +137,235 @@ reduce_free(struct reduce_desc **desc)
 }
 
 int
-reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read)
+reduce_read(struct reduce_desc *desc, struct zip_legacy_io *io)
 {
-	int err = 0;
-	uint64_t cmp_size = desc->arch.cmp_size;
-	size_t b_read;
+	int eodata = 0;
+	size_t total_in = io->total_in;
+	size_t total_out = io->total_out;
+	unsigned num_bits = desc->num_bits;
 
-	b_read = 0;
-	while (b_read < num_bytes) {
-		uint8_t byte;
+	/* Set up the follower sets at the start */
+	if (desc->f_state < READ_LITERAL_FLAG) {
+		int err = reduce_setup(desc, io);
+		if (err) {
+			return err;
+		}
+	}
+	if (desc->f_state < READ_LITERAL_FLAG) {
+		/* We're out of input but the follower sets are not complete */
+		eodata = 1;
+	}
+
+	/* If we get here with eodata = 0, the follower sets are read and
+	   we are ready to decompress */
+
+	while (!eodata && io->total_out < io->avail_out) {
 		size_t count;
 
 		/* Fulfill any pending copy */
-		count = lz77_copy(&desc->lz77, bytes + b_read, num_bytes - b_read);
-		b_read += count;
+		count = lz77_copy(&desc->lz77, io->next_out + io->total_out,
+			io->avail_out - io->total_out);
+		io->total_out += count;
 
-		if (b_read >= num_bytes) {
+		if (io->total_out >= io->avail_out) {
 			break;
 		}
 
-		/* desc->copy_size is 0 at this point */
-		/* Decode one byte from the follower set encoding */
-		err = reduce_read_byte(desc, &byte);
-		if (err) {
-			goto fail;
-		}
-
-		if (byte != 0x90) {
-			/* Literal byte */
-			lz77_add_byte(&desc->lz77, byte);
-		} else {
-			/* May be a copy marker or a literal 0x90 */
-			err = reduce_read_byte(desc, &byte);
-			if (err) {
-				goto fail;
-			}
-			if (byte == 0x00) {
-				/* Literal 0x90 */
-				lz77_add_byte(&desc->lz77, 0x90);
+		switch (desc->f_state) {
+		/* "Ground state" for the follower set decoder */
+		case READ_LITERAL_FLAG:
+			if (desc->folset[desc->last_ch].size == 0) {
+				/* Consume no input; read a literal byte */
+				desc->f_state = READ_BYTE;
 			} else {
-				/* Copy marker */
-				unsigned distance = byte >> (7 - desc->level);
-				unsigned length = byte & desc->length_mask;
-				if (length == desc->length_mask) {
-					/* Need another length byte */
-					err = reduce_read_byte(desc, &byte);
-					if (err) {
-						goto fail;
-					}
-					length += byte;
+				unsigned literal;
+
+				eodata = archive_read_bits_2(desc, io, 1, &literal);
+				if (eodata) {
+					break;
 				}
-				length += 3;
-				err = reduce_read_byte(desc, &byte);
-				if (err) {
-					goto fail;
+				if (literal) {
+					desc->f_state = READ_BYTE;
+				} else {
+					desc->f_state = READ_INDEX;
 				}
-				distance = (distance << 8) + byte + 1;
-				lz77_set_copy(&desc->lz77, distance, length);
+			}
+			/* Proceed to READ_BYTE or READ_INDEX */
+			break;
+
+		case READ_BYTE:         /* Read 8 bits for literal byte */
+			{
+				unsigned byte;
+
+				eodata = archive_read_bits_2(desc, io, 8, &byte);
+				if (eodata) {
+					break;
+				}
+				desc->last_ch = byte;
+			}
+			desc->f_state = PROCESS_BYTE;
+			break;
+
+		case READ_INDEX:        /* Read 1-6 bits for follower set index */
+			{
+				unsigned byte;
+
+				eodata = archive_read_bits_2(desc, io, desc->folset[desc->last_ch].bits, &byte);
+				if (eodata) {
+					break;
+				}
+				if (byte >= desc->folset[desc->last_ch].size) {
+					return file_inconsistent;
+				}
+				desc->last_ch = desc->folset[desc->last_ch].chr[byte];
+			}
+			desc->f_state = PROCESS_BYTE;
+			break;
+
+		case PROCESS_BYTE:      /* Process byte according to b_state */
+			process_byte(desc);
+			desc->f_state = READ_LITERAL_FLAG;
+			break;
+
+		default:
+			assert(0);
+		}
+	}
+
+	if (total_in == io->total_in && total_out == io->total_out
+	&&  num_bits == desc->num_bits) {
+		return ARCHIVE_EOF;
+	}
+	return ARCHIVE_OK;
+}
+
+static int
+reduce_setup(struct reduce_desc *desc, struct zip_legacy_io *io)
+{
+	int eodata;
+
+	while (desc->f_state < READ_LITERAL_FLAG && io->total_in < io->avail_in) {
+		switch (desc->f_state) {
+		case READ_FOLSET_SIZE:
+			{
+				unsigned i;
+				unsigned size;
+
+				eodata = archive_read_bits_2(desc, io, 6, &size);
+				if (eodata) {
+					return eodata;
+				}
+				desc->folset[desc->last_ch].size = size;
+				for (i = 1; (1U << i) < size; ++i) { /*nothing needed here*/ }
+				desc->folset[desc->last_ch].bits = i;
+				desc->bytes_read = 0;
+				desc->f_state = READ_FOLSET_DATA;
+			}
+			break;
+
+		case READ_FOLSET_DATA:
+			if (desc->folset[desc->last_ch].size != 0) {
+				unsigned byte;
+
+				eodata = archive_read_bits_2(desc, io, 8, &byte);
+				if (eodata) {
+					return eodata;
+				}
+				desc->folset[desc->last_ch].chr[desc->bytes_read++] = byte;
+			}
+			if (desc->bytes_read >= desc->folset[desc->last_ch].size) {
+				if (desc->last_ch == 0) {
+					/* All follower sets read */
+					desc->f_state = READ_LITERAL_FLAG;
+				} else {
+					/* Read next follower set */
+					--desc->last_ch;
+					desc->bytes_read = 0;
+					desc->f_state = READ_FOLSET_SIZE;
+				}
+			}
+			break;
+
+		default:
+			assert(0);
+		}
+	}
+
+	return 0;
+}
+
+static void
+process_byte(struct reduce_desc *desc)
+{
+	uint8_t byte = desc->last_ch;
+	unsigned distance;
+
+	/* State machine is according to APPNOTE.TXT 5.2.5 */
+	switch (desc->b_state) {
+	case BYTE_LITERAL:      /* Byte is literal unless equal to 0x90 */
+		if (byte == 0x90) {
+			desc->b_state = BYTE_COPY1;
+		} else {
+			lz77_add_byte(&desc->lz77, byte);
+			/* remain in BYTE_LITERAL */
+		}
+		break;
+
+	case BYTE_COPY1:        /* First byte of copy marker, or 0 for literal 0x90 */
+		if (byte == 0x00) {
+			/* Literal 0x90 */
+			lz77_add_byte(&desc->lz77, 0x90);
+			desc->b_state = BYTE_LITERAL;
+		} else {
+			desc->distance = byte >> (7 - desc->level);
+			desc->length = byte & desc->length_mask;
+			if (desc->length == desc->length_mask) {
+				desc->b_state = BYTE_COPY2;
+			} else {
+				desc->b_state = BYTE_COPY3;
 			}
 		}
+		break;
+
+	case BYTE_COPY2:        /* Second byte of copy marker */
+		desc->length += byte;
+		desc->b_state = BYTE_COPY3;
+		break;
+
+	case BYTE_COPY3:        /* Third byte of copy marker */
+		distance = (desc->distance << 8) + byte + 1;
+		lz77_set_copy(&desc->lz77, distance, desc->length + 3);
+		desc->b_state = BYTE_LITERAL;
+		break;
 	}
-
-	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
-	return 0;
-
-fail:
-	/* If we reach the end of the compressed data, return success with the
-	   number of bytes read so far */
-	*bytes_read = b_read;
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
-	return err == end_of_data ? ARCHIVE_EOF : err;
 }
 
+/* Read the given number of bits, possibly not byte aligned */
+/* Return -1 if end of data reached, else 0 */
 static int
-read_follower_set(struct reduce_desc *desc,
-	struct follower_set *folset)
+archive_read_bits_2(struct reduce_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits)
 {
-	unsigned size;
-	int err;
-	unsigned i;
+	if (desc->num_bits < num_bits) {
+		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
 
-	/* Size of follower set */
-	err = archive_read_bits(&desc->arch, 6, &size);
-	if (err) {
-		return err;
-	}
-	folset->size = size;
-
-	/* Size in terms of bits (e.g. 64 -> 6 bits) */
-	for (i = 1; (1U << i) < size; ++i) { /*nothing needed here*/ }
-	folset->bits = i;
-
-	/* Read the set of bytes */
-	for (i = 0; i < size; ++i) {
-		unsigned byte;
-		err = archive_read_bits(&desc->arch, 8, &byte);
-		if (err) {
-			return err;
+		if (io->total_in + num_bytes > io->avail_in) {
+			num_bytes = (unsigned)(io->avail_in - io->total_in);
 		}
-		folset->chr[i] = byte;
-	}
-
-	return 0;
-}
-
-/* Read one byte from the follower set encoding */
-static int
-reduce_read_byte(struct reduce_desc *desc, uint8_t *byte)
-{
-	unsigned literal;
-	int err;
-
-	if (desc->folset[desc->last_ch].size == 0) {
-		/* Always literal if the follower set is empty */
-		literal = 1;
-	} else {
-		/* If the follower set is empty, the next bit determines
-		   whether a literal follows */
-		err = archive_read_bits(&desc->arch, 1, &literal);
-		if (err) {
-			return err;
+		for (unsigned i = 0; i < num_bytes; ++i) {
+			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
+			desc->num_bits += 8;
 		}
 	}
-	if (literal) {
-		unsigned bits;
-		err = archive_read_bits(&desc->arch, 8, &bits);
-		if (err) {
-			return err;
-		}
-		assert(bits <= 255);
-		*byte = (uint8_t)bits;
-	} else {
-		unsigned index;
-		err = archive_read_bits(&desc->arch, desc->folset[desc->last_ch].bits, &index);
-		if (err) {
-			return err;
-		}
-		if (index >= desc->folset[desc->last_ch].size) {
-			return file_inconsistent;
-		}
-		*byte = desc->folset[desc->last_ch].chr[index];
+	if (desc->num_bits < num_bits) {
+		return -1;
 	}
-	desc->last_ch = *byte;
+
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
 	return 0;
 }
 

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -155,7 +155,6 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 
 		if (byte != 0x90) {
 			/* Literal byte */
-			bytes[b_read++] = byte;
 			lz77_add_byte(&desc->lz77, byte);
 		} else {
 			/* May be a copy marker or a literal 0x90 */
@@ -165,7 +164,6 @@ reduce_read(struct reduce_desc *desc, uint8_t bytes[], size_t num_bytes,
 			}
 			if (byte == 0x00) {
 				/* Literal 0x90 */
-				bytes[b_read++] = 0x90;
 				lz77_add_byte(&desc->lz77, 0x90);
 			} else {
 				/* Copy marker */

--- a/libarchive/archive_zip_legacy_reduce.c
+++ b/libarchive/archive_zip_legacy_reduce.c
@@ -1,4 +1,27 @@
-/* reduce */
+/*-
+ * Copyright (c) 2026 Ray Chason
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "archive_platform.h"
 

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -40,21 +40,9 @@
 #  include <stdlib.h>
 #endif
 
-#include "archive_read_private.h"
 #include "archive_zip_legacy.h"
 
 #define SIZE(x) (sizeof(x)/sizeof((x)[0]))
-
-/* Archive data, remaining bytes, decryption */
-struct arch_data {
-	/* Archive data from caller */
-	struct archive_read *arch;
-	/* Compressed bytes remaining */
-	uint64_t cmp_size;
-	/* Traditional PKZIP decryption */
-	struct trad_enc_ctx *decrypt;
-	uint8_t decrypt_buf[256];
-};
 
 /*
  * The dictionary is built as codes are received. "byte" is the last character
@@ -90,12 +78,10 @@ enum {
 
 struct shrink_desc {
 	/* Source of bytes */
-	struct arch_data arch_;
+	struct arch_data arch;
 	/* Decompressor state */
-	uint32_t bits;
-	unsigned num_bits;
 	unsigned code_size;
-	int old_code;
+	unsigned old_code;
 	struct shrink_dictionary dictionary[8192 - 257];
 	uint16_t free_list;
 	uint8_t last_byte;
@@ -107,18 +93,9 @@ struct shrink_desc {
 	uint64_t unc_size;
 };
 
-/* Errors occurring within the ZIP format */
-enum {
-	end_of_data = -1,
-	file_truncated = -2,
-	file_inconsistent = -3
-};
-
 static int lookup(struct shrink_desc *desc, int code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
-static int read_code_with_escapes(struct shrink_desc *desc, int *code);
-static int read_code(struct shrink_desc *desc, int *code);
-static void const *read_bytes(struct arch_data *arch, unsigned num_bytes);
+static int read_code_with_escapes(struct shrink_desc *desc, unsigned *code);
 
 /* Initialize the shrink_desc structure */
 int
@@ -132,13 +109,13 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch_.arch = a;
-	(*desc)->arch_.cmp_size = cmp_size;
-	(*desc)->arch_.decrypt = decrypt;
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
+	(*desc)->arch.arch = a;
+	(*desc)->arch.cmp_size = cmp_size;
+	(*desc)->arch.decrypt = decrypt;
+	(*desc)->arch.bits = 0;
+	(*desc)->arch.num_bits = 0;
 	(*desc)->code_size = 9;
-	(*desc)->old_code = -1;
+	(*desc)->old_code = 0xFFFF;
 	(*desc)->last_byte = 0;
 	(*desc)->outstr_size = 0;
 	(*desc)->outstr_start = 0;
@@ -166,7 +143,7 @@ int
 shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
 {
-	uint64_t cmp_size = desc->arch_.cmp_size;
+	uint64_t cmp_size = desc->arch.cmp_size;
 	int err = 0;
 
 	*bytes_read = 0;
@@ -191,7 +168,7 @@ shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 		desc->outstr_size = 0;
 
 		/* Read and decode */
-		if (desc->old_code == -1) {
+		if (desc->old_code == 0xFFFF) {
 			/* First time through */
 			err = read_code_with_escapes(desc, &desc->old_code);
 			if (err != 0) {
@@ -205,7 +182,7 @@ shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 			desc->outstr_size = 1;
 			desc->last_byte = desc->old_code;
 		} else {
-			int new_code;
+			unsigned new_code;
 
 			err = read_code_with_escapes(desc, &new_code);
 			if (err != 0) {
@@ -220,32 +197,14 @@ shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 		}
 	}
 
-	*cmp_bytes_read = cmp_size - desc->arch_.cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return ARCHIVE_OK;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
-	*cmp_bytes_read = cmp_size - desc->arch_.cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
-}
-
-const char *
-shrink_error(int err)
-{
-	switch (err) {
-	case end_of_data:
-		return "End of compressed data";
-
-	case file_truncated:
-		return "Truncated ZIP file data";
-
-	case file_inconsistent:
-		return "Corrupted ZIP file data";
-
-	default:
-		return strerror(err);
-	}
 }
 
 static int
@@ -326,17 +285,17 @@ add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte)
 
 /* Read a code from the file, and process any 256 escapes */
 static int
-read_code_with_escapes(struct shrink_desc *desc, int *code)
+read_code_with_escapes(struct shrink_desc *desc, unsigned *code)
 {
 	while (1) {
-		int code2;
-		int err = read_code(desc, code);
+		unsigned code2;
+		int err = archive_read_bits(&desc->arch, desc->code_size, code);
 		if (err != 0 || *code != 256) {
 			/* Not an escape code */
 			return err;
 		}
 
-		err = read_code(desc, &code2);
+		err = archive_read_bits(&desc->arch, desc->code_size, &code2);
 		if (err != 0) {
 			return err;
 		}
@@ -378,55 +337,6 @@ read_code_with_escapes(struct shrink_desc *desc, int *code)
 			return file_inconsistent;
 		}
 	}
-}
-
-/* Read a single code from the file */
-static int
-read_code(struct shrink_desc *desc, int *code)
-{
-	while (desc->num_bits < desc->code_size) {
-		const uint8_t *ptr;
-		ssize_t avail;
-
-		if (desc->arch_.cmp_size == 0) {
-			return end_of_data;
-		}
-		ptr = read_bytes(&desc->arch_, 1);
-		if (ptr == NULL) {
-			return file_truncated;
-		}
-		desc->bits |= ptr[0] << desc->num_bits;
-		desc->num_bits += 8;
-	}
-
-	*code = desc->bits & ((1 << desc->code_size) - 1);
-	desc->num_bits -= desc->code_size;
-	desc->bits >>= desc->code_size;
-	return ARCHIVE_OK;
-}
-
-/* Read and possibly decrypt one or more bytes */
-static void const *
-read_bytes(struct arch_data *arch, unsigned num_bytes)
-{
-	void const *ptr;
-	ssize_t avail;
-
-	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
-	if (ptr == NULL) {
-		return NULL;
-	}
-	__archive_read_consume(arch->arch, num_bytes);
-	arch->cmp_size -= num_bytes;
-
-	if (arch->decrypt) {
-		trad_enc_decrypt_update(arch->decrypt,
-			ptr, num_bytes,
-			arch->decrypt_buf, num_bytes);
-		ptr = arch->decrypt_buf;
-	}
-
-	return ptr;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -94,6 +94,7 @@ struct shrink_desc {
 static int lookup(struct shrink_desc *desc, int code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
 static int read_code_with_escapes(struct shrink_desc *desc, unsigned *code);
+static void clear_dictionary(struct shrink_desc *desc);
 
 /* Initialize the shrink_desc structure */
 int
@@ -307,32 +308,38 @@ read_code_with_escapes(struct shrink_desc *desc, unsigned *code)
 			break;
 
 		case 2: /* Partial clearing */
-			for (unsigned i = 0; i < SIZE(desc->dictionary); ++i) {
-				struct shrink_dictionary const *node = &desc->dictionary[i];
-				if (node->flag != node_free) {
-					unsigned j = node->next;
-					if (j >= 257) {
-						desc->dictionary[j - 257].flag = node_parent;
-					}
-				}
-			}
-			desc->free_list = 0xFFFF;
-			for (unsigned i = SIZE(desc->dictionary); i-- != 0; ) {
-				struct shrink_dictionary *node = &desc->dictionary[i];
-				if (node->flag == node_used) {
-					node->flag = node_free;
-				} else if (node->flag == node_parent) {
-					node->flag = node_used;
-				}
-				if (node->flag == node_free) {
-					node->next = desc->free_list;
-					desc->free_list = i;
-				}
-			}
+			clear_dictionary(desc);
 			break;
 
 		default: /* Invalid code */
 			return file_inconsistent;
+		}
+	}
+}
+
+static void
+clear_dictionary(struct shrink_desc *desc)
+{
+	for (unsigned i = 0; i < SIZE(desc->dictionary); ++i) {
+		struct shrink_dictionary const *node = &desc->dictionary[i];
+		if (node->flag != node_free) {
+			unsigned j = node->next;
+			if (j >= 257) {
+				desc->dictionary[j - 257].flag = node_parent;
+			}
+		}
+	}
+	desc->free_list = 0xFFFF;
+	for (unsigned i = SIZE(desc->dictionary); i-- != 0; ) {
+		struct shrink_dictionary *node = &desc->dictionary[i];
+		if (node->flag == node_used) {
+			node->flag = node_free;
+		} else if (node->flag == node_parent) {
+			node->flag = node_used;
+		}
+		if (node->flag == node_free) {
+			node->next = desc->free_list;
+			desc->free_list = i;
 		}
 	}
 }

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -89,8 +89,6 @@ struct shrink_desc {
 	uint8_t outstr[8192];
 	unsigned outstr_size;
 	unsigned outstr_start;
-	/* Debug */
-	uint64_t unc_size;
 };
 
 static int lookup(struct shrink_desc *desc, int code);

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -12,10 +12,19 @@
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"
 
+#define SIZE(x) (sizeof(x)/sizeof((x)[0]))
+
 struct shrink_dictionary {
 	uint16_t next;
 	uint8_t byte;
 	uint8_t flag;
+};
+
+/* Values for shrink_dictionary::flag */
+enum {
+    node_free,
+    node_used,
+    node_parent
 };
 
 struct shrink_desc {
@@ -28,7 +37,7 @@ struct shrink_desc {
 	unsigned code_size;
 	int old_code;
 	struct shrink_dictionary dictionary[8192 - 257];
-	uint16_t next_node;
+	uint16_t free_list;
 	uint8_t last_byte;
 	/* Output string */
 	uint8_t outstr[8192];
@@ -66,10 +75,17 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 	(*desc)->num_bits = 0;
 	(*desc)->code_size = 9;
 	(*desc)->old_code = -1;
-	(*desc)->next_node = 0;
 	(*desc)->last_byte = 0;
 	(*desc)->outstr_size = 0;
 	(*desc)->outstr_start = 0;
+
+    /* The dictionary is initially empty */
+	(*desc)->free_list = 0;
+    for (unsigned i = 0; i < SIZE((*desc)->dictionary) - 1; ++i) {
+        (*desc)->dictionary[i].flag = node_free;
+        (*desc)->dictionary[i].next = i + 1;
+    }
+    (*desc)->dictionary[SIZE((*desc)->dictionary) - 1].next = 0xFFFF;
 
 	*cmp_bytes_read = 0;
 	return ARCHIVE_OK;
@@ -178,8 +194,10 @@ lookup(struct shrink_desc *desc, int code)
 	int end_byte = -1;
 
 	// If code equals the next node, issue last_byte at the end
-	if ((code >= desc->next_node + 257)
-	||  (code >= 257 && desc->dictionary[code - 257].next == 0xFFFF)) {
+	if (code >= 257 && desc->dictionary[code - 257].flag == node_free) {
+		if (code - 257 != desc->free_list) {
+			return file_inconsistent;
+		}
 		end_byte = desc->last_byte;
 		code = desc->old_code;
 	}
@@ -219,27 +237,20 @@ lookup(struct shrink_desc *desc, int code)
 static void
 add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte)
 {
-	unsigned empty = 0xFFFF;
+	unsigned empty;
 
-	/* Look for an empty node */
-	for (uint16_t i = 0; i < desc->next_node; ++i) {
-		if (empty == 0xFFFF && desc->dictionary[i].next == 0xFFFF) {
-			empty = i;
-		}
-	}
-
-	/* If no empty node, use the next unused one */
+	/* Use the first empty node */
+	empty = desc->free_list;
 	if (empty == 0xFFFF) {
-		/* Don't overflow the array */
-		if (desc->next_node >= sizeof(desc->dictionary)/sizeof(desc->dictionary[0])) {
-			return;
-		}
-		empty = desc->next_node++;
+		/* Dictionary is full */
+		return;
 	}
+	desc->free_list = desc->dictionary[empty].next;
 
 	/* Add the new entry */
 	desc->dictionary[empty].next = code;
 	desc->dictionary[empty].byte = byte;
+	desc->dictionary[empty].flag = node_used;
 }
 
 /* Read a code from the file, and process any 256 escapes */
@@ -268,18 +279,26 @@ read_code_with_escapes(struct shrink_desc *desc, int *code)
 			break;
 
 		case 2: /* Partial clearing */
-			for (unsigned i = 0; i < desc->next_node; ++i) {
-				desc->dictionary[i].flag = 0;
-			}
-			for (unsigned i = 0; i < desc->next_node; ++i) {
-				unsigned j = desc->dictionary[i].next;
-				if (j >= 257) {
-					desc->dictionary[j - 257].flag = 1;
+			for (unsigned i = 0; i < SIZE(desc->dictionary); ++i) {
+				struct shrink_dictionary *node = &desc->dictionary[i];
+				if (node->flag != node_free) {
+					unsigned j = node->next;
+					if (j >= 257) {
+						desc->dictionary[j - 257].flag = node_parent;
+					}
 				}
 			}
-			for (unsigned i = 0; i < desc->next_node; ++i) {
-				if (!desc->dictionary[i].flag) {
-					desc->dictionary[i].next = 0xFFFF;
+			desc->free_list = 0xFFFF;
+			for (unsigned i = SIZE(desc->dictionary); i-- != 0; ) {
+				struct shrink_dictionary *node = &desc->dictionary[i];
+				if (node->flag == node_used) {
+					node->flag = node_free;
+				} else if (node->flag == node_parent) {
+					node->flag = node_used;
+				}
+				if (node->flag == node_free) {
+					node->next = desc->free_list;
+					desc->free_list = i;
 				}
 			}
 			break;

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -1,8 +1,8 @@
 /* shrink */
 
-// #if HAVE_LEGACY
-
 #include "archive_platform.h"
+
+#if HAVE_LEGACY
 
 #include <errno.h>
 #include <stdint.h>
@@ -317,4 +317,4 @@ read_code(struct shrink_desc *desc, int *code)
 	return ARCHIVE_OK;
 }
 
-// #endif /* HAVE_LEGACY */
+#endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -1,0 +1,320 @@
+/* shrink */
+
+// #if HAVE_LEGACY
+
+#include "archive_platform.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "archive_read_private.h"
+#include "archive_zip_legacy.h"
+
+struct shrink_dictionary {
+	uint16_t next;
+	uint8_t byte;
+	uint8_t flag;
+};
+
+struct shrink_desc {
+	/* Source of bytes */
+	struct archive_read *arch;
+	uint64_t cmp_size;
+	/* Decompressor state */
+	uint32_t bits;
+	unsigned num_bits;
+	unsigned code_size;
+	int old_code;
+	struct shrink_dictionary dictionary[8192 - 257];
+	uint16_t next_node;
+	uint8_t last_byte;
+	/* Output string */
+	uint8_t outstr[8192];
+	unsigned outstr_size;
+	unsigned outstr_start;
+	/* Debug */
+	uint64_t unc_size;
+};
+
+/* Errors occurring within the ZIP format */
+enum {
+	end_of_data = -1,
+	file_truncated = -2,
+	file_inconsistent = -3
+};
+
+static int lookup(struct shrink_desc *desc, int code);
+static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
+static int read_code_with_escapes(struct shrink_desc *desc, int *code);
+static int read_code(struct shrink_desc *desc, int *code);
+
+/* Initialize the shrink_desc structure */
+int
+shrink_init(struct shrink_desc **desc, struct archive_read *a,
+	uint64_t cmp_size, size_t *cmp_bytes_read)
+{
+	*desc = calloc(1, sizeof(**desc));
+	if (*desc == NULL) {
+		return errno;
+	}
+
+	(*desc)->arch = a;
+	(*desc)->cmp_size = cmp_size;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
+	(*desc)->code_size = 9;
+	(*desc)->old_code = -1;
+	(*desc)->next_node = 0;
+	(*desc)->last_byte = 0;
+	(*desc)->outstr_size = 0;
+	(*desc)->outstr_start = 0;
+
+	*cmp_bytes_read = 0;
+	return ARCHIVE_OK;
+}
+
+void
+shrink_free(struct shrink_desc **desc)
+{
+	free(*desc);
+	*desc = NULL;
+}
+
+int
+shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
+	size_t *bytes_read, size_t *cmp_bytes_read)
+{
+	uint64_t cmp_size = desc->cmp_size;
+	int err = 0;
+
+	*bytes_read = 0;
+	while (1) {
+		/* Return any partial string still pending */
+		if (desc->outstr_size > desc->outstr_start) {
+			unsigned outstr_size = desc->outstr_size - desc->outstr_start;
+			if (outstr_size > num_bytes) {
+				outstr_size = num_bytes;
+			}
+			memcpy(bytes, desc->outstr + desc->outstr_start, outstr_size);
+			*bytes_read += outstr_size;
+			desc->outstr_start += outstr_size;
+			bytes += outstr_size;
+			num_bytes -= outstr_size;
+			if (num_bytes == 0) {
+				break;
+			}
+		}
+
+		desc->outstr_start = 0;
+		desc->outstr_size = 0;
+
+		/* Read and decode */
+		if (desc->old_code == -1) {
+			/* First time through */
+			err = read_code_with_escapes(desc, &desc->old_code);
+			if (err != 0) {
+				goto fail;
+			}
+			if (desc->old_code >= 256) {
+				err = file_inconsistent;
+				goto fail;
+			}
+			desc->outstr[0] = desc->old_code;
+			desc->outstr_size = 1;
+			desc->last_byte = desc->old_code;
+		} else {
+			int new_code;
+
+			err = read_code_with_escapes(desc, &new_code);
+			if (err != 0) {
+				goto fail;
+			}
+			err = lookup(desc, new_code);
+			if (err != 0) {
+				goto fail;
+			}
+			add_string(desc, desc->old_code, desc->outstr[0]);
+			desc->old_code = new_code;
+		}
+	}
+
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return ARCHIVE_OK;
+
+fail:
+	/* If we reach the end of the compressed data, return success with the
+	   number of bytes read so far */
+	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	return err == end_of_data ? ARCHIVE_EOF : err;
+}
+
+const char *
+shrink_error(int err)
+{
+	switch (err) {
+	case end_of_data:
+		return "End of compressed data";
+
+	case file_truncated:
+		return "Truncated ZIP file data";
+
+	case file_inconsistent:
+		return "Corrupted ZIP file data";
+
+	default:
+		return strerror(err);
+	}
+}
+
+static int
+lookup(struct shrink_desc *desc, int code)
+{
+	uint8_t *str = desc->outstr;
+	unsigned length;
+	int index;
+	unsigned i;
+	int end_byte = -1;
+
+	// If code equals the next node, issue last_byte at the end
+	if ((code >= desc->next_node + 257)
+	||  (code >= 257 && desc->dictionary[code - 257].next == 0xFFFF)) {
+		end_byte = desc->last_byte;
+		code = desc->old_code;
+	}
+
+	// Determine the length of the output string
+	length = 1;
+	index = code;
+	while (index >= 257) {
+		if (index == 0xFFFF) {
+			return file_inconsistent;
+		}
+		++length;
+		index = desc->dictionary[index - 257].next;
+	}
+
+	// Write the string in the opposite order from how the nodes are linked
+	i = length;
+	index = code;
+	while (index >= 257) {
+		str[--i] = desc->dictionary[index - 257].byte;
+		index = desc->dictionary[index - 257].next;
+	}
+	str[0] = index;
+
+	// Update last_byte for code equal to the next node
+	if (end_byte >= 0) {
+		str[length++] = end_byte;
+	}
+	desc->last_byte = str[0];
+
+	desc->outstr_start = 0;
+	desc->outstr_size = length;
+
+	return 0;
+}
+
+static void
+add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte)
+{
+	unsigned empty = 0xFFFF;
+
+	/* Look for an empty node */
+	for (uint16_t i = 0; i < desc->next_node; ++i) {
+		if (empty == 0xFFFF && desc->dictionary[i].next == 0xFFFF) {
+			empty = i;
+		}
+	}
+
+	/* If no empty node, use the next unused one */
+	if (empty == 0xFFFF) {
+		/* Don't overflow the array */
+		if (desc->next_node >= sizeof(desc->dictionary)/sizeof(desc->dictionary[0])) {
+			return;
+		}
+		empty = desc->next_node++;
+	}
+
+	/* Add the new entry */
+	desc->dictionary[empty].next = code;
+	desc->dictionary[empty].byte = byte;
+}
+
+/* Read a code from the file, and process any 256 escapes */
+static int
+read_code_with_escapes(struct shrink_desc *desc, int *code)
+{
+	while (1) {
+		int code2;
+		int err = read_code(desc, code);
+		if (err != 0 || *code != 256) {
+			/* Not an escape code */
+			return err;
+		}
+
+		err = read_code(desc, &code2);
+		if (err != 0) {
+			return err;
+		}
+
+		switch (code2) {
+		case 1: /* Change the code size */
+			if (desc->code_size >= 13) {
+				return file_inconsistent;
+			}
+			++desc->code_size;
+			break;
+
+		case 2: /* Partial clearing */
+			for (unsigned i = 0; i < desc->next_node; ++i) {
+				desc->dictionary[i].flag = 0;
+			}
+			for (unsigned i = 0; i < desc->next_node; ++i) {
+				unsigned j = desc->dictionary[i].next;
+				if (j >= 257) {
+					desc->dictionary[j - 257].flag = 1;
+				}
+			}
+			for (unsigned i = 0; i < desc->next_node; ++i) {
+				if (!desc->dictionary[i].flag) {
+					desc->dictionary[i].next = 0xFFFF;
+				}
+			}
+			break;
+
+		default: /* Invalid code */
+			return file_inconsistent;
+		}
+	}
+}
+
+/* Read a single code from the file */
+static int
+read_code(struct shrink_desc *desc, int *code)
+{
+	while (desc->num_bits < desc->code_size) {
+		const uint8_t *ptr;
+		ssize_t avail;
+
+		if (desc->cmp_size == 0) {
+			return end_of_data;
+		}
+		ptr = __archive_read_ahead(desc->arch, 1, &avail);
+		if (ptr == NULL) {
+			return file_truncated;
+		}
+		desc->bits |= ptr[0] << desc->num_bits;
+		__archive_read_consume(desc->arch, 1);
+		desc->num_bits += 8;
+		--desc->cmp_size;
+	}
+
+	*code = desc->bits & ((1 << desc->code_size) - 1);
+	desc->num_bits -= desc->code_size;
+	desc->bits >>= desc->code_size;
+	return ARCHIVE_OK;
+}
+
+// #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -78,8 +78,7 @@ enum {
 
 struct shrink_desc {
 	/* To read bits not on a byte boundary */
-	uint64_t bits;
-	uint8_t num_bits;
+	struct arch_bits bits;
 	/* Decompressor state */
 	unsigned code_size;
 	unsigned old_code;
@@ -98,8 +97,6 @@ static int process_shifted(struct shrink_desc *desc, struct zip_legacy_io *io);
 static int lookup(struct shrink_desc *desc, unsigned code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
 static void clear_dictionary(struct shrink_desc *desc);
-static int archive_read_bits_2(struct shrink_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits);
 
 /* Initialize the shrink_desc structure */
 int
@@ -112,8 +109,8 @@ shrink_init(struct shrink_desc **desc)
 		}
 	}
 
-	(*desc)->bits = 0;
-	(*desc)->num_bits = 0;
+	(*desc)->bits.bits = 0;
+	(*desc)->bits.num_bits = 0;
 	(*desc)->code_size = 9;
 	(*desc)->old_code = 0xFFFF;
 	(*desc)->last_byte = 0;
@@ -145,7 +142,7 @@ shrink_read(struct shrink_desc *desc, struct zip_legacy_io *io)
 	int err = 0;
 	size_t total_in = io->total_in;
 	size_t total_out = io->total_out;
-	unsigned num_bits = desc->num_bits;
+	unsigned num_bits = desc->bits.num_bits;
 
 	while (!err && io->total_out < io->avail_out) {
 		/* Return any partial string still pending */
@@ -182,7 +179,7 @@ shrink_read(struct shrink_desc *desc, struct zip_legacy_io *io)
 		return err;
 	}
 	if (total_in == io->total_in && total_out == io->total_out
-	&&  num_bits == desc->num_bits) {
+	&&  num_bits == desc->bits.num_bits) {
 		return ARCHIVE_EOF;
 	}
 	return ARCHIVE_OK;
@@ -193,7 +190,7 @@ static int
 process_unshifted(struct shrink_desc *desc, struct zip_legacy_io *io)
 {
 	unsigned new_code;
-	int eodata = archive_read_bits_2(desc, io, desc->code_size, &new_code);
+	int eodata = archive_read_bits(&desc->bits, io, desc->code_size, &new_code);
 	if (eodata) {
 		return end_of_data;
 	}
@@ -231,7 +228,7 @@ static int
 process_shifted(struct shrink_desc *desc, struct zip_legacy_io *io)
 {
 	unsigned new_code;
-	int eodata = archive_read_bits_2(desc, io, desc->code_size, &new_code);
+	int eodata = archive_read_bits(&desc->bits, io, desc->code_size, &new_code);
 	if (eodata) {
 		return end_of_data;
 	}
@@ -367,35 +364,6 @@ clear_dictionary(struct shrink_desc *desc)
 			desc->free_list = i;
 		}
 	}
-}
-
-/* Read the given number of bits, possibly not byte aligned */
-/* Return -1 if end of data reached, else 0 */
-static int
-archive_read_bits_2(struct shrink_desc *desc, struct zip_legacy_io *io,
-	unsigned num_bits, unsigned *bits)
-{
-	if (desc->num_bits < num_bits) {
-		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
-
-		if (io->total_in + num_bytes > io->avail_in) {
-			num_bytes = (unsigned)(io->avail_in - io->total_in);
-		}
-		for (unsigned i = 0; i < num_bytes; ++i) {
-			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
-			desc->num_bits += 8;
-		}
-	}
-	if (desc->num_bits < num_bits) {
-		return -1;
-	}
-
-	*bits = desc->bits;
-	desc->bits >>= num_bits;
-	desc->num_bits -= num_bits;
-	*bits &= (1 << num_bits) - 1;
-
-	return 0;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -1,4 +1,27 @@
-/* shrink */
+/*-
+ * Copyright (c) 2026 Ray Chason
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "archive_platform.h"
 
@@ -14,6 +37,25 @@
 
 #define SIZE(x) (sizeof(x)/sizeof((x)[0]))
 
+/*
+ * The dictionary is built as codes are received. "byte" is the last character
+ * of the string and "next" is the code for the rest of the string. The string
+ * is built by chasing the "next" field until a literal (less than 257) is
+ * found, and then outputting the "byte" fields in the reverse of the order in
+ * which they were found. "flag" indicates used and free nodes, and while
+ * clearing, also indicates nodes that will not be cleared.
+ *
+ * The index of a used node is the code that it stands for, minus 257.
+ * Codes 0 through 255 are literal bytes, and 256 is an escape code used to
+ * change the code size or partially clear the dictionary.
+ *
+ * The dictionary is an array of size 8192-257. The largest code size is 13,
+ * and so there can never be more than 8192-257 nodes in the dictionary.
+ *
+ * Unused nodes are kept in a free list, where "next" is the index of the next
+ * free node (not offset by 257 in this case). The free list is built at
+ * initialization and again when the clear code is received.
+ */
 struct shrink_dictionary {
 	uint16_t next;
 	uint8_t byte;
@@ -22,9 +64,9 @@ struct shrink_dictionary {
 
 /* Values for shrink_dictionary::flag */
 enum {
-	node_free,
-	node_used,
-	node_parent
+	node_free,      /* Node is free */
+	node_used,      /* Node is in use */
+	node_parent     /* Temporary while clearing: a used node that will not be cleared */
 };
 
 struct shrink_desc {

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -208,19 +208,26 @@ lookup(struct shrink_desc *desc, int code)
 	length = 1;
 	index = code;
 	while (index >= 257) {
-		if (index == 0xFFFF) {
-			return file_inconsistent;
+		if (desc->dictionary[index - 257].flag == node_free) {
+			end_byte = desc->last_byte;
+			index = desc->old_code;
+		} else {
+			index = desc->dictionary[index - 257].next;
+			++length;
 		}
-		++length;
-		index = desc->dictionary[index - 257].next;
 	}
 
 	// Write the string in the opposite order from how the nodes are linked
 	i = length;
 	index = code;
 	while (index >= 257) {
-		str[--i] = desc->dictionary[index - 257].byte;
-		index = desc->dictionary[index - 257].next;
+		if (desc->dictionary[index - 257].flag == node_free) {
+			end_byte = desc->last_byte;
+			index = desc->old_code;
+		} else {
+			str[--i] = desc->dictionary[index - 257].byte;
+			index = desc->dictionary[index - 257].next;
+		}
 	}
 	str[0] = index;
 

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -77,29 +77,33 @@ enum {
 };
 
 struct shrink_desc {
-	/* Source of bytes */
-	struct arch_data arch;
+	/* To read bits not on a byte boundary */
+	uint64_t bits;
+	uint8_t num_bits;
 	/* Decompressor state */
 	unsigned code_size;
 	unsigned old_code;
 	struct shrink_dictionary dictionary[8192 - 257];
 	uint16_t free_list;
 	uint8_t last_byte;
+	uint8_t shifted;
 	/* Output string */
 	uint8_t outstr[8192];
 	unsigned outstr_size;
 	unsigned outstr_start;
 };
 
+static int process_unshifted(struct shrink_desc *desc, struct zip_legacy_io *io);
+static int process_shifted(struct shrink_desc *desc, struct zip_legacy_io *io);
 static int lookup(struct shrink_desc *desc, unsigned code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
-static int read_code_with_escapes(struct shrink_desc *desc, unsigned *code);
 static void clear_dictionary(struct shrink_desc *desc);
+static int archive_read_bits_2(struct shrink_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits);
 
 /* Initialize the shrink_desc structure */
 int
-shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, uint64_t *cmp_bytes_read)
+shrink_init(struct shrink_desc **desc)
 {
 	if (*desc == NULL) {
 		*desc = calloc(1, sizeof(**desc));
@@ -108,14 +112,12 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch.arch = a;
-	(*desc)->arch.cmp_size = cmp_size;
-	(*desc)->arch.decrypt = decrypt;
-	(*desc)->arch.bits = 0;
-	(*desc)->arch.num_bits = 0;
+	(*desc)->bits = 0;
+	(*desc)->num_bits = 0;
 	(*desc)->code_size = 9;
 	(*desc)->old_code = 0xFFFF;
 	(*desc)->last_byte = 0;
+	(*desc)->shifted = 0;
 	(*desc)->outstr_size = 0;
 	(*desc)->outstr_start = 0;
 
@@ -127,7 +129,6 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 	}
 	(*desc)->dictionary[SIZE((*desc)->dictionary) - 1].next = 0xFFFF;
 
-	*cmp_bytes_read = 0;
 	return ARCHIVE_OK;
 }
 
@@ -139,26 +140,27 @@ shrink_free(struct shrink_desc **desc)
 }
 
 int
-shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, uint64_t *cmp_bytes_read)
+shrink_read(struct shrink_desc *desc, struct zip_legacy_io *io)
 {
-	uint64_t cmp_size = desc->arch.cmp_size;
 	int err = 0;
+	size_t total_in = io->total_in;
+	size_t total_out = io->total_out;
+	unsigned num_bits = desc->num_bits;
 
-	*bytes_read = 0;
-	while (1) {
+	while (!err && io->total_out < io->avail_out) {
 		/* Return any partial string still pending */
 		if (desc->outstr_size > desc->outstr_start) {
+			size_t num_bytes = io->avail_out - io->total_out;
 			unsigned outstr_size = desc->outstr_size - desc->outstr_start;
 			if (outstr_size > num_bytes) {
 				outstr_size = num_bytes;
 			}
-			memcpy(bytes, desc->outstr + desc->outstr_start, outstr_size);
-			*bytes_read += outstr_size;
+			memcpy(io->next_out + io->total_out,
+			       desc->outstr + desc->outstr_start,
+			       outstr_size);
+			io->total_out += outstr_size;
 			desc->outstr_start += outstr_size;
-			bytes += outstr_size;
-			num_bytes -= outstr_size;
-			if (num_bytes == 0) {
+			if (io->total_out >= io->avail_out) {
 				break;
 			}
 		}
@@ -167,43 +169,91 @@ shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 		desc->outstr_size = 0;
 
 		/* Read and decode */
-		if (desc->old_code == 0xFFFF) {
-			/* First time through */
-			err = read_code_with_escapes(desc, &desc->old_code);
-			if (err != 0) {
-				goto fail;
-			}
-			if (desc->old_code >= 256) {
-				err = file_inconsistent;
-				goto fail;
-			}
-			desc->outstr[0] = desc->old_code;
-			desc->outstr_size = 1;
-			desc->last_byte = desc->old_code;
+		if (desc->shifted) {
+			err = process_shifted(desc, io);
+			/* Proceeds to unshifted state */
 		} else {
-			unsigned new_code;
-
-			err = read_code_with_escapes(desc, &new_code);
-			if (err != 0) {
-				goto fail;
-			}
-			err = lookup(desc, new_code);
-			if (err != 0) {
-				goto fail;
-			}
-			add_string(desc, desc->old_code, desc->outstr[0]);
-			desc->old_code = new_code;
+			err = process_unshifted(desc, io);
+			/* May go to shifted or unshifted state */
 		}
 	}
 
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
+	if (err != 0 && err != end_of_data) {
+		return err;
+	}
+	if (total_in == io->total_in && total_out == io->total_out
+	&&  num_bits == desc->num_bits) {
+		return ARCHIVE_EOF;
+	}
 	return ARCHIVE_OK;
+}
 
-fail:
-	/* If we reach the end of the compressed data, return success with the
-	   number of bytes read so far */
-	*cmp_bytes_read = cmp_size - desc->arch.cmp_size;
-	return err == end_of_data ? ARCHIVE_EOF : err;
+/* Read one code while in the unshifted state */
+static int
+process_unshifted(struct shrink_desc *desc, struct zip_legacy_io *io)
+{
+	unsigned new_code;
+	int eodata = archive_read_bits_2(desc, io, desc->code_size, &new_code);
+	if (eodata) {
+		return end_of_data;
+	}
+
+	if (new_code == 256) {
+		/* Go to shifted state */
+		desc->shifted = 1;
+		return 0;
+	}
+
+	if (desc->old_code == 0xFFFF) {
+		/* First time through */
+		desc->old_code = new_code;
+		if (new_code >= 256) {
+			return file_inconsistent;
+		}
+		desc->outstr[0] = new_code;
+		desc->outstr_size = 1;
+		desc->last_byte = new_code;
+	} else {
+		/* Look up string in dictionary */
+		int err = lookup(desc, new_code);
+		if (err != 0) {
+			return err;
+		}
+		add_string(desc, desc->old_code, desc->outstr[0]);
+		desc->old_code = new_code;
+	}
+
+	return 0;
+}
+
+/* Read one code while in the shifted state */
+static int
+process_shifted(struct shrink_desc *desc, struct zip_legacy_io *io)
+{
+	unsigned new_code;
+	int eodata = archive_read_bits_2(desc, io, desc->code_size, &new_code);
+	if (eodata) {
+		return end_of_data;
+	}
+
+	switch (new_code) {
+	case 1: /* Change the code size */
+		if (desc->code_size >= 13) {
+			return file_inconsistent;
+		}
+		++desc->code_size;
+		break;
+
+	case 2: /* Partial clearing */
+		clear_dictionary(desc);
+		break;
+
+	default: /* Invalid code */
+		return file_inconsistent;
+	}
+
+	desc->shifted = 0;
+	return 0;
 }
 
 static int
@@ -292,41 +342,6 @@ add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte)
 	desc->dictionary[empty].flag = node_used;
 }
 
-/* Read a code from the file, and process any 256 escapes */
-static int
-read_code_with_escapes(struct shrink_desc *desc, unsigned *code)
-{
-	while (1) {
-		unsigned code2;
-		int err = archive_read_bits(&desc->arch, desc->code_size, code);
-		if (err != 0 || *code != 256) {
-			/* Not an escape code */
-			return err;
-		}
-
-		err = archive_read_bits(&desc->arch, desc->code_size, &code2);
-		if (err != 0) {
-			return err;
-		}
-
-		switch (code2) {
-		case 1: /* Change the code size */
-			if (desc->code_size >= 13) {
-				return file_inconsistent;
-			}
-			++desc->code_size;
-			break;
-
-		case 2: /* Partial clearing */
-			clear_dictionary(desc);
-			break;
-
-		default: /* Invalid code */
-			return file_inconsistent;
-		}
-	}
-}
-
 static void
 clear_dictionary(struct shrink_desc *desc)
 {
@@ -352,6 +367,35 @@ clear_dictionary(struct shrink_desc *desc)
 			desc->free_list = i;
 		}
 	}
+}
+
+/* Read the given number of bits, possibly not byte aligned */
+/* Return -1 if end of data reached, else 0 */
+static int
+archive_read_bits_2(struct shrink_desc *desc, struct zip_legacy_io *io,
+	unsigned num_bits, unsigned *bits)
+{
+	if (desc->num_bits < num_bits) {
+		unsigned num_bytes = (num_bits - desc->num_bits + 7) / 8;
+
+		if (io->total_in + num_bytes > io->avail_in) {
+			num_bytes = (unsigned)(io->avail_in - io->total_in);
+		}
+		for (unsigned i = 0; i < num_bytes; ++i) {
+			desc->bits |= io->next_in[io->total_in++] << desc->num_bits;
+			desc->num_bits += 8;
+		}
+	}
+	if (desc->num_bits < num_bits) {
+		return -1;
+	}
+
+	*bits = desc->bits;
+	desc->bits >>= num_bits;
+	desc->num_bits -= num_bits;
+	*bits &= (1 << num_bits) - 1;
+
+	return 0;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -213,6 +213,7 @@ lookup(struct shrink_desc *desc, int code)
 	unsigned length;
 	int index;
 	unsigned i;
+	unsigned depth;
 	int end_byte = -1;
 
 	// If code equals the next node, issue last_byte at the end
@@ -227,13 +228,22 @@ lookup(struct shrink_desc *desc, int code)
 	// Determine the length of the output string
 	length = 1;
 	index = code;
+	depth = 0;
 	while (index >= 257) {
 		if (desc->dictionary[index - 257].flag == node_free) {
 			end_byte = desc->last_byte;
+			if (index == desc->old_code) {
+				return file_inconsistent;
+			}
 			index = desc->old_code;
 		} else {
 			index = desc->dictionary[index - 257].next;
 			++length;
+		}
+		++depth;
+		if (depth >= SIZE(desc->dictionary)) {
+			// Can't happen unless the tree contains cycles
+			return file_inconsistent;
 		}
 	}
 

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -27,10 +27,18 @@
 
 #if HAVE_LEGACY
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#if HAVE_ERRNO_H
+#  include <errno.h>
+#endif
+#if HAVE_STDINT_H
+#  include <stdint.h>
+#endif
+#if HAVE_STDIO_H
+#  include <stdio.h>
+#endif
+#if HAVE_STDLIB_H
+#  include <stdlib.h>
+#endif
 
 #include "archive_read_private.h"
 #include "archive_zip_legacy.h"

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -22,9 +22,9 @@ struct shrink_dictionary {
 
 /* Values for shrink_dictionary::flag */
 enum {
-    node_free,
-    node_used,
-    node_parent
+	node_free,
+	node_used,
+	node_parent
 };
 
 struct shrink_desc {
@@ -64,9 +64,11 @@ int
 shrink_init(struct shrink_desc **desc, struct archive_read *a,
 	uint64_t cmp_size, size_t *cmp_bytes_read)
 {
-	*desc = calloc(1, sizeof(**desc));
 	if (*desc == NULL) {
-		return errno;
+		*desc = calloc(1, sizeof(**desc));
+		if (*desc == NULL) {
+			return errno;
+		}
 	}
 
 	(*desc)->arch = a;
@@ -79,13 +81,13 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 	(*desc)->outstr_size = 0;
 	(*desc)->outstr_start = 0;
 
-    /* The dictionary is initially empty */
+	/* The dictionary is initially empty */
 	(*desc)->free_list = 0;
-    for (unsigned i = 0; i < SIZE((*desc)->dictionary) - 1; ++i) {
-        (*desc)->dictionary[i].flag = node_free;
-        (*desc)->dictionary[i].next = i + 1;
-    }
-    (*desc)->dictionary[SIZE((*desc)->dictionary) - 1].next = 0xFFFF;
+	for (unsigned i = 0; i < SIZE((*desc)->dictionary) - 1; ++i) {
+		(*desc)->dictionary[i].flag = node_free;
+		(*desc)->dictionary[i].next = i + 1;
+	}
+	(*desc)->dictionary[SIZE((*desc)->dictionary) - 1].next = 0xFFFF;
 
 	*cmp_bytes_read = 0;
 	return ARCHIVE_OK;

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -99,7 +99,7 @@ static void clear_dictionary(struct shrink_desc *desc);
 /* Initialize the shrink_desc structure */
 int
 shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, struct trad_enc_ctx *decrypt, size_t *cmp_bytes_read)
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, uint64_t *cmp_bytes_read)
 {
 	if (*desc == NULL) {
 		*desc = calloc(1, sizeof(**desc));
@@ -140,7 +140,7 @@ shrink_free(struct shrink_desc **desc)
 
 int
 shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
-	size_t *bytes_read, size_t *cmp_bytes_read)
+	size_t *bytes_read, uint64_t *cmp_bytes_read)
 {
 	uint64_t cmp_size = desc->arch.cmp_size;
 	int err = 0;

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -45,6 +45,17 @@
 
 #define SIZE(x) (sizeof(x)/sizeof((x)[0]))
 
+/* Archive data, remaining bytes, decryption */
+struct arch_data {
+	/* Archive data from caller */
+	struct archive_read *arch;
+	/* Compressed bytes remaining */
+	uint64_t cmp_size;
+	/* Traditional PKZIP decryption */
+	struct trad_enc_ctx *decrypt;
+	uint8_t decrypt_buf[256];
+};
+
 /*
  * The dictionary is built as codes are received. "byte" is the last character
  * of the string and "next" is the code for the rest of the string. The string
@@ -79,8 +90,7 @@ enum {
 
 struct shrink_desc {
 	/* Source of bytes */
-	struct archive_read *arch;
-	uint64_t cmp_size;
+	struct arch_data arch_;
 	/* Decompressor state */
 	uint32_t bits;
 	unsigned num_bits;
@@ -108,11 +118,12 @@ static int lookup(struct shrink_desc *desc, int code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
 static int read_code_with_escapes(struct shrink_desc *desc, int *code);
 static int read_code(struct shrink_desc *desc, int *code);
+static void const *read_bytes(struct arch_data *arch, unsigned num_bytes);
 
 /* Initialize the shrink_desc structure */
 int
 shrink_init(struct shrink_desc **desc, struct archive_read *a,
-	uint64_t cmp_size, size_t *cmp_bytes_read)
+	uint64_t cmp_size, struct trad_enc_ctx *decrypt, size_t *cmp_bytes_read)
 {
 	if (*desc == NULL) {
 		*desc = calloc(1, sizeof(**desc));
@@ -121,8 +132,9 @@ shrink_init(struct shrink_desc **desc, struct archive_read *a,
 		}
 	}
 
-	(*desc)->arch = a;
-	(*desc)->cmp_size = cmp_size;
+	(*desc)->arch_.arch = a;
+	(*desc)->arch_.cmp_size = cmp_size;
+	(*desc)->arch_.decrypt = decrypt;
 	(*desc)->bits = 0;
 	(*desc)->num_bits = 0;
 	(*desc)->code_size = 9;
@@ -154,7 +166,7 @@ int
 shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 	size_t *bytes_read, size_t *cmp_bytes_read)
 {
-	uint64_t cmp_size = desc->cmp_size;
+	uint64_t cmp_size = desc->arch_.cmp_size;
 	int err = 0;
 
 	*bytes_read = 0;
@@ -208,13 +220,13 @@ shrink_read(struct shrink_desc *desc, uint8_t bytes[], size_t num_bytes,
 		}
 	}
 
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch_.cmp_size;
 	return ARCHIVE_OK;
 
 fail:
 	/* If we reach the end of the compressed data, return success with the
 	   number of bytes read so far */
-	*cmp_bytes_read = cmp_size - desc->cmp_size;
+	*cmp_bytes_read = cmp_size - desc->arch_.cmp_size;
 	return err == end_of_data ? ARCHIVE_EOF : err;
 }
 
@@ -376,23 +388,45 @@ read_code(struct shrink_desc *desc, int *code)
 		const uint8_t *ptr;
 		ssize_t avail;
 
-		if (desc->cmp_size == 0) {
+		if (desc->arch_.cmp_size == 0) {
 			return end_of_data;
 		}
-		ptr = __archive_read_ahead(desc->arch, 1, &avail);
+		ptr = read_bytes(&desc->arch_, 1);
 		if (ptr == NULL) {
 			return file_truncated;
 		}
 		desc->bits |= ptr[0] << desc->num_bits;
-		__archive_read_consume(desc->arch, 1);
 		desc->num_bits += 8;
-		--desc->cmp_size;
 	}
 
 	*code = desc->bits & ((1 << desc->code_size) - 1);
 	desc->num_bits -= desc->code_size;
 	desc->bits >>= desc->code_size;
 	return ARCHIVE_OK;
+}
+
+/* Read and possibly decrypt one or more bytes */
+static void const *
+read_bytes(struct arch_data *arch, unsigned num_bytes)
+{
+	void const *ptr;
+	ssize_t avail;
+
+	ptr = __archive_read_ahead(arch->arch, num_bytes, &avail);
+	if (ptr == NULL) {
+		return NULL;
+	}
+	__archive_read_consume(arch->arch, num_bytes);
+	arch->cmp_size -= num_bytes;
+
+	if (arch->decrypt) {
+		trad_enc_decrypt_update(arch->decrypt,
+			ptr, num_bytes,
+			arch->decrypt_buf, num_bytes);
+		ptr = arch->decrypt_buf;
+	}
+
+	return ptr;
 }
 
 #endif /* HAVE_LEGACY */

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -91,7 +91,7 @@ struct shrink_desc {
 	unsigned outstr_start;
 };
 
-static int lookup(struct shrink_desc *desc, int code);
+static int lookup(struct shrink_desc *desc, unsigned code);
 static void add_string(struct shrink_desc *desc, uint16_t code, uint8_t byte);
 static int read_code_with_escapes(struct shrink_desc *desc, unsigned *code);
 static void clear_dictionary(struct shrink_desc *desc);
@@ -207,11 +207,11 @@ fail:
 }
 
 static int
-lookup(struct shrink_desc *desc, int code)
+lookup(struct shrink_desc *desc, unsigned code)
 {
 	uint8_t *str = desc->outstr;
 	unsigned length;
-	int index;
+	unsigned index;
 	unsigned i;
 	unsigned depth;
 	int end_byte = -1;

--- a/libarchive/archive_zip_legacy_shrink.c
+++ b/libarchive/archive_zip_legacy_shrink.c
@@ -308,7 +308,7 @@ read_code_with_escapes(struct shrink_desc *desc, unsigned *code)
 
 		case 2: /* Partial clearing */
 			for (unsigned i = 0; i < SIZE(desc->dictionary); ++i) {
-				struct shrink_dictionary *node = &desc->dictionary[i];
+				struct shrink_dictionary const *node = &desc->dictionary[i];
 				if (node->flag != node_free) {
 					unsigned j = node->next;
 					if (j >= 257) {

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -177,6 +177,40 @@ DEFINE_TEST(test_read_append_wrong_filter)
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 
+DEFINE_TEST(test_read_append_lzop_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
+  if (archive_liblzo2_version() != NULL) {
+    assertEqualIntA(a, ARCHIVE_OK, r);
+  } else if (canLzop()) {
+    // We're using an external program
+    assertEqualIntA(a, ARCHIVE_WARN, r);
+  }
+
+  archive_read_free(a);
+}
+
+DEFINE_TEST(test_read_append_grzip_filter)
+{
+  struct archive *a;
+  int r;
+
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  r = archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP);
+  // Grzip currently always uses an external program.
+  if (canGrzip()) {
+    assertEqualIntA(a, ARCHIVE_WARN, r);
+  }
+
+  archive_read_free(a);
+}
+
 DEFINE_TEST(test_read_append_filter_program)
 {
   struct archive_entry *ae;


### PR DESCRIPTION
This patch adds support for the Shrink, Reduce and Implode formats. Traditional PKWare encryption is supported. A configure-time option (--enable-legacy for Autotools, ENABLE_LEGACY for CMake) controls whether the build includes these formats.

Some resources for testing the legacy decompressors:

* Gigabyte Shareware at https://archive.org/details/GigabyteShareware contains more than 10,000 ZIPs, all using Shrink or Implode, and 55 using Reduce. The files 010a/congress.zip, 017b/fsp_151.zip and 017d/winutil.zip are the only ZIPs I've seen in the wild that use Reduce at a level other than 4.

* Garbo at https://archive.org/details/Garbo contains more than 2,000 archives using the legacy formats. 15 of them use Reduce.

* The Hall of Fame CDROM at https://archive.org/details/HallofFameCDROM has the file arc/pkz092.exe . This is the PKZIP 0.92 distribution. It runs under DOSBox and can be used to create new Reduced archives, particulary at levels 1, 2 and 3.

* The Info-ZIP zipcrypt program applies traditional PKWare encryption to an existing ZIP. No version of PKZIP produces the combination of Reduce and encryption (PKZIP 0.92 does not support encryption) but one can produce such an archive by creating it with PKZIP 0.92 and then running zipcrypt.