### PR TITLE
iso9660: Fix memory leaks on error paths

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1170,6 +1170,7 @@ archive_write_set_format_iso9660(struct archive *_a)
 	iso9660->cur_dirent = iso9660->primary.rootent;
 	archive_string_init(&(iso9660->cur_dirstr));
 	if (archive_string_ensure(&(iso9660->cur_dirstr), 1) == NULL) {
+		free(iso9660->cur_dirent);
 		free(iso9660);
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory");
@@ -6764,7 +6765,12 @@ isoent_rr_move_dir(struct archive_write *a, struct isoent **rr_moved,
 	/*
 	 * The mvent becomes a child of the rr_moved entry.
 	 */
-	isoent_add_child_tail(rrmoved, mvent);
+	if (!isoent_add_child_tail(rrmoved, mvent)) {
+		_isoent_free(mvent);
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Unable to insert rr_moved entry");
+		return (ARCHIVE_FATAL);
+	}
 	archive_entry_set_nlink(rrmoved->file->entry,
 	    archive_entry_nlink(rrmoved->file->entry) + 1);
 	/*


### PR DESCRIPTION
- Release memory in case of allocation failure.
- Treat failure to add an entry to rr_moved as fatal error

Fixes ASAN test run with test_write_format_iso9660_null_deref:

```
./libarchive_test test_write_format_iso9660_null_deref
```
```
Direct leak of 240 byte(s) in 1 object(s) allocated from:
    #0 0x7fac1c12bf49 in calloc (/usr/lib/libasan.so.8+0x12bf49) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x563c5d20f7a1 in isoent_clone ../libarchive/archive_write_set_format_iso9660.c:5181
    #2 0x563c5d20f7a1 in isoent_rr_move_dir ../libarchive/archive_write_set_format_iso9660.c:6779
    #3 0x563c5d20f7a1 in isoent_rr_move ../libarchive/archive_write_set_format_iso9660.c:6875
    #4 0x563c5d20f7a1 in isoent_make_path_table ../libarchive/archive_write_set_format_iso9660.c:7132
    #5 0x563c5d20f7a1 in iso9660_close ../libarchive/archive_write_set_format_iso9660.c:1940
```

There are some more unchecked `isoent_add_child_tail` callers, but I'm definitely not experienced enough with the ISO9660 writer code to know how to properly handle these.