### PR TITLE
Fix mem leaks found with ASAN-enabled test suites

### DIFF
--- a/cpio/test/test_extract_cpio_absolute_paths.c
+++ b/cpio/test/test_extract_cpio_absolute_paths.c
@@ -50,4 +50,5 @@ DEFINE_TEST(test_extract_cpio_absolute_paths)
 	r = systemf("%s -i --insecure < archive.cpio 2> stderr3.txt", testprog);
 	assert(r == 0);
 	assertFileExists(temp_absolute_file_name);
+	free(temp_absolute_file_name);
 }

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -2009,6 +2009,7 @@ header_pax_extension(struct archive_read *a, struct tar *tar,
 		/* Consume size, name, and `=` */
 		*unconsumed += p - attr_start;
 		if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
+			archive_string_free(&attr_name);
 			return (ARCHIVE_FATAL);
 		}
 
@@ -2016,6 +2017,7 @@ header_pax_extension(struct archive_read *a, struct tar *tar,
 			archive_set_error(&a->archive, EINVAL,
 					  "Malformed pax attributes");
 			*unconsumed += ext_size + ext_padding;
+			archive_string_free(&attr_name);
 			return (ARCHIVE_WARN);
 		}
 

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1611,6 +1611,7 @@ sum_update(struct mtree_writer *mtree, const void *buff, size_t n)
 static void
 sum_final(struct mtree_writer *mtree, struct reg_info *reg)
 {
+	struct ae_digest digest;
 
 	if (mtree->compute_sum & F_CKSUM) {
 		uint64_t len;
@@ -1620,40 +1621,34 @@ sum_final(struct mtree_writer *mtree, struct reg_info *reg)
 		reg->crc = ~mtree->crc;
 	}
 #ifdef ARCHIVE_HAS_MD5
-	if ((mtree->compute_sum & F_MD5)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_MD5))
+	if (mtree->compute_sum & F_MD5)
 
-		archive_md5_final(&mtree->md5ctx, reg->digest.md5);
+		archive_md5_final(&mtree->md5ctx, (reg->mset_digest & AE_MSET_DIGEST_MD5) ? digest.md5 : reg->digest.md5);
 #endif
 #ifdef ARCHIVE_HAS_RMD160
-	if ((mtree->compute_sum & F_RMD160)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_RMD160))
+	if (mtree->compute_sum & F_RMD160)
 
-		archive_rmd160_final(&mtree->rmd160ctx, reg->digest.rmd160);
+		archive_rmd160_final(&mtree->rmd160ctx, (reg->mset_digest & AE_MSET_DIGEST_RMD160) ? digest.rmd160 : reg->digest.rmd160);
 #endif
 #ifdef ARCHIVE_HAS_SHA1
-	if ((mtree->compute_sum & F_SHA1)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_SHA1))
+	if (mtree->compute_sum & F_SHA1)
 
-		archive_sha1_final(&mtree->sha1ctx, reg->digest.sha1);
+		archive_sha1_final(&mtree->sha1ctx, (reg->mset_digest & AE_MSET_DIGEST_SHA1) ? digest.sha1 : reg->digest.sha1);
 #endif
 #ifdef ARCHIVE_HAS_SHA256
-	if ((mtree->compute_sum & F_SHA256)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_SHA256))
+	if (mtree->compute_sum & F_SHA256)
 
-		archive_sha256_final(&mtree->sha256ctx, reg->digest.sha256);
+		archive_sha256_final(&mtree->sha256ctx, (reg->mset_digest & AE_MSET_DIGEST_SHA256) ? digest.sha256 : reg->digest.sha256);
 #endif
 #ifdef ARCHIVE_HAS_SHA384
-	if ((mtree->compute_sum & F_SHA384)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_SHA384))
+	if (mtree->compute_sum & F_SHA384)
 
-		archive_sha384_final(&mtree->sha384ctx, reg->digest.sha384);
+		archive_sha384_final(&mtree->sha384ctx, (reg->mset_digest & AE_MSET_DIGEST_SHA384) ? digest.sha384 : reg->digest.sha384);
 #endif
 #ifdef ARCHIVE_HAS_SHA512
-	if ((mtree->compute_sum & F_SHA512)
-		&& !(reg->mset_digest & AE_MSET_DIGEST_SHA512))
+	if (mtree->compute_sum & F_SHA512)
 
