### PR TITLE
iso9660: Fix `..` (dot dot) path normalization

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -4916,10 +4916,10 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 					--rp;
 				}
 				if (rp > dirname) {
-					strcpy(rp, p+3);
+					memmove(rp, p + 3, strlen(p + 3) + 1);
 					p = rp;
 				} else {
-					strcpy(dirname, p+4);
+					memmove(dirname, p + 4, strlen(p + 4) + 1);
 					p = dirname;
 				}
 			} else

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -4927,6 +4927,12 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 				}
 			} else
 				p++;
+		} else if (p == dirname && p[0] == '.' && p[1] == '.' && p[2] == '/') {
+			size_t off;
+			for (off = 3; p[off] == '/'; off++)
+				;
+			memmove(dirname, p + off, strlen(p + off) + 1);
+			p = dirname;
 		} else
 			p++;
 	}

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -4910,16 +4910,19 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 				 *     --> 'dir/dir2/'
 				 */
 				char *rp = p -1;
+				size_t off;
+				for (off = 4; p[off] == '/'; off++)
+					;
 				while (rp >= dirname) {
 					if (*rp == '/')
 						break;
 					--rp;
 				}
 				if (rp > dirname) {
-					memmove(rp, p + 3, strlen(p + 3) + 1);
+					memmove(rp + 1, p + off, strlen(p + off) + 1);
 					p = rp;
 				} else {
-					memmove(dirname, p + 4, strlen(p + 4) + 1);
+					memmove(dirname, p + off, strlen(p + off) + 1);
 					p = dirname;
 				}
 			} else

--- a/libarchive/test/test_write_format_iso9660.c
+++ b/libarchive/test/test_write_format_iso9660.c
@@ -154,7 +154,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	archive_entry_set_birthtime(ae, 3, 30);
 	archive_entry_set_ctime(ae, 4, 40);
 	archive_entry_set_mtime(ae, 5, 50);
-	archive_entry_copy_pathname(ae, "dir0/dir1/file1");
+	archive_entry_copy_pathname(ae, "dir0/../../dir0/dir1/file1");
 	archive_entry_set_mode(ae, AE_IFREG | 0755);
 	archive_entry_set_size(ae, 8);
 	archive_entry_set_nlink(ae, 1);

--- a/libarchive/test/test_write_format_iso9660.c
+++ b/libarchive/test/test_write_format_iso9660.c
@@ -170,7 +170,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	archive_entry_set_birthtime(ae, 3, 30);
 	archive_entry_set_ctime(ae, 4, 40);
 	archive_entry_set_mtime(ae, 5, 50);
-	archive_entry_copy_pathname(ae, "dir0/dir1/file2");
+	archive_entry_copy_pathname(ae, "dir0/..//dir0/dir1/file2");
 	archive_entry_set_mode(ae, AE_IFREG | 0755);
 	archive_entry_set_size(ae, 8);
 	archive_entry_set_nlink(ae, 1);


### PR DESCRIPTION
The `isofile_gen_utility_names` function normalizes paths. It takes these from archive entries.

Two cases exist in which the path normalization does not work as expected:
- `dir/..//file` does not lead to `file` but `/file`
- `dir/../../file` does not lead to `file` but `../file`

Later in the call stack, this can lead to out of boundary accesses because empty entries are not expected (`/file` would imply two path elements: ` ` (empty string) in front of / and `file`). This has been reported in https://github.com/libarchive/libarchive/issues/2937.

While at it, avoid `strcpy` because memory can very easily overlap. Since `strcpy` at least on my system eventually calls `memcpy`, use `memmove` as done in other parts of the function already.

Resolves https://github.com/libarchive/libarchive/issues/2937.