### PR TITLE
[pathmatch] Heap buffer over-read

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -397,6 +397,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_match_time.c \
 	libarchive/test/test_archive_parse_date.c \
 	libarchive/test/test_archive_pathmatch.c \
+	libarchive/test/test_archive_pathmatch_oob.c \
 	libarchive/test/test_archive_read.c \
 	libarchive/test/test_archive_read_add_passphrase.c \
 	libarchive/test/test_archive_read_close_twice.c \
@@ -726,6 +727,8 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_acl_pax_posix1e.tar.uu \
 	libarchive/test/test_acl_pax_nfs4.tar.uu \
 	libarchive/test/test_archive_string_conversion.txt.Z.uu \
+	libarchive/test/test_archive_pathmatch_oob_bracket.bin.uu \
+	libarchive/test/test_archive_pathmatch_oob_strchr.bin.uu \
 	libarchive/test/test_compat_bzip2_1.tbz.uu \
 	libarchive/test/test_compat_bzip2_2.tbz.uu \
 	libarchive/test/test_compat_cpio_1.cpio.uu \

--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -220,7 +220,7 @@ pm(const char *p, const char *s, int flags)
 			}
 			if (*end == ']') {
 				/* We found [...], try to match it. */
-				if (!pm_list(p + 1, end, *s, flags))
+				if (*s == '\0' || !pm_list(p + 1, end, *s, flags))
 					return (0);
 				p = end; /* Jump to trailing ']' char. */
 				break;

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -29,6 +29,7 @@ IF(ENABLE_TEST)
     test_archive_match_time.c
     test_archive_parse_date.c
     test_archive_pathmatch.c
+    test_archive_pathmatch_oob.c
     test_archive_read.c
     test_archive_read_add_passphrase.c
     test_archive_read_close_twice.c

--- a/libarchive/test/test_archive_pathmatch_oob.c
+++ b/libarchive/test/test_archive_pathmatch_oob.c
@@ -1,0 +1,117 @@
+/*-
+ * Copyright (c) 2025 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Regression test: malformed bracket expressions in patterns caused
+ * heap-buffer-overflow reads in pm() (BUG-003) and strchr OOB via
+ * archive_match (BUG-007).
+ *
+ * To reproduce under ASan, we must allocate tight heap buffers for the
+ * pattern and string (just like the fuzzer does), so that ASan's
+ * redzones detect overreads.
+ */
+
+/* Declare the internal function we want to test. */
+int __archive_pathmatch(const char *pattern, const char *string, int flags);
+
+/*
+ * Replay a fuzzer repro file through __archive_pathmatch().
+ * Format: byte 0 = flags, then rest is split at first '\0' into
+ * pattern and string, each copied into tight malloc'd buffers.
+ */
+static void
+replay_pathmatch_repro(const char *refname)
+{
+	FILE *f;
+	unsigned char buf[4096];
+	size_t size, split, rest_len, str_start, str_len;
+	const unsigned char *rest;
+	char *pattern, *string;
+	int flags;
+	size_t i;
+
+	extract_reference_file(refname);
+
+	f = fopen(refname, "rb");
+	if (!assert(f != NULL))
+		return;
+	size = fread(buf, 1, sizeof(buf), f);
+	fclose(f);
+	if (!assert(size >= 4))
+		return;
+
+	flags = buf[0] % 8;
+	rest = buf + 1;
+	rest_len = size - 1;
+
+	/* Find split point (first null byte in rest). */
+	split = 0;
+	for (i = 0; i < rest_len; i++) {
+		if (rest[i] == 0) {
+			split = i;
+			break;
+		}
+	}
+	if (split == 0)
+		split = rest_len / 2;
+
+	/* Allocate tight buffers so ASan can detect overreads. */
+	pattern = (char *)malloc(split + 1);
+	if (!assert(pattern != NULL))
+		return;
+	memcpy(pattern, rest, split);
+	pattern[split] = '\0';
+
+	str_start = (split < rest_len && rest[split] == 0)
+	    ? split + 1 : split;
+	str_len = rest_len - str_start;
+	string = (char *)malloc(str_len + 1);
+	if (!assert(string != NULL)) {
+		free(pattern);
+		return;
+	}
+	memcpy(string, rest + str_start, str_len);
+	string[str_len] = '\0';
+
+	/* This must not read past the allocated buffers. */
+	__archive_pathmatch(pattern, string, flags);
+
+	free(pattern);
+	free(string);
+}
+
+DEFINE_TEST(test_archive_pathmatch_oob_bracket)
+{
+	replay_pathmatch_repro("test_archive_pathmatch_oob_bracket.bin");
+}
+
+DEFINE_TEST(test_archive_pathmatch_oob_strchr)
+{
+	replay_pathmatch_repro("test_archive_pathmatch_oob_strchr.bin");
+}

--- a/libarchive/test/test_archive_pathmatch_oob_bracket.bin.uu
+++ b/libarchive/test/test_archive_pathmatch_oob_bracket.bin.uu
@@ -1,0 +1,4 @@
+begin 644 test_archive_pathmatch_oob_bracket.bin
+,6ULAC"&,*HPJ73\`
+`
+end

--- a/libarchive/test/test_archive_pathmatch_oob_strchr.bin.uu
+++ b/libarchive/test/test_archive_pathmatch_oob_strchr.bin.uu
@@ -1,0 +1,8 @@
+begin 644 test_archive_pathmatch_oob_strchr.bin
+M`2H_*C];(0(M7%@K,`+;725S871U<F1A>5SX*@`!*ELI+2]=`0!A$``!9(`!
+M*BI;(0(J72KEY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7E
+MY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>7EY>4``0@"`0`0&@``*@`J*BH`
+M`2HJ*@``)```&P`!*"HJ``$`"#\D```J`"JJ``(`T@(J*@`#`"H``2HJ*@`!
+'*@"3`5L``@``
+`
+end


### PR DESCRIPTION
The bracket expression matching [ in the pathmatch engine fails to handle malformed patterns, specifically when a closing ] is missing or when high-byte characters are used. The scanner advances the pattern pointer beyond the allocated buffer.

Reported-by: Kamil Frankowicz