### PR TITLE
build: Add more entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.lo
 *.recipe
 *.sln
+*.slnx
 *.tlog
 *.cmake
 *.vcxproj
@@ -27,6 +28,8 @@ bsdcat
 bsdcpio
 bsdtar
 bsdunzip
+build/.ninja_deps
+build/.ninja_log
 build/autoconf/compile
 build/autoconf/config.guess
 build/autoconf/config.sub
@@ -39,8 +42,10 @@ build/autoconf/ltsugar.m4
 build/autoconf/ltversion.m4
 build/autoconf/lt~obsolete.m4
 build/autoconf/missing
+build/build.ninja
 build/build/pkgconfig/libarchive.pc
 build/cat/test/list.h
+build/compile_commands.json
 build/cpio/test/list.h
 build/libarchive/test/list.h
 build/pkgconfig/libarchive.pc
@@ -80,9 +85,9 @@ libarchive-*.tar.gz
 libarchive-*.zip
 
 Testing/
-libarchive/libarchive.a
-libarchive/libarchive.so
-libarchive/libarchive.so.*
+**/libarchive/libarchive.a
+**/libarchive/libarchive.so
+**/libarchive/libarchive.so.*
 
 .DS_Store
 


### PR DESCRIPTION
Using cmake within VSCode leads to creation of files which are not covered by .gitignore so far. Covers Linux and Windows builds.

It's debatable if build environment files belong into project-specific .gitignore files or a global custom one, but since there are already quite some entries within this file, extend it for missing ones.