### PR TITLE
7zip: Harden SFX parser

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -533,6 +533,9 @@ static int
 archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 {
 	const unsigned char *p;
+	ssize_t min_addr;
+	ssize_t offset;
+	ssize_t window;
 
 	/* If someone has already bid more than 32, then avoid
 	   trashing the look-ahead buffers with a seek. */
@@ -555,31 +558,34 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 	 * performing a seek, find_elf_data_sec requires one,
 	 * thus a performance difference between the two is expected. 
 	 */
-	if ((p[0] == 'M' && p[1] == 'Z') || memcmp(p, "\x7F\x45LF", 4) == 0) {
-		const ssize_t min_addr = p[0] == 'M' ? find_pe_overlay(a) :
-						       find_elf_data_sec(a);
-		ssize_t offset = min_addr;
-		ssize_t window = 4096;
+	if ((p[0] == 'M' && p[1] == 'Z'))
+		min_addr = find_pe_overlay(a);
+	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
+		min_addr = find_elf_data_sec(a);
+	else
+		return (0);
+
+	offset = min_addr;
+	window = 4096;
+	while (offset + window <= (min_addr + SFX_MAX_OFFSET)) {
 		ssize_t bytes_avail;
-		while (offset + window <= (min_addr + SFX_MAX_OFFSET)) {
-			const unsigned char *buff = __archive_read_ahead(a,
-					offset + window, &bytes_avail);
-			if (buff == NULL) {
-				/* Remaining bytes are less than window. */
-				window >>= 1;
-				if (window < 0x40)
-					return (0);
-				continue;
-			}
-			p = buff + offset;
-			while (p + 32 < buff + bytes_avail) {
-				int step = check_7zip_header_in_sfx(p);
-				if (step == 0)
-					return (48);
-				p += step;
-			}
-			offset = p - buff;
+		const unsigned char *buff = __archive_read_ahead(a,
+				offset + window, &bytes_avail);
+		if (buff == NULL) {
+			/* Remaining bytes are less than window. */
+			window >>= 1;
+			if (window < 0x40)
+				return (0);
+			continue;
 		}
+		p = buff + offset;
+		while (p + 32 < buff + bytes_avail) {
+			int step = check_7zip_header_in_sfx(p);
+			if (step == 0)
+				return (48);
+			p += step;
+		}
+		offset = p - buff;
 	}
 	return (0);
 }

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -449,7 +449,6 @@ static ssize_t	read_stream(struct archive_read *, const void **, size_t,
 		    size_t);
 static int	seek_pack(struct archive_read *);
 static int64_t	skip_stream(struct archive_read *, size_t);
-static int	skip_sfx(struct archive_read *, const ssize_t);
 static int	get_data_offset(struct archive_read *, int64_t *);
 static ssize_t	find_pe_overlay(struct archive_read *);
 static ssize_t	find_elf_data_sec(struct archive_read *);
@@ -539,7 +538,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	ssize_t window;
 
 	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
-		return (ARCHIVE_FATAL);
+		goto fail;
 
 	/* If first six bytes are the 7-Zip signature,
 	 * return the offset right now. */
@@ -561,7 +560,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
 		min_addr = find_elf_data_sec(a);
 	else
-		return (ARCHIVE_FATAL);
+		goto fail;
 
 	offset = min_addr;
 	window = 4096;
@@ -573,7 +572,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 			/* Remaining bytes are less than window. */
 			window >>= 1;
 			if (window < 0x40)
-				return (ARCHIVE_FATAL);
+				goto fail;
 			continue;
 		}
 		p = buff + offset;
@@ -587,6 +586,9 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 		}
 		offset = p - buff;
 	}
+fail:
+	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+	    "Couldn't find out 7-Zip header");
 	return (ARCHIVE_FATAL);
 }
 
@@ -629,63 +631,6 @@ check_7zip_header_in_sfx(const unsigned char *p)
 	case 0x27: return (1);
 	default: return (6);
 	}
