### PR TITLE
filter: Fix mismatched filter function dispatch table entry in archive_write_add_filter.c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -415,6 +415,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_set_error.c \
 	libarchive/test/test_archive_string.c \
 	libarchive/test/test_archive_string_conversion.c \
+	libarchive/test/test_archive_write_add_filter.c \
 	libarchive/test/test_archive_write_add_filter_by_name.c \
 	libarchive/test/test_archive_write_set_filter_option.c \
 	libarchive/test/test_archive_write_set_format_by_name.c \

--- a/libarchive/archive_write_add_filter.c
+++ b/libarchive/archive_write_add_filter.c
@@ -49,7 +49,7 @@ struct { int code; int (*setter)(struct archive *); } codes[] =
 	{ ARCHIVE_FILTER_LZ4,		archive_write_add_filter_lz4 },
 	{ ARCHIVE_FILTER_LZIP,		archive_write_add_filter_lzip },
 	{ ARCHIVE_FILTER_LZMA,		archive_write_add_filter_lzma },
-	{ ARCHIVE_FILTER_LZOP,		archive_write_add_filter_lzip },
+	{ ARCHIVE_FILTER_LZOP,		archive_write_add_filter_lzop },
 	{ ARCHIVE_FILTER_UU,		archive_write_add_filter_uuencode },
 	{ ARCHIVE_FILTER_XZ,		archive_write_add_filter_xz },
 	{ ARCHIVE_FILTER_ZSTD,		archive_write_add_filter_zstd },

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -47,6 +47,7 @@ IF(ENABLE_TEST)
     test_archive_set_error.c
     test_archive_string.c
     test_archive_string_conversion.c
+    test_archive_write_add_filter.c
     test_archive_write_add_filter_by_name.c
     test_archive_write_set_filter_option.c
     test_archive_write_set_format_by_name.c

--- a/libarchive/test/test_archive_write_add_filter.c
+++ b/libarchive/test/test_archive_write_add_filter.c
@@ -1,0 +1,208 @@
+/*-
+ * Copyright (c) 2012 Michihiro NAKAJIMA
+ * Copyright (c) 2026 i1011
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+static void
+test_add_filter_by_code(int filter_code,
+    int (*can_filter_prog)(void))
+{
+	struct archive_entry *ae;
+	struct archive *a;
+	size_t used;
+	size_t buffsize = 1024 * 128;
+	char *buff;
+	int r;
+
+	assert((buff = calloc(buffsize, sizeof(*buff))) != NULL);
+	if (buff == NULL)
+		return;
+
+	/* Create a new archive in memory. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
+	r = archive_write_add_filter(a, filter_code);
+	if (r == ARCHIVE_WARN) {
+		if (!can_filter_prog()) {
+			skipping("Filter code \"%d\" not supported on this platform",
+			    filter_code);
+			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+			free(buff);
+			return;
+		}
+	} else if (r == ARCHIVE_FATAL &&
+	    (strcmp(archive_error_string(a),
+		   "lzma compression not supported on this platform") == 0 ||
+	     strcmp(archive_error_string(a),
+		   "xz compression not supported on this platform") == 0)) {
+		skipping("Filter code \"%d\" not supported on this platform",
+			filter_code);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+		free(buff);
+		return;
+	} else {
+		if (!assertEqualIntA(a, ARCHIVE_OK, r)) {
+			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+			free(buff);
+			return;
+		}
+	}
+	if (filter_code == ARCHIVE_FILTER_LRZIP)
+	{
+		/*
+		 * There's a bug in lrzip (as of release 0.612) where 2nd stage
+		 * compression can't be performed on smaller files. Set lrzip to
+		 * use no 2nd stage compression.
+		 */
+		assertEqualIntA(a, ARCHIVE_OK,
+			archive_write_set_options(a, "lrzip:compression=none"));
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 10));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+
+	/*
+	 * Write a file to it.
+	 */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_mtime(ae, 1, 0);
+	assertEqualInt(1, archive_entry_mtime(ae));
+	archive_entry_set_ctime(ae, 1, 0);
+	assertEqualInt(1, archive_entry_ctime(ae));
+	archive_entry_set_atime(ae, 1, 0);
+	assertEqualInt(1, archive_entry_atime(ae));
+	archive_entry_copy_pathname(ae, "file");
+	assertEqualString("file", archive_entry_pathname(ae));
+	archive_entry_set_mode(ae, AE_IFREG | 0755);
+	assertEqualInt((AE_IFREG | 0755), archive_entry_mode(ae));
+	archive_entry_set_size(ae, 8);
+	assertEqualInt(0, archive_write_header(a, ae));
+	archive_entry_free(ae);
+	assertEqualInt(8, archive_write_data(a, "12345678", 8));
+
+	/* Close out the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/*
+	 * Now, read the data back.
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+
+	/*
+	 * Read and verify the file.
+	 */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualInt(1, archive_entry_mtime(ae));
+	assertEqualString("file", archive_entry_pathname(ae));
+	assertEqualInt(AE_IFREG, archive_entry_filetype(ae));
+	assertEqualInt(8, archive_entry_size(ae));
+
+	/* Verify the end of the archive. */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+
+	/* Verify archive format. */
+	assertEqualIntA(a, filter_code, archive_filter_code(a, 0));
+	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(buff);
+}
+
+static int
+canAlways(void)
+{
+	return 1;
+}
+
+DEFINE_TEST(test_archive_write_add_filter_none)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_NONE, canAlways);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_gzip)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_GZIP, canGzip);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_bzip2)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_BZIP2, canBzip2);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_compress)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_COMPRESS, canAlways);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_grzip)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_GRZIP, canGrzip);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_lrzip)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_LRZIP, canLrzip);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_lz4)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_LZ4, canLz4);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_lzip)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_LZIP, canLzip);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_lzma)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_LZMA, canLzma);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_lzop)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_LZOP, canLzop);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_uuencode)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_UU, canAlways);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_xz)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_XZ, canXz);
+}
+
+DEFINE_TEST(test_archive_write_add_filter_zstd)
+{
+	test_add_filter_by_code(ARCHIVE_FILTER_ZSTD, canZstd);
+}


### PR DESCRIPTION
The integer-code dispatch table in `archive_write_add_filter()` maps `ARCHIVE_FILTER_LZOP` to the function pointer `archive_write_add_filter_lzip` (the lzip filter setter) instead of `archive_write_add_filter_lzop`. Any call to `archive_write_add_filter(a, ARCHIVE_FILTER_LZOP)` therefore silently installs an **lzip** compressor.

This PR changes the mismatched table entry, and add a testfile analogous to `archive_write_add_filter_by_name.c`.