### PR TITLE
[sparse] UAF in sparse_reset

### DIFF
--- a/libarchive/archive_entry_sparse.c
+++ b/libarchive/archive_entry_sparse.c
@@ -127,9 +127,10 @@ archive_entry_sparse_count(struct archive_entry *entry)
 int
 archive_entry_sparse_reset(struct archive_entry * entry)
 {
+	/* Counting can change sparse_head, so do it first */
+	int count = archive_entry_sparse_count(entry);
 	entry->sparse_p = entry->sparse_head;
-
-	return archive_entry_sparse_count(entry);
+	return (count);
 }
 
 int


### PR DESCRIPTION
sparse_count normalizes the list, which can change the head pointer, so we need to do that before storing the new head.