-}
-
-static int
-skip_sfx(struct archive_read *a, const ssize_t min_addr)
-{
-	const unsigned char *h, *p, *q;
-	size_t skip, offset;
-	ssize_t bytes, window;
-
-	if (__archive_read_seek(a, min_addr, SEEK_SET) < 0)
-		return (ARCHIVE_FATAL);
-
-	offset = 0;
-	window = 1;
-	while (offset + window <= SFX_MAX_ADDR - SFX_MIN_ADDR) {
-		h = __archive_read_ahead(a, window, &bytes);
-		if (h == NULL) {
-			/* Remaining bytes are less than window. */
-			window >>= 1;
-			if (window < 0x40)
-				goto fatal;
-			continue;
-		}
-		if (bytes < 6) {
-			/* This case might happen when window == 1. */
-			window = 4096;
-			continue;
-		}
-		p = h;
-		q = p + bytes;
-
-		/*
-		 * Scan ahead until we find something that looks
-		 * like the 7-Zip header.
-		 */
-		while (p + 32 < q) {
-			int step = check_7zip_header_in_sfx(p);
-			if (step == 0) {
-				struct _7zip *zip =
-				    (struct _7zip *)a->format->data;
-				skip = p - h;
-				__archive_read_consume(a, skip);
-				zip->seek_base = min_addr + offset + skip;
-				return (ARCHIVE_OK);
-			}
-			p += step;
-		}
-		skip = p - h;
-		__archive_read_consume(a, skip);
-		offset += skip;
-		if (window == 1)
-			window = 4096;
-	}
-fatal:
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
-	    "Couldn't find out 7-Zip header");
-	return (ARCHIVE_FATAL);
 }
 
 static ssize_t
@@ -3255,22 +3200,17 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	uint64_t next_header_size;
 	uint32_t next_header_crc;
 	ssize_t bytes_avail;
+	int64_t data_offset;
 	int check_header_crc, r;
 
+	if (get_data_offset(a, &data_offset) < 0)
+		return (ARCHIVE_FATAL);
+	if (__archive_read_seek(a, data_offset, SEEK_SET) < 0)
+		return (ARCHIVE_FATAL);
 	if ((p = __archive_read_ahead(a, 32, &bytes_avail)) == NULL)
 		return (ARCHIVE_FATAL);
 
