### PR TITLE
cmdline: Use free+strdup instead of realloc+strcpy

### DIFF
--- a/libarchive/archive_cmdline.c
+++ b/libarchive/archive_cmdline.c
@@ -36,7 +36,6 @@
 #include "archive_cmdline_private.h"
 #include "archive_string.h"
 
-static int cmdline_set_path(struct archive_cmdline *, const char *);
 static int cmdline_add_arg(struct archive_cmdline *, const char *);
 
 static ssize_t
@@ -98,7 +97,7 @@ get_argument(struct archive_string *as, const char *p)
 
 /*
  * Set up command line arguments.
- * Returns ARCHIVE_OK if everything okey.
+ * Returns ARCHIVE_OK if everything okay.
  * Returns ARCHIVE_FAILED if there is a lack of the `"' terminator or an
  * empty command line.
  * Returns ARCHIVE_FATAL if no memory.
@@ -123,9 +122,12 @@ __archive_cmdline_parse(struct archive_cmdline *data, const char *cmd)
 		r = ARCHIVE_FAILED;/* An empty command path. */
 		goto exit_function;
 	}
-	r = cmdline_set_path(data, as.s);
-	if (r != ARCHIVE_OK)
+	free(data->path);
+	data->path = strdup(as.s);
+	if (data->path == NULL) {
+		r = ARCHIVE_FATAL;
 		goto exit_function;
+	}
 	p = strrchr(as.s, '/');
 	if (p == NULL)
 		p = as.s;
@@ -158,23 +160,7 @@ exit_function:
 }
 
 /*
- * Set the program path.
- */
-static int
-cmdline_set_path(struct archive_cmdline *data, const char *path)
-{
-	char *newptr;
-
-	newptr = realloc(data->path, strlen(path) + 1);
-	if (newptr == NULL)
-		return (ARCHIVE_FATAL);
-	data->path = newptr;
-	strcpy(data->path, path);
-	return (ARCHIVE_OK);
-}
-
-/*
- * Add a argument for the program.
+ * Add an argument for the program.
  */
 static int
 cmdline_add_arg(struct archive_cmdline *data, const char *arg)


### PR DESCRIPTION
The cmdline_set_path function contains logic to reallocate memory of command path and copy a new value into it.

Inline a simpler free+strdup alternative into __archive_cmdline_parse. Since the function is always called with empty data, free could be removed as well. I've kept it that way just to make sure that it's 100 % compatible with previous code.