### PR TITLE
cab reader: Fix use of uninitialized values from Huffman table

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -3211,6 +3211,10 @@ lzx_make_huffman_table(struct huffman *hf)
 	bitlen = hf->bitlen;
 	len_avail = hf->len_size;
 	hf->tree_used = 0;
+	/* Initialize table to invalid values */
+	for (i = 0; i < tbl_size; i++) {
+		tbl[i] = (uint16_t)hf->len_size;
+	}
 	for (i = 0; i < len_avail; i++) {
 		uint16_t *p;
 		int len, cnt;


### PR DESCRIPTION
Initialize the Huffman table to invalid values, which doesn't otherwise affect the computation but avoids use of uninitialized values upon extraction of some archives (as reported by `valgrind`).

cc: @bradking 