### PR TITLE
Minor manpage fixes

### DIFF
--- a/libarchive/archive_read_filter.3
+++ b/libarchive/archive_read_filter.3
@@ -142,7 +142,9 @@ These functions return
 .Cm ARCHIVE_OK
 if the compression is fully supported,
 .Cm ARCHIVE_WARN
-if the compression is supported only through an external program.
+if the compression is supported only through an external program, or
+.Cm ARCHIVE_FATAL
+on error.
 .Pp
 .Fn archive_read_support_filter_none
 always succeeds.
@@ -157,6 +159,5 @@ functions.
 .Sh SEE ALSO
 .Xr archive_read 3 ,
 .Xr archive_read_data 3 ,
-.Xr archive_read_format 3 ,
 .Xr archive_read_format 3 ,
 .Xr libarchive 3

--- a/libarchive/archive_read_open.3
+++ b/libarchive/archive_read_open.3
@@ -31,6 +31,7 @@
 .Nm archive_read_open_fd ,
 .Nm archive_read_open_FILE ,
 .Nm archive_read_open_filename ,
+.Nm archive_read_open_filenames ,
 .Nm archive_read_open_memory
 .Nd functions for reading streaming archives
 .Sh LIBRARY
@@ -62,6 +63,12 @@ Streaming Archive Library (libarchive, -larchive)
 .Fo archive_read_open_filename
 .Fa "struct archive *"
 .Fa "const char *filename"
+.Fa "size_t block_size"
+.Fc
+.Ft int
+.Fo archive_read_open_filenames
+.Fa "struct archive *"
+.Fa "const char **filenames"
 .Fa "size_t block_size"
 .Fc
 .Ft int
@@ -110,6 +117,15 @@ Like
 .Fn archive_read_open ,
 except that it accepts a simple filename and a block size.
 A NULL filename represents standard input.
+This function is safe for use with tape drives or other blocked devices.
+.It Fn archive_read_open_filenames
+Like
+.Fn archive_read_open ,
+except that it accepts a NULL-terminated array of filenames to open in
+sequence (as would be created by the
+.Xr split 1
+command) and a block size.
+A NULL filename at the beginning of the array represents standard input.
 This function is safe for use with tape drives or other blocked devices.
 .It Fn archive_read_open_memory
 Like

--- a/libarchive/archive_util.3
+++ b/libarchive/archive_util.3
@@ -33,12 +33,15 @@
 .Nm archive_errno ,
 .Nm archive_error_string ,
 .Nm archive_file_count ,
+.Nm archive_filter_bytes ,
 .Nm archive_filter_code ,
 .Nm archive_filter_count ,
 .Nm archive_filter_name ,
 .Nm archive_format ,
 .Nm archive_format_name ,
-.Nm archive_position ,
+.Nm archive_free ,
+.Nm archive_position_compressed ,
+.Nm archive_position_uncompressed ,
 .Nm archive_set_error
 .Nd libarchive utility functions
 .Sh LIBRARY
@@ -59,6 +62,8 @@ Streaming Archive Library (libarchive, -larchive)
 .Fn archive_error_string "struct archive *"
 .Ft int
 .Fn archive_file_count "struct archive *"
+.Ft int64_t
+.Fn archive_filter_bytes "struct archive *" "int"
 .Ft int
 .Fn archive_filter_code "struct archive *" "int"
 .Ft int
@@ -69,8 +74,12 @@ Streaming Archive Library (libarchive, -larchive)
 .Fn archive_format "struct archive *"
 .Ft const char *
 .Fn archive_format_name "struct archive *"
+.Ft int
+.Fn archive_free "struct archive *"
 .Ft int64_t
-.Fn archive_position "struct archive *" "int"
+.Fn archive_position_compressed "struct archive *"
+.Ft int64_t
+.Fn archive_position_uncompressed "struct archive *"
 .Ft void
 .Fo archive_set_error
 .Fa "struct archive *"
@@ -140,13 +149,13 @@ filter 0 is the gunzip filter,
 filter 1 is the uudecode filter,
 and filter 2 is the pseudo-filter that wraps the archive read functions.
 In this case, requesting
