### PR TITLE
xar: Fix writer OOB accesses with fflags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -690,6 +690,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_xar.c \
 	libarchive/test/test_write_format_xar_bugs.c \
 	libarchive/test/test_write_format_xar_empty.c \
+	libarchive/test/test_write_format_xar_fflags.c \
 	libarchive/test/test_write_format_zip.c \
 	libarchive/test/test_write_format_zip64_stream.c \
 	libarchive/test/test_write_format_zip_compression_store.c \

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1110,30 +1110,27 @@ make_fflags_entry(struct archive_write *a, struct xml_writer *writer,
 		{ NULL, NULL}
 	};
 	const struct flagentry *fe, *flagentry;
-#define FLAGENTRY_MAXSIZE ((sizeof(flagbsd)+sizeof(flagext2))/sizeof(flagbsd))
-	const struct flagentry *avail[FLAGENTRY_MAXSIZE];
 	const char *p;
-	int i, n, r;
+	int r, started;
 
 	if (strcmp(element, "ext2") == 0)
 		flagentry = flagext2;
 	else
 		flagentry = flagbsd;
-	n = 0;
 	p = fflags_text;
+	started = 0;
 	do {
-		const char *cp;
+		const char *cp, *name = NULL;
 
 		cp = strchr(p, ',');
 		if (cp == NULL)
 			cp = p + strlen(p);
 
 		for (fe = flagentry; fe->name != NULL; fe++) {
-			if (fe->name[cp - p] != '\0'
-			    || p[0] != fe->name[0])
-				continue;
 			if (strncmp(p, fe->name, cp - p) == 0) {
-				avail[n++] = fe;
+				if (fe->name[cp - p] != '\0')
+					continue;
+				name = fe->xarname;
 				break;
 			}
 		}
@@ -1141,23 +1138,26 @@ make_fflags_entry(struct archive_write *a, struct xml_writer *writer,
 			p = cp + 1;
 		else
 			p = NULL;
-	} while (p != NULL);
 
-	if (n > 0) {
-		r = xml_writer_start_element(writer, element);
-		if (r < 0) {
-			archive_set_error(&a->archive,
-			    ARCHIVE_ERRNO_MISC,
-			    "xml_writer_start_element() failed: %d", r);
-			return (ARCHIVE_FATAL);
-		}
-		for (i = 0; i < n; i++) {
-			r = xmlwrite_string(a, writer,
-			    avail[i]->xarname, NULL);
+		if (name != NULL) {
+			if (!started) {
+				r = xml_writer_start_element(writer, element);
+				if (r < 0) {
+					archive_set_error(&a->archive,
+						ARCHIVE_ERRNO_MISC,
+						"xml_writer_start_element()"
+						" failed: %d", r);
+					return (ARCHIVE_FATAL);
+				}
+				started = 1;
+			}
+			r = xmlwrite_string(a, writer, name, NULL);
 			if (r != ARCHIVE_OK)
 				return (r);
 		}
+	} while (p != NULL);
 
+	if (started) {
 		r = xml_writer_end_element(writer);
 		if (r < 0) {
 			archive_set_error(&a->archive,

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -321,6 +321,7 @@ IF(ENABLE_TEST)
     test_write_format_warc_empty.c
     test_write_format_xar.c
     test_write_format_xar_empty.c
+    test_write_format_xar_fflags.c
     test_write_format_xar_bugs.c
     test_write_format_zip.c
     test_write_format_zip64_stream.c

--- a/libarchive/test/test_write_format_xar_fflags.c
+++ b/libarchive/test/test_write_format_xar_fflags.c
@@ -1,0 +1,78 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+DEFINE_TEST(test_write_format_xar_fflags)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[4096];
+	size_t used;
+
+	/* Xar format: Create a new archive in memory. */
+	assert((a = archive_write_new()) != NULL);
+	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
+		skipping("xar is not supported on this platform");
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_in_last_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	/* Add "file" entry. */ 
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "file");
+	archive_entry_set_mode(ae, S_IFREG | 0644);
+	archive_entry_set_size(ae, 0);
+	archive_entry_copy_fflags_text(ae, "sappnd,sappnd,sappnd,very_long_name_but_unknown");
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Close out the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+
+	/*
+	 * Now, read the data back.
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, 0, archive_read_support_format_all(a));
+	assertEqualIntA(a, 0, archive_read_support_filter_all(a));
+	assertEqualIntA(a, 0, archive_read_open_memory(a, buff, used));
+
+	/* Read "file". */
+	assertEqualIntA(a, 0, archive_read_next_header(a, &ae));
+	assertEqualString("file", archive_entry_pathname(ae));
+	assert((AE_IFREG | 0644) == archive_entry_mode(ae));
+	assertEqualInt(0, archive_entry_size(ae));
+
+	/* Verify the end of the archive. */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
It is possible to trigger stack OOB writes and heap OOB reads with fflags in xar writer.

Resolves GHSA-wfvr-54j8-47r9.