### PR TITLE
archive_write_disk: guard HFS compression ResourceFork bounds

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1468,6 +1468,9 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 	if (a->decmpfs_block_count == (unsigned)-1) {
 		void *new_block;
 		size_t new_size;
+		uint64_t block_count64;
+		uint64_t data_start64;
+		uint64_t rsrc_size64;
 		unsigned int block_count;
 
 		if (a->decmpfs_header_p == NULL) {
@@ -1489,18 +1492,29 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		    a->filesize);
 
 		/* Calculate a block count of the file. */
-		block_count =
-		    (a->filesize + MAX_DECMPFS_BLOCK_SIZE -1) /
-			MAX_DECMPFS_BLOCK_SIZE;
+		block_count64 =
+		    ((uint64_t)a->filesize + MAX_DECMPFS_BLOCK_SIZE - 1) /
+		    MAX_DECMPFS_BLOCK_SIZE;
+		if (block_count64 > UINT_MAX) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "File too large for HFS+ compression");
+			return (ARCHIVE_FAILED);
+		}
+		data_start64 = RSRC_H_SIZE + 4 +
+		    block_count64 * sizeof(uint32_t) * 2;
+		rsrc_size64 = data_start64 + RSRC_F_SIZE;
+		if (data_start64 > UINT32_MAX || rsrc_size64 > SIZE_MAX) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "Can't allocate memory for ResourceFork");
+			return (ARCHIVE_FATAL);
+		}
+		block_count = (unsigned int)block_count64;
 		/*
 		 * Allocate buffer for resource fork.
 		 * Set up related pointers;
 		 */
-		new_size =
-		    RSRC_H_SIZE + /* header */
-		    4 + /* Block count */
-		    (block_count * sizeof(uint32_t) * 2) +
-		    RSRC_F_SIZE; /* footer */
+		new_size = (size_t)rsrc_size64;
 		if (new_size > a->resource_fork_allocated_size) {
 			new_block = realloc(a->resource_fork, new_size);
 			if (new_block == NULL) {
@@ -1538,8 +1552,7 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		archive_le32enc(a->decmpfs_block_info++, block_count);
 		/* Get the position where we are going to set compressed
 		 * data. */
-		a->compressed_rsrc_position =
-		    RSRC_H_SIZE + 4 + (block_count * 8);
+		a->compressed_rsrc_position = (uint32_t)data_start64;
 		a->compressed_rsrc_position_v = a->compressed_rsrc_position;
 		a->decmpfs_block_count = block_count;
 	}

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1175,10 +1175,18 @@ hfs_write_compressed_data(struct archive_write_disk *a, size_t bytes_compressed)
 {
 	int ret;
 
+	if (bytes_compressed > UINT32_MAX ||
+	    bytes_compressed > UINT32_MAX - a->compressed_rsrc_position) {
+		archive_set_error(&a->archive,
+		    ARCHIVE_ERRNO_FILE_FORMAT,
+		    "HFS+ compression ResourceFork is too large");
+		return (ARCHIVE_FAILED);
+	}
+
 	ret = hfs_write_resource_fork(a, a->compressed_buffer,
 	    bytes_compressed, a->compressed_rsrc_position);
 	if (ret == ARCHIVE_OK)
-		a->compressed_rsrc_position += bytes_compressed;
+		a->compressed_rsrc_position += (uint32_t)bytes_compressed;
 	return (ret);
 }
 
@@ -1391,10 +1399,17 @@ hfs_drive_compressor(struct archive_write_disk *a, const char *buff,
 	}
 
 	/* Update block info. */
+	if (bytes_compressed > UINT32_MAX ||
+	    bytes_compressed > UINT32_MAX - a->compressed_rsrc_position_v) {
+		archive_set_error(&a->archive,
+		    ARCHIVE_ERRNO_FILE_FORMAT,
+		    "HFS+ compression ResourceFork is too large");
+		return (ARCHIVE_FAILED);
+	}
 	archive_le32enc(a->decmpfs_block_info++,
 	    a->compressed_rsrc_position_v - RSRC_H_SIZE);
-	archive_le32enc(a->decmpfs_block_info++, bytes_compressed);
-	a->compressed_rsrc_position_v += bytes_compressed;
+	archive_le32enc(a->decmpfs_block_info++, (uint32_t)bytes_compressed);
+	a->compressed_rsrc_position_v += (uint32_t)bytes_compressed;
 
 	/*
 	 * Write the compressed data to the resource fork.
@@ -1471,7 +1486,7 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		uint64_t block_count64;
 		uint64_t data_start64;
 		uint64_t rsrc_size64;
-		unsigned int block_count;
+		uint32_t block_count;
 
 		if (a->decmpfs_header_p == NULL) {
 			new_block = malloc(MAX_DECMPFS_XATTR_SIZE
@@ -1492,10 +1507,16 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		    a->filesize);
 
 		/* Calculate a block count of the file. */
+		if (a->filesize < 0) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Unknown file size for HFS+ compression");
+			return (ARCHIVE_FAILED);
+		}
 		block_count64 =
 		    ((uint64_t)a->filesize + MAX_DECMPFS_BLOCK_SIZE - 1) /
 		    MAX_DECMPFS_BLOCK_SIZE;