-.Fn archive_position a -1
+.Fn archive_filter_bytes a -1
 would be a synonym for
-.Fn archive_position a 2
+.Fn archive_filter_bytes a 2
 which would return the number of bytes currently read from the archive, while
-.Fn archive_position a 1
+.Fn archive_filter_bytes a 1
 would return the number of bytes after uudecoding, and
-.Fn archive_position a 0
+.Fn archive_filter_bytes a 0
 would return the number of bytes after decompression.
 .It Fn archive_filter_name
 Returns a textual name identifying the indicated filter.
@@ -165,16 +174,24 @@ utilize GNU tar extensions and several entries that do not.
 These entries will have different format codes.
 .It Fn archive_format_name
 A textual description of the format of the current entry.
-.It Fn archive_position
+.It Fn archive_free
+Closes the archive if necessary, then releases all resources.
+.It Fn archive_filter_bytes
 Returns the number of bytes read from or written to the indicated filter.
 In particular,
-.Fn archive_position a 0
+.Fn archive_filter_bytes a 0
 returns the number of bytes read or written by the format handler, while
-.Fn archive_position a -1
+.Fn archive_filter_bytes a -1
 returns the number of bytes read or written to the archive.
 See
 .Fn archive_filter_count
 for details of the numbering here.
+.It Fn archive_position_compressed
+Synonym for
+.Fn archive_filter_bytes a -1 .
+.It Fn archive_position_uncompressed
+Synonym for
+.Fn archive_filter_bytes a 0 .
 .It Fn archive_set_error
 Sets the numeric error code and error description that will be returned
 by

--- a/libarchive/archive_write_filter.3
+++ b/libarchive/archive_write_filter.3
@@ -50,6 +50,8 @@ Streaming Archive Library (libarchive, -larchive)
 .Ft int
 .Fn archive_write_add_filter_b64encode "struct archive *"
 .Ft int
+.Fn archive_write_add_filter_by_name "struct archive *" "const char *name"
+.Ft int
 .Fn archive_write_add_filter_bzip2 "struct archive *"
 .Ft int
 .Fn archive_write_add_filter_compress "struct archive *"
@@ -100,6 +102,8 @@ Note that the compressed output is always properly blocked.
 .Xc
 The output will be encoded as specified.
 The encoded output is always properly blocked.
+.It Fn archive_write_add_filter_by_name
+Sets the corresponding filter based on the common name.
 .It Fn archive_write_add_filter_none
 This is never necessary.
 It is provided only for backwards compatibility.
@@ -111,6 +115,10 @@ write callbacks.
 .Sh RETURN VALUES
 These functions return
 .Cm ARCHIVE_OK
+.Po or
+.Cm ARCHIVE_WARN
+if an external program had to be executed to handle the filter
+.Pc
 on success, or
 .Cm ARCHIVE_FATAL .
 .\"

--- a/libarchive/archive_write_format.3
+++ b/libarchive/archive_write_format.3
@@ -129,7 +129,9 @@ Sets the corresponding format based on the common name.
 .Fn archive_write_set_format_filter_by_ext
 .Fn archive_write_set_format_filter_by_ext_def
 .Xc
-Sets both filters and format based on the output filename.
+Sets both filters and format based on the output filename, optionally
+referring to a default extension if the supplied filename does not have a
+known one.
 Supported extensions: .7z, .zip, .jar, .cpio, .iso, .a, .ar, .tar, .tgz, .tar.gz, .tar.bz2, .tar.xz
 .It Xo
 .Fn archive_write_set_format_7zip


### PR DESCRIPTION
While playing around with librarchive, I noticed that documentation for some common functions were either missing, outdated, or incomplete.  

This adds documentation for archive_free, archive_position_compressed, archive_position_uncompressed, archive_read_open_filenames, archive_write_add_filter_by_name, and archive_write_set_format_filter_by_ext_def, renames archive_position to archive_filter_bytes, and describes more return values for the archive_read_support_filter archive_write_add_filter function families.
