### PR TITLE
7zip: Add pre-malloc check to prevent heap overflow on 32-bit builds

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3933,6 +3933,13 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 
 			/* Allocate memory for the decoded data of a sub
 			 * stream. */
+			if (zip->folder_outbytes_remaining > SIZE_MAX) {
+				free(b[0]); free(b[1]); free(b[2]);
+				archive_set_error(&a->archive, ENOMEM,
+				    "7-Zip sub-stream size exceeds"
+				    " addressable memory");
+				return (ARCHIVE_FATAL);
+			}
 			b[i] = malloc((size_t)zip->folder_outbytes_remaining);
 			if (b[i] == NULL) {
 				free(b[0]); free(b[1]); free(b[2]);


### PR DESCRIPTION
## Summary

In `setup_decode_folder()`, the BCJ2 source-type-1 path (search: `Source type 1`) copies `folder->unPackSize[0]` and `unPackSize[1]` directly into `sunpack[]` without bounding them to `SIZE_MAX` before the cast in

```c
b[i] = malloc((size_t)zip->folder_outbytes_remaining);
```

On 32-bit platforms `sizeof(size_t)==4`, a crafted archive with `unPackSize = 0x1_0000_0001` truncates to `malloc(1)`.  The subsequent `memcpy` loop then triggers a heap buffer overflow with attacker-controlled write data, leading to DoS/RCE.

## Fix

Reject `zip->folder_outbytes_remaining > SIZE_MAX`.

## PoC

```
begin 664 poc.7z
M-WJ\KR<<``17P*Y]$`````````!1`````````)X!HE=-04E.4U5",5-50C)3
M54(S`00&``0)!`0$!``'"P$`!`$``0`!`!0#`P$;!`$%`@0!`P```0(&#/@!
G`````?@!`````00$``@```4!$1$`<`!O`&,`+@!T`'@`=```````
`
end
```
