### PR TITLE
7zip writer: free file->utf16name on symlink UTF-8 conversion failure

### DIFF
--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1685,7 +1685,7 @@ file_new(struct archive_write *a, struct archive_entry *entry,
 		const char* linkpath;
 		linkpath = archive_entry_symlink_utf8(entry);
 		if (linkpath == NULL) {
-			free(file);
+			file_free(file);
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "symlink path could not be converted to UTF-8");
 			return (ARCHIVE_FAILED);


### PR DESCRIPTION
  ## Summary
  
  `file_new()` at `archive_write_set_format_7zip.c:1688` calls `free(file)` on the symlink-UTF8-failure branch, leaving `file->utf16name` (allocated at line 1666) leaked. The two earlier `free(file)`
  calls in this function (lines 1656, 1668) are correct because they happen BEFORE `utf16name` is allocated, but the third one happens after.
 
  The rest of the function uses `file_free()` on every other post-`utf16name` error path; `file_free()` does `free(file->utf16name); free(file)`, which is the cleanup convention. Replacing the bare 
  `free(file)` with `file_free(file)` makes the symlink-error branch consistent with everything else.
  
  ## Reproduce (with bundled bsdtar — pure data-driven trigger)

  A symlink whose target is non-UTF-8, archived under a non-UTF-8 locale:
  
  ln -s "$(printf 'broken_\xff\xfe_link_target')" symlink_broken
  LC_ALL=C ASAN_OPTIONS=detect_leaks=1
    bsdtar --format=7zip -cf out.7z symlink_broken
  
  LSan reports:
  
  Direct leak of N bytes in 1 object(s):
    malloc                                       (libc)
    file_new                                     archive_write_set_format_7zip.c:1666
    _7z_write_header                             archive_write_set_format_7zip.c:577
    ...
    main                                         tar/bsdtar.c:1004
  
  Equivalent trigger: any libarchive caller that sets `AE_IFLNK` filetype on an entry without ever calling `archive_entry_set_symlink()` — then `archive_entry_symlink_utf8()` returns NULL on the first
  check and the buggy `free(file)` branch fires.
  
  ## Fix
  
  One-line change: replace `free(file)` with `file_free(file)` on the symlink-failure branch. `file_free()` is the existing dedicated cleanup helper (`free(file->utf16name); free(file)`) used by every
  other post-`utf16name` error path in the same function.
  
  ## Notes
 
  - Code unchanged since the 7zip writer's introduction.
  - No existing test exercises this error path.

  ## Discovery
  
  Identified by Neurolog, a code-analysis tool I'm developing that combines Souffle Datalog with LLM-assisted fact extraction (and Z3 for path feasibility where applicable). The reproducer was
  separately validated under LeakSanitizer against current master; the tool's role was to flag the candidate.