### PR TITLE
xar: Do not modify variables in DEBUG block

### DIFF
--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -2685,11 +2685,12 @@ xml_data(void *userData, const char *s, size_t len)
 #if DEBUG
 	{
 		char buff[1024];
-		if (len > (int)(sizeof(buff)-1))
-			len = (int)(sizeof(buff)-1);
-		strncpy(buff, s, len);
-		buff[len] = 0;
-		fprintf(stderr, "\tlen=%d:\"%s\"\n", len, buff);
+		size_t dlen = len;
+		if (dlen > sizeof(buff) - 1)
+			dlen = sizeof(buff) - 1;
+		strncpy(buff, s, dlen);
+		buff[dlen] = 0;
+		fprintf(stderr, "\tlen=%zu:\"%s\"\n", dlen, buff);
 	}
 #endif
 	switch (xar->xmlsts) {


### PR DESCRIPTION
The len variable is used later on. Introduce a new one (debug length) to limit the amount of characters written to stderr.

Could be further improved with %.*s but let's keep it as simple as possible, since DEBUG is not default and has to be manually set in line 89.