### PR TITLE
bzip2: Support large in-memory archives

### DIFF
--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -28,6 +28,9 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
@@ -232,6 +235,8 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 
 	/* Try to fill the output buffer. */
 	for (;;) {
+		ssize_t max_in;
+
 		if (!state->valid) {
 			if (bzip2_reader_bid(self->bidder, self->upstream) == 0) {
 				state->eof = 1;
@@ -286,6 +291,12 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 			return (ARCHIVE_FATAL);
 		}
 		state->stream.next_in = (char *)(uintptr_t)read_buf;
+		if (UINT_MAX >= SSIZE_MAX)
+			max_in = SSIZE_MAX;
+		else
+			max_in = UINT_MAX;
+		if (ret > max_in)
+			ret = max_in;
 		state->stream.avail_in = (uint32_t)ret;
 		/* There is no more data, return whatever we have. */
 		if (ret == 0) {


### PR DESCRIPTION
If an archive has more than `UINT_MAX` (4 GB) bytes available, the bzip2 filter will enter an endless loop.

Apply same logic of gzip filter from commit 256c71ad4eee22a7dac2f13df1e20d85717cbdf6.

Proof of Concept:
1. Create a 4 GB sparse file which starts with bzip2 data
```
touch empty
bsdtar -cjf empty.tar.bz2 empty
dd if=/dev/zero bs=1 count=1 conv=notrunc seek=4294967300 of=empty.tar.bz2
```
2. Compile and run proof of concept code (memory-map the file)
```
cat > poc.c << EOF
#include <sys/mman.h>

#include <archive.h>
#include <err.h>
#include <fcntl.h>

char *map_file(char *fname, size_t *size) {
        struct stat sb;
        char *mem;
        int fd;

        fd = open(fname, O_RDONLY);
        if (fd == -1)
                err(1, "open");
        if (fstat(fd, &sb) == -1)
                err(1, "fstat");
        if (sb.st_size == 0)
                errx(1, "empty file");
        if (sb.st_size > SIZE_MAX)
                errx(1, "file too large");
        mem = mmap(NULL, (size_t)sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
        if (mem == MAP_FAILED)
                errx(1, "mmap");
        close(fd);
        *size = (size_t)sb.st_size;

        return mem;
}

int main(int argc, char *argv[]) {
        char *mem;
        struct archive *reader;
        struct archive_entry *entry;
        size_t size;

        if (argc != 2)
                errx(1, "usage: poc file");
        reader = archive_read_new();
        if (reader == NULL)
                return 0;
        mem = map_file(argv[1], &size);
        archive_read_support_format_all(reader);
        archive_read_support_filter_all(reader);
        if (archive_read_open_memory(reader, mem, size) != ARCHIVE_OK)
                errx(1, "archive_read_open_memory");
        while (archive_read_next_header(reader, &entry) == ARCHIVE_OK)
                ;
        return 0;
}
EOF
cc -larchive -o poc poc.c
./poc
```