### PR TITLE
Port iso9660 fix for `..` (dot dot) path normalization to mtree and xar

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -670,6 +670,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_mtree_absolute_path.c \
 	libarchive/test/test_write_format_mtree_classic.c \
 	libarchive/test/test_write_format_mtree_classic_indent.c\
+	libarchive/test/test_write_format_mtree_dotdot.c \
 	libarchive/test/test_write_format_mtree_fflags.c \
 	libarchive/test/test_write_format_mtree_no_separator.c \
 	libarchive/test/test_write_format_mtree_preset_digests.c \

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1884,20 +1884,29 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 				 *     --> 'dir/dir2/'
 				 */
 				char *rp = p -1;
+				size_t off;
+				for (off = 4; p[off] == '/'; off++)
+					;
 				while (rp >= dirname) {
 					if (*rp == '/')
 						break;
 					--rp;
 				}
 				if (rp > dirname) {
-					strcpy(rp, p+3);
+					memmove(rp + 1, p + off, strlen(p + off) + 1);
 					p = rp;
 				} else {
-					strcpy(dirname, p+4);
+					memmove(dirname, p + off, strlen(p + off) + 1);
 					p = dirname;
 				}
 			} else
 				p++;
+		} else if (p == dirname && p[0] == '.' && p[1] == '.' && p[2] == '/') {
+			size_t off;
+			for (off = 3; p[off] == '/'; off++)
+				;
+			memmove(dirname, p + off, strlen(p + off) + 1);
+			p = dirname;
 		} else
 			p++;
 	}

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -2205,20 +2205,29 @@ file_gen_utility_names(struct archive_write *a, struct file *file)
 				 *     --> 'dir/dir2/'
 				 */
 				char *rp = p -1;
+				size_t off;
+				for (off = 4; p[off] == '/'; off++)
+					;
 				while (rp >= dirname) {
 					if (*rp == '/')
 						break;
 					--rp;
 				}
 				if (rp > dirname) {
-					memmove(rp, p+3, strlen(p+3) + 1);
+					memmove(rp + 1, p + off, strlen(p + off) + 1);
 					p = rp;
 				} else {
-					memmove(dirname, p+4, strlen(p+4) + 1);
+					memmove(dirname, p + off, strlen(p + off) + 1);
 					p = dirname;
 				}
 			} else
 				p++;
+		} else if (p == dirname && p[0] == '.' && p[1] == '.' && p[2] == '/') {
+			size_t off;
+			for (off = 3; p[off] == '/'; off++)
+				;
+			memmove(dirname, p + off, strlen(p + off) + 1);
+			p = dirname;
 		} else
 			p++;
 	}

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -302,6 +302,7 @@ IF(ENABLE_TEST)
     test_write_format_mtree_absolute_path.c
     test_write_format_mtree_classic.c
     test_write_format_mtree_classic_indent.c
+    test_write_format_mtree_dotdot.c
     test_write_format_mtree_fflags.c
     test_write_format_mtree_no_separator.c
     test_write_format_mtree_preset_digests.c

--- a/libarchive/test/test_write_format_mtree_dotdot.c
+++ b/libarchive/test/test_write_format_mtree_dotdot.c
@@ -1,0 +1,103 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
+static char buff[4096];
+
+DEFINE_TEST(test_write_format_mtree_dotdot)
+{
+	struct archive_entry *ae;
+	struct archive* a;
+	size_t used;
+
+	/* Create an mtree format archive. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff)-1, &used));
+
+	/* Write "./dir0/dir1" directory.  */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "./dir0/dir1");
+	archive_entry_set_mode(ae, AE_IFDIR | 0755);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Write "dir0/../../dir0/dir1/file1" file.  */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "dir0/../../dir0/dir1/file1");
+	archive_entry_set_size(ae, 0);
+	archive_entry_set_mode(ae, AE_IFREG | 0644);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Write "dir0/..//dir0/dir1/file2" file.  */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "dir0/..//dir0/dir1/file2");
+	archive_entry_set_size(ae, 0);
+	archive_entry_set_mode(ae, AE_IFREG | 0644);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/*
+	 * Read the data and check it.
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+
+	/* Read "./dir0/dir1" directory. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	failure("The path should be just \"./dir0/dir1\"");
+	assertEqualString(archive_entry_pathname(ae), "./dir0/dir1");
+	assertEqualInt(archive_entry_mode(ae), AE_IFDIR | 0755);
+
+	/* Read "./dir0/dir1/file1" file. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	failure("The path should be just \"./dir0/dir1/file1\"");
+	assertEqualString(archive_entry_pathname(ae), "./dir0/dir1/file1");
+	assertEqualInt(archive_entry_mode(ae), AE_IFREG | 0644);
+
+	/* Read "./dir0/dir1/file2" file. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	failure("The path should be just \"./dir0/dir1/file2\"");
+	assertEqualString(archive_entry_pathname(ae), "./dir0/dir1/file2");
+	assertEqualInt(archive_entry_size(ae), 0);
+	assertEqualInt(archive_entry_mode(ae), AE_IFREG | 0644);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -93,13 +93,13 @@ test_xar(const char *option)
 	archive_entry_free(ae);
 
 	/*
-	 * "dir/file3" has a bunch of attributes and 8 bytes of data.
+	 * "dir/file" has a bunch of attributes and 8 bytes of data.
 	 */
 	assert((ae = archive_entry_new()) != NULL);
 	archive_entry_set_atime(ae, 2, 20);
 	archive_entry_set_ctime(ae, 4, 40);
 	archive_entry_set_mtime(ae, 5, 50);
-	archive_entry_copy_pathname(ae, "dir/file");
+	archive_entry_copy_pathname(ae, "dir/../../dir/file");
 	archive_entry_set_mode(ae, AE_IFREG | 0755);
 	archive_entry_set_size(ae, 8);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
@@ -113,7 +113,7 @@ test_xar(const char *option)
 	archive_entry_set_atime(ae, 2, 20);
 	archive_entry_set_ctime(ae, 4, 40);
 	archive_entry_set_mtime(ae, 5, 50);
-	archive_entry_copy_pathname(ae, "dir/dir2/file4");
+	archive_entry_copy_pathname(ae, "dir/..//dir/dir2/file4");
 	archive_entry_copy_hardlink(ae, "file");
 	archive_entry_set_mode(ae, AE_IFREG | 0755);
 	archive_entry_set_nlink(ae, 2);


### PR DESCRIPTION
The PR https://github.com/libarchive/libarchive/pull/2968 fixed ISO9660 dot dot handling, which was discovered due to a subsequent OOB read. Such a read does not happen in mtree or xar, but both share the same code, which means that the functional errors exist there as well.

Also fixes an overlapping strcpy in mtree, which was already fixed in xar.

Eventually, this functionality should be separated into its own source file to reduce amount of redundant code.