### PR TITLE
Fix a double-free in the link resolver

### DIFF
--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -163,8 +163,10 @@ archive_entry_linkresolver_free(struct archive_entry_linkresolver *res)
 	if (res == NULL)
 		return;
 
-	while ((le = next_entry(res, NEXT_ENTRY_ALL)) != NULL)
-		archive_entry_free(le->entry);
+	/* Finish walking the entries; next_entry() frees each
+	 * entry after it is visited. */
+	while ((le = next_entry(res, NEXT_ENTRY_ALL)) != NULL) {
+	}
 	free(res->buckets);
 	free(res);
 }

--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -158,8 +158,6 @@ archive_entry_linkresolver_set_strategy(struct archive_entry_linkresolver *res,
 void
 archive_entry_linkresolver_free(struct archive_entry_linkresolver *res)
 {
-	const struct links_entry *le;
-
 	if (res == NULL)
 		return;
 

--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -158,14 +158,13 @@ archive_entry_linkresolver_set_strategy(struct archive_entry_linkresolver *res,
 void
 archive_entry_linkresolver_free(struct archive_entry_linkresolver *res)
 {
-	struct links_entry *le;
+	const struct links_entry *le;
 
 	if (res == NULL)
 		return;
 
-	/* Finish walking the entries; next_entry() frees each
-	 * entry after it is visited. */
-	while ((le = next_entry(res, NEXT_ENTRY_ALL)) != NULL) {
+	while (next_entry(res, NEXT_ENTRY_ALL) != NULL) {
+		/* Actual freeing done by next_entry() */
 	}
 	free(res->buckets);
 	free(res);


### PR DESCRIPTION
The link resolver is a helper utility that tracks linked entries so they can be correctly restored.  Clients add link information to the link resolver and incrementally query it to correctly link entries as they are restored to disk.  The link resolver incrementally releases entries as they are consumed in order to minimize memory usage.

The `archive_entry_linkresolver_free()` method cleans up by repeatedly querying the cache and freeing each entry. But this conflicted with the incremental clean up, leading to double-frees of leftover items.

The easy fix here is to have `archive_entry_linkresolver_free()` just repeatedly query the list without trying to free, relying on the incremental clean up mechanism.

Credit: Tianshuo Han reported the issue and suggested the fix.