### PR TITLE
Nits

### DIFF
--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -187,10 +187,10 @@ const char *testprog;
 
 #ifdef RUN_TEST_UNPRIV
 /* Unprivileged user to run as */
-const char *tuser = "nobody";
+static const char *tuser = "nobody";
 /* Original and test credentials */
-uid_t ouid, tuid;
-uid_t ogid, tgid;
+static uid_t ouid, tuid;
+static uid_t ogid, tgid;
 #endif
 
 #if defined(_WIN32) && !defined(__CYGWIN__)

--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -51,9 +51,6 @@
 #include <sys/time.h>
 #endif
 #endif
-#ifdef HAVE_GETOPT_OPTRESET
-#include <getopt.h>
-#endif
 
 #include "bsdunzip.h"
 #include "passphrase.h"


### PR DESCRIPTION
* unzip: Remove dead code

  Remove an #include controlled by a preprocessor symbol that nothing
  defines.  I'm not sure if this has ever been needed, or what for, but
  it serves no purpose today.

* test_main: Staticize some variables

  These variables are not used outside test_main, so they should be static.
  
  Fixes:                a252c603080a ("test_main: Run tests as unprivileged user")
