### PR TITLE
cpio: Fix UAF in error path

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -1122,11 +1122,6 @@ record_hardlink(struct archive_read *a,
 		return (ARCHIVE_FATAL);
 	}
 
-	if (cpio->links_head != NULL)
-		cpio->links_head->previous = le;
-	le->next = cpio->links_head;
-	le->previous = NULL;
-	cpio->links_head = le;
 	le->dev = dev;
 	le->ino = ino;
 	le->links = archive_entry_nlink(entry) - 1;
@@ -1137,6 +1132,12 @@ record_hardlink(struct archive_read *a,
 		free(le);
 		return (ARCHIVE_FATAL);
 	}
+
+	if (cpio->links_head != NULL)
+		cpio->links_head->previous = le;
+	le->next = cpio->links_head;
+	le->previous = NULL;
+	cpio->links_head = le;
 
 	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
Add entry only after its full initialization into list. Otherwise the error handling of a failing strdup would have to unlink the entry again.

Fixes: 16ad9310733e ("cpio reader: Validate pathname in record_hardlink")

Resolves #3053.