### PR TITLE
iso9660: check data_length before dereferencing data in parse_rockridge_ZF1()

### DIFF
--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -2755,7 +2755,7 @@ parse_rockridge_ZF1(struct file_info *file, const unsigned char *data,
     int data_length)
 {
 
-	if (data[0] == 0x70 && data[1] == 0x7a && data_length == 12) {
+	if (data_length == 12 && data[0] == 0x70 && data[1] == 0x7a) {
         /* paged zlib */
         file->pz = 1;
         file->pz_log2_bs = data[3];


### PR DESCRIPTION
## Summary

`parse_rockridge_ZF1()` in `libarchive/archive_read_support_format_iso9660.c` dereferences `data[0]` and `data[1]` before verifying that `data_length` is large enough. The caller in `parse_rockridge()` only guarantees that the SUSP record fits in the directory-record buffer (`p[2] >= 4` and `p + p[2] <= end`), so a crafted `ZF` entry with `p[2] == 4` reaches `parse_rockridge_ZF1()` with `data_length == 0` and `data == rr_end`. The old expression then reads one byte past the end of the Rock Ridge region.

## Impact

In practice the underlying directory block buffer returned by `__archive_read_ahead(a, vd->size, NULL)` is larger than `vd->size`, so the one-byte OOB read stays within the allocation and does not cause memory corruption. The symptom is limited to an ASan/UBSan bounds violation on contrived inputs, guard is trivial.

## Fix

Reorder the condition so `data_length == 12` is evaluated first. C's short-circuit `&&` then skips the `data[0]` / `data[1]` reads whenever the record is too short.