-		if (block_count64 > UINT_MAX) {
+		if (block_count64 > UINT32_MAX) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "File too large for HFS+ compression");
@@ -1509,7 +1530,7 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 			    "Can't allocate memory for ResourceFork");
 			return (ARCHIVE_FATAL);
 		}
-		block_count = (unsigned int)block_count64;
+		block_count = (uint32_t)block_count64;
 		/*
 		 * Allocate buffer for resource fork.
 		 * Set up related pointers;

--- a/libarchive/test/test_write_disk_hfs_compression.c
+++ b/libarchive/test/test_write_disk_hfs_compression.c
@@ -275,3 +275,43 @@ DEFINE_TEST(test_write_disk_hfs_compression)
 	assertEqualFile("hfscmp/Makefile", "nocmp/Makefile");
 #endif
 }
+
+
+DEFINE_TEST(test_write_disk_hfs_compression_large_file)
+{
+#if !defined(__APPLE__) || !defined(UF_COMPRESSED) || !defined(HAVE_SYS_XATTR_H)\
+	|| !defined(HAVE_ZLIB_H)
+	skipping("MacOS-specific HFS+ Compression test");
+#else
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[1024];
+	la_ssize_t r;
+
+	memset(buff, 0, sizeof(buff));
+
+	assert((a = archive_write_disk_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_disk_set_options(a,
+		ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "hfs-block-count-overflow");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_perm(ae, 0600);
+	archive_entry_set_size(ae, ((int64_t)1) << 48);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+
+	/*
+	 * Very large HFS-compressed files must be rejected before
+	 * ResourceFork metadata is initialized beyond supported limits.
+	 */
+	r = archive_write_data(a, buff, sizeof(buff));
+	failure("Large HFS+ compressed file must be rejected");
+	assert(r < ARCHIVE_OK);
+
+	archive_entry_free(ae);
+	archive_write_free(a);
+#endif
+}

--- a/libarchive/test/test_write_disk_hfs_compression.c
+++ b/libarchive/test/test_write_disk_hfs_compression.c
@@ -291,9 +291,9 @@ DEFINE_TEST(test_write_disk_hfs_compression_large_file)
 
 	memset(buff, 0, sizeof(buff));
 