-	if ((p[0] == 'M' && p[1] == 'Z') || memcmp(p, "\x7F\x45LF", 4) == 0) {
-		/* This is an executable ? Must be self-extracting... */
-		const ssize_t min_addr = p[0] == 'M' ? find_pe_overlay(a) :
-						       find_elf_data_sec(a);
-		r = skip_sfx(a, min_addr);
-		if (r < ARCHIVE_WARN)
-			return (r);
-		if ((p = __archive_read_ahead(a, 32, &bytes_avail)) == NULL)
-			return (ARCHIVE_FATAL);
-	}
-	zip->seek_base += 32;
+	zip->seek_base = data_offset + 32;
 
 	if (memcmp(p, _7ZIP_SIGNATURE, 6) != 0) {
 		archive_set_error(&a->archive, -1, "Not 7-Zip archive file");

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -407,7 +407,7 @@ static int	archive_read_format_7zip_read_data(struct archive_read *,
 static int	archive_read_format_7zip_read_data_skip(struct archive_read *);
 static int	archive_read_format_7zip_read_header(struct archive_read *,
 		    struct archive_entry *);
-static int	check_7zip_header_in_sfx(const char *);
+static int	check_7zip_header_in_sfx(const unsigned char *);
 static unsigned long decode_codec_id(const unsigned char *, size_t);
 static int	decode_encoded_header_info(struct archive_read *,
 		    struct _7z_stream_info *);
@@ -532,7 +532,7 @@ archive_read_format_7zip_has_encrypted_entries(struct archive_read *_a)
 static int
 archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 {
-	const char *p;
+	const unsigned char *p;
 
 	/* If someone has already bid more than 32, then avoid
 	   trashing the look-ahead buffers with a seek. */
@@ -562,7 +562,7 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 		ssize_t window = 4096;
 		ssize_t bytes_avail;
 		while (offset + window <= (min_addr + SFX_MAX_OFFSET)) {
-			const char *buff = __archive_read_ahead(a,
+			const unsigned char *buff = __archive_read_ahead(a,
 					offset + window, &bytes_avail);
 			if (buff == NULL) {
 				/* Remaining bytes are less than window. */
@@ -585,9 +585,9 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 }
 
 static int
-check_7zip_header_in_sfx(const char *p)
+check_7zip_header_in_sfx(const unsigned char *p)
 {
-	switch ((unsigned char)p[5]) {
+	switch (p[5]) {
 	case 0x1C:
 		if (memcmp(p, _7ZIP_SIGNATURE, 6) != 0)
 			return (6);
@@ -596,8 +596,7 @@ check_7zip_header_in_sfx(const char *p)
 		 * Magic Code, so we should do this in order not to
 		 * make a mis-detection.
 		 */
-		if (crc32(0, (const unsigned char *)p + 12, 20)
-			!= archive_le32dec(p + 8))
+		if (crc32(0, p + 12, 20) != archive_le32dec(p + 8))
 			return (6);
 		/* Hit the header! */
 		return (0);
@@ -613,8 +612,7 @@ check_7zip_header_in_sfx(const char *p)
 static int
 skip_sfx(struct archive_read *a, const ssize_t min_addr)
 {
-	const void *h;
-	const char *p, *q;
+	const unsigned char *h, *p, *q;
 	size_t skip, offset;
 	ssize_t bytes, window;
 
@@ -637,7 +635,7 @@ skip_sfx(struct archive_read *a, const ssize_t min_addr)
 			window = 4096;
 			continue;
 		}
-		p = (const char *)h;
+		p = h;
 		q = p + bytes;
 
 		/*
@@ -649,14 +647,14 @@ skip_sfx(struct archive_read *a, const ssize_t min_addr)
 			if (step == 0) {
 				struct _7zip *zip =
 				    (struct _7zip *)a->format->data;
-				skip = p - (const char *)h;
+				skip = p - h;
 				__archive_read_consume(a, skip);
 				zip->seek_base = min_addr + offset + skip;
 				return (ARCHIVE_OK);
 			}
 			p += step;
 		}
-		skip = p - (const char *)h;
+		skip = p - h;
 		__archive_read_consume(a, skip);
 		offset += skip;
 		if (window == 1)
@@ -3258,7 +3256,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	}
 
 	/* CRC check. */
-	if (crc32(0, (const unsigned char *)p + 12, 20)
+	if (crc32(0, p + 12, 20)
 	    != archive_le32dec(p + 8)) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
 		archive_set_error(&a->archive, -1, "Header CRC error");

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -548,9 +548,9 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	}
 
 	/*
-	 * It may a 7-Zip SFX archive file. If first two bytes are
-	 * 'M' and 'Z' available on Windows or first four bytes are
-	 * "\x7F\x45LF" available on posix like system, seek the 7-Zip
+	 * It may be a 7-Zip SFX archive file. If first two bytes are
+	 * 'M' and 'Z' (PE, Windows) or first four bytes are
+	 * "\x7F\x45LF" (ELF, Posix-like systems), seek the 7-Zip
 	 * signature. While get_pe_sfx_offset can be performed without
 	 * performing a seek, get_elf_sfx_offset requires one,
 	 * thus a performance difference between the two is expected. 

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -67,6 +67,7 @@
 #define SFX_MIN_ADDR	0x27000
 #define SFX_MAX_ADDR	0x60000
 #define SFX_MAX_OFFSET	(SFX_MAX_ADDR - SFX_MIN_ADDR)
+#define SFX_MAX_SEEK	0x800000
 
 /*
  * PE format
@@ -560,7 +561,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 		r = get_elf_sfx_offset(a, &sfx_offset);
 	else
 		r = ARCHIVE_FATAL;
-	if (r < ARCHIVE_WARN)
+	if (r < ARCHIVE_WARN || sfx_offset > SFX_MAX_SEEK)
 		goto fail;
 
 	offset = sfx_offset;
@@ -659,6 +660,9 @@ get_pe_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 			break;
 		}
 		offset = archive_le32dec(h + PE_DOS_HDR_ELFANEW_OFFSET);
+		if (offset > SFX_MAX_SEEK) {
+			return (ARCHIVE_FATAL);
+		}
 
 		/*
 		 * Read COFF header to find opt header size and sec cnt
@@ -685,6 +689,10 @@ get_pe_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 			offset += PE_COFF_HDR_LEN + opt_hdr_sz;
 		} else {
 			break;
+		}
+
+		if (offset + sec_cnt * PE_SEC_HDR_LEN > SFX_MAX_SEEK) {
+			return (ARCHIVE_FATAL);
 		}
 
 		/*
@@ -779,6 +787,10 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 				break;
 		}
 
+		if ((int64_t)e_shoff < 0) {
+			return (ARCHIVE_FATAL);
+		}
+
 		/*
 		 * Reading the section table to find strtab section
 		 */
@@ -789,6 +801,9 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 			request = (size_t)e_shnum * e_shentsize + 0x28;
 		} else {
 			request = (size_t)e_shnum * e_shentsize + 0x18;
+		}
+		if (request > SFX_MAX_SEEK) {
+			return (ARCHIVE_FATAL);
 		}
 		h = __archive_read_ahead(a, request, &bytes);
 		if (h == NULL) {
@@ -805,8 +820,9 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 			strtab_size = (*dec32)(
 			    h + e_shstrndx * e_shentsize + 0x14);
 		}
-		if (strtab_size < 6 || strtab_size > SIZE_MAX)
-			break;
+		if ((int64_t)strtab_offset < 0 || strtab_size < 6 ||
+		    strtab_size > SFX_MAX_SEEK)
+			return (ARCHIVE_FATAL);
 
 		/*
 		 * Read the STRTAB section to find the .data offset

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -450,8 +450,8 @@ static ssize_t	read_stream(struct archive_read *, const void **, size_t,
 static int	seek_pack(struct archive_read *);
 static int64_t	skip_stream(struct archive_read *, size_t);
 static int	get_data_offset(struct archive_read *, int64_t *);
-static int	get_pe_sfx_offset(struct archive_read *, ssize_t *);
-static int	get_elf_sfx_offset(struct archive_read *, ssize_t *);
+static int	get_pe_sfx_offset(struct archive_read *, int64_t *);
+static int	get_elf_sfx_offset(struct archive_read *, int64_t *);
 static int	slurp_central_directory(struct archive_read *, struct _7zip *,
 		    struct _7z_header_info *);
 static int	setup_decode_folder(struct archive_read *, struct _7z_folder *,
@@ -533,10 +533,8 @@ static int
 get_data_offset(struct archive_read *a, int64_t *data_offset)
 {
 	const unsigned char *p;
-	ssize_t min_addr;
-	ssize_t offset;
-	ssize_t window;
-	int r;
+	int64_t offset, sfx_offset;
+	int r, window;
 
 	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
 		goto fail;
@@ -557,17 +555,17 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	 * thus a performance difference between the two is expected. 
 	 */
 	if ((p[0] == 'M' && p[1] == 'Z'))
-		r = get_pe_sfx_offset(a, &min_addr);
+		r = get_pe_sfx_offset(a, &sfx_offset);
 	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
-		r = get_elf_sfx_offset(a, &min_addr);
+		r = get_elf_sfx_offset(a, &sfx_offset);
 	else
 		r = ARCHIVE_FATAL;
 	if (r < ARCHIVE_WARN)
 		goto fail;
 
-	offset = min_addr;
+	offset = sfx_offset;
 	window = 4096;
-	while (offset + window <= (min_addr + SFX_MAX_OFFSET)) {
+	while (offset + window <= (sfx_offset + SFX_MAX_OFFSET)) {
 		ssize_t bytes_avail;
 		const unsigned char *buff = __archive_read_ahead(a,
 				offset + window, &bytes_avail);
@@ -637,16 +635,17 @@ check_7zip_header_in_sfx(const unsigned char *p)
 }
 
 static int
-get_pe_sfx_offset(struct archive_read *a, ssize_t *minaddr)
+get_pe_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 {
 	const char *h;
-	ssize_t bytes, max_offset, offset, sec_end;
-	ssize_t opt_hdr_sz, sec_cnt;
+	int64_t max_offset, offset;
+	ssize_t bytes;
+	uint16_t opt_hdr_sz, sec_cnt;
 
 	/*
 	 * If encounter any weirdness, revert to old brute-force style search
 	 */
-	*minaddr = SFX_MIN_ADDR;
+	*sfx_offset = SFX_MIN_ADDR;
 
 	for (;;) {
 		/*
@@ -700,6 +699,8 @@ get_pe_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 		}
 		max_offset = offset;
 		while (sec_cnt > 0) {
+			uint32_t sec_end;
+
 			sec_end = archive_le32dec(
 				      h + offset + PE_SEC_HDR_RAW_SZ_OFFSET) +
 			    archive_le32dec(
@@ -710,7 +711,7 @@ get_pe_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 			offset += PE_SEC_HDR_LEN;
 			sec_cnt--;
 		}
-		*minaddr = max_offset;
+		*sfx_offset = max_offset;
 		break;
 	}
 
@@ -718,12 +719,12 @@ get_pe_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 }
 
 static int
-get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
+get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 {
 	const char *h;
 	char big_endian, format_64;
 	ssize_t bytes;
-	ssize_t request;
+	size_t request;
 	uint64_t e_shoff, strtab_offset, strtab_size;
 	uint16_t e_shentsize, e_shnum, e_shstrndx;
 	uint16_t (*dec16)(const void *);
@@ -733,7 +734,7 @@ get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 	/*
 	 * If encounter any weirdness, revert to old brute-force style search
 	 */
-	*minaddr = SFX_MIN_ADDR;
+	*sfx_offset = SFX_MIN_ADDR;
 
 	for (;;) {
 		/*
@@ -785,9 +786,9 @@ get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 			return (ARCHIVE_FATAL);
 		}
 		if (format_64) {
-		  request = (size_t)e_shnum * (size_t)e_shentsize + 0x28;
+			request = (size_t)e_shnum * e_shentsize + 0x28;
 		} else {
-		  request = (size_t)e_shnum * (size_t)e_shentsize + 0x18;
+			request = (size_t)e_shnum * e_shentsize + 0x18;
 		}
 		h = __archive_read_ahead(a, request, &bytes);
 		if (h == NULL) {
@@ -817,14 +818,14 @@ get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 		if (h == NULL) {
 			return (ARCHIVE_FATAL);
 		}
-		ssize_t data_sym_offset = -1;
+		size_t data_sym_offset = strtab_size;
 		for (size_t offset = 0; offset < strtab_size - 6; offset++) {
 			if (memcmp(h + offset, ".data\00", 6) == 0) {
 				data_sym_offset = offset;
 				break;
 			}
 		}
-		if (data_sym_offset == -1) {
+		if (data_sym_offset == strtab_size) {
 			break;
 		}
 
@@ -834,15 +835,17 @@ get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 		if (__archive_read_seek(a, e_shoff, SEEK_SET) < 0) {
 			return (ARCHIVE_FATAL);
 		}
-		h = __archive_read_ahead(a, (size_t)e_shnum * (size_t)e_shentsize, NULL);
+		h = __archive_read_ahead(a, (size_t)e_shnum * e_shentsize, NULL);
 		if (h == NULL) {
 			return (ARCHIVE_FATAL);
 		}
-		ssize_t sec_tbl_offset = 0, name_offset;
+		size_t sec_tbl_offset = 0;
 		while (e_shnum > 0) {
+			uint32_t name_offset;
+
 			name_offset = (*dec32)(h + sec_tbl_offset);
 			if (name_offset == data_sym_offset) {
-				uint64_t sel_offset;
+				int64_t sel_offset;
 
 				if (format_64) {
 					sel_offset = (*dec64)(
@@ -851,9 +854,8 @@ get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 					sel_offset = (*dec32)(
 					    h + sec_tbl_offset + 0x10);
 				}
-				if (sel_offset > SSIZE_MAX)
-					break;
-				*minaddr = (ssize_t)sel_offset;
+				if (sel_offset >= 0)
+					*sfx_offset = sel_offset;
 				break;
 			}
 			sec_tbl_offset += e_shentsize;
@@ -3228,7 +3230,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	if ((p = __archive_read_ahead(a, 32, &bytes_avail)) == NULL)
 		return (ARCHIVE_FATAL);
 
-	zip->seek_base = data_offset + 32;
+	zip->seek_base = (uint64_t)data_offset + 32;
 
 	if (memcmp(p, _7ZIP_SIGNATURE, 6) != 0) {
 		archive_set_error(&a->archive, -1, "Not 7-Zip archive file");

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -450,8 +450,8 @@ static ssize_t	read_stream(struct archive_read *, const void **, size_t,
 static int	seek_pack(struct archive_read *);
 static int64_t	skip_stream(struct archive_read *, size_t);
 static int	get_data_offset(struct archive_read *, int64_t *);
-static ssize_t	find_pe_overlay(struct archive_read *);
-static ssize_t	find_elf_data_sec(struct archive_read *);
+static int	get_pe_sfx_offset(struct archive_read *, ssize_t *);
+static int	get_elf_sfx_offset(struct archive_read *, ssize_t *);
 static int	slurp_central_directory(struct archive_read *, struct _7zip *,
 		    struct _7z_header_info *);
 static int	setup_decode_folder(struct archive_read *, struct _7z_folder *,
@@ -536,6 +536,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	ssize_t min_addr;
 	ssize_t offset;
 	ssize_t window;
+	int r;
 
 	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
 		goto fail;
@@ -551,15 +552,17 @@ get_data_offset(struct archive_read *a, int64_t *data_offset)
 	 * It may a 7-Zip SFX archive file. If first two bytes are
 	 * 'M' and 'Z' available on Windows or first four bytes are
 	 * "\x7F\x45LF" available on posix like system, seek the 7-Zip
-	 * signature. While find_pe_overlay can be performed without
-	 * performing a seek, find_elf_data_sec requires one,
+	 * signature. While get_pe_sfx_offset can be performed without
+	 * performing a seek, get_elf_sfx_offset requires one,
 	 * thus a performance difference between the two is expected. 
 	 */
 	if ((p[0] == 'M' && p[1] == 'Z'))
-		min_addr = find_pe_overlay(a);
+		r = get_pe_sfx_offset(a, &min_addr);
 	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
-		min_addr = find_elf_data_sec(a);
+		r = get_elf_sfx_offset(a, &min_addr);
 	else
+		r = ARCHIVE_FATAL;
+	if (r < ARCHIVE_WARN)
 		goto fail;
 
 	offset = min_addr;
@@ -633,19 +636,27 @@ check_7zip_header_in_sfx(const unsigned char *p)
 	}
 }
 
-static ssize_t
-find_pe_overlay(struct archive_read *a)
+static int
+get_pe_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 {
 	const char *h;
 	ssize_t bytes, max_offset, offset, sec_end;
 	ssize_t opt_hdr_sz, sec_cnt;
+
+	/*
+	 * If encounter any weirdness, revert to old brute-force style search
+	 */
+	*minaddr = SFX_MIN_ADDR;
 
 	for (;;) {
 		/*
 		 * Read Dos header to find e_lfanew
 		 */
 		h = __archive_read_ahead(a, PE_DOS_HDR_LEN, &bytes);
-		if (h == NULL || h[0] != 'M' || h[1] != 'Z') {
+		if (h == NULL) {
+			return (ARCHIVE_FATAL);
+		}
+		if (h[0] != 'M' || h[1] != 'Z') {
 			break;
 		}
 		offset = archive_le32dec(h + PE_DOS_HDR_ELFANEW_OFFSET);
@@ -656,8 +667,10 @@ find_pe_overlay(struct archive_read *a)
 		if (bytes < offset + PE_COFF_HDR_LEN) {
 			h = __archive_read_ahead(a, offset + PE_COFF_HDR_LEN,
 			    &bytes);
-			if (h == NULL || h[offset] != 'P' ||
-			    h[offset + 1] != 'E') {
+			if (h == NULL) {
+				return (ARCHIVE_FATAL);
+			}
+			if (h[offset] != 'P' || h[offset + 1] != 'E') {
 				break;
 			}
 		}
@@ -682,7 +695,7 @@ find_pe_overlay(struct archive_read *a)
 			h = __archive_read_ahead(a,
 			    offset + sec_cnt * PE_SEC_HDR_LEN, NULL);
 			if (h == NULL) {
-				break;
+				return (ARCHIVE_FATAL);
 			}
 		}
 		max_offset = offset;
@@ -697,21 +710,19 @@ find_pe_overlay(struct archive_read *a)
 			offset += PE_SEC_HDR_LEN;
 			sec_cnt--;
 		}
-		return (max_offset);
+		*minaddr = max_offset;
+		break;
 	}
 
-	/*
-	 * If encounter any weirdness, revert to old brute-force style search
-	 */
-	return (SFX_MIN_ADDR);
+	return (ARCHIVE_OK);
 }
 
-static ssize_t
-find_elf_data_sec(struct archive_read *a)
+static int
+get_elf_sfx_offset(struct archive_read *a, ssize_t *minaddr)
 {
 	const char *h;
 	char big_endian, format_64;
-	ssize_t bytes, min_addr = SFX_MIN_ADDR;
+	ssize_t bytes;
 	ssize_t request;
 	uint64_t e_shoff, strtab_offset, strtab_size;
 	uint16_t e_shentsize, e_shnum, e_shstrndx;
@@ -719,12 +730,20 @@ find_elf_data_sec(struct archive_read *a)
 	uint32_t (*dec32)(const void *);
 	uint64_t (*dec64)(const void *);
 
+	/*
+	 * If encounter any weirdness, revert to old brute-force style search
+	 */
+	*minaddr = SFX_MIN_ADDR;
+
 	for (;;) {
 		/*
 		 * Read Elf header to find bitness & endianness
 		 */
 		h = __archive_read_ahead(a, ELF_HDR_MIN_LEN, &bytes);
-		if (h == NULL || memcmp(h, "\x7F\x45LF", 4) != 0) {
+		if (h == NULL) {
+			return (ARCHIVE_FATAL);
+		}
+		if (memcmp(h, "\x7F\x45LF", 4) != 0) {
 			break;
 		}
 		format_64 = h[ELF_HDR_EI_CLASS_OFFSET] == 0x2;
@@ -763,7 +782,7 @@ find_elf_data_sec(struct archive_read *a)
 		 * Reading the section table to find strtab section
 		 */
 		if (__archive_read_seek(a, e_shoff, SEEK_SET) < 0) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		if (format_64) {
 		  request = (size_t)e_shnum * (size_t)e_shentsize + 0x28;
@@ -772,7 +791,7 @@ find_elf_data_sec(struct archive_read *a)
 		}
 		h = __archive_read_ahead(a, request, &bytes);
 		if (h == NULL) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		if (format_64) {
 			strtab_offset = (*dec64)(
@@ -792,11 +811,11 @@ find_elf_data_sec(struct archive_read *a)
 		 * Read the STRTAB section to find the .data offset
 		 */
 		if (__archive_read_seek(a, strtab_offset, SEEK_SET) < 0) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		h = __archive_read_ahead(a, strtab_size, NULL);
 		if (h == NULL) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		ssize_t data_sym_offset = -1;
 		for (size_t offset = 0; offset < strtab_size - 6; offset++) {
@@ -813,11 +832,11 @@ find_elf_data_sec(struct archive_read *a)
 		 * Find the section with the .data name
 		 */
 		if (__archive_read_seek(a, e_shoff, SEEK_SET) < 0) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		h = __archive_read_ahead(a, (size_t)e_shnum * (size_t)e_shentsize, NULL);
 		if (h == NULL) {
-			break;
+			return (ARCHIVE_FATAL);
 		}
 		ssize_t sec_tbl_offset = 0, name_offset;
 		while (e_shnum > 0) {
@@ -834,7 +853,7 @@ find_elf_data_sec(struct archive_read *a)
 				}
 				if (sel_offset > SSIZE_MAX)
 					break;
-				min_addr = (ssize_t)sel_offset;
+				*minaddr = (ssize_t)sel_offset;
 				break;
 			}
 			sec_tbl_offset += e_shentsize;
@@ -843,8 +862,7 @@ find_elf_data_sec(struct archive_read *a)
 		break;
 	}
 
-	__archive_read_seek(a, 0, SEEK_SET);
-	return (min_addr);
+	return __archive_read_seek(a, 0, SEEK_SET);
 }
 
 static int

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -450,6 +450,7 @@ static ssize_t	read_stream(struct archive_read *, const void **, size_t,
 static int	seek_pack(struct archive_read *);
 static int64_t	skip_stream(struct archive_read *, size_t);
 static int	skip_sfx(struct archive_read *, const ssize_t);
+static int	get_data_offset(struct archive_read *, int64_t *);
 static ssize_t	find_pe_overlay(struct archive_read *);
 static ssize_t	find_elf_data_sec(struct archive_read *);
 static int	slurp_central_directory(struct archive_read *, struct _7zip *,
@@ -530,25 +531,22 @@ archive_read_format_7zip_has_encrypted_entries(struct archive_read *_a)
 }
 
 static int
-archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
+get_data_offset(struct archive_read *a, int64_t *data_offset)
 {
 	const unsigned char *p;
 	ssize_t min_addr;
 	ssize_t offset;
 	ssize_t window;
 
-	/* If someone has already bid more than 32, then avoid
-	   trashing the look-ahead buffers with a seek. */
-	if (best_bid > 32)
-		return (-1);
-
 	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
-		return (0);
+		return (ARCHIVE_FATAL);
 
 	/* If first six bytes are the 7-Zip signature,
-	 * return the bid right now. */
-	if (memcmp(p, _7ZIP_SIGNATURE, 6) == 0)
-		return (48);
+	 * return the offset right now. */
+	if (memcmp(p, _7ZIP_SIGNATURE, 6) == 0) {
+		*data_offset = 0;
+		return (ARCHIVE_OK);
+	}
 
 	/*
 	 * It may a 7-Zip SFX archive file. If first two bytes are
@@ -563,7 +561,7 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
 		min_addr = find_elf_data_sec(a);
 	else
-		return (0);
+		return (ARCHIVE_FATAL);
 
 	offset = min_addr;
 	window = 4096;
@@ -575,19 +573,37 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 			/* Remaining bytes are less than window. */
 			window >>= 1;
 			if (window < 0x40)
-				return (0);
+				return (ARCHIVE_FATAL);
 			continue;
 		}
 		p = buff + offset;
 		while (p + 32 < buff + bytes_avail) {
 			int step = check_7zip_header_in_sfx(p);
-			if (step == 0)
-				return (48);
+			if (step == 0) {
+				*data_offset = p - buff;
+				return (ARCHIVE_OK);
+			}
 			p += step;
 		}
 		offset = p - buff;
 	}
-	return (0);
+	return (ARCHIVE_FATAL);
+}
+
+static int
+archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
+{
+	int64_t data_offset;
+
+	/* If someone has already bid more than 32, then avoid
+	   trashing the look-ahead buffers with a seek. */
+	if (best_bid > 32)
+		return (-1);
+
+	if (get_data_offset(a, &data_offset) < 0)
+		return (0);
+
+	return (48);
 }
 
 static int


### PR DESCRIPTION
The SFX parser is prone to out of memory conditions due to attacker controlled memory size specifications and possible integer truncations on 32 bit systems.

Increase robustness against both issues and merge bidding and central directory handling to use the exact same code base.

Reported by various individuals:
- Amemoyoi
- b4sh5i
- Jie Zhu
- Tikket
- wooseokdotkim

Supersedes https://github.com/libarchive/libarchive/pull/2770