### PR TITLE
Date parsing: reject dates with numbers of more than 4 digits

### DIFF
--- a/libarchive/archive_parse_date.c
+++ b/libarchive/archive_parse_date.c
@@ -823,8 +823,8 @@ RelativeMonth(time_t Start, time_t Timezone, time_t RelMonth)
  */
 static uint64_t
 consume_unsigned_number(const char **in) {
-	const static uint64_t limit = (UINT64_MAX / 10);
-	const static uint64_t final_digit = (UINT64_MAX % 10);
+	static const uint64_t limit = (UINT64_MAX / 10);
+	static const uint64_t final_digit = (UINT64_MAX % 10);
 
 	uint64_t value = 0;
 	unsigned char c;

--- a/libarchive/archive_parse_date.c
+++ b/libarchive/archive_parse_date.c
@@ -49,7 +49,7 @@ enum DSTMODE { DSTon, DSToff, DSTmaybe };
 enum { tAM, tPM };
 /* Token types returned by nexttoken() */
 enum { tAGO = 260, tDAY, tDAYZONE, tAMPM, tMONTH, tMONTH_UNIT, tSEC_UNIT,
-       tUNUMBER, tZONE, tDST };
+       tUNUMBER, tZONE, tDST, tERROR };
 struct token { int token; time_t value; };
 
 /*
@@ -818,20 +818,36 @@ RelativeMonth(time_t Start, time_t Timezone, time_t RelMonth)
 }
 
 /*
- * Parses and consumes an unsigned number.
- * Returns 1 if any number is parsed. Otherwise, *value is unchanged.
+ * Parses and consumes an unsigned 64-bit number.
+ * Returns UINT64_MAX if the number overflows.
  */
