### PR TITLE
Fix `test_write_filter_gzip` on s390x zlib patched for DFLTCC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -698,7 +698,7 @@ libarchive/test/list.h: $(libarchive_test_SOURCES)
 	$(MKDIR_P) libarchive/test
 	grep -h '^DEFINE_TEST(' $^ | LC_COLLATE=C sort > $@
 
-libarchive_TESTS_ENVIRONMENT= LIBARCHIVE_TEST_FILES=`cd $(top_srcdir);/bin/pwd`/libarchive/test LRZIP=NOCONFIG
+libarchive_TESTS_ENVIRONMENT= LIBARCHIVE_TEST_FILES=`cd $(top_srcdir);/bin/pwd`/libarchive/test LRZIP=NOCONFIG DFLTCC=0
 
 libarchive_test_EXTRA_DIST=\
 	libarchive/test/list.h \

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -349,7 +349,9 @@ IF(ENABLE_TEST)
                               -r ${CMAKE_CURRENT_SOURCE_DIR}
                               -s
                               ${_testname})
-    SET_TESTS_PROPERTIES(libarchive_${_testname} PROPERTIES SKIP_RETURN_CODE 2)
+    SET_TESTS_PROPERTIES(libarchive_${_testname} PROPERTIES
+                         SKIP_RETURN_CODE 2
+                         ENVIRONMENT "LRZIP=NOCONFIG;DFLTCC=0")
   ENDMACRO (DEFINE_TEST _testname)
 
   INCLUDE(${CMAKE_CURRENT_BINARY_DIR}/list.h)


### PR DESCRIPTION
Ubuntu patches zlib to use DFLTCC hardware DEFLATE acceleration on s390x on compression levels 1-6, causing levels 1 and 6 to produce output with the same length.  Avoid the resulting test failure by running tests with the `DFLTCC` environment variable set to `0`, disabling hardware acceleration.

zlib-ng supports DFLTCC and does not read this environment variable, but only uses DFLTCC on compression level 1 by default.  If a distro uses zlib-ng, overrides this default to include level 6, and does not patch in support for the env var, this problem will resurface.

Also set `LRZIP=NOCONFIG` when running libarchive tests with CMake, matching Autotools.

Tested on Ubuntu 24.04 on s390x hardware.

Fixes: https://github.com/libarchive/libarchive/issues/1515