### PR TITLE
warc writer: free hdr on _popul_ehdr overflow in _warc_header

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -245,6 +245,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 		r = _popul_ehdr(&hdr, MAX_HDR_SIZE, rh);
 		if (r < 0) {
 			/* don't bother */
+			archive_string_free(&hdr);
 			archive_set_error(
 				&a->archive,
 				ARCHIVE_ERRNO_FILE_FORMAT,


### PR DESCRIPTION
  ## Summary
  
  `_warc_header()` at `archive_write_set_format_warc.c:245` returns `ARCHIVE_WARN` without calling `archive_string_free(&hdr)` when `_popul_ehdr()` returns -1 (header size > `MAX_HDR_SIZE` = 512,
  reachable with a long enough pathname since `WARC-Target-URI` carries `archive_entry_pathname()`). At that point `hdr` already holds the WARC version line, WARC-Type, WARC-Target-URI (long path),
  WARC-Date, Last-Modified, WARC-Record-ID, optional Content-Type, and Content-Length headers — ~1 KB+ leaked per entry.

  ## Reproduce (with bundled bsdtar)
  
  Build libarchive with ASan/LSan, create a regular file with a long pathname (~400+ chars), then:

  ASAN_OPTIONS=detect_leaks=1 bsdtar --format=warc -cf out.warc
  
  LSan reports:

  Direct leak of ~1 KB in 1 object(s) allocated from:
    archive_string_sprintf      archive_string_sprintf.c:81 
    _popul_ehdr                 archive_write_set_format_warc.c:383
    _warc_header                archive_write_set_format_warc.c:245
    _archive_write_header       archive_write.c:782
    write_entry                 tar/write.c:1002
    ...
    main                        tar/bsdtar.c:1004
  
  ## Fix

  One-line addition: free `hdr` on the `r < 0` error path before returning `ARCHIVE_WARN`. `archive_string_free()` on an uninitialised `archive_string` is a no-op, so this is safe.
  
  ## Notes
  
  - Code unchanged since the WARC writer's introduction in 2014.
  - No existing test exercises the long-pathname path.
  - The warcinfo branch above (line ~217) handles this case correctly already (frees `hdr` unconditionally outside the `if (r >= 0)` block); only the WT_RSRC branch was missed.

  ## Discovery

  Identified by Neurolog, a code-analysis tool I'm developing that combines Souffle Datalog with LLM-assisted fact extraction (and Z3 for path feasibility where applicable). The reproducer was
  hand-validated under LeakSanitizer against current master; the tool's role was to flag the candidate.