### PR TITLE
mtree: Fix null dereference for some corner cases

### DIFF
--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -2088,6 +2088,11 @@ mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 	file = *filep;
 	if (file->parentdir.length == 0 && file->basename.length == 1 &&
 	    file->basename.s[0] == '.') {
+		if (file->filetype != AE_IFDIR) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+				"Root entry '.' must be a directory");
+			return (ARCHIVE_FAILED);
+		}
 		file->parent = file;
 		if (mtree->root != NULL) {
 			np = mtree->root;

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -801,6 +801,8 @@ mtree_entry_new(struct archive_write *a, struct archive_entry *entry,
 		archive_strcpy(&me->symlink, s);
 	me->nlink = archive_entry_nlink(entry);
 	me->filetype = archive_entry_filetype(entry);
+	if (me->filetype == AE_IFLNK && me->symlink.s == NULL)
+		archive_strcpy(&me->symlink, "");
 	me->mode = archive_entry_mode(entry) & 07777;
 	me->uid = archive_entry_uid(entry);
 	me->gid = archive_entry_gid(entry);

--- a/libarchive/test/test_write_format_mtree_null_deref.c
+++ b/libarchive/test/test_write_format_mtree_null_deref.c
@@ -171,3 +171,63 @@ DEFINE_TEST(test_write_format_mtree_null_deref)
 	archive_write_free(a);
 	free(out_buf);
 }
+
+DEFINE_TEST(test_write_format_mtree_no_set_symlink)
+{
+	struct archive *a;
+	size_t buffsize = 4096;
+	char *buff;
+	size_t used;
+	assert((buff = malloc(buffsize)) != NULL);
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+		archive_write_open_memory(a, buff, buffsize, &used));
+
+	struct archive_entry *ae;
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "./badlink"),
+	archive_entry_set_filetype(ae, AE_IFLNK);
+	archive_entry_set_perm(ae, 0777);
+	/* archive_entry_set_symlink(ae, "target"); (omitted) */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	free(buff);
+}
+
+DEFINE_TEST(test_write_format_mtree_reg_dot_root)
+{
+	struct archive *a;
+	size_t buffsize = 4096;
+	char *buff;
+	size_t used;
+	assert((buff = malloc(buffsize)) != NULL);
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+		archive_write_open_memory(a, buff, buffsize, &used));
+
+	struct archive_entry *ae;
+	/* Entry 1: "." with filetype AE_IFREG (not AE_IFDIR). */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "."),
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_perm(ae, 0644);
+	assertEqualIntA(a, ARCHIVE_FAILED, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/* Entry 2: any child path. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "./foo"),
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_perm(ae, 0644);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	free(buff);
+}


### PR DESCRIPTION
## Missing `archive_entry_set_symlink()` call

### Summary

`mtree_entry_new` conditionally copies the symlink target only if `archive_entry_symlink(entry)` is non-NULL; otherwise `me->symlink.s` stays `NULL`. At close/flush time, `write_mtree_entry` passes this NULL pointer to `mtree_quote`, which immediately dereferences it in the first loop iteration, crashing the process.

### Code

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L800-L801

`me->symlink.s = NULL, s = NULL`

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L1041-L1043

`mtree_quote(str, me->symlink.s) => mtree_quote(str, NULL)`

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L332-L341

## Root entry is not restricted to `AE_IFDIR`

### Summary

`mtree_entry_tree_add` accepts any entry with `basename == "."` and `parentdir.length == 0` as the tree root, without checking that it is a directory. `dir_info` is only allocated for `AE_IFDIR` entries, so a non-directory `"."` root has `dir_info == NULL`. When the next entry (e.g., `"./foo"`) is added, the lookup dereferences `dir_info->rbtree` and crashes.

### Code

`path = '.' => Accept`

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L2087-L2097

`me->filetype != AE_IFDIR => me->dir_info = NULL`

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L822-L830

First entry: `'.', AE_IFREG`
Second entry: `'./foo', AE_IFREG`
`archive_write_mtree_header => mtree_entry_tree_add => deref NULL dir_info`

https://github.com/libarchive/libarchive/blob/fd182c5ba56cff54d6963c3928ca4d9f363b9ff9/libarchive/archive_write_set_format_mtree.c#L2240-L2246