### PR TITLE
libarchive: Force GNU iconv compatibility on FreeBSD

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -1314,7 +1314,17 @@ create_sconv_object(const char *fc, const char *tc,
 			else if (strcmp(fc, "CP932") == 0)
 				sc->cd = iconv_open(tc, "SJIS");
 		}
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(__FreeBSD__) && !defined(HAVE_LIBICONV)
+		/*
+		 * FreeBSD's native iconv() by default returns the number of
+		 * invalid characters in the input string, as specified by
+		 * POSIX, but iconv_strncat_in_locale() assumes GNU iconv
+		 * semantics.
+		 */
+		int v = 1;
+
+		(void)iconvctl(sc->cd, ICONV_SET_ILSEQ_INVALID, &v);
+#elif defined(_WIN32) && !defined(__CYGWIN__)
 		/*
 		 * archive_mstring on Windows directly convert multi-bytes
 		 * into archive_wstring in order not to depend on locale


### PR DESCRIPTION
This resolves some test failures with libarchive in the FreeBSD base system, which uses native iconv(3) instead of libiconv. See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294577