### PR TITLE
[XAR] Fix two UB

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -724,6 +724,7 @@ libarchive_TESTS_ENVIRONMENT= LIBARCHIVE_TEST_FILES=`cd $(top_srcdir);/bin/pwd`/
 
 libarchive_test_EXTRA_DIST=\
 	libarchive/test/list.h \
+	libarchive/test/test_fuzz_consumer.h \
 	libarchive/test/test_acl_pax_posix1e.tar.uu \
 	libarchive/test/test_acl_pax_nfs4.tar.uu \
 	libarchive/test/test_archive_string_conversion.txt.Z.uu \

--- a/Makefile.am
+++ b/Makefile.am
@@ -681,6 +681,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_warc.c \
 	libarchive/test/test_write_format_warc_empty.c \
 	libarchive/test/test_write_format_xar.c \
+	libarchive/test/test_write_format_xar_bugs.c \
 	libarchive/test/test_write_format_xar_empty.c \
 	libarchive/test/test_write_format_zip.c \
 	libarchive/test/test_write_format_zip64_stream.c \
@@ -1115,6 +1116,8 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_write_disk_hfs_compression.tgz.uu \
 	libarchive/test/test_write_disk_mac_metadata.tar.gz.uu \
 	libarchive/test/test_write_disk_no_hfs_compression.tgz.uu \
+	libarchive/test/test_write_format_xar_strcpy_overlap.bin.uu \
+	libarchive/test/test_write_format_xar_underflow.bin.uu \
 	libarchive/test/CMakeLists.txt \
 	libarchive/test/README
 

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -2211,10 +2211,10 @@ file_gen_utility_names(struct archive_write *a, struct file *file)
 					--rp;
 				}
 				if (rp > dirname) {
-					strcpy(rp, p+3);
+					memmove(rp, p+3, strlen(p+3) + 1);
 					p = rp;
 				} else {
-					strcpy(dirname, p+4);
+					memmove(dirname, p+4, strlen(p+4) + 1);
 					p = dirname;
 				}
 			} else
@@ -2378,9 +2378,23 @@ file_tree(struct archive_write *a, struct file **filepp)
 
 			archive_string_init(&as);
 			archive_strncat(&as, p, fn - p + l);
