### PR TITLE
Fix libattr version returned in archive_version_details

### DIFF
--- a/libarchive/archive_version_details.c
+++ b/libarchive/archive_version_details.c
@@ -176,7 +176,7 @@ archive_version_details(void)
 	const char *libiconv = archive_libiconv_version();
 	const char *libacl = archive_libacl_version();
 	const char *librichacl = archive_librichacl_version();
-	const char *libattr = archive_libacl_version();
+	const char *libattr = archive_libattr_version();
 
 	if (!init) {
 		archive_string_init(&str);
@@ -230,6 +230,7 @@ archive_version_details(void)
 			archive_strcat(&str, " libiconv/");
 			archive_strcat(&str, libiconv);
 		}
+		init = 1;
 	}
 	return str.s;
 }


### PR DESCRIPTION
Currently, `archive_version_details` mistakenly uses `archive_libacl_version` for libattr.
In addition, the `init` flag is never set after the initialization of version string.
This leads to memory leak because each call allocates a new buffer.