### PR TITLE
Fix build with glibc 2.43

### DIFF
--- a/libarchive/archive_options.c
+++ b/libarchive/archive_options.c
@@ -31,9 +31,9 @@
 
 #include "archive_options_private.h"
 
-static const char *
-parse_option(const char **str,
-    const char **mod, const char **opt, const char **val);
+static char *
+parse_option(char **str,
+    char **mod, char **opt, char **val);
 
 int
 _archive_set_option(struct archive *a,
@@ -103,7 +103,7 @@ _archive_set_options(struct archive *a, const char *options,
 {
 	int allok = 1, anyok = 0, ignore_mod_err = 0, r;
 	char *data;
-	const char *s, *mod, *opt, *val;
+	char *s, *mod, *opt, *val;
 
 	archive_check_magic(a, magic, ARCHIVE_STATE_NEW, fn);
 
@@ -115,7 +115,7 @@ _archive_set_options(struct archive *a, const char *options,
 		    ENOMEM, "Out of memory adding file to list");
 		return (ARCHIVE_FATAL);
 	}
-	s = (const char *)data;
+	s = data;
 
 	do {
 		mod = opt = val = NULL;
@@ -167,10 +167,10 @@ _archive_set_options(struct archive *a, const char *options,
 	return allok ? ARCHIVE_OK : anyok ? ARCHIVE_WARN : ARCHIVE_FAILED;
 }
 
-static const char *
-parse_option(const char **s, const char **m, const char **o, const char **v)
+static char *
+parse_option(char **s, char **m, char **o, char **v)
 {
-	const char *end, *mod, *opt, *val;
+	char *end, *mod, *opt, *val;
 	char *p;
 
 	end = NULL;
@@ -182,7 +182,7 @@ parse_option(const char **s, const char **m, const char **o, const char **v)
 
 	if (p != NULL) {
 		*p = '\0';
-		end = ((const char *)p) + 1;
+		end = p + 1;
 	}
 
 	if (0 == strlen(opt)) {

--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -319,7 +319,7 @@ compare_format(const void *key, const void *element)
 pack_t *
 pack_find(const char *name)
 {
-	struct format	*format;
+	const struct format	*format;
 
 	format = bsearch(name, formats,
 	    sizeof(formats)/sizeof(formats[0]),

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -2100,8 +2100,7 @@ readline(struct archive_read *a, struct mtree *mtree, char **start,
 	ssize_t bytes_read;
 	ssize_t total_size = 0;
 	ssize_t find_off = 0;
-	const void *t;
-	void *nl;
+	const void *nl, *t;
 	char *u;
 
 	/* Accumulate line in a line buffer. */

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -3636,9 +3636,8 @@ readline(struct archive_read *a, struct tar *tar, const char **start,
 {
 	ssize_t bytes_read;
 	ssize_t total_size = 0;
-	const void *t;
+	const void *p, *t;
 	const char *s;
-	void *p;
 
 	if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
 		return (ARCHIVE_FATAL);

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -5537,7 +5537,7 @@ isoent_setup_file_location(struct iso9660 *iso9660, int location)
 static int
 get_path_component(char *name, size_t n, const char *fn)
 {
-	char *p;
+	const char *p;
 	size_t l;
 
 	p = strchr(fn, '/');

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -2039,7 +2039,7 @@ mtree_entry_find_child(struct mtree_entry *parent, const char *child_name)
 static int
 get_path_component(char *name, size_t n, const char *fn)
 {
-	char *p;
+	const char *p;
 	size_t l;
 
 	p = strchr(fn, '/');

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -371,7 +371,7 @@ _popul_ehdr(struct archive_string *tgt, size_t tsz, warc_essential_hdr_t hdr)
 		static const char _uri[] = "";
 		static const char _fil[] = "file://";
 		const char *u;
-		char *chk = strchr(hdr.tgturi, ':');
+		const char *chk = strchr(hdr.tgturi, ':');
 
 		if (chk != NULL && chk[1U] == '/' && chk[2U] == '/') {
 			/* yep, it's definitely a URI */

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -2272,7 +2272,7 @@ file_gen_utility_names(struct archive_write *a, struct file *file)
 static int
 get_path_component(char *name, int n, const char *fn)
 {
-	char *p;
+	const char *p;
 	int l;
 
 	p = strchr(fn, '/');

--- a/libarchive/test/test_write_format_mtree.c
+++ b/libarchive/test/test_write_format_mtree.c
@@ -109,7 +109,7 @@ test_write_format_mtree_sub(int use_set, int dironly)
         assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	if (use_set) {
-		const char *p;
+		char *p;
 
 		buff[used] = '\0';
 		assert(NULL != (p = strstr(buff, "\n/set ")));
@@ -197,7 +197,7 @@ test_write_format_mtree_sub2(int use_set, int dironly)
         assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
   if (use_set) {
-    const char *p;
+    char *p;
 
     buff[used] = '\0';
     assert(NULL != (p = strstr(buff, "\n/set ")));

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -67,7 +67,7 @@ struct bsdtar {
 	/* Miscellaneous state information */
 	int		  argc;
 	char		**argv;
-	const char	 *argument;
+	char		 *argument;
 	size_t		  gs_width; /* For 'list_item' in read.c */
 	size_t		  u_width; /* for 'list_item' in read.c */
 	uid_t		  user_uid; /* UID running this program */


### PR DESCRIPTION
Extends https://github.com/libarchive/libarchive/pull/2866 by adding missing changes. This allows a complete build on Arch Linux with glibc 2.43.

Cherry-picked commits from @heitbaum's PR, so copyright and authorship is kept.