-			if (as.s[as.length-1] == '/') {
+			if (as.length > 0 && as.s[as.length-1] == '/') {
 				as.s[as.length-1] = '\0';
 				as.length--;
+			}
+			if (as.length == 0) {
+				archive_string_free(&as);
+				fn += strspn(fn, "/");
+				l = get_path_component(name, sizeof(name), fn);
+				if (l < 0) {
+					archive_set_error(&a->archive,
+					    ARCHIVE_ERRNO_MISC,
+					    "A name buffer is too small");
+					file_free(file);
+					*filepp = NULL;
+					return (ARCHIVE_FATAL);
+				}
+				continue;
 			}
 			vp = file_create_virtual_dir(a, xar, as.s);
 			if (vp == NULL) {

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -314,6 +314,7 @@ IF(ENABLE_TEST)
     test_write_format_warc_empty.c
     test_write_format_xar.c
     test_write_format_xar_empty.c
+    test_write_format_xar_bugs.c
     test_write_format_zip.c
     test_write_format_zip64_stream.c
     test_write_format_zip_compression_store.c

--- a/libarchive/test/test_fuzz_consumer.h
+++ b/libarchive/test/test_fuzz_consumer.h
@@ -1,0 +1,136 @@
+/*-
+ * Copyright (c) 2025 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * C99 equivalent of the DataConsumer class used by the C++ fuzzers.
+ * Consumes bytes sequentially from a buffer, matching the fuzzer protocol.
+ */
+#ifndef TEST_FUZZ_CONSUMER_H
+#define TEST_FUZZ_CONSUMER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+struct fuzz_consumer {
+	const uint8_t *data;
+	size_t size;
+	size_t pos;
+	char string_buf[512];
+};
+
+static void
+fuzz_consumer_init(struct fuzz_consumer *c, const uint8_t *data, size_t size)
+{
+	c->data = data;
+	c->size = size;
+	c->pos = 0;
+}
+
+static size_t
+fuzz_consumer_remaining(const struct fuzz_consumer *c)
+{
+	return c->size - c->pos;
+}
+
+static uint8_t
+fuzz_consume_byte(struct fuzz_consumer *c)
+{
+	if (c->pos >= c->size)
+		return 0;
+	return c->data[c->pos++];
+}
+
+static uint16_t
+fuzz_consume_u16(struct fuzz_consumer *c)
+{
+	uint16_t val = 0;
+	if (c->pos + 2 <= c->size) {
+		val = (uint16_t)c->data[c->pos]
+		    | ((uint16_t)c->data[c->pos + 1] << 8);
+		c->pos += 2;
+	}
+	return val;
+}
+
+static uint32_t
+fuzz_consume_u32(struct fuzz_consumer *c)
+{
+	uint32_t val = 0;
+	if (c->pos + 4 <= c->size) {
+		val = (uint32_t)c->data[c->pos]
+		    | ((uint32_t)c->data[c->pos + 1] << 8)
+		    | ((uint32_t)c->data[c->pos + 2] << 16)
+		    | ((uint32_t)c->data[c->pos + 3] << 24);
+		c->pos += 4;
+	}
+	return val;
+}
+
+static int64_t
+fuzz_consume_i64(struct fuzz_consumer *c)
+{
+	int64_t val = 0;
+	if (c->pos + 8 <= c->size) {
+		int i;
+		for (i = 0; i < 8; i++)
+			val |= (int64_t)c->data[c->pos + i] << (8 * i);
+		c->pos += 8;
+	}
+	return val;
+}
+
+static const char *
+fuzz_consume_string(struct fuzz_consumer *c, size_t max_len)
+{
+	size_t avail, len, actual_len;
+	if (max_len > sizeof(c->string_buf) - 1)
+		max_len = sizeof(c->string_buf) - 1;
+	avail = c->size - c->pos;
+	len = (avail < max_len) ? avail : max_len;
+	actual_len = 0;
+	while (actual_len < len && c->pos < c->size) {
+		char ch = (char)c->data[c->pos++];
+		if (ch == '\0')
+			break;
+		c->string_buf[actual_len++] = ch;
+	}
+	c->string_buf[actual_len] = '\0';
+	return c->string_buf;
+}
+
+static size_t
+fuzz_consume_bytes(struct fuzz_consumer *c, void *out, size_t len)
+{
+	size_t avail = c->size - c->pos;
+	size_t to_copy = (avail < len) ? avail : len;
+	if (to_copy > 0) {
+		memcpy(out, c->data + c->pos, to_copy);
+		c->pos += to_copy;
+	}
+	return to_copy;
+}
+
+#endif /* TEST_FUZZ_CONSUMER_H */

--- a/libarchive/test/test_write_format_xar_bugs.c
+++ b/libarchive/test/test_write_format_xar_bugs.c
@@ -1,0 +1,172 @@
+/*-
+ * Copyright (c) 2025 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+#include "test_fuzz_consumer.h"
+
+#include <stdlib.h>
+#include <sys/stat.h>
+
+/*
+ * Replay a fuzzer binary through the XAR writer, matching the protocol
+ * in fuzzers/custom/fuzz_writer_xar.cc.
+ */
+static void
+replay_xar_writer(const char *refname)
+{
+	FILE *f;
+	uint8_t raw[16384];
+	size_t rawsize;
+	struct fuzz_consumer consumer;
+	uint8_t opts, num_entries;
+	struct archive *a;
+	struct archive_entry *entry;
+	size_t used;
+	char *out_buf;
+	int i;
+
+	extract_reference_file(refname);
+	f = fopen(refname, "rb");
+	if (!assert(f != NULL))
+		return;
+	rawsize = fread(raw, 1, sizeof(raw), f);
+	fclose(f);
+	if (!assert(rawsize >= 6))
+		return;
+
+	fuzz_consumer_init(&consumer, raw, rawsize);
+	opts = fuzz_consume_byte(&consumer);
+	num_entries = (fuzz_consume_byte(&consumer) % 5) + 1;
+
+	a = archive_write_new();
+	if (!assert(a != NULL))
+		return;
+
+	archive_write_set_format_xar(a);
+	archive_write_add_filter_none(a);
+
+	if (opts & 0x01)
+		archive_write_set_options(a, "xar:compression=gzip");
+	if (opts & 0x02)
+		archive_write_set_options(a, "xar:compression=bzip2");
+	if (opts & 0x04)
+		archive_write_set_options(a, "xar:checksum=sha1");
+	if (opts & 0x08)
+		archive_write_set_options(a, "xar:checksum=md5");
+
+	out_buf = (char *)malloc(512 * 1024);
+	if (!assert(out_buf != NULL)) {
+		archive_write_free(a);
+		return;
+	}
+	if (archive_write_open_memory(a, out_buf, 512 * 1024, &used)
+	    != ARCHIVE_OK) {
+		archive_write_free(a);
+		free(out_buf);
+		return;
+	}
+
+	entry = archive_entry_new();
+	if (!assert(entry != NULL)) {
+		archive_write_free(a);
+		free(out_buf);
+		return;
+	}
+
+	for (i = 0; i < num_entries && fuzz_consumer_remaining(&consumer) > 4;
+	    i++) {
+		const char *path;
+		uint8_t ftype;
+		uint16_t raw_mode;
+		mode_t mode;
+		int64_t file_size = 0;
+
+		archive_entry_clear(entry);
+
+		path = fuzz_consume_string(&consumer, 200);
+		if (path[0] == '\0')
+			path = "file.txt";
+		archive_entry_set_pathname(entry, path);
+
+		ftype = fuzz_consume_byte(&consumer) % 4;
+		raw_mode = fuzz_consume_u16(&consumer) & 07777;
+		switch (ftype) {
+		case 0: mode = raw_mode | S_IFREG; break;
+		case 1: mode = raw_mode | S_IFDIR; break;
+		case 2: mode = raw_mode | S_IFLNK; break;
+		default: mode = raw_mode | S_IFCHR; break;
+		}
+		archive_entry_set_mode(entry, mode);
+
+		archive_entry_set_uname(entry,
+		    fuzz_consume_string(&consumer, 32));
+		archive_entry_set_gname(entry,
+		    fuzz_consume_string(&consumer, 32));
+		archive_entry_set_uid(entry, fuzz_consume_u32(&consumer));
+		archive_entry_set_gid(entry, fuzz_consume_u32(&consumer));
+		archive_entry_set_mtime(entry,
+		    fuzz_consume_i64(&consumer), fuzz_consume_u32(&consumer));
+		archive_entry_set_atime(entry,
+		    fuzz_consume_i64(&consumer), 0);
+		archive_entry_set_ctime(entry,
+		    fuzz_consume_i64(&consumer), 0);
+
+		if ((mode & S_IFMT) == S_IFREG) {
+			file_size = fuzz_consume_byte(&consumer) % 200;
+			archive_entry_set_size(entry, file_size);
+		}
+
+		if ((mode & S_IFMT) == S_IFLNK)
+			archive_entry_set_symlink(entry,
+			    fuzz_consume_string(&consumer, 64));
+
+		if (archive_write_header(a, entry) == ARCHIVE_OK
+		    && file_size > 0) {
+			size_t write_len = (size_t)file_size;
+			if (write_len > fuzz_consumer_remaining(&consumer))
+				write_len = fuzz_consumer_remaining(&consumer);
+			if (write_len > 0) {
+				uint8_t file_data[200];
+				fuzz_consume_bytes(&consumer, file_data,
+				    write_len);
+				archive_write_data(a, file_data, write_len);
+			}
+		}
+	}
+
+	archive_entry_free(entry);
+	archive_write_close(a);
+	archive_write_free(a);
+	free(out_buf);
+}
+
+DEFINE_TEST(test_write_format_xar_strcpy_overlap)
+{
+	replay_xar_writer("test_write_format_xar_strcpy_overlap.bin");
+}
+
+DEFINE_TEST(test_write_format_xar_underflow)
+{
+	replay_xar_writer("test_write_format_xar_underflow.bin");
+}

--- a/libarchive/test/test_write_format_xar_bugs.c
+++ b/libarchive/test/test_write_format_xar_bugs.c
@@ -26,7 +26,6 @@
 #include "test_fuzz_consumer.h"
 
 #include <stdlib.h>
-#include <sys/stat.h>
 
 /*
  * Replay a fuzzer binary through the XAR writer, matching the protocol
@@ -99,7 +98,6 @@ replay_xar_writer(const char *refname)
 		const char *path;
 		uint8_t ftype;
 		uint16_t raw_mode;
-		mode_t mode;
 		int64_t file_size = 0;
 
 		archive_entry_clear(entry);
@@ -112,12 +110,12 @@ replay_xar_writer(const char *refname)
 		ftype = fuzz_consume_byte(&consumer) % 4;
 		raw_mode = fuzz_consume_u16(&consumer) & 07777;
 		switch (ftype) {
-		case 0: mode = raw_mode | S_IFREG; break;
-		case 1: mode = raw_mode | S_IFDIR; break;
-		case 2: mode = raw_mode | S_IFLNK; break;
-		default: mode = raw_mode | S_IFCHR; break;
+		case 0: archive_entry_set_filetype(entry, AE_IFREG); break;
+		case 1: archive_entry_set_filetype(entry, AE_IFDIR); break;
+		case 2: archive_entry_set_filetype(entry, AE_IFLNK); break;
+		default: archive_entry_set_filetype(entry, AE_IFCHR); break;
 		}
-		archive_entry_set_mode(entry, mode);
+		archive_entry_set_perm(entry, raw_mode);
 
 		archive_entry_set_uname(entry,
 		    fuzz_consume_string(&consumer, 32));
@@ -132,12 +130,12 @@ replay_xar_writer(const char *refname)
 		archive_entry_set_ctime(entry,
 		    fuzz_consume_i64(&consumer), 0);
 
-		if ((mode & S_IFMT) == S_IFREG) {
+		if (ftype == 0) {
 			file_size = fuzz_consume_byte(&consumer) % 200;
 			archive_entry_set_size(entry, file_size);
 		}
 
-		if ((mode & S_IFMT) == S_IFLNK)
+		if (ftype == 2)
 			archive_entry_set_symlink(entry,
 			    fuzz_consume_string(&consumer, 64));
 

--- a/libarchive/test/test_write_format_xar_strcpy_overlap.bin.uu
+++ b/libarchive/test/test_write_format_xar_strcpy_overlap.bin.uu
@@ -1,0 +1,6 @@
+begin 644 test_write_format_xar_strcpy_overlap.bin
+M=&EI9/____\L261I+&1I+"\N+B\L9"UF+&8L+(0M:2YT9C8L+RXN+R\N+B]T
+M+(0M9C8L+RXN+R\N+F8L9BPLA"UF9$G_-BPO+B[__XLN+R\N+B]T+(0M9C8L
+.+RXN+R\N:2XO/2]T=/\`
+`
+end

--- a/libarchive/test/test_write_format_xar_underflow.bin.uu
+++ b/libarchive/test/test_write_format_xar_underflow.bin.uu
@@ -1,0 +1,6 @@
+begin 644 test_write_format_xar_underflow.bin
+M=&EI9/____\L261I+&1I+"\N+B\L9"UF+&8L+(0M:2YT9C8L+RXN+R\N+B]T
+M+(0M9C8L+RXN+R\N+F8L9BPLA"UF9$G_-BPO+B[__XLN+R\N+B]T+(0M9C8L
+.+RXN+R\N:2XO/2]T=/\`
+`
+end


### PR DESCRIPTION
1. The XAR writer's path normalization code uses strcpy() to move parts of a path string within the same buffer. The source and destination ranges overlap, which is undefined behavior for strcpy().

2. Failure to check string length before accessing the last character of a path component. For empty components (e.g., //), the length is 0, and length-1 underflows to SIZE_MAX.

Reported-by: Kamil Frankowicz