### PR TITLE
Fix a number of unchecked memory allocations

### DIFF
--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1634,6 +1634,8 @@ tree_push(struct tree *t, const wchar_t *path, const wchar_t *full_path,
 	struct tree_entry *te;
 
 	te = calloc(1, sizeof(*te));
+	if (te == NULL)
+		return;
 	te->next = t->stack;
 	te->parent = t->current;
 	if (te->parent)

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -358,6 +358,8 @@ la_linkname_from_handle(HANDLE h, wchar_t **linkname, int *linktype)
 	}
 
 	indata = malloc(MAXIMUM_REPARSE_DATA_BUFFER_SIZE);
+	if (indata == NULL)
+		return (-1);
 	ret = DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, indata,
 	    1024, &inbytes, NULL);
 	if (ret == 0) {

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1708,6 +1708,8 @@ tree_open(const wchar_t *path, int symlink_mode, int restore_time)
 	struct tree *t;
 
 	t = calloc(1, sizeof(*t));
+	if (t == NULL)
+		return (NULL);
 	archive_string_init(&(t->full_path));
 	archive_string_init(&t->path);
 	if (archive_wstring_ensure(&t->path, 15) == NULL) {

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -2840,6 +2840,10 @@ make_table(struct archive_read *a, struct huffman_code *code)
     code->tablesize = code->maxlength;
 
   code->table = calloc(((size_t)1U) << code->tablesize, sizeof(*code->table));
+  if (code->table == NULL) {
+    archive_set_error(&a->archive, ENOMEM, "Can't allocate memory");
+    return (ARCHIVE_FATAL);
+  }
 
   return make_table_recurse(a, code, 0, code->table, 0, code->tablesize);
 }

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2561,7 +2561,7 @@ static int rar5_read_header(struct archive_read *a,
 	return ret;
 }
 
-static void init_unpack(struct rar5* rar) {
+static int init_unpack(struct rar5* rar) {
 	rar->file.calculated_crc32 = 0;
 	init_window_mask(rar);
 
@@ -2570,7 +2570,11 @@ static void init_unpack(struct rar5* rar) {
 
 	if(rar->cstate.window_size > 0) {
 		rar->cstate.window_buf = calloc(1, rar->cstate.window_size);
+		if(rar->cstate.window_buf == NULL)
+			return ARCHIVE_FATAL;
 		rar->cstate.filtered_buf = calloc(1, rar->cstate.window_size);
+		if(rar->cstate.filtered_buf == NULL)
+			return ARCHIVE_FATAL;
 	} else {
 		rar->cstate.window_buf = NULL;
 		rar->cstate.filtered_buf = NULL;
@@ -2586,6 +2590,7 @@ static void init_unpack(struct rar5* rar) {
 	memset(&rar->cstate.dd, 0, sizeof(rar->cstate.dd));
 	memset(&rar->cstate.ldd, 0, sizeof(rar->cstate.ldd));
 	memset(&rar->cstate.rd, 0, sizeof(rar->cstate.rd));
+	return ARCHIVE_OK;
 }
 
 static void update_crc(struct rar5* rar, const uint8_t* p, size_t to_read) {
@@ -3881,7 +3886,8 @@ static int do_uncompress_file(struct archive_read* a) {
 		/* Don't perform full context reinitialization if we're
 		 * processing a solid archive. */
 		if(!rar->main.solid || !rar->cstate.window_buf) {
-			init_unpack(rar);
+			if((ret = init_unpack(rar)) != ARCHIVE_OK)
+				return ret;
 		}
 
 		rar->cstate.initialized = 1;

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -184,6 +184,10 @@ __archive_write_program_allocate(const char *program)
 	data->child_stdin = -1;
 	data->child_stdout = -1;
 	data->program_name = strdup(program);
+	if (data->program_name == NULL) {
+		free(data);
+		return (NULL);
+	}
 	return (data);
 }
 

--- a/libarchive/xxhash.c
+++ b/libarchive/xxhash.c
@@ -361,6 +361,8 @@ static
 void* XXH32_init (U32 seed)
 {
     void* state = XXH_malloc (sizeof(struct XXH_state32_t));
+    if (state == NULL)
+        return NULL;
     XXH32_resetState(state, seed);
     return state;
 }


### PR DESCRIPTION
A bunch of malloc/calloc calls were not checked and handled properly.

Credit: Michael Wildman, Veracode SCA for finding and reporting these.
