### PR TITLE
[test_utils] Fix a minor UB

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -4311,7 +4311,7 @@ sparc_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 	size &= ~(size_t)3;
 
 	for (i = 0; i < size; i += 4) {
-		instr = (uint32_t)(buf[i] << 24)
+		instr = ((uint32_t)buf[i] << 24)
 			| ((uint32_t)buf[i+1] << 16)
 			| ((uint32_t)buf[i+2] << 8)
 			| (uint32_t)buf[i+3];

--- a/test_utils/test_utils.c
+++ b/test_utils/test_utils.c
@@ -149,7 +149,7 @@ unsigned int
 i4le(const void* p_)
 {
 	const char *p = p_;
-	return (i2le(p) | (i2le(p + 2) << 16));
+	return (i2le(p) | ((unsigned int)i2le(p + 2) << 16));
 }
 unsigned long long
 i8le(const void* p_)


### PR DESCRIPTION
(UBSan occasionally finds something interesting and often reports whacky non-bugs like this one. "Fixing" it will make the real UB bugs easier to identify, so...)

According to C's integer promotion rules, `unsigned short` gets promoted to _signed_ `int`, and shifting into the sign bit of an `int` is technically UB.  Explicit cast to `unsigned` quiets UBSan.