### PR TITLE
Have `make distcheck` verify CMake build succeeds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,11 @@ dist-hook:
 	-rm -f $(distdir)/*/Makefile $(distdir)/*/*/Makefile
 	cd $(distdir)/doc && /bin/sh update.sh
 
+# Verify dist includes all files needed by CMake
+distcheck-hook:
+	mkdir $(distdir)/_build/cmake
+	cd $(distdir)/_build/cmake && cmake ../.. && make && make test
+
 #
 # Extra rules for cleanup
 #


### PR DESCRIPTION
There have been multiple instances of test cases being added to the CMake build but not the Autotools one, thus omitting them from the released dist tarball.  Prevent this by testing the CMake build during `make distcheck`.