-	for (i = 0; i < 2; i++) {
+	for (i = 0; i < 3; i++) {
 		assert((a = archive_write_disk_new()) != NULL);
-		if (i == 0) {
+		if (i != 1) {
 			assertEqualIntA(a, ARCHIVE_OK,
 			    archive_write_disk_set_options(a,
 				ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED));
@@ -302,10 +302,14 @@ DEFINE_TEST(test_write_disk_hfs_compression_large_file)
 		assert((ae = archive_entry_new()) != NULL);
 		archive_entry_set_pathname(ae, i == 0
 		    ? "hfs-large-forced"
-		    : "hfs-large-preserved");
+		    : i == 1
+		    ? "hfs-large-preserved"
+		    : "hfs-large-boundary");
 		archive_entry_set_filetype(ae, AE_IFREG);
 		archive_entry_set_perm(ae, 0600);
-		archive_entry_set_size(ae, ((int64_t)1) << 48);
+		archive_entry_set_size(ae, i == 2
+		    ? ((int64_t)0xffffffff) << 16
+		    : ((int64_t)1) << 48);
 		if (i == 1)
 			archive_entry_set_fflags(ae, UF_COMPRESSED, 0);
 

--- a/libarchive/test/test_write_disk_hfs_compression.c
+++ b/libarchive/test/test_write_disk_hfs_compression.c
@@ -287,31 +287,40 @@ DEFINE_TEST(test_write_disk_hfs_compression_large_file)
 	struct archive_entry *ae;
 	char buff[1024];
 	la_ssize_t r;
+	int i;
 
 	memset(buff, 0, sizeof(buff));
 
-	assert((a = archive_write_disk_new()) != NULL);
-	assertEqualIntA(a, ARCHIVE_OK,
-	    archive_write_disk_set_options(a,
-		ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED));
+	for (i = 0; i < 2; i++) {
+		assert((a = archive_write_disk_new()) != NULL);
+		if (i == 0) {
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_write_disk_set_options(a,
+				ARCHIVE_EXTRACT_HFS_COMPRESSION_FORCED));
+		}
 
-	assert((ae = archive_entry_new()) != NULL);
-	archive_entry_set_pathname(ae, "hfs-block-count-overflow");
-	archive_entry_set_filetype(ae, AE_IFREG);
-	archive_entry_set_perm(ae, 0600);
-	archive_entry_set_size(ae, ((int64_t)1) << 48);
+		assert((ae = archive_entry_new()) != NULL);
+		archive_entry_set_pathname(ae, i == 0
+		    ? "hfs-large-forced"
+		    : "hfs-large-preserved");
+		archive_entry_set_filetype(ae, AE_IFREG);
+		archive_entry_set_perm(ae, 0600);
+		archive_entry_set_size(ae, ((int64_t)1) << 48);
+		if (i == 1)
+			archive_entry_set_fflags(ae, UF_COMPRESSED, 0);
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 
-	/*
-	 * Very large HFS-compressed files must be rejected before
-	 * ResourceFork metadata is initialized beyond supported limits.
-	 */
-	r = archive_write_data(a, buff, sizeof(buff));
-	failure("Large HFS+ compressed file must be rejected");
-	assert(r < ARCHIVE_OK);
+		/*
+		 * Very large HFS-compressed files must be rejected before
+		 * ResourceFork metadata is initialized beyond supported limits.
+		 */
+		r = archive_write_data(a, buff, sizeof(buff));
+		failure("Large HFS+ compressed file must be rejected");
+		assert(r < ARCHIVE_OK);
 
-	archive_entry_free(ae);
-	archive_write_free(a);
+		archive_entry_free(ae);
+		archive_write_free(a);
+	}
 #endif
 }


### PR DESCRIPTION
Fix oversized HFS compression metadata handling on macOS.

This validates `decmpfs` block counts and `ResourceFork` offsets before allocation or block-info writes, and rejects unsupported large-file cases cleanly.

Adds a macOS regression test covering forced HFS compression, preserved `UF_COMPRESSED` metadata, and the 32-bit `ResourceFork` offset boundary.

Tested on macOS:
* unpatched + new test fails
* patched + new test passes
* existing HFS compression test passes