### PR TITLE
[7zip] Sanity-check the number of files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -474,6 +474,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_7zip_encryption_data.c \
 	libarchive/test/test_read_format_7zip_encryption_partially.c \
 	libarchive/test/test_read_format_7zip_encryption_header.c \
+	libarchive/test/test_read_format_7zip_entries_oom.c \
 	libarchive/test/test_read_format_7zip_issue2765.c \
 	libarchive/test/test_read_format_7zip_malformed.c \
 	libarchive/test/test_read_format_7zip_packinfo_digests.c \
@@ -827,6 +828,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_encryption.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption_header.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption_partially.7z.uu \
+	libarchive/test/test_read_format_7zip_entries_oom.7z.uu \
 	libarchive/test/test_read_format_7zip_extract_second.7z.uu \
 	libarchive/test/test_read_format_7zip_issue2765.7z.uu \
 	libarchive/test/test_read_format_7zip_lzma1.7z.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2808,6 +2808,14 @@ read_Header(struct archive_read *a, struct _7z_header_info *h,
 		return (-1);
 	if (UMAX_ENTRY < zip->numFiles)
 		return (-1);
+	/* Empty-file entries (those beyond the known stream count) require a
+	 * kEmptyStream bitmap of ceil(numFiles/8) bytes; reject if that cannot
+	 * fit in the remaining header bytes. Non-empty files need no header
+	 * space here because they map directly to already-parsed streams. */
+	if (zip->numFiles > (uint64_t)zip->si.ss.unpack_streams &&
+	    zip->numFiles - (uint64_t)zip->si.ss.unpack_streams >
+	    8 * zip->header_bytes_remaining)
+		return (-1);
 
 	zip->entries = calloc((size_t)zip->numFiles, sizeof(*zip->entries));
 	if (zip->entries == NULL)

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -108,6 +108,7 @@ IF(ENABLE_TEST)
     test_read_format_7zip_encryption_data.c
     test_read_format_7zip_encryption_header.c
     test_read_format_7zip_encryption_partially.c
+    test_read_format_7zip_entries_oom.c
     test_read_format_7zip_issue2765.c
     test_read_format_7zip_malformed.c
     test_read_format_7zip_packinfo_digests.c

--- a/libarchive/test/test_read_format_7zip_entries_oom.7z.uu
+++ b/libarchive/test/test_read_format_7zip_entries_oom.7z.uu
@@ -1,0 +1,8 @@
+begin 644 test_read_format_7zip_entries_oom.7z
+M-WJ\KR<<``,%;\HA```````````N`````````,Z^!W,!!>'AX>'AX>'AX>'A
+MX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'A
+MX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'AX>'A
+MX>'AX>'AX>'AX0$.`8`/`8`1#0!E`&T`<`!T`'D````4"@$`@-9``*BRG0$5
+)!@$`(("D@0``
+`
+end

--- a/libarchive/test/test_read_format_7zip_entries_oom.c
+++ b/libarchive/test/test_read_format_7zip_entries_oom.c
@@ -1,0 +1,56 @@
+/*-
+ * Copyright (c) 2026 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * A 7z archive whose FilesInfo section declares far more files than the
+ * remaining header bytes can structurally support previously caused
+ * libarchive to attempt a ~2.5 GiB calloc().  The fix rejects the file
+ * count before allocating: empty-file entries require a kEmptyStream
+ * bitmap of ceil(numFiles/8) bytes, so numFiles beyond the known stream
+ * count cannot exceed 8 * header_bytes_remaining.
+ */
+DEFINE_TEST(test_read_format_7zip_entries_oom)
+{
+	const char *refname = "test_read_format_7zip_entries_oom.7z";
+	struct archive *a;
+	struct archive_entry *ae;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+
+	/*
+	 * Header parsing must fail gracefully rather than attempting a
+	 * multi-gigabyte allocation for the entry array.
+	 */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
We allocate space early on to support the advertised number of files.  A malicious archive can set a nonsensical value here to exhaust memory.  This adds a check comparing the number of files to the number of streams and the size of the total header.