### PR TITLE
iso9660: Fix OOB during Joliet ID generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -663,6 +663,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_iso9660_bugs.c \
 	libarchive/test/test_write_format_iso9660_empty.c \
 	libarchive/test/test_write_format_iso9660_filename.c \
+	libarchive/test/test_write_format_iso9660_joliet_id.c \
 	libarchive/test/test_write_format_iso9660_zisofs.c \
 	libarchive/test/test_write_format_mtree.c \
 	libarchive/test/test_write_format_mtree_absolute.c \

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -6261,6 +6261,8 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 	static const struct archive_rb_tree_ops rb_ops = {
 		isoent_cmp_node_joliet, isoent_cmp_key_joliet
 	};
+	const int num_size = 6;
+	const int null_size = 2;
 
 	if (isoent->children.cnt == 0)
 		return (0);
@@ -6271,7 +6273,7 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 	else
 		ffmax = 128;
 
-	r = idr_start(a, idr, isoent->children.cnt, (int)ffmax, 6, 2, &rb_ops);
+	r = idr_start(a, idr, isoent->children.cnt, (int)ffmax, num_size, null_size, &rb_ops);
 	if (r < 0)
 		return (r);
 
@@ -6287,7 +6289,7 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 		if ((l = np->file->basename_utf16.length) > ffmax)
 			l = ffmax;
 
-		p = malloc((l+1)*2);
+		p = malloc(l + num_size + null_size);
 		if (p == NULL) {
 			archive_set_error(&a->archive, ENOMEM,
 			    "Can't allocate memory");

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -294,6 +294,7 @@ IF(ENABLE_TEST)
     test_write_format_iso9660_boot.c
     test_write_format_iso9660_empty.c
     test_write_format_iso9660_filename.c
+    test_write_format_iso9660_joliet_id.c
     test_write_format_iso9660_zisofs.c
     test_write_format_iso9660_bugs.c
     test_write_format_mtree.c

--- a/libarchive/test/test_write_format_iso9660_joliet_id.c
+++ b/libarchive/test/test_write_format_iso9660_joliet_id.c
@@ -1,0 +1,113 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * Check that joliet identifier creation avoids naming collision.
+ */
+
+DEFINE_TEST(test_write_format_iso9660_joliet_id)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	unsigned char *buff;
+	size_t buffsize = 190 * 2048;
+	size_t used;
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+	if (buff == NULL)
+		return;
+
+	/* ISO9660 format: Create a new archive in memory. */
+	assert((a = archive_write_new()) != NULL);
+	assertA(0 == archive_write_set_format_iso9660(a));
+	assertA(0 == archive_write_add_filter_none(a));
+	assertA(0 == archive_write_set_bytes_per_block(a, 1));
+	assertA(0 == archive_write_set_bytes_in_last_block(a, 1));
+	assertA(0 == archive_write_open_memory(a, buff, buffsize, &used));
+
+	/* Add ":" entry. */ 
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, ":");
+	archive_entry_set_mode(ae, S_IFDIR | 0755);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Add "_" entry. */ 
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "_");
+	archive_entry_set_mode(ae, S_IFDIR | 0755);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Close out the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+
+	/*
+	 * Read ISO image.
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, 0, archive_read_support_format_all(a));
+	assertEqualIntA(a, 0, archive_read_support_filter_all(a));
+	assertEqualIntA(a, 0, archive_read_open_memory(a, buff, used));
+
+	/*
+	 * Read Root Directory
+	 * Root Directory entry must be in ISO image.
+	 */
+	assertEqualIntA(a, 0, archive_read_next_header(a, &ae));
+	assertEqualInt(archive_entry_atime(ae), archive_entry_ctime(ae));
+	assertEqualInt(archive_entry_atime(ae), archive_entry_mtime(ae));
+	assertEqualString(".", archive_entry_pathname(ae));
+	assert((S_IFDIR | 0555) == archive_entry_mode(ae));
+	assertEqualInt(2048, archive_entry_size(ae));
+
+	/*
+	 * Read ":" entry.
+	 */
+	assertEqualIntA(a, 0, archive_read_next_header(a, &ae));
+	assertEqualString(":", archive_entry_pathname(ae));
+	assert((S_IFDIR | 0555) == archive_entry_mode(ae));
+	assertEqualInt(2048, archive_entry_size(ae));
+
+	/*
+	 * Read "_" entry.
+	 */
+	assertEqualIntA(a, 0, archive_read_next_header(a, &ae));
+	assertEqualString("_", archive_entry_pathname(ae));
+	assert((S_IFDIR | 0555) == archive_entry_mode(ae));
+	assertEqualInt(2048, archive_entry_size(ae));
+
+	/*
+	 * Verify the end of the archive.
+	 */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+
+	free(buff);
+}


### PR DESCRIPTION
It is possible to trigger OOB write during Joliet ID generation if conflicting short filenames are encountered. Solve this by allocating proper amount of memory.

Resolves https://github.com/libarchive/libarchive/issues/2935.