### PR TITLE
libarchive/ppmd8: mark the remaining functions static

### DIFF
--- a/libarchive/archive_ppmd8.c
+++ b/libarchive/archive_ppmd8.c
@@ -61,7 +61,7 @@ typedef struct CPpmd8_Node_
 
 #define EMPTY_NODE 0xFFFFFFFF
 
-void Ppmd8_Construct(CPpmd8 *p)
+static void Ppmd8_Construct(CPpmd8 *p)
 {
   unsigned i, k, m;
 
@@ -89,14 +89,14 @@ void Ppmd8_Construct(CPpmd8 *p)
   }
 }
 
-void Ppmd8_Free(CPpmd8 *p)
+static void Ppmd8_Free(CPpmd8 *p)
 {
   free(p->Base);
   p->Size = 0;
   p->Base = 0;
 }
 
-Bool Ppmd8_Alloc(CPpmd8 *p, UInt32 size)
+static Bool Ppmd8_Alloc(CPpmd8 *p, UInt32 size)
 {
   if (p->Base == 0 || p->Size != size)
   {
@@ -407,7 +407,7 @@ static void RestartModel(CPpmd8 *p)
   }
 }
 
-void Ppmd8_Init(CPpmd8 *p, unsigned maxOrder, unsigned restoreMethod)
+static void Ppmd8_Init(CPpmd8 *p, unsigned maxOrder, unsigned restoreMethod)
 {
   p->MaxOrder = maxOrder;
   p->RestoreMethod = restoreMethod;
@@ -1042,7 +1042,7 @@ static void Rescale(CPpmd8 *p)
   p->FoundState = STATS(p->MinContext);
 }
 
-CPpmd_See *Ppmd8_MakeEscFreq(CPpmd8 *p, unsigned numMasked1, UInt32 *escFreq)
+static CPpmd_See *Ppmd8_MakeEscFreq(CPpmd8 *p, unsigned numMasked1, UInt32 *escFreq)
 {
   CPpmd_See *see;
   if (p->MinContext->NumStats != 0xFF)
@@ -1078,7 +1078,7 @@ static void NextContext(CPpmd8 *p)
   }
 }
 
-void Ppmd8_Update1(CPpmd8 *p)
+static void Ppmd8_Update1(CPpmd8 *p)
 {
   CPpmd_State *s = p->FoundState;
   s->Freq += 4;
@@ -1093,7 +1093,7 @@ void Ppmd8_Update1(CPpmd8 *p)
   NextContext(p);
 }
 
-void Ppmd8_Update1_0(CPpmd8 *p)
+static void Ppmd8_Update1_0(CPpmd8 *p)
 {
   p->PrevSuccess = (2 * p->FoundState->Freq >= p->MinContext->SummFreq);
   p->RunLength += p->PrevSuccess;
@@ -1103,7 +1103,7 @@ void Ppmd8_Update1_0(CPpmd8 *p)
   NextContext(p);
 }
 
-void Ppmd8_UpdateBin(CPpmd8 *p)
+static void Ppmd8_UpdateBin(CPpmd8 *p)
 {
   p->FoundState->Freq = (Byte)(p->FoundState->Freq + (p->FoundState->Freq < 196));
   p->PrevSuccess = 1;
@@ -1111,7 +1111,7 @@ void Ppmd8_UpdateBin(CPpmd8 *p)
   NextContext(p);
 }
 
-void Ppmd8_Update2(CPpmd8 *p)
+static void Ppmd8_Update2(CPpmd8 *p)
 {
   p->MinContext->SummFreq += 4;
   if ((p->FoundState->Freq += 4) > MAX_FREQ)
@@ -1127,7 +1127,7 @@ This code is based on:
   PPMd var.I (2002): Dmitry Shkarin : Public domain
   Carryless rangecoder (1999): Dmitry Subbotin : Public domain */
 
-Bool Ppmd8_RangeDec_Init(CPpmd8 *p)
+static Bool Ppmd8_RangeDec_Init(CPpmd8 *p)
 {
   unsigned i;
   p->Low = 0;
@@ -1161,7 +1161,7 @@ static void RangeDec_Decode(CPpmd8 *p, UInt32 start, UInt32 size)
 
 #define MASK(sym) ((signed char *)charMask)[sym]
 
-int Ppmd8_DecodeSymbol(CPpmd8 *p)
+static int Ppmd8_DecodeSymbol(CPpmd8 *p)
 {
   size_t charMask[256 / sizeof(size_t)];
   if (p->MinContext->NumStats != 0)

--- a/libarchive/archive_ppmd8_private.h
+++ b/libarchive/archive_ppmd8_private.h
@@ -83,12 +83,6 @@ typedef struct
   UInt16 BinSumm[25][64];
 } CPpmd8;
 
-void Ppmd8_Construct(CPpmd8 *p);
-Bool Ppmd8_Alloc(CPpmd8 *p, UInt32 size);
-void Ppmd8_Free(CPpmd8 *p);
-void Ppmd8_Init(CPpmd8 *p, unsigned maxOrder, unsigned restoreMethod);
-#define Ppmd8_WasAllocated(p) ((p)->Base != NULL)
-
 
 /* ---------- Internal Functions ---------- */
 
@@ -104,30 +98,11 @@ extern const Byte PPMD8_kExpEscape[16];
   #define Ppmd8_GetStats(p, ctx) ((CPpmd_State *)Ppmd8_GetPtr((p), ((ctx)->Stats)))
 #endif
 
-void Ppmd8_Update1(CPpmd8 *p);
-void Ppmd8_Update1_0(CPpmd8 *p);
-void Ppmd8_Update2(CPpmd8 *p);
-void Ppmd8_UpdateBin(CPpmd8 *p);
-
 #define Ppmd8_GetBinSumm(p) \
     &p->BinSumm[p->NS2Indx[Ppmd8Context_OneState(p->MinContext)->Freq - 1]][ \
     p->NS2BSIndx[Ppmd8_GetContext(p, p->MinContext->Suffix)->NumStats] + \
     p->PrevSuccess + p->MinContext->Flags + ((p->RunLength >> 26) & 0x20)]
 
-CPpmd_See *Ppmd8_MakeEscFreq(CPpmd8 *p, unsigned numMasked, UInt32 *scale);
-
-
-/* ---------- Decode ---------- */
-
-Bool Ppmd8_RangeDec_Init(CPpmd8 *p);
-#define Ppmd8_RangeDec_IsFinishedOK(p) ((p)->Code == 0)
-int Ppmd8_DecodeSymbol(CPpmd8 *p); /* returns: -1 as EndMarker, -2 as DataError */
-
-/* ---------- Encode ---------- */
-
-#define Ppmd8_RangeEnc_Init(p) { (p)->Low = 0; (p)->Range = 0xFFFFFFFF; }
-void Ppmd8_RangeEnc_FlushData(CPpmd8 *p);
-void Ppmd8_EncodeSymbol(CPpmd8 *p, int symbol); /* symbol = -1 means EndMarker */
 
 typedef struct
 {


### PR DESCRIPTION
Those 9 are not used anywhere outside the file (the actual functionality is exported as a callback structure).
Make them static for a bit better compiler optimization opportunities and, more important, to avoid symbol conflict when static linking libarchive and any library which uses the original Ppmd*.c from the LZMA SDK (like minizip-ng).

Also remove a couple declarations and macros not used anywhere at all while we're here.