### PR TITLE
mtree: Do not append '/' when basename is '.'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -662,6 +662,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_iso9660_filename.c \
 	libarchive/test/test_write_format_iso9660_zisofs.c \
 	libarchive/test/test_write_format_mtree.c \
+	libarchive/test/test_write_format_mtree_absolute.c \
 	libarchive/test/test_write_format_mtree_absolute_path.c \
 	libarchive/test/test_write_format_mtree_classic.c \
 	libarchive/test/test_write_format_mtree_classic_indent.c\

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -988,7 +988,8 @@ write_mtree_entry(struct archive_write *a, struct mtree_entry *me)
 		 * a full pathname.
 		 */
 		mtree_quote(str, me->parentdir.s);
-		archive_strappend_char(str, '/');
+		if (strcmp(me->basename.s, ".") != 0)
+			archive_strappend_char(str, '/');
 	}
 	mtree_quote(str, me->basename.s);
 

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -294,6 +294,7 @@ IF(ENABLE_TEST)
     test_write_format_iso9660_filename.c
     test_write_format_iso9660_zisofs.c
     test_write_format_mtree.c
+    test_write_format_mtree_absolute.c
     test_write_format_mtree_absolute_path.c
     test_write_format_mtree_classic.c
     test_write_format_mtree_classic_indent.c

--- a/libarchive/test/test_write_format_mtree_absolute.c
+++ b/libarchive/test/test_write_format_mtree_absolute.c
@@ -1,0 +1,132 @@
+/*-
+ * Copyright (c) 2012 Michihiro NAKAJIMA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+static char buff[4096];
+static struct {
+	const char	*path;
+	mode_t		 mode;
+	int		 nlink;
+	time_t		 mtime;
+	uid_t		 uid;
+	gid_t		 gid;
+} entries[] = {
+	{ ".",			S_IFDIR | 0755, 3, 1231975636, 1001, 1001 },
+	{ "./COPYING",		S_IFREG | 0644, 1, 1231975636, 1001, 1001 },
+	{ "./Makefile",		S_IFREG | 0644, 1, 1233041050, 1001, 1001 },
+	{ "./NEWS",		S_IFREG | 0644, 1, 1231975636, 1001, 1001 },
+	{ "./PROJECTS",		S_IFREG | 0644, 1, 1231975636, 1001, 1001 },
+	{ "./README",		S_IFREG | 0644, 1, 1231975636, 1001, 1001 },
+	{ "./subdir",		S_IFDIR | 0755, 3, 1233504586, 1001, 1001 },
+	{ "./subdir/README",	S_IFREG | 0664, 1, 1231975636, 1002, 1001 },
+	{ "./subdir/config",	S_IFREG | 0664, 1, 1232266273, 1003, 1003 },
+	{ "./subdir2",		S_IFDIR | 0755, 3, 1233504586, 1001, 1001 },
+	{ "./subdir3",		S_IFDIR | 0755, 3, 1233504586, 1001, 1001 },
+	{ "./subdir3/mtree",	S_IFREG | 0664, 2, 1232266273, 1003, 1003 },
+	{ NULL, 0, 0, 0, 0, 0 }
+};
+
+static const char image [] = {
+"#mtree\n"
+". time=1231975636.0 mode=755 gid=1001 uid=1001 type=dir\n"
+"./COPYING time=1231975636.0 mode=644 gid=1001 uid=1001 type=file size=8\n"
+"./Makefile time=1233041050.0 mode=644 gid=1001 uid=1001 type=file size=8\n"
+"./NEWS time=1231975636.0 mode=644 gid=1001 uid=1001 type=file size=8\n"
+"./PROJECTS time=1231975636.0 mode=644 gid=1001 uid=1001 type=file size=8\n"
+"./README time=1231975636.0 mode=644 gid=1001 uid=1001 type=file size=8\n"
+"./subdir time=1233504586.0 mode=755 gid=1001 uid=1001 type=dir\n"
+"./subdir/README time=1231975636.0 mode=664 gid=1001 uid=1002 type=file size=8\n"
+"./subdir/config time=1232266273.0 mode=664 gid=1003 uid=1003 type=file size=8\n"
+"./subdir2 time=1233504586.0 mode=755 gid=1001 uid=1001 type=dir\n"
+"./subdir3 time=1233504586.0 mode=755 gid=1001 uid=1001 type=dir\n"
+"./subdir3/mtree nlink=2 time=1232266273.0 mode=664 gid=1003 uid=1003 type=file size=8\n"
+};
+
+DEFINE_TEST(test_write_format_mtree_absolute)
+{
+	struct archive_entry *ae;
+	struct archive* a;
+	size_t used;
+	int i;
+
+	/* Create a mtree format archive. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff) - 1, &used));
+
+	/* Write entries */
+	for (i = 0; entries[i].path != NULL; i++) {
+		assert((ae = archive_entry_new()) != NULL);
+		archive_entry_set_nlink(ae, entries[i].nlink);
+		assertEqualInt(entries[i].nlink, archive_entry_nlink(ae));
+		archive_entry_set_mtime(ae, entries[i].mtime, 0);
+		assertEqualInt(entries[i].mtime, archive_entry_mtime(ae));
+		archive_entry_set_mode(ae, entries[i].mode);
+		assertEqualInt(entries[i].mode, archive_entry_mode(ae));
+		archive_entry_set_uid(ae, entries[i].uid);
+		assertEqualInt(entries[i].uid, archive_entry_uid(ae));
+		archive_entry_set_gid(ae, entries[i].gid);
+		assertEqualInt(entries[i].gid, archive_entry_gid(ae));
+		archive_entry_copy_pathname(ae, entries[i].path);
+		if ((entries[i].mode & AE_IFMT) != S_IFDIR)
+			archive_entry_set_size(ae, 8);
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+		if ((entries[i].mode & AE_IFMT) != S_IFDIR)
+			assertEqualIntA(a, 8,
+			    archive_write_data(a, "Hello012", 15));
+		archive_entry_free(ae);
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	buff[used] = '\0';
+	assertEqualString(buff, image);
+
+	/*
+	 * Read the data and check it.
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+
+	/* Read entries */
+	for (i = 0; entries[i].path != NULL; i++) {
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+		assertEqualInt(entries[i].mtime, archive_entry_mtime(ae));
+		assertEqualInt(entries[i].mode, archive_entry_mode(ae));
+		assertEqualInt(entries[i].uid, archive_entry_uid(ae));
+		assertEqualInt(entries[i].gid, archive_entry_gid(ae));
+		assertEqualString(entries[i].path,
+		    archive_entry_pathname(ae));
+		if ((entries[i].mode & AE_IFMT) != S_IFDIR)
+			assertEqualInt(8, archive_entry_size(ae));
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
If the basename is '.', it means it is the root directory ('/').  Do not append '/' to '.', as this will produce a path '/.', resulting in an invalid mtree entry.

For example, using base.txz from FreeBSD:

    tar -c -f - --format=mtree @base.txz | mtree -C