### PR TITLE
7zip: reject malformed substream metadata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -881,6 +881,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_malformed.7z.uu \
 	libarchive/test/test_read_format_7zip_malformed2.7z.uu \
 	libarchive/test/test_read_format_7zip_malformed3.7z.uu \
+	libarchive/test/test_read_format_7zip_malformed4.7z.uu \
 	libarchive/test/test_read_format_7zip_packinfo_digests.7z.uu \
 	libarchive/test/test_read_format_7zip_ppmd.7z.uu \
 	libarchive/test/test_read_format_7zip_sfx_elf.elf.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2557,9 +2557,8 @@ read_SubStreamsInfo(struct archive_read *a, struct _7z_substream_info *ss,
 		for (i = 0; i < numFolders; i++) {
 			if (parse_7zip_uint64(a, &(f[i].numUnpackStreams)) < 0)
 				return (-1);
-			if (UMAX_ENTRY < f[i].numUnpackStreams)
-				return (-1);
-			if (unpack_streams > SIZE_MAX - UMAX_ENTRY) {
+			if (f[i].numUnpackStreams >
+			    UMAX_ENTRY - unpack_streams) {
 				return (-1);
 			}
 			unpack_streams += (size_t)f[i].numUnpackStreams;
@@ -2569,6 +2568,13 @@ read_SubStreamsInfo(struct archive_read *a, struct _7z_substream_info *ss,
 		type = *p;
 	} else
 		unpack_streams = numFolders;
+
+	if (type != kSize) {
+		for (i = 0; i < numFolders; i++) {
+			if (f[i].numUnpackStreams > 1)
+				return (-1);
+		}
+	}
 
 	ss->unpack_streams = unpack_streams;
 	if (unpack_streams) {
@@ -2611,11 +2617,6 @@ read_SubStreamsInfo(struct archive_read *a, struct _7z_substream_info *ss,
 		if ((p = header_bytes(a, 1)) == NULL)
 			return (-1);
 		type = *p;
-	}
-
-	for (i = 0; i < unpack_streams; i++) {
-		ss->digestsDefined[i] = 0;
-		ss->digests[i] = 0;
 	}
 
 	numDigests = 0;

--- a/libarchive/test/test_read_format_7zip_malformed.c
+++ b/libarchive/test/test_read_format_7zip_malformed.c
@@ -75,9 +75,28 @@ test_malformed3(void)
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
+
+static void
+test_malformed4(void)
+{
+	const char *refname = "test_read_format_7zip_malformed4.7z";
+	struct archive *a;
+	struct archive_entry *ae;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_read_format_7zip_malformed)
 {
 	test_malformed1();
 	test_malformed2();
 	test_malformed3();
+	test_malformed4();
 }

--- a/libarchive/test/test_read_format_7zip_malformed4.7z.uu
+++ b/libarchive/test/test_read_format_7zip_malformed4.7z.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_7zip_malformed4.7z
+M-WJ\KR<<``0N^]EU```````````9`````````&WKXL4!!`8``0D```<+`0`!
+,`0`,```(#0(`````
+`
+end


### PR DESCRIPTION
Add validation for SubStreamsInfo consistency before allocating per-stream metadata, and add a malformed-header regression case.