### PR TITLE
[CAB] Harden the handling of invalid headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -485,6 +485,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_cab.c \
 	libarchive/test/test_read_format_cab_filename.c \
 	libarchive/test/test_read_format_cab_lzx_oob.c \
+	libarchive/test/test_read_format_cab_mszip_oob.c \
 	libarchive/test/test_read_format_cab_skip_malformed.c \
 	libarchive/test/test_read_format_cpio_afio.c \
 	libarchive/test/test_read_format_cpio_bin.c \

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1336,6 +1336,10 @@ cab_next_cfdata(struct archive_read *a)
 	}
 	return (ARCHIVE_OK);
 invalid:
+	cfdata->compressed_size = 0;
+	cfdata->compressed_bytes_remaining = 0;
+	cfdata->uncompressed_size = 0;
+	cfdata->uncompressed_bytes_remaining = 0;
 	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 	    "Invalid CFDATA");
 	return (ARCHIVE_FATAL);
@@ -1478,6 +1482,14 @@ cab_read_ahead_cfdata_deflate(struct archive_read *a, ssize_t *avail)
 		    cab->uncompressed_buffer + cab->stream.total_out;
 		cab->stream.avail_out =
 		    cfdata->uncompressed_size - cab->stream.total_out;
+		if ((size_t)cfdata->uncompressed_size >
+		    cab->uncompressed_buffer_size) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Invalid CFDATA uncompressed size");
+			*avail = ARCHIVE_FATAL;
+			return (NULL);
+		}
 
 		d = __archive_read_ahead(a, 1, &bytes_avail);
 		if (bytes_avail <= 0) {

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -119,6 +119,7 @@ IF(ENABLE_TEST)
     test_read_format_cab.c
     test_read_format_cab_filename.c
     test_read_format_cab_lzx_oob.c
+    test_read_format_cab_mszip_oob.c
     test_read_format_cab_skip_malformed.c
     test_read_format_cpio_afio.c
     test_read_format_cpio_bin.c

--- a/libarchive/test/test_read_format_cab_mszip_oob.c
+++ b/libarchive/test/test_read_format_cab_mszip_oob.c
@@ -1,0 +1,87 @@
+#include "test.h"
+
+/*
+ * Regression test for OOB read/write in the CAB MSZIP decoder.
+ *
+ * A crafted CFDATA block carries a stored-block deflate header whose LEN
+ * field (0x9000) is larger than the actual compressed payload.  Without the
+ * fix, the decoder reads one byte past the end of the input buffer on the
+ * second archive_read_next_header() call (after the first call returns
+ * ARCHIVE_FATAL due to the truncated payload).
+ */
+DEFINE_TEST(test_read_format_cab_mszip_oob)
+{
+	const uint16_t LEN   = 0x9000;
+	const uint16_t NLEN  = (uint16_t)~LEN;
+	const uint8_t  first = 0xFF;
+
+	/*
+	 * cbData and cbUncomp are chosen so that the two-byte sequences they
+	 * occupy inside the CFDATA header also form a valid deflate stored-block
+	 * length / complement pair when the decoder's read pointer is positioned
+	 * one field early.
+	 */
+	const uint16_t cbData   = (LEN  >> 8) | ((NLEN & 0xff) << 8);
+	const uint16_t cbUncomp = (NLEN >> 8) | ((uint16_t)first << 8);
+
+	const size_t payload = (size_t)LEN - 1;   /* one byte short of LEN */
+	const size_t total   = 36 + 8 + 18 + 8 + payload;
+
+	uint8_t *b = (uint8_t *)calloc(1, total);
+	assert(b != NULL);
+
+	/* CFHEADER (36 bytes) */
+	memcpy(b, "MSCF", 4);
+	b[8]  = (uint8_t)(total);
+	b[9]  = (uint8_t)(total >> 8);
+	b[10] = (uint8_t)(total >> 16);
+	b[11] = (uint8_t)(total >> 24);
+	b[16] = 44;                     /* coffFiles: first CFFILE at offset 44 */
+	b[24] = 3;  b[25] = 1;          /* version 1.3 */
+	b[26] = 1;                      /* cFolders = 1 */
+	b[28] = 1;                      /* cFiles   = 1 */
+
+	/* CFFOLDER (8 bytes at offset 36) */
+	b[36] = 62;                     /* coffCabStart: first CFDATA at offset 62 */
+	b[40] = 1;                      /* cCFData = 1 */
+	b[42] = 0x01;                   /* typeCompress = MSZIP */
+
+	/* CFFILE (18 bytes at offset 44) */
+	b[44] = 0x00; b[45] = 0x01;     /* cbFile = 0x100 */
+	b[54] = 0x21;                   /* date low */
+	b[58] = 0x20;                   /* attribs low */
+	b[60] = 'a';  b[61] = 0;        /* szName "a" */
+
+	/* CFDATA header (8 bytes at offset 62) */
+	b[62] = 0x43; b[63] = 0x4B;     /* checksum bytes (also MSZIP "CK" marker) */
+	b[64] = 0x01;
+	b[65] = (uint8_t)(LEN & 0xff);
+	b[66] = (uint8_t)(cbData);
+	b[67] = (uint8_t)(cbData >> 8);
+	b[68] = (uint8_t)(cbUncomp);
+	b[69] = (uint8_t)(cbUncomp >> 8);
+
+	/* Compressed payload: one byte short of what the stored-block LEN claims */
+	memset(b + 70, first, payload);
+
+	/* Open the crafted archive from memory */
+	struct archive *a = archive_read_new();
+	assert(a != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_cab(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, b, total));
+
+	/*
+	 * Drive the read loop the same way the PoC does.  The first
+	 * archive_read_data() call is expected to fail (ARCHIVE_FATAL or
+	 * ARCHIVE_FAILED) because the payload is truncated.  The second
+	 * archive_read_next_header() call is where the OOB access occurs in
+	 * unfixed code; it must return an error rather than corrupt memory.
+	 */
+	struct archive_entry *ae;
+	char buf[4096];
+	while (archive_read_next_header(a, &ae) == ARCHIVE_OK)
+		archive_read_data(a, buf, sizeof(buf));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(b);
+}


### PR DESCRIPTION
Clear invalid data when a header is invalid.
Check for data being larger than the allocated buffer.

Thanks to @ReverseWarrior for pointing out this issue, and providing the fix.