### PR TITLE
libarchive: fix Windows compilation with `ENABLE_CNG=OFF`

### DIFF
--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -57,7 +57,7 @@ static void la_arc4random_buf(void *, size_t);
 #include "archive.h"
 #include "archive_random_private.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <bcrypt.h>
 
 /* Common in other bcrypt implementations, but missing from VS2008. */

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -42,13 +42,11 @@
 #include <string.h>
 #endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
-#if defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 
 /* Common in other bcrypt implementations, but missing from VS2008. */
 #ifndef BCRYPT_SUCCESS
 #define BCRYPT_SUCCESS(r) ((NTSTATUS)(r) == STATUS_SUCCESS)
-#endif
 #endif
 #endif
 #ifdef HAVE_ZLIB_H


### PR DESCRIPTION
Currently, `libarchive_{random,util}.c` use a couple bcrypt functions regardless of whether `HAVE_BCRYPT_H` is defined as there are no other implementations for Windows, but the actual `<bcrypt.h>` header is included only under this macro.

To be able to build libarchive with `ENABLE_CNG=OFF` (for example, to prefer a different crypto/digest engine) on Windows, don't guard the include in these two files. In that case, bcrypt will still be used, but only as an RNG.
This won't break anything because, as mentioned above, bcrypt is used unconditionally here and if it's not present in the system, the library won't build either way, with or without the change. At least until we implement an RNG for Windows based on something else.