-		archive_sha512_final(&mtree->sha512ctx, reg->digest.sha512);
+		archive_sha512_final(&mtree->sha512ctx, (reg->mset_digest & AE_MSET_DIGEST_SHA512) ? digest.sha512 : reg->digest.sha512);
 #endif
 	/* Save what types of sum are computed. */
 	reg->compute_sum = mtree->compute_sum;

--- a/libarchive/test/test_archive_string.c
+++ b/libarchive/test/test_archive_string.c
@@ -388,6 +388,7 @@ test_archive_string_dirname(void)
 		archive_string_dirname(&s);
 		assertEqualString(pair->exp, s.s);
 	}
+	archive_string_free(&s);
 }
 
 DEFINE_TEST(test_archive_string)

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -1503,6 +1503,7 @@ DEFINE_TEST(test_read_format_7zip_lzma2_riscv)
 	} else {
 		test_riscv_filter("test_read_format_7zip_lzma2_riscv.7z");
 	}
+	archive_read_free(a);
 #else
 	skipping("This version of liblzma does not support LZMA_FILTER_RISCV");
 #endif

--- a/libarchive/test/test_write_disk_secure_noabsolutepaths.c
+++ b/libarchive/test/test_write_disk_secure_noabsolutepaths.c
@@ -85,4 +85,5 @@ DEFINE_TEST(test_write_disk_secure_noabsolutepaths)
 
 	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(temp_absolute_file_name);
 }

--- a/libarchive/test/test_write_format_mtree_preset_digests.c
+++ b/libarchive/test/test_write_format_mtree_preset_digests.c
@@ -102,7 +102,6 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -131,7 +130,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
@@ -193,7 +192,6 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -222,7 +220,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
@@ -285,7 +283,6 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -314,7 +311,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
@@ -376,7 +373,6 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -403,7 +399,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -470,7 +466,6 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -503,7 +498,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -570,7 +565,6 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -603,7 +597,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -667,7 +661,6 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -694,7 +687,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -761,7 +754,6 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -794,7 +786,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -861,7 +853,6 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -894,7 +885,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -960,7 +951,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -987,7 +977,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1054,7 +1044,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1087,7 +1076,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1154,7 +1143,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1187,7 +1175,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1255,7 +1243,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1282,7 +1269,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1351,7 +1338,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1384,7 +1370,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1453,7 +1439,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1486,7 +1471,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1555,7 +1540,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1582,7 +1566,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1652,7 +1636,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1685,7 +1668,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1755,7 +1738,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1788,7 +1770,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1859,7 +1841,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1887,7 +1868,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_no_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA512");
 	return;
@@ -1959,7 +1940,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -1993,7 +1973,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_empty_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA512");
 	return;
@@ -2065,7 +2045,6 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_non_empty_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
-	assert((entry = archive_entry_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
@@ -2099,7 +2078,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_non_empty_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_entry_free(entry);
+	archive_read_free(a);
 #else
 	skipping("This platform does not support SHA512");
 	return;

--- a/libarchive/test/test_write_format_zip_windows_path.c
+++ b/libarchive/test/test_write_format_zip_windows_path.c
@@ -88,6 +88,7 @@ test_with_hdrcharset(const char *charset)
 	assertEqualInt(2, expected_found);
 	failure("should not find unexpected path in anywhere (charset=%s)", charset);
 	assertEqualInt(0, unexpected_found);
+	free(buff);
 }
 
 DEFINE_TEST(test_write_format_zip_windows_path)

--- a/tar/test/test_option_P_upper.c
+++ b/tar/test/test_option_P_upper.c
@@ -79,4 +79,5 @@ DEFINE_TEST(test_extract_tar_absolute_paths)
 #else
 	assertFileNotExists(temp_absolute_file_name + 1); // Skip the slash.
 #endif
+	free(temp_absolute_file_name);
 }


### PR DESCRIPTION
Two memory leaks exist outside the test suites themselves:
- tar leaks memory in PAX parser error handling
- mtree leaks memory if a checksum but no data is supplied

Both cases were found while running test suites with ASAN, so no new tests added for them.

With this PR applied, at least Linux is able to run a successful default `ninja test` with ASAN enabled.