### PR TITLE
xar: fix fflags_text leak in file_free

### DIFF
--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1808,6 +1808,7 @@ file_free(struct xar_file *file)
 	archive_string_free(&(file->uname));
 	archive_string_free(&(file->gname));
 	archive_string_free(&(file->hardlink));
+	archive_string_free(&(file->fflags_text));
 	xattr = file->xattr_list;
 	while (xattr != NULL) {
 		struct xattr *next;


### PR DESCRIPTION
file_free() releases pathname, symlink, uname, gname, and hardlink but omits fflags_text. When a XAR archive describes a file with <flags> or <ext2> children (e.g. <SystemNoUnlink/>, <Compress/>), xml_parse_file_flags / xml_parse_file_ext2 populate xar_file->fflags_text via archive_strcat, which heap-allocates. The buffer leaks on every file_free().

Reproduces with ASan+LSan via the bundled bsdtar:
  bsdtar -tvf <xar-with-flags>
=> Direct leak of N bytes ... archive_strcat ... xml_parse_file_flags

Same shape as commit 6767cbe3 ("Free XAR xattr fstype metadata"), which fixed the analogous miss in xattr_free().

Existing release of fflags_text in archive_string_free is a no-op when the field was never populated (.s == NULL, free(NULL) is safe), so the patch is harmless on the non-flags path.

Resolves #3058.