-static char
-consume_unsigned_number(const char **in, time_t *value)
-{
-	char c;
-	if (isdigit((unsigned char)(c = **in))) {
-		for (*value = 0; isdigit((unsigned char)(c = *(*in)++)); )
-			*value = 10 * *value + c - '0';
-		(*in)--;
-		return 1;
+static uint64_t
+consume_unsigned_number(const char **in) {
+	const static uint64_t limit = (UINT64_MAX / 10);
+	const static uint64_t final_digit = (UINT64_MAX % 10);
+
+	uint64_t value = 0;
+	unsigned char c;
+
+	/* Get the first character, abort if it's not a digit */
+	c = (unsigned char)(**in);
+	if (c < '0' || c > '9') {
+		return UINT64_MAX;
 	}
-	return 0;
+
+	/* Fold digits into the value, abort on overflow */
+	while (c >= '0' && c <= '9') {
+		unsigned char digit = c - '0';
+
+		/* Return error if the result would overflow UINT64_MAX */
+		if (value > limit || (value == limit && final_digit > digit)) {
+			return UINT64_MAX;
+		}
+		value = 10 * value + c - '0';
+		(*in)++;
+		c = (unsigned char)(**in);
+	}
+	return value;
 }
 
 /*
@@ -906,12 +922,19 @@ nexttoken(const char **in, time_t *value)
 		}
 
 		/*
-		 * Not in the word table, maybe it's a number.  Note:
-		 * Because '-' and '+' have other special meanings, I
-		 * don't deal with signed numbers here.
+		 * Not in the word table. If it starts with a digit,
+		 * it must be a number. Note: Because '-' and '+' have
+		 * other special meanings, I don't deal with signed
+		 * numbers here.
 		 */
-		if (consume_unsigned_number(in, value)) {
-			return (tUNUMBER);
+		if (isdigit((unsigned char)(**in))) {
+			uint64_t val = consume_unsigned_number(in);
+			if (val > 9999) {
+				return (tERROR);
+			} else {
+				*value = val;
+				return (tUNUMBER);
+			}
 		}
 
 		return *(*in)++;
@@ -949,6 +972,7 @@ difftm (struct tm *a, struct tm *b)
 static time_t
 parse_unix_epoch(const char *p)
 {
+	uint64_t val;
 	time_t epoch;
 
 	/* may begin with + */
@@ -957,12 +981,18 @@ parse_unix_epoch(const char *p)
 	}
 
 	/* followed by some number */
-	if (!consume_unsigned_number(&p, &epoch))
+	val = consume_unsigned_number(&p);
+	/* Truncate to time_t */
+	epoch = (time_t)val;
+	/* If truncated value is different, then
+	 * the value is too large for `time_t`. */
+	if (epoch < 0 || (uint64_t)epoch != val) {
 		return (time_t)-1;
-
-	/* ...and nothing else */
-	if (*p != '\0')
+	}
+	/* If there's any more characters, fail. */
+	if (*p != '\0') {
 		return (time_t)-1;
+	}
 
 	return epoch;
 }

--- a/libarchive/test/test_archive_parse_date.c
+++ b/libarchive/test/test_archive_parse_date.c
@@ -36,64 +36,69 @@ DEFINE_TEST(test_archive_parse_date)
 {
 	time_t now = time(NULL);
 
-	assertEqualInt(get_date(now, "Jan 1, 1970 UTC"), 0);
-	assertEqualInt(get_date(now, "7:12:18-0530 4 May 1983"), 420900138);
-	assertEqualInt(get_date(now, "2004/01/29 513 mest"), 1075345980);
-	assertEqualInt(get_date(now, "2038-06-01 00:01:02 UTC"),
+	assertEqualInt(archive_parse_date(now, "Jan 1, 1970 UTC"), 0);
+	assertEqualInt(archive_parse_date(now, "7:12:18-0530 4 May 1983"), 420900138);
+	assertEqualInt(archive_parse_date(now, "2004/01/29 513 mest"), 1075345980);
+	assertEqualInt(archive_parse_date(now, "2038-06-01 00:01:02 UTC"),
 	    sizeof(time_t) <= 4 ? -1 : 2158963262);
-	assertEqualInt(get_date(now, "99/02/17 7pm utc"), 919278000);
-	assertEqualInt(get_date(now, "02/17/99 7:11am est"), 919253460);
-	assertEqualInt(get_date(now, "now - 2 hours"),
-	    get_date(now, "2 hours ago"));
-	assertEqualInt(get_date(now, "2 hours ago"),
-	    get_date(now, "+2 hours ago"));
-	assertEqualInt(get_date(now, "now - 2 hours"),
-	    get_date(now, "-2 hours"));
+	assertEqualInt(archive_parse_date(now, "99/02/17 7pm utc"), 919278000);
+	assertEqualInt(archive_parse_date(now, "02/17/99 7:11am est"), 919253460);
+	assertEqualInt(archive_parse_date(now, "now - 2 hours"),
+	    archive_parse_date(now, "2 hours ago"));
+	assertEqualInt(archive_parse_date(now, "2 hours ago"),
+	    archive_parse_date(now, "+2 hours ago"));
+	assertEqualInt(archive_parse_date(now, "now - 2 hours"),
+	    archive_parse_date(now, "-2 hours"));
 	/* It's important that we handle ctime() format. */
-	assertEqualInt(get_date(now, "Sun Feb 22 17:38:26 PST 2009"),
+	assertEqualInt(archive_parse_date(now, "Sun Feb 22 17:38:26 PST 2009"),
 	    1235353106);
 	/* Basic relative offsets. */
 	/* If we use the actual current time as the reference, then
 	 * these tests break around DST changes, so it's actually
 	 * important to use a specific reference time here. */
-	assertEqualInt(get_date(0, "tomorrow"), 24 * 60 * 60);
-	assertEqualInt(get_date(0, "yesterday"), - 24 * 60 * 60);
-	assertEqualInt(get_date(0, "now + 1 hour"), 60 * 60);
-	assertEqualInt(get_date(0, "now + 1 hour + 1 minute"), 60 * 60 + 60);
+	assertEqualInt(archive_parse_date(0, "tomorrow"), 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(0, "yesterday"), - 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(0, "now + 1 hour"), 60 * 60);
+	assertEqualInt(archive_parse_date(0, "now + 1 hour + 1 minute"), 60 * 60 + 60);
 	/* Repeat the above for a different start time. */
 	now = 1231113600; /* Jan 5, 2009 00:00 UTC */
-	assertEqualInt(get_date(0, "Jan 5, 2009 00:00 UTC"), now);
-	assertEqualInt(get_date(now, "tomorrow"), now + 24 * 60 * 60);
-	assertEqualInt(get_date(now, "yesterday"), now - 24 * 60 * 60);
-	assertEqualInt(get_date(now, "now + 1 hour"), now + 60 * 60);
-	assertEqualInt(get_date(now, "now + 1 hour + 1 minute"),
+	assertEqualInt(archive_parse_date(0, "Jan 5, 2009 00:00 UTC"), now);
+	assertEqualInt(archive_parse_date(now, "tomorrow"), now + 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(now, "yesterday"), now - 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(now, "now + 1 hour"), now + 60 * 60);
+	assertEqualInt(archive_parse_date(now, "now + 1 hour + 1 minute"),
 	    now + 60 * 60 + 60);
-	assertEqualInt(get_date(now, "tomorrow 5:16am UTC"),
+	assertEqualInt(archive_parse_date(now, "tomorrow 5:16am UTC"),
 	    now + 24 * 60 * 60 + 5 * 60 * 60 + 16 * 60);
-	assertEqualInt(get_date(now, "UTC 5:16am tomorrow"),
+	assertEqualInt(archive_parse_date(now, "UTC 5:16am tomorrow"),
 	    now + 24 * 60 * 60 + 5 * 60 * 60 + 16 * 60);
 
 	/* Jan 5, 2009 was a Monday. */
-	assertEqualInt(get_date(now, "monday UTC"), now);
-	assertEqualInt(get_date(now, "sunday UTC"), now + 6 * 24 * 60 * 60);
-	assertEqualInt(get_date(now, "tuesday UTC"), now + 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(now, "monday UTC"), now);
+	assertEqualInt(archive_parse_date(now, "sunday UTC"), now + 6 * 24 * 60 * 60);
+	assertEqualInt(archive_parse_date(now, "tuesday UTC"), now + 24 * 60 * 60);
 	/* "next tuesday" is one week after "tuesday" */
-	assertEqualInt(get_date(now, "UTC next tuesday"),
+	assertEqualInt(archive_parse_date(now, "UTC next tuesday"),
 	    now + 8 * 24 * 60 * 60);
 	/* "last tuesday" is one week before "tuesday" */
-	assertEqualInt(get_date(now, "last tuesday UTC"),
+	assertEqualInt(archive_parse_date(now, "last tuesday UTC"),
 	    now - 6 * 24 * 60 * 60);
 
 	/* Unix epoch timestamps */
-	assertEqualInt(get_date(now, "@0"), 0);
-	assertEqualInt(get_date(now, "@100"), 100);
-	assertEqualInt(get_date(now, "@+100"), 100);
+	assertEqualInt(archive_parse_date(now, "@0"), 0);
+	assertEqualInt(archive_parse_date(now, "@100"), 100);
+	assertEqualInt(archive_parse_date(now, "@1000000000"), 1000000000);
+	assertEqualInt(archive_parse_date(now, "@+100"), 100);
 
-	assertEqualInt(get_date(now, "@"), -1);
-	assertEqualInt(get_date(now, "@-"), -1);
-	assertEqualInt(get_date(now, "@+"), -1);
-	assertEqualInt(get_date(now, "@tenth"), -1);
-	assertEqualInt(get_date(now, "@100 tomorrow"), -1);
+	assertEqualInt(archive_parse_date(now, "@"), -1);
+	assertEqualInt(archive_parse_date(now, "@-"), -1);
+	assertEqualInt(archive_parse_date(now, "@+"), -1);
+	assertEqualInt(archive_parse_date(now, "@tenth"), -1);
+	assertEqualInt(archive_parse_date(now, "@100 tomorrow"), -1);
 
-	/* TODO: Lots more tests here. */
+	/* Verify handling of overlarge numbers */
+	assertEqualInt(archive_parse_date(now, "Jan 1, 9999 UTC"), 253375948800LL);
+	assertEqualInt(archive_parse_date(now, "Jan 1, 10000 UTC"), -1);
+	assertEqualInt(archive_parse_date(now, "Jan 1, 99999 UTC"), -1);
+	assertEqualInt(archive_parse_date(time(NULL), "2147483647-01-01 00:00:00"), -1);
 }


### PR DESCRIPTION
We don't support date formats with numbers of more than 4 digits, so this is always correct.

It also avoids a time-consuming leap-year correction for nonsensically large dates.