### PR TITLE
tests: Unify close/free checks for archives

### DIFF
--- a/libarchive/test/test_7zip_filename_encoding.c
+++ b/libarchive/test/test_7zip_filename_encoding.c
@@ -95,6 +95,6 @@ DEFINE_TEST(test_7zip_filename_encoding_UTF16_win)
 	/* NOTE: Trailing slash added automatically for us */
 	assertEqualWString(L"\u8868/", archive_entry_pathname_w(entry));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }

--- a/libarchive/test/test_ar_mode.c
+++ b/libarchive/test/test_ar_mode.c
@@ -36,5 +36,5 @@ DEFINE_TEST(test_ar_mode)
 	assertEqualIntA(ar, archive_read_next_header(ar, &entry), ARCHIVE_OK);
 	assertEqualIntA(ar, archive_entry_mode(entry), S_IFREG | 0644);
 
-	archive_read_free(ar);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(ar));
 }

--- a/libarchive/test/test_archive_clear_error.c
+++ b/libarchive/test/test_archive_clear_error.c
@@ -37,5 +37,5 @@ DEFINE_TEST(test_archive_clear_error)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_archive_match_time.c
+++ b/libarchive/test/test_archive_match_time.c
@@ -307,7 +307,7 @@ test_newer_mtime_than_file_mbs(void)
 	assertEqualInt(0, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -368,7 +368,7 @@ test_newer_ctime_than_file_mbs(void)
 	assertEqualInt(0, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif
@@ -426,7 +426,7 @@ test_newer_mtime_than_file_wcs(void)
 	assertEqualInt(0, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -488,7 +488,7 @@ test_newer_ctime_than_file_wcs(void)
 	assertEqualInt(0, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif
@@ -778,7 +778,7 @@ test_older_mtime_than_file_mbs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -840,7 +840,7 @@ test_older_ctime_than_file_mbs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif
@@ -898,7 +898,7 @@ test_older_mtime_than_file_wcs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -960,7 +960,7 @@ test_older_ctime_than_file_wcs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif
@@ -1020,7 +1020,7 @@ test_mtime_between_files_mbs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -1079,7 +1079,7 @@ test_mtime_between_files_wcs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 }
@@ -1142,7 +1142,7 @@ test_ctime_between_files_mbs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif
@@ -1206,7 +1206,7 @@ test_ctime_between_files_wcs(void)
 	assertEqualInt(1, archive_match_excluded(m, ae));
 
 	/* Clean up. */
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
 	archive_match_free(m);
 #endif

--- a/libarchive/test/test_archive_read.c
+++ b/libarchive/test/test_archive_read.c
@@ -59,5 +59,5 @@ DEFINE_TEST(test_archive_read_ahead_eof)
 	assert(NULL != __archive_read_ahead(ar, sizeof(buf), &avail));
 	assertEqualInt(sizeof(buf), avail);
 
-	assert(0 == archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_archive_read_add_passphrase.c
+++ b/libarchive/test/test_archive_read_add_passphrase.c
@@ -46,7 +46,7 @@ test(int pristine)
 	/* NULL passphrases cannot be accepted. */
 	assertEqualInt(ARCHIVE_FAILED, archive_read_add_passphrase(a, NULL));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase)
@@ -66,7 +66,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_incorrect_sequance)
 	 * get NULL even if a user has passed a passphrases. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase_single)
@@ -83,7 +83,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_single)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase_multiple)
@@ -103,7 +103,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_multiple)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static const char *
@@ -128,7 +128,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_set_callback1)
 	/* Second call, we still get "passCallBack" as a passphrase. */
 	assertEqualString("passCallBack", __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Without __archive_read_reset_passphrase call, the callback
 	 * should work fine. */
@@ -141,7 +141,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_set_callback1)
 	/* Second call, we still get "passCallBack" as a passphrase. */
 	assertEqualString("passCallBack", __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static const char *
@@ -174,7 +174,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_set_callback2)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase_set_callback3)
@@ -196,7 +196,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_set_callback3)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase_multiple_with_callback)
@@ -221,7 +221,7 @@ DEFINE_TEST(test_archive_read_add_passphrase_multiple_with_callback)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_add_passphrase_multiple_with_callback2)
@@ -254,6 +254,6 @@ DEFINE_TEST(test_archive_read_add_passphrase_multiple_with_callback2)
 	 * are passed already. */
 	assertEqualString(NULL, __archive_read_next_passphrase(ar));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_archive_read_close_twice.c
+++ b/libarchive/test/test_archive_read_close_twice.c
@@ -29,11 +29,11 @@ DEFINE_TEST(test_archive_read_close_twice)
 {
 	struct archive* a = archive_read_new();
 
-	assertEqualInt(0, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(0, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_read_close_twice.c
+++ b/libarchive/test/test_archive_read_close_twice.c
@@ -37,5 +37,5 @@ DEFINE_TEST(test_archive_read_close_twice)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_archive_read_close_twice_open_fd.c
+++ b/libarchive/test/test_archive_read_close_twice_open_fd.c
@@ -34,11 +34,11 @@ DEFINE_TEST(test_archive_read_close_twice_open_fd)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_read_close_twice_open_filename.c
+++ b/libarchive/test/test_archive_read_close_twice_open_filename.c
@@ -36,11 +36,11 @@ DEFINE_TEST(test_archive_read_close_twice_open_filename)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_read_next_header_empty.c
+++ b/libarchive/test/test_archive_read_next_header_empty.c
@@ -39,7 +39,7 @@ test_empty_file1(void)
 	assertEqualInt(ARCHIVE_FATAL, archive_read_open_filename(a, "emptyfile", 0));
 	assert(NULL != archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -57,7 +57,7 @@ test_empty_file2_check(struct archive* a)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -98,7 +98,7 @@ test_empty_tarfile(void)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 /* 512 zero bytes. */

--- a/libarchive/test/test_archive_read_next_header_raw.c
+++ b/libarchive/test/test_archive_read_next_header_raw.c
@@ -54,7 +54,7 @@ test(int skip_explicitely)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_next_header_raw)

--- a/libarchive/test/test_archive_read_open2.c
+++ b/libarchive/test/test_archive_read_open2.c
@@ -67,7 +67,7 @@ test(int formatted, archive_open_callback *o, archive_read_callback *r,
 	assertEqualInt(rv,
 	    archive_read_open2(a, NULL, o, r, s, c));
 	assertEqualString(msg, archive_error_string(a));
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_open2)

--- a/libarchive/test/test_archive_read_set_filter_option.c
+++ b/libarchive/test/test_archive_read_set_filter_option.c
@@ -44,7 +44,7 @@ test(int pristine)
 	should(a, ARCHIVE_FAILED, "fubar", "snafu", NULL);
 	should(a, ARCHIVE_FAILED, "fubar", "snafu", "betcha");
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_set_filter_option)

--- a/libarchive/test/test_archive_read_set_format_option.c
+++ b/libarchive/test/test_archive_read_set_format_option.c
@@ -56,7 +56,7 @@ test(int pristine)
 	should(a, known_option_rv, NULL, "joliet", NULL);
 	should(a, known_option_rv, NULL, "joliet", NULL);
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_set_format_option)

--- a/libarchive/test/test_archive_read_set_option.c
+++ b/libarchive/test/test_archive_read_set_option.c
@@ -58,7 +58,7 @@ test(int pristine)
 	should(a, known_option_rv, NULL, "joliet", NULL);
 	should(a, known_option_rv, NULL, "joliet", NULL);
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_set_option)

--- a/libarchive/test/test_archive_read_set_options.c
+++ b/libarchive/test/test_archive_read_set_options.c
@@ -115,7 +115,7 @@ test(int pristine)
 		    archive_error_string(a));
 	}
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_archive_read_set_options)

--- a/libarchive/test/test_archive_set_error.c
+++ b/libarchive/test/test_archive_set_error.c
@@ -46,5 +46,5 @@ DEFINE_TEST(test_archive_set_error)
 	test(a, -1, "tuvw");
 	test(a, 34, "XYZ");
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_archive_string_conversion.c
+++ b/libarchive/test/test_archive_string_conversion.c
@@ -1140,10 +1140,10 @@ DEFINE_TEST(test_archive_string_update_utf8_koi8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	r = archive_mstring_update_utf8(NULL, &mstr, utf8_string);
 

--- a/libarchive/test/test_archive_write_add_filter.c
+++ b/libarchive/test/test_archive_write_add_filter.c
@@ -131,7 +131,7 @@ test_add_filter_by_code(int filter_code,
 	assertEqualIntA(a, filter_code, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(buff);
 }

--- a/libarchive/test/test_archive_write_add_filter_by_name.c
+++ b/libarchive/test/test_archive_write_add_filter_by_name.c
@@ -129,7 +129,7 @@ test_filter_by_name(const char *filter_name, int filter_code,
 	assertEqualIntA(a, filter_code, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(buff);
 }

--- a/libarchive/test/test_archive_write_set_filter_option.c
+++ b/libarchive/test/test_archive_write_set_filter_option.c
@@ -44,7 +44,7 @@ test(int pristine)
 	should(a, ARCHIVE_FAILED, "fubar", "snafu", NULL);
 	should(a, ARCHIVE_FAILED, "fubar", "snafu", "betcha");
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_archive_write_set_filter_option)

--- a/libarchive/test/test_archive_write_set_format_by_name.c
+++ b/libarchive/test/test_archive_write_set_format_by_name.c
@@ -130,7 +130,7 @@ test_format_by_name(const char *format_name, const char *compression_type,
 		    archive_filter_code(a, 0));
 		assertEqualIntA(a, format_id, archive_format(a));
 
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(buff);

--- a/libarchive/test/test_archive_write_set_format_filter_by_ext.c
+++ b/libarchive/test/test_archive_write_set_format_filter_by_ext.c
@@ -137,7 +137,7 @@ test_format_filter_by_ext(const char *output_file,
 		    archive_filter_code(a, 0));
 		assertEqualIntA(a, format_id, archive_format(a) & ARCHIVE_FORMAT_BASE_MASK );
 
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(buff);

--- a/libarchive/test/test_archive_write_set_format_option.c
+++ b/libarchive/test/test_archive_write_set_format_option.c
@@ -56,7 +56,7 @@ test(int pristine)
 	should(a, known_option_rv, NULL, "joliet", NULL);
 	should(a, known_option_rv, NULL, "joliet", NULL);
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_archive_write_set_format_option)

--- a/libarchive/test/test_archive_write_set_option.c
+++ b/libarchive/test/test_archive_write_set_option.c
@@ -58,7 +58,7 @@ test(int pristine)
 	should(a, known_option_rv, NULL, "joliet", NULL);
 	should(a, known_option_rv, NULL, "joliet", NULL);
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_archive_write_set_option)

--- a/libarchive/test/test_archive_write_set_options.c
+++ b/libarchive/test/test_archive_write_set_options.c
@@ -115,7 +115,7 @@ test(int pristine)
 		    archive_error_string(a));
 	}
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_archive_write_set_options)

--- a/libarchive/test/test_archive_write_set_passphrase.c
+++ b/libarchive/test/test_archive_write_set_passphrase.c
@@ -51,7 +51,7 @@ test(int pristine)
 	assertEqualInt(ARCHIVE_OK, archive_write_set_passphrase(a, "pass2"));
 	assertEqualString("pass2", __archive_write_get_passphrase(aw));
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_archive_write_set_passphrase)
@@ -90,5 +90,5 @@ DEFINE_TEST(test_archive_write_set_passphrase_callback)
 	assertEqualString("passCallBack", __archive_write_get_passphrase(aw));
 	assertEqualInt(1, cnt);
 
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }

--- a/libarchive/test/test_compat_cpio.c
+++ b/libarchive/test/test_compat_cpio.c
@@ -92,7 +92,7 @@ test_compat_cpio_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_gtar.c
+++ b/libarchive/test/test_compat_gtar.c
@@ -53,7 +53,7 @@ test_compat_gtar_1(void)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString(
@@ -72,7 +72,7 @@ test_compat_gtar_1(void)
 	/* Read second entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString(
@@ -126,7 +126,7 @@ test_compat_gtar_2(void)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 

--- a/libarchive/test/test_compat_gtar.c
+++ b/libarchive/test/test_compat_gtar.c
@@ -101,7 +101,7 @@ test_compat_gtar_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -141,7 +141,7 @@ test_compat_gtar_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_gtar_large.c
+++ b/libarchive/test/test_compat_gtar_large.c
@@ -194,7 +194,7 @@ DEFINE_TEST(test_compat_gtar_large)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString("test.bin", archive_entry_pathname(ae));

--- a/libarchive/test/test_compat_gtar_large.c
+++ b/libarchive/test/test_compat_gtar_large.c
@@ -218,7 +218,7 @@ DEFINE_TEST(test_compat_gtar_large)
 	/* Verify that the reader actually read to the end of data */
 	assertEqualInt(reader.zero_blocks_remaining, 0);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(reader.zero_block);
 }

--- a/libarchive/test/test_compat_gzip.c
+++ b/libarchive/test/test_compat_gzip.c
@@ -77,7 +77,7 @@ verify(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_gzip.c
+++ b/libarchive/test/test_compat_gzip.c
@@ -63,7 +63,7 @@ verify(const char *name)
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_next_header(a, &ae));
 		if (r != ARCHIVE_OK) {
-			archive_read_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 			return;
 		}
 		assertEqualString(n[i], archive_entry_pathname(ae));

--- a/libarchive/test/test_compat_lz4.c
+++ b/libarchive/test/test_compat_lz4.c
@@ -78,7 +78,7 @@ verify(const char *name, const char *n[])
 	assertEqualString(archive_filter_name(a, 0), "lz4");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lz4.c
+++ b/libarchive/test/test_compat_lz4.c
@@ -64,7 +64,7 @@ verify(const char *name, const char *n[])
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_read_next_header(a, &ae));
 		if (r != ARCHIVE_OK) {
-			archive_read_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 			return;
 		}
 		assertEqualString(n[i], archive_entry_pathname(ae));

--- a/libarchive/test/test_compat_lzip.c
+++ b/libarchive/test/test_compat_lzip.c
@@ -124,7 +124,7 @@ compat_lzip(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -165,7 +165,7 @@ compat_lzip_3(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_RAW);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -202,7 +202,7 @@ compat_lzip_4(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lzma.c
+++ b/libarchive/test/test_compat_lzma.c
@@ -133,7 +133,7 @@ compat_lzma(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzma");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lzop.c
+++ b/libarchive/test/test_compat_lzop.c
@@ -70,7 +70,7 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -101,7 +101,7 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -125,6 +125,6 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_mac.c
+++ b/libarchive/test/test_compat_mac.c
@@ -130,7 +130,7 @@ test_compat_mac_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -201,7 +201,7 @@ test_compat_mac_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_perl_archive_tar.c
+++ b/libarchive/test/test_compat_perl_archive_tar.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_compat_perl_archive_tar)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_perl_archive_tar.c
+++ b/libarchive/test/test_compat_perl_archive_tar.c
@@ -45,7 +45,7 @@ DEFINE_TEST(test_compat_perl_archive_tar)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString("file1", archive_entry_pathname(ae));

--- a/libarchive/test/test_compat_plexus_archiver_tar.c
+++ b/libarchive/test/test_compat_plexus_archiver_tar.c
@@ -63,6 +63,6 @@ DEFINE_TEST(test_compat_plexus_archiver_tar)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_plexus_archiver_tar.c
+++ b/libarchive/test/test_compat_plexus_archiver_tar.c
@@ -49,7 +49,7 @@ DEFINE_TEST(test_compat_plexus_archiver_tar)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString("commons-logging-1.2/NOTICE.txt",

--- a/libarchive/test/test_compat_solaris_pax_sparse.c
+++ b/libarchive/test/test_compat_solaris_pax_sparse.c
@@ -48,7 +48,7 @@ test_compat_solaris_pax_sparse_1(void)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString("hole", archive_entry_pathname(ae));
@@ -128,7 +128,7 @@ test_compat_solaris_pax_sparse_2(void)
 	/* Read first entry. */
 	assertEqualIntA(a, ARCHIVE_OK, r = archive_read_next_header(a, &ae));
 	if (r != ARCHIVE_OK) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualString("hole", archive_entry_pathname(ae));

--- a/libarchive/test/test_compat_solaris_pax_sparse.c
+++ b/libarchive/test/test_compat_solaris_pax_sparse.c
@@ -100,7 +100,7 @@ test_compat_solaris_pax_sparse_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -172,7 +172,7 @@ test_compat_solaris_pax_sparse_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_tar_directory.c
+++ b/libarchive/test/test_compat_tar_directory.c
@@ -64,7 +64,7 @@ test_compat_tar_directory_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_tar_hardlink.c
+++ b/libarchive/test/test_compat_tar_hardlink.c
@@ -91,7 +91,7 @@ test_compat_tar_hardlink_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_xz.c
+++ b/libarchive/test/test_compat_xz.c
@@ -72,7 +72,7 @@ compat_xz(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "xz");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_zip.c
+++ b/libarchive/test/test_compat_zip.c
@@ -58,7 +58,7 @@ DEFINE_TEST(test_compat_zip_1)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_ZIP);
 
 finish:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -89,7 +89,7 @@ DEFINE_TEST(test_compat_zip_2)
 	assertEqualString("file2", archive_entry_pathname(ae));
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_zip.c
+++ b/libarchive/test/test_compat_zip.c
@@ -140,7 +140,7 @@ DEFINE_TEST(test_compat_zip_3)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 /**
@@ -188,7 +188,7 @@ DEFINE_TEST(test_compat_zip_4)
 	assertEqualInt(0644, archive_entry_perm(ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Try reading without seek support and watch it fail. */
 	assert((a = archive_read_new()) != NULL);
@@ -196,7 +196,7 @@ DEFINE_TEST(test_compat_zip_4)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_FATAL, read_open_memory(a, p, s, 3));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 /**
@@ -273,7 +273,7 @@ DEFINE_TEST(test_compat_zip_5)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Try reading without seek support. */
 	assert((a = archive_read_new()) != NULL);
@@ -332,7 +332,7 @@ DEFINE_TEST(test_compat_zip_5)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 
@@ -376,14 +376,14 @@ DEFINE_TEST(test_compat_zip_6)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory_seek(a, p, s, 7));
 	compat_zip_6_verify(a);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, p, s, 7));
 	compat_zip_6_verify(a);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 
@@ -417,7 +417,7 @@ DEFINE_TEST(test_compat_zip_7)
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_data_skip(a));
 
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(p);
 }
@@ -444,6 +444,6 @@ DEFINE_TEST(test_compat_zip_8)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 	/* This file is in the archive as arc\test */
 	assertEqualString("arc/test", archive_entry_pathname(ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_compat_zstd.c
+++ b/libarchive/test/test_compat_zstd.c
@@ -67,7 +67,7 @@ compat_zstd(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "zstd");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_filter_count.c
+++ b/libarchive/test/test_filter_count.c
@@ -46,7 +46,7 @@ read_test(const char *name)
 	/* bzip2 and none */
 	assertEqualInt(2, archive_filter_count(a));
 	
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -67,7 +67,7 @@ write_test(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, 4096, 0));
 	/* bzip2 and none */
 	assertEqualInt(2, archive_filter_count(a));
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_filter_count)

--- a/libarchive/test/test_fuzz.c
+++ b/libarchive/test/test_fuzz.c
@@ -197,7 +197,8 @@ test_fuzz(const struct files *filesets)
 						&blk, &blk_size, &blk_offset))
 						continue;
 				}
-				archive_read_close(a);
+				assertEqualIntA(a, ARCHIVE_OK,
+				    archive_read_close(a));
 			}
 			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -211,7 +212,8 @@ test_fuzz(const struct files *filesets)
 			if (0 == archive_read_open_memory(a, image, size)) {
 				while(0 == archive_read_next_header(a, &ae)) {
 				}
-				archive_read_close(a);
+				assertEqualIntA(a, ARCHIVE_OK,
+				    archive_read_close(a));
 			}
 			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		}

--- a/libarchive/test/test_fuzz.c
+++ b/libarchive/test/test_fuzz.c
@@ -85,7 +85,7 @@ test_fuzz(const struct files *filesets)
 			    archive_read_support_format_raw(a));
 			r = archive_read_open_filenames(a, filesets[n].names, 16384);
 			if (r != ARCHIVE_OK) {
-				archive_read_free(a);
+				assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 				if (filesets[n].names[0] == NULL || filesets[n].names[1] == NULL) {
 					skipping("Cannot uncompress fileset");
 				} else {
@@ -199,7 +199,7 @@ test_fuzz(const struct files *filesets)
 				}
 				archive_read_close(a);
 			}
-			archive_read_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 			// Just list headers, skip bodies.
 			assert((a = archive_read_new()) != NULL);
@@ -213,7 +213,7 @@ test_fuzz(const struct files *filesets)
 				}
 				archive_read_close(a);
 			}
-			archive_read_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		}
 		free(image);
 		free(rawimage);

--- a/libarchive/test/test_gnutar_filename_encoding.c
+++ b/libarchive/test/test_gnutar_filename_encoding.c
@@ -46,7 +46,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_UTF8_CP866)
 	if (archive_write_set_options(a, "hdrcharset=CP866") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-8 to CP866.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -87,7 +87,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_KOI8R_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -128,7 +128,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_KOI8R_CP866)
 	if (archive_write_set_options(a, "hdrcharset=CP866") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to CP866.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -170,7 +170,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP1251_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -288,7 +288,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_EUCJP_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -328,7 +328,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_EUCJP_CP932)
 	if (archive_write_set_options(a, "hdrcharset=CP932") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to CP932.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -369,7 +369,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP932_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from CP932/SJIS to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -412,7 +412,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -511,7 +511,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_fail_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=CP437") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to CP437.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,

--- a/libarchive/test/test_pax_filename_encoding.c
+++ b/libarchive/test/test_pax_filename_encoding.c
@@ -76,7 +76,7 @@ test_pax_filename_encoding_1(void)
 	    " characters in it without generating a warning");
 	assertEqualInt(ARCHIVE_OK, archive_read_next_header(a, &entry));
 	assertEqualString(filename, archive_entry_pathname(entry));
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 /*
@@ -352,10 +352,10 @@ DEFINE_TEST(test_pax_filename_encoding_KOI8R)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Re-create a write archive object since filenames should be written
 	 * in UTF-8 by default. */
@@ -399,10 +399,10 @@ DEFINE_TEST(test_pax_filename_encoding_CP1251)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Re-create a write archive object since filenames should be written
 	 * in UTF-8 by default. */
@@ -445,10 +445,10 @@ DEFINE_TEST(test_pax_filename_encoding_EUCJP)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Re-create a write archive object since filenames should be written
 	 * in UTF-8 by default. */
@@ -493,10 +493,10 @@ DEFINE_TEST(test_pax_filename_encoding_CP932)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from CP932/SJIS to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Re-create a write archive object since filenames should be written
 	 * in UTF-8 by default. */
@@ -606,10 +606,10 @@ DEFINE_TEST(test_pax_filename_encoding_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Create a new archive handle with default charset handling

--- a/libarchive/test/test_pax_xattr_header.c
+++ b/libarchive/test/test_pax_xattr_header.c
@@ -67,7 +67,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test1.tar","test_pax_xattr_header_all.tar");
 
@@ -86,7 +86,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test2.tar","test_pax_xattr_header_schily.tar");
 
@@ -105,7 +105,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test3.tar","test_pax_xattr_header_libarchive.tar");
 
@@ -123,7 +123,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test4.tar","test_pax_xattr_header_all.tar");
 }

--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -1357,7 +1357,7 @@ test_callbacks(void)
 	assert((m = archive_match_new()) != NULL);
 	if (m == NULL) {
 		archive_entry_free(ae);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		archive_match_free(m);
 		return;
 	}

--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -230,7 +230,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test that call archive_read_disk_open_w, wchar_t version.
@@ -358,7 +358,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test that call archive_read_disk_open with a regular file.
@@ -381,7 +381,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -427,7 +427,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test for a full-path beginning with "//?/"
@@ -458,7 +458,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	free(fullpath);
 
 	/*
@@ -515,7 +515,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	free(fullpath);
 
 #endif
@@ -658,7 +658,7 @@ test_symlink_hybrid(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Specified file is a directory and it has symbolic files.
@@ -722,7 +722,7 @@ test_symlink_hybrid(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	/* Destroy the disk object. */
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
@@ -827,7 +827,7 @@ test_symlink_logical(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Specified file is a directory and it has symbolic files.
@@ -953,7 +953,7 @@ test_symlink_logical(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	/* Destroy the disk object. */
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1131,7 +1131,7 @@ test_restore_atime(void)
 	assertFileAtime("at/fe", 886611, 0);
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test2: Traversals with archive_read_disk_set_atime_restored().
@@ -1197,7 +1197,7 @@ test_restore_atime(void)
 	assertFileAtime("at/fe", 886611, 0);
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test3: Traversals with archive_read_disk_set_atime_restored() but
@@ -1254,7 +1254,7 @@ test_restore_atime(void)
 	}
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test4: Traversals with ARCHIVE_READDISK_RESTORE_ATIME and
@@ -1406,7 +1406,7 @@ test_callbacks(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/* Reset name filter */
 	assertEqualIntA(a, ARCHIVE_OK,
@@ -1539,7 +1539,7 @@ test_nodump(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test2: Traversals with ARCHIVE_READDISK_HONOR_NODUMP
@@ -1671,7 +1671,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	assertChdir("../..");
 
@@ -1720,7 +1720,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test3: Traverse lock/dir1/.
@@ -1767,7 +1767,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test4: Traverse lock/lock2/dir1 from inside lock.
@@ -1793,7 +1793,7 @@ test_parent(void)
 			assertEqualIntA(a, ARCHIVE_OK, r);
 #endif
 		/* Close the disk object. */
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	} else {
 		file_count = 2;
 		match_count = 0;
@@ -1842,7 +1842,7 @@ test_parent(void)
 		    archive_read_next_header2(a, ae));
 
 		/* Close the disk object. */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	}
 
 	assertChdir("..");

--- a/libarchive/test/test_read_file_nonexistent.c
+++ b/libarchive/test/test_read_file_nonexistent.c
@@ -30,7 +30,7 @@ DEFINE_TEST(test_read_file_nonexistent)
 	assertEqualInt(ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualInt(ARCHIVE_FATAL,
 	    archive_read_open_filename(a, "notexistent.tar", 512));
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 

--- a/libarchive/test/test_read_files_compressed.c
+++ b/libarchive/test/test_read_files_compressed.c
@@ -44,5 +44,5 @@ DEFINE_TEST(test_read_files_compressed)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &entry));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_compress.c
+++ b/libarchive/test/test_read_filter_compress.c
@@ -35,7 +35,7 @@ DEFINE_TEST(test_read_filter_compress_truncated)
 	assertEqualIntA(a, ARCHIVE_FATAL,
 	    archive_read_open_memory(a, data, sizeof(data)));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -59,7 +59,7 @@ DEFINE_TEST(test_read_filter_compress_empty2)
 	assertEqualString(archive_filter_name(a, 0), "compress (.Z)");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_EMPTY);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -75,6 +75,6 @@ DEFINE_TEST(test_read_filter_compress_invalid)
 	assertEqualIntA(a, ARCHIVE_FATAL,
 	    archive_read_open_memory(a, data, sizeof(data)));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_grzip.c
+++ b/libarchive/test/test_read_filter_grzip.c
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_grzip)
 	assertEqualString(archive_filter_name(a, 0), "grzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_gzip_recursive.c
+++ b/libarchive/test/test_read_filter_gzip_recursive.c
@@ -45,6 +45,6 @@ DEFINE_TEST(test_read_filter_gzip_recursive)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_GZIP);
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lrzip.c
+++ b/libarchive/test/test_read_filter_lrzip.c
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_lrzip)
 	assertEqualString(archive_filter_name(a, 0), "lrzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lzop.c
+++ b/libarchive/test/test_read_filter_lzop.c
@@ -72,6 +72,6 @@ DEFINE_TEST(test_read_filter_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lzop_multiple_parts.c
+++ b/libarchive/test/test_read_filter_lzop_multiple_parts.c
@@ -71,6 +71,6 @@ DEFINE_TEST(test_read_filter_lzop_multiple_parts)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_uudecode_raw.c
+++ b/libarchive/test/test_read_filter_uudecode_raw.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_read_filter_uudecode_raw)
 	assertEqualInt((AE_IFREG | 0755), archive_entry_mode(ae));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_uudecode_base64_raw)
 	assertEqualInt((AE_IFREG | 0600), archive_entry_mode(ae));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -1505,7 +1505,7 @@ DEFINE_TEST(test_read_format_7zip_lzma2_riscv)
 	} else {
 		test_riscv_filter("test_read_format_7zip_lzma2_riscv.7z");
 	}
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This version of liblzma does not support LZMA_FILTER_RISCV");
 #endif

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -82,7 +82,7 @@ test_copy(int use_open_fd)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	if (fd != -1)
 		close(fd);
@@ -115,7 +115,7 @@ test_empty_archive(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -156,7 +156,7 @@ test_empty_file(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -199,7 +199,7 @@ test_plain_header(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -284,7 +284,7 @@ test_extract_all_files(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -369,7 +369,7 @@ test_extract_all_files_zstd(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -419,7 +419,7 @@ test_extract_file_zstd_bcj_nobjc(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -498,7 +498,7 @@ test_extract_last_file(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -629,7 +629,7 @@ test_extract_all_files2(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -685,7 +685,7 @@ test_delta_lzma(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -741,7 +741,7 @@ test_bcj(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -798,7 +798,7 @@ test_ppmd(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -847,7 +847,7 @@ test_symname(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1081,7 +1081,7 @@ test_arm_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1155,7 +1155,7 @@ test_arm64_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1404,7 +1404,7 @@ DEFINE_TEST(test_read_format_7zip_sfx_elf64trunc)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
 	assertEqualInt(0, archive_file_count(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1486,7 +1486,7 @@ test_riscv_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 #endif
@@ -1546,7 +1546,7 @@ test_sparc_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -1619,7 +1619,7 @@ test_powerpc_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_read_format_7zip_encryption_data.c
+++ b/libarchive/test/test_read_format_7zip_encryption_data.c
@@ -63,7 +63,7 @@ DEFINE_TEST(test_read_format_7zip_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_header.c
+++ b/libarchive/test/test_read_format_7zip_encryption_header.c
@@ -65,7 +65,7 @@ DEFINE_TEST(test_read_format_7zip_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_partially.c
+++ b/libarchive/test/test_read_format_7zip_encryption_partially.c
@@ -76,6 +76,6 @@ DEFINE_TEST(test_read_format_7zip_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip_issue2765.c
+++ b/libarchive/test/test_read_format_7zip_issue2765.c
@@ -46,6 +46,6 @@ DEFINE_TEST(test_read_format_7zip_issue2765)
 	assertEqualInt(0, archive_file_count(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip_malformed.c
+++ b/libarchive/test/test_read_format_7zip_malformed.c
@@ -39,7 +39,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -56,7 +56,7 @@ test_malformed2(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 
@@ -72,7 +72,7 @@ test_malformed3(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_open_filename(a, refname, 10240));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_7zip_malformed)

--- a/libarchive/test/test_read_format_7zip_packinfo_digests.c
+++ b/libarchive/test/test_read_format_7zip_packinfo_digests.c
@@ -82,7 +82,7 @@ DEFINE_TEST(test_read_format_7zip_packinfo_digests)
 		    archive_format(a));
 
 		/* Close the archive. */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	}
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_cab.c
+++ b/libarchive/test/test_read_format_cab.c
@@ -266,7 +266,7 @@ verify(const char *refname, enum comp_type comp)
 
 	/* Close the archive. */
 finish:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -332,7 +332,7 @@ verify2(const char *refname, enum comp_type comp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CAB, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -387,7 +387,7 @@ verify3(const char *refname, enum comp_type comp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CAB, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cab_filename.c
+++ b/libarchive/test/test_read_format_cab_filename.c
@@ -79,7 +79,7 @@ test_read_format_cab_filename_CP932_eucJP(const char *refname)
 
 	/* Close the archive. */
 cleanup:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -157,7 +157,7 @@ test_read_format_cab_filename_CP932_UTF8(const char *refname)
 
 	/* Close the archive. */
 cleanup:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_afio.c
+++ b/libarchive/test/test_read_format_cpio_afio.c
@@ -102,7 +102,7 @@ DEFINE_TEST(test_read_format_cpio_afio)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertA(archive_filter_code(a, 0) == ARCHIVE_FILTER_NONE);
 	assertA(archive_format(a) == ARCHIVE_FORMAT_CPIO_AFIO_LARGE);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);

--- a/libarchive/test/test_read_format_cpio_afio.c
+++ b/libarchive/test/test_read_format_cpio_afio.c
@@ -123,5 +123,5 @@ DEFINE_TEST(test_read_format_cpio_afio_broken)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_AFIO_LARGE);
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_cpio_bin_bz2.c
+++ b/libarchive/test/test_read_format_cpio_bin_bz2.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_read_format_cpio_bin_bz2)
 	r = archive_read_support_filter_bzip2(a);
 	if (r != ARCHIVE_OK) {
 		skipping("bzip2 support unavailable");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_read_format_cpio_bin_gz.c
+++ b/libarchive/test/test_read_format_cpio_bin_gz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_cpio_bin_gz)
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_BIN_LE);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_filename.c
+++ b/libarchive/test/test_read_format_cpio_filename.c
@@ -76,7 +76,7 @@ DEFINE_TEST(test_read_format_cpio_filename_eucJP_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -182,7 +182,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -235,7 +235,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_jp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }
@@ -288,7 +288,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -340,7 +340,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -393,7 +393,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -445,7 +445,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -498,7 +498,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -551,7 +551,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -603,7 +603,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_ru)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }
@@ -654,7 +654,7 @@ DEFINE_TEST(test_read_format_cpio_filename_eucJP_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -706,7 +706,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -759,7 +759,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -812,7 +812,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -864,7 +864,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -917,7 +917,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_cpio_svr4_bzip2_rpm.c
+++ b/libarchive/test/test_read_format_cpio_svr4_bzip2_rpm.c
@@ -123,7 +123,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_bzip2_rpm)
 	assertEqualString(archive_filter_name(a, 0), "bzip2");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_svr4_gzip.c
+++ b/libarchive/test/test_read_format_cpio_svr4_gzip.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_gzip)
 	    ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_svr4_gzip_rpm.c
+++ b/libarchive/test/test_read_format_cpio_svr4_gzip_rpm.c
@@ -123,7 +123,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_gzip_rpm)
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
  
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_gtar_filename.c
+++ b/libarchive/test/test_read_format_gtar_filename.c
@@ -74,7 +74,7 @@ DEFINE_TEST(test_read_format_gtar_filename_eucJP_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -127,7 +127,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -179,7 +179,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -232,7 +232,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -284,7 +284,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -335,7 +335,7 @@ DEFINE_TEST(test_read_format_gtar_filename_eucJP_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -388,7 +388,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -441,7 +441,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -493,7 +493,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_gtar_gz.c
+++ b/libarchive/test/test_read_format_gtar_gz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_gtar_gz)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_gtar_redundant_L.c
+++ b/libarchive/test/test_read_format_gtar_redundant_L.c
@@ -35,6 +35,6 @@ DEFINE_TEST(test_read_format_gtar_redundant_L)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_gtar_sparse.c
+++ b/libarchive/test/test_read_format_gtar_sparse.c
@@ -234,7 +234,8 @@ verify_archive_file(const char *name, struct archive_contents *ac)
 					failure("%s: Unexpected trailing data",
 					    name);
 					assert(actual.o <= expect.o);
-					archive_read_free(a);
+					assertEqualInt(ARCHIVE_OK,
+					    archive_read_free(a));
 					return;
 				}
 				actual.d++;

--- a/libarchive/test/test_read_format_gtar_sparse_skip_entry.c
+++ b/libarchive/test/test_read_format_gtar_sparse_skip_entry.c
@@ -74,7 +74,7 @@ DEFINE_TEST(test_read_format_gtar_sparse_skip_entry)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -117,7 +117,7 @@ DEFINE_TEST(test_read_format_gtar_sparse_skip_entry)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_huge_rpm.c
+++ b/libarchive/test/test_read_format_huge_rpm.c
@@ -44,7 +44,7 @@ DEFINE_TEST(test_read_format_huge_rpm)
 	assertEqualString("rpm", archive_filter_name(a, 0));
 	assertEqualInt(ARCHIVE_FORMAT_EMPTY, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha.c
+++ b/libarchive/test/test_read_format_lha.c
@@ -266,7 +266,7 @@ verify(const char *refname, int posix)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha_bugfix_0.c
+++ b/libarchive/test/test_read_format_lha_bugfix_0.c
@@ -69,7 +69,7 @@ DEFINE_TEST(test_read_format_lha_bugfix_0)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha_filename.c
+++ b/libarchive/test/test_read_format_lha_filename.c
@@ -85,7 +85,7 @@ test_read_format_lha_filename_CP932_eucJP(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -145,7 +145,7 @@ test_read_format_lha_filename_CP932_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -195,7 +195,7 @@ test_read_format_lha_filename_CP932_Windows(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 #else

--- a/libarchive/test/test_read_format_lha_filename_utf16.c
+++ b/libarchive/test/test_read_format_lha_filename_utf16.c
@@ -127,7 +127,7 @@ test_read_format_lha_filename_UTF16_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_mtree.c
+++ b/libarchive/test/test_read_format_mtree.c
@@ -269,7 +269,7 @@ test_read_format_mtree1(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(30, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -299,7 +299,7 @@ test_read_format_mtree2(void)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -348,7 +348,7 @@ test_read_format_mtree3(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	assertChdir("..");
@@ -418,7 +418,7 @@ DEFINE_TEST(test_read_format_mtree_filenames_only)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -477,7 +477,7 @@ DEFINE_TEST(test_read_format_mtree_nochange)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -518,7 +518,7 @@ DEFINE_TEST(test_read_format_mtree_nochange)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -620,7 +620,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v1_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(12, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -687,7 +687,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v2_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -754,7 +754,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v2_netbsd_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -785,7 +785,7 @@ DEFINE_TEST(test_read_format_mtree_nonexistent_contents_file)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -811,7 +811,7 @@ DEFINE_TEST(test_read_format_mtree_noprint)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
 	assertEqualString("Can't parse line 3", archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -840,7 +840,7 @@ DEFINE_TEST(test_read_format_mtree_tab)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -875,6 +875,6 @@ DEFINE_TEST(test_read_format_mtree_nano)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(2, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_pax_bz2.c
+++ b/libarchive/test/test_read_format_pax_bz2.c
@@ -48,7 +48,7 @@ DEFINE_TEST(test_read_format_pax_bz2)
 	assert((a = archive_read_new()) != NULL);
 	r = archive_read_support_filter_bzip2(a);
 	if (r != ARCHIVE_OK) {
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		skipping("Bzip2 unavailable");
 		return;
 	}

--- a/libarchive/test/test_read_format_rar.c
+++ b/libarchive/test/test_read_format_rar.c
@@ -3807,7 +3807,7 @@ DEFINE_TEST(test_read_format_rar_multivolume_uncompressed_files)
   assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
   assertEqualIntA(a, 16, archive_file_count(a));
   assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-  assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_rar_endarc_huge)

--- a/libarchive/test/test_read_format_rar_encryption.c
+++ b/libarchive/test/test_read_format_rar_encryption.c
@@ -81,7 +81,7 @@ static void test_encrypted_rar_archive(const char *filename, int filenamesEncryp
 		assertEqualInt(ARCHIVE_FATAL, archive_read_data(a, buff, sizeof(buff)));
 
 		/* Additional attempts to read headers are futile */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -126,7 +126,7 @@ static void test_encrypted_rar_archive(const char *filename, int filenamesEncryp
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_rar_encryption_data.c
+++ b/libarchive/test/test_read_format_rar_encryption_data.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_read_format_rar_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_rar_encryption_header.c
+++ b/libarchive/test/test_read_format_rar_encryption_header.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_format_rar_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_rar_encryption_partially.c
+++ b/libarchive/test/test_read_format_rar_encryption_partially.c
@@ -73,6 +73,6 @@ DEFINE_TEST(test_read_format_rar_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_concatenated.c
+++ b/libarchive/test/test_read_format_tar_concatenated.c
@@ -54,7 +54,7 @@ DEFINE_TEST(test_read_format_tar_concatenated)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -80,6 +80,6 @@ DEFINE_TEST(test_read_format_tar_concatenated)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_empty_filename.c
+++ b/libarchive/test/test_read_format_tar_empty_filename.c
@@ -58,6 +58,6 @@ DEFINE_TEST(test_read_format_tar_empty_filename)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_empty_with_gnulabel.c
+++ b/libarchive/test/test_read_format_tar_empty_with_gnulabel.c
@@ -47,6 +47,6 @@ DEFINE_TEST(test_read_format_tar_empty_with_gnulabel)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_filename.c
+++ b/libarchive/test/test_read_format_tar_filename.c
@@ -100,7 +100,7 @@ test_read_format_tar_filename_KOI8R_CP866(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -150,7 +150,7 @@ next_test:
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -214,7 +214,7 @@ test_read_format_tar_filename_KOI8R_UTF8(const char *refname)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -261,7 +261,7 @@ test_read_format_tar_filename_KOI8R_UTF8(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -329,7 +329,7 @@ test_read_format_tar_filename_KOI8R_CP1251(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -377,7 +377,7 @@ next_test:
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_tar_mac_metadata.c
+++ b/libarchive/test/test_read_format_tar_mac_metadata.c
@@ -79,7 +79,7 @@ DEFINE_TEST(test_read_format_tar_mac_metadata)
 	/* ... and nothing else */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_tar_pax_g_large.c
+++ b/libarchive/test/test_read_format_tar_pax_g_large.c
@@ -48,6 +48,6 @@ DEFINE_TEST(test_read_format_tar_pax_g_large)
 	assertEqualInt(ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualInt(ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_large_attr.c
+++ b/libarchive/test/test_read_format_tar_pax_large_attr.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_format_tar_pax_large_attr)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_negative_time.c
+++ b/libarchive/test/test_read_format_tar_pax_negative_time.c
@@ -63,6 +63,6 @@ DEFINE_TEST(test_read_format_tar_pax_negative_time)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_timestamps.c
+++ b/libarchive/test/test_read_format_tar_pax_timestamps.c
@@ -59,6 +59,6 @@ DEFINE_TEST(test_read_format_tar_pax_timestamps)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_timestamp_overflow.c
+++ b/libarchive/test/test_read_format_tar_timestamp_overflow.c
@@ -50,6 +50,6 @@ DEFINE_TEST(test_read_format_tar_timestamp_overflow)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tbz.c
+++ b/libarchive/test/test_read_format_tbz.c
@@ -42,7 +42,7 @@ DEFINE_TEST(test_read_format_tbz)
 	r = archive_read_support_filter_bzip2(a);
 	if (r != ARCHIVE_OK) {
 		skipping("Bzip2 support");
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_read_format_tgz.c
+++ b/libarchive/test/test_read_format_tgz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_tgz)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_ustar_filename.c
+++ b/libarchive/test/test_read_format_ustar_filename.c
@@ -75,7 +75,7 @@ test_read_format_ustar_filename_eucJP_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -130,7 +130,7 @@ test_read_format_ustar_filename_CP866_KOI8R(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -185,7 +185,7 @@ test_read_format_ustar_filename_CP866_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -241,7 +241,7 @@ test_read_format_ustar_filename_KOI8R_CP866(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -296,7 +296,7 @@ test_read_format_ustar_filename_KOI8R_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -350,7 +350,7 @@ test_read_format_ustar_filename_eucJP_CP932(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -406,7 +406,7 @@ test_read_format_ustar_filename_CP866_CP1251(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -462,7 +462,7 @@ test_read_format_ustar_filename_CP866_CP1251_win(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -517,7 +517,7 @@ test_read_format_ustar_filename_KOI8R_CP1251(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -629,7 +629,7 @@ has the corresponding timestamps unset.
   archive_write_header(a, ae);
   archive_entry_free(ae);
   archive_write_data(a, "12345678", 9);
-  archive_write_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
   std::cout << std::string(buff, used);
   free(buff);

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -305,7 +305,7 @@ verify_extract_length_at_end(struct archive *a, int seek_checks)
 	}
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -368,7 +368,7 @@ test_symlink(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }
@@ -398,7 +398,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_one_file_blockread)
@@ -418,7 +418,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_multi)
@@ -450,7 +450,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_multi_blockread)
@@ -482,7 +482,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_one_file)
@@ -507,7 +507,7 @@ DEFINE_TEST(test_read_format_zip_lzma_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_one_file_blockread)
@@ -532,7 +532,7 @@ DEFINE_TEST(test_read_format_zip_lzma_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_multi)
@@ -569,7 +569,7 @@ DEFINE_TEST(test_read_format_zip_lzma_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_multi_blockread)
@@ -606,7 +606,7 @@ DEFINE_TEST(test_read_format_zip_lzma_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 
@@ -632,7 +632,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
@@ -657,7 +657,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_multi)
@@ -694,7 +694,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
@@ -731,7 +731,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_one_file)
@@ -744,7 +744,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file)
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
 		archive_read_close(a);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -757,7 +757,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
@@ -770,7 +770,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
 		archive_read_close(a);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -783,7 +783,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_multi)
@@ -796,7 +796,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi)
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
 		archive_read_close(a);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -821,7 +821,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
@@ -834,7 +834,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
 		archive_read_close(a);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -859,7 +859,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_xz_multi)
@@ -896,7 +896,7 @@ DEFINE_TEST(test_read_format_zip_xz_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_xz_multi_blockread)
@@ -933,7 +933,7 @@ DEFINE_TEST(test_read_format_zip_xz_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
@@ -955,7 +955,7 @@ DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
 	 * proper fix, the unpacker was entering an unlimited loop. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 1));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
@@ -981,7 +981,7 @@ DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
 	 * But it shouldn't crash. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd8_crash_2)
@@ -1002,7 +1002,7 @@ DEFINE_TEST(test_read_format_zip_ppmd8_crash_2)
 	 * But it shouldn't crash. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
@@ -1019,7 +1019,7 @@ DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
 	if(ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
 		skipping("lzma reading is not fully supported on this platform");
 		archive_read_close(a);
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 
@@ -1037,7 +1037,7 @@ DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* This testcase shouldn't produce any memory leaks. When running test
 	 * suite under Valgrind or ASan, the test runner won't return with
@@ -1066,7 +1066,7 @@ DEFINE_TEST(test_read_format_zip_lzma_stream_end)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_stream_end_blockread)
@@ -1091,7 +1091,7 @@ DEFINE_TEST(test_read_format_zip_lzma_stream_end_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_7z_lzma)
@@ -1123,7 +1123,7 @@ DEFINE_TEST(test_read_format_zip_7z_lzma)
 		"/src/abc_measurement_analysis_sample.py",
 		archive_entry_symlink(ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_7z_deflate)
@@ -1169,5 +1169,5 @@ DEFINE_TEST(test_read_format_zip_7z_deflate)
 	}
 	assertEqualInt(AE_IFLNK, archive_entry_filetype(ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -619,7 +619,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -644,7 +644,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -669,7 +669,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -706,7 +706,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -743,7 +743,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -769,7 +769,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -795,7 +795,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -833,7 +833,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_zstd(a)) {
 		skipping("zstd is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -968,7 +968,7 @@ DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		return;
 	}
 	extract_reference_file(refname);
@@ -1018,7 +1018,7 @@ DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
 	assert((a = archive_read_new()) != NULL);
 	if(ARCHIVE_OK != archive_read_support_filter_lzma(a)) {
 		skipping("lzma reading is not fully supported on this platform");
-		archive_read_close(a);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}

--- a/libarchive/test/test_read_format_zip_7075_utf8_paths.c
+++ b/libarchive/test/test_read_format_zip_7075_utf8_paths.c
@@ -86,7 +86,7 @@ DEFINE_TEST(test_read_format_zip_utf8_paths)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	verify(a);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Verify with streaming reader. */
 	p = slurpfile(&s, "%s", refname);

--- a/libarchive/test/test_read_format_zip_comment_stored.c
+++ b/libarchive/test/test_read_format_zip_comment_stored.c
@@ -61,7 +61,7 @@ verify(const char *refname)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), 0);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_encryption_data.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_read_format_zip_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_encryption_header.c
+++ b/libarchive/test/test_read_format_zip_encryption_header.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_format_zip_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_encryption_partially.c
+++ b/libarchive/test/test_read_format_zip_encryption_partially.c
@@ -73,6 +73,6 @@ DEFINE_TEST(test_read_format_zip_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_filename.c
+++ b/libarchive/test/test_read_format_zip_filename.c
@@ -81,7 +81,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -159,7 +159,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -234,7 +234,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -329,7 +329,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -385,7 +385,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -441,7 +441,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -498,7 +498,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -554,7 +554,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -616,7 +616,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -681,7 +681,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -734,7 +734,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_UTF8_ru)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -792,7 +792,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -869,7 +869,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -926,7 +926,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -983,7 +983,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1039,7 +1039,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1103,7 +1103,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1173,7 +1173,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_UTF8_2)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -1223,7 +1223,7 @@ next_test:
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }

--- a/libarchive/test/test_read_format_zip_jar.c
+++ b/libarchive/test/test_read_format_zip_jar.c
@@ -53,6 +53,6 @@ DEFINE_TEST(test_read_format_zip_jar)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_mac_metadata.c
+++ b/libarchive/test/test_read_format_zip_mac_metadata.c
@@ -110,7 +110,7 @@ DEFINE_TEST(test_read_format_zip_mac_metadata)
 	}
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_malformed.c
+++ b/libarchive/test/test_read_format_zip_malformed.c
@@ -42,7 +42,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Verify with streaming reader. */
 	p = slurpfile(&s, "%s", refname);
@@ -51,7 +51,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, p, s, 31));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 

--- a/libarchive/test/test_read_format_zip_nested.c
+++ b/libarchive/test/test_read_format_zip_nested.c
@@ -62,7 +62,7 @@ DEFINE_TEST(test_read_format_zip_nested)
 	/* Close outer Zip */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 
@@ -80,7 +80,7 @@ DEFINE_TEST(test_read_format_zip_nested)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(inner);
 }

--- a/libarchive/test/test_read_format_zip_nofiletype.c
+++ b/libarchive/test/test_read_format_zip_nofiletype.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_format_zip_nofiletype)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_padded.c
+++ b/libarchive/test/test_read_format_zip_padded.c
@@ -51,7 +51,7 @@ verify_padded_archive(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_sfx.c
+++ b/libarchive/test/test_read_format_zip_sfx.c
@@ -58,7 +58,7 @@ DEFINE_TEST(test_read_format_zip_sfx)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_traditional_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_traditional_encryption_data.c
@@ -92,7 +92,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -161,7 +161,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_traditional_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_traditional_encryption_data.c
@@ -42,10 +42,10 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 	if (ARCHIVE_OK != archive_write_set_options(a,
 				"zip:encryption=traditional")) {
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 	extract_reference_file(refname);

--- a/libarchive/test/test_read_format_zip_winzip_aes.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes.c
@@ -39,10 +39,10 @@ test_winzip_aes(const char *refname, int need_libz)
 	if (ARCHIVE_OK != archive_write_set_options(a,
 				"zip:encryption=aes256")) {
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 	extract_reference_file(refname);

--- a/libarchive/test/test_read_format_zip_winzip_aes.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes.c
@@ -78,7 +78,7 @@ test_winzip_aes(const char *refname, int need_libz)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -128,7 +128,7 @@ test_winzip_aes(const char *refname, int need_libz)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_winzip_aes_large.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes_large.c
@@ -110,7 +110,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -210,7 +210,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_winzip_aes_large.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes_large.c
@@ -40,10 +40,10 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 	if (ARCHIVE_OK != archive_write_set_options(a,
 				"zip:encryption=aes256")) {
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 	extract_reference_file(refname);

--- a/libarchive/test/test_read_format_zip_with_invalid_traditional_eocd.c
+++ b/libarchive/test/test_read_format_zip_with_invalid_traditional_eocd.c
@@ -53,6 +53,6 @@ DEFINE_TEST(test_read_format_zip_with_invalid_traditional_eocd)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_zip64.c
+++ b/libarchive/test/test_read_format_zip_zip64.c
@@ -47,7 +47,7 @@ verify_file0_seek(struct archive *a)
 #endif
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -76,7 +76,7 @@ verify_file0_stream(struct archive *a, int size_known)
 #endif
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zip64a)

--- a/libarchive/test/test_read_format_zip_zipx_lzma_oom.c
+++ b/libarchive/test/test_read_format_zip_zipx_lzma_oom.c
@@ -58,6 +58,6 @@ DEFINE_TEST(test_read_format_zip_zipx_lzma_oom)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
 	assertEqualInt(ENOMEM, archive_errno(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_empty_val_no_nl.c
+++ b/libarchive/test/test_read_pax_empty_val_no_nl.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_pax_empty_val_no_nl)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_xattr_rht_security_selinux.c
+++ b/libarchive/test/test_read_pax_xattr_rht_security_selinux.c
@@ -57,6 +57,6 @@ DEFINE_TEST(test_read_pax_xattr_rht_security_selinux)
 	assertEqualInt((int)xsize, strlen(string));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_xattr_schily.c
+++ b/libarchive/test/test_read_pax_xattr_schily.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_pax_xattr_schily)
 	assertEqualMem(xval, array, 12);
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_position.c
+++ b/libarchive/test/test_read_position.c
@@ -99,13 +99,13 @@ DEFINE_TEST(test_read_position)
 	assertA(0 == archive_read_support_format_tar(a));
 	assertA(0 == read_open_memory(a, buff, sizeof(buff), 512));
 	verify_read_positions(a);
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Read the archive back without a skip function. */
 	assert(NULL != (a = archive_read_new()));
 	assertA(0 == archive_read_support_format_tar(a));
 	assertA(0 == read_open_memory_minimal(a, buff, sizeof(buff), 512));
 	verify_read_positions(a);
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 }

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -148,7 +148,7 @@ DEFINE_TEST(test_read_append_filter)
   assertEqualInt(1, archive_file_count(a));
   assertEqualInt(archive_filter_code(a, 0), ARCHIVE_COMPRESSION_GZIP);
   assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
-  assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -163,7 +163,7 @@ DEFINE_TEST(test_read_append_wrong_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_XZ);
   if (r == ARCHIVE_WARN && !canXz()) {
     skipping("xz reading not fully supported on this platform");
-    assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   assertEqualInt(ARCHIVE_OK,
@@ -180,35 +180,33 @@ DEFINE_TEST(test_read_append_wrong_filter)
 DEFINE_TEST(test_read_append_lzop_filter)
 {
   struct archive *a;
-  int r;
+  int expected;
 
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
-  r = archive_read_append_filter(a, ARCHIVE_FILTER_LZOP);
   if (archive_liblzo2_version() != NULL) {
-    assertEqualIntA(a, ARCHIVE_OK, r);
-  } else if (canLzop()) {
+    expected = ARCHIVE_OK;
+  } else {
     // We're using an external program
-    assertEqualIntA(a, ARCHIVE_WARN, r);
+    expected = ARCHIVE_WARN;
   }
+  assertEqualIntA(a, expected,
+    archive_read_append_filter(a, ARCHIVE_FILTER_LZOP));
 
-  archive_read_free(a);
+  assertEqualInt(expected, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_grzip_filter)
 {
   struct archive *a;
-  int r;
 
   assert((a = archive_read_new()) != NULL);
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
-  r = archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP);
   // Grzip currently always uses an external program.
-  if (canGrzip()) {
-    assertEqualIntA(a, ARCHIVE_WARN, r);
-  }
+  assertEqualIntA(a, ARCHIVE_WARN,
+    archive_read_append_filter(a, ARCHIVE_FILTER_GRZIP));
 
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_compress_filter)
@@ -233,14 +231,14 @@ DEFINE_TEST(test_read_append_bzip2_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_BZIP2);
   if (r != ARCHIVE_OK && archive_bzlib_version() == NULL && !canBzip2()) {
     skipping("bzip2 tests require bzlib or working bzip2 command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canBzip2())
     assertEqualString(archive_error_string(a), "Using external bzip2 program");
   else
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_lrzip_filter)
@@ -253,14 +251,15 @@ DEFINE_TEST(test_read_append_lrzip_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LRZIP);
   if (r != ARCHIVE_OK && !canLrzip()) {
     skipping("lrzip tests require working lrzip command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canLrzip())
     assertEqualString(archive_error_string(a), "Using external lrzip program for lrzip decompression");
-  else
+  else {
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  }
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_lz4_filter)
@@ -273,14 +272,14 @@ DEFINE_TEST(test_read_append_lz4_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZ4);
   if (r != ARCHIVE_OK && archive_liblz4_version() == NULL && !canLz4()) {
     skipping("lz4 tests require liblz4 or working lz4 command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canLz4())
     assertEqualString(archive_error_string(a), "Using external lz4 program");
   else
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_lzip_filter)
@@ -293,14 +292,14 @@ DEFINE_TEST(test_read_append_lzip_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZIP);
   if (r != ARCHIVE_OK && archive_liblzma_version() == NULL && !canLzip()) {
     skipping("lzip tests require liblzma or working lzip command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canLzip())
     assertEqualString(archive_error_string(a), "Using external lzip program for lzip decompression");
   else
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_lzma_filter)
@@ -313,14 +312,14 @@ DEFINE_TEST(test_read_append_lzma_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_LZMA);
   if (r != ARCHIVE_OK && archive_liblzma_version() == NULL && !canLzma()) {
     skipping("lzma tests require liblzma or working lzma command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canLzma())
     assertEqualString(archive_error_string(a), "Using external lzma program for lzma decompression");
   else
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_zstd_filter)
@@ -333,14 +332,14 @@ DEFINE_TEST(test_read_append_zstd_filter)
   r = archive_read_append_filter(a, ARCHIVE_FILTER_ZSTD);
   if (r != ARCHIVE_OK && archive_libzstd_version() == NULL && !canZstd()) {
     skipping("zstd tests require libzstd or working zstd command");
-    archive_read_free(a);
+    assertEqualInt(ARCHIVE_WARN, archive_read_free(a));
     return;
   }
   if (r == ARCHIVE_WARN && canZstd())
     assertEqualString(archive_error_string(a), "Using external zstd program for zstd decompression");
   else
     assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_rpm_filter)
@@ -352,7 +351,7 @@ DEFINE_TEST(test_read_append_rpm_filter)
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_RPM);
   assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_uu_filter)
@@ -364,7 +363,7 @@ DEFINE_TEST(test_read_append_uu_filter)
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_UU);
   assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_none_filter)
@@ -376,7 +375,7 @@ DEFINE_TEST(test_read_append_none_filter)
   assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_NONE);
   assertEqualIntA(a, ARCHIVE_OK, r);
-  archive_read_free(a);
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_filter_program)

--- a/libarchive/test/test_read_truncated_filter.c
+++ b/libarchive/test/test_read_truncated_filter.c
@@ -85,7 +85,7 @@ test_truncation(const char *compression,
 		failure("%s", path);
 		if (!assertEqualIntA(a, ARCHIVE_OK,
 		    archive_write_header(a, ae))) {
-			archive_write_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 			free(data);
 			free(buff);
 			return;
@@ -94,7 +94,7 @@ test_truncation(const char *compression,
 		failure("%s", path);
 		if (!assertEqualIntA(a, datasize,
 		    archive_write_data(a, data, datasize))) {
-			archive_write_free(a);
+			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 			free(data);
 			free(buff);
 			return;

--- a/libarchive/test/test_short_writes.c
+++ b/libarchive/test/test_short_writes.c
@@ -171,8 +171,8 @@ checker_free(struct checker *checker)
 {
         free(checker->shortbuf);
         free(checker->fullbuf);
-	archive_read_free(checker->short_archive);
-	archive_read_free(checker->full_archive);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(checker->short_archive));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(checker->full_archive));
         free(checker);
 }
 

--- a/libarchive/test/test_ustar_filename_encoding.c
+++ b/libarchive/test/test_ustar_filename_encoding.c
@@ -47,7 +47,7 @@ DEFINE_TEST(test_ustar_filename_encoding_UTF8_CP866)
 	if (archive_write_set_options(a, "hdrcharset=CP866") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-8 to CP866.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -88,7 +88,7 @@ DEFINE_TEST(test_ustar_filename_encoding_KOI8R_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -129,7 +129,7 @@ DEFINE_TEST(test_ustar_filename_encoding_KOI8R_CP866)
 	if (archive_write_set_options(a, "hdrcharset=CP866") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to CP866.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -171,7 +171,7 @@ DEFINE_TEST(test_ustar_filename_encoding_CP1251_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -289,7 +289,7 @@ DEFINE_TEST(test_ustar_filename_encoding_EUCJP_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -329,7 +329,7 @@ DEFINE_TEST(test_ustar_filename_encoding_EUCJP_CP932)
 	if (archive_write_set_options(a, "hdrcharset=CP932") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to CP932.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -370,7 +370,7 @@ DEFINE_TEST(test_ustar_filename_encoding_CP932_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from CP932/SJIS to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -413,7 +413,7 @@ DEFINE_TEST(test_ustar_filename_encoding_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -512,7 +512,7 @@ DEFINE_TEST(test_ustar_filename_encoding_fail_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=CP437") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to CP437.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,

--- a/libarchive/test/test_v7tar_filename_encoding.c
+++ b/libarchive/test/test_v7tar_filename_encoding.c
@@ -45,7 +45,7 @@ DEFINE_TEST(test_v7tar_filename_encoding_fail_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=CP437") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to CP437.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,

--- a/libarchive/test/test_write_disk_appledouble.c
+++ b/libarchive/test/test_write_disk_appledouble.c
@@ -151,7 +151,7 @@ DEFINE_TEST(test_write_disk_appledouble)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -210,7 +210,7 @@ DEFINE_TEST(test_write_disk_appledouble)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -296,7 +296,7 @@ DEFINE_TEST(test_write_disk_appledouble_zip)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test test_file */
 	assertEqualInt(0, stat("apple_double_dir/test_file", &st));

--- a/libarchive/test/test_write_disk_hfs_compression.c
+++ b/libarchive/test/test_write_disk_hfs_compression.c
@@ -146,7 +146,7 @@ DEFINE_TEST(test_write_disk_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));
@@ -229,7 +229,7 @@ DEFINE_TEST(test_write_disk_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));

--- a/libarchive/test/test_write_disk_mac_metadata.c
+++ b/libarchive/test/test_write_disk_mac_metadata.c
@@ -144,7 +144,7 @@ DEFINE_TEST(test_write_disk_mac_metadata)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -195,7 +195,7 @@ DEFINE_TEST(test_write_disk_mac_metadata)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));

--- a/libarchive/test/test_write_disk_no_hfs_compression.c
+++ b/libarchive/test/test_write_disk_no_hfs_compression.c
@@ -120,7 +120,7 @@ DEFINE_TEST(test_write_disk_no_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));
@@ -190,7 +190,7 @@ DEFINE_TEST(test_write_disk_no_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));

--- a/libarchive/test/test_write_disk_secure745.c
+++ b/libarchive/test/test_write_disk_secure745.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_write_disk_secure745)
 	/* Permission of target dir should not have changed. */
 	assertFileMode("../target", 0700);
 
-	assert(0 == archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 #endif
 }

--- a/libarchive/test/test_write_disk_secure745.c
+++ b/libarchive/test/test_write_disk_secure745.c
@@ -73,6 +73,6 @@ DEFINE_TEST(test_write_disk_secure745)
 	assertFileMode("../target", 0700);
 
 	assert(0 == archive_write_close(a));
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 #endif
 }

--- a/libarchive/test/test_write_disk_secure746.c
+++ b/libarchive/test/test_write_disk_secure746.c
@@ -70,7 +70,7 @@ DEFINE_TEST(test_write_disk_secure746a)
 	assertTextFileContents("unmodified", "../target/foo");
 
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_FATAL, archive_write_free(a));
 }
 
 /*
@@ -122,6 +122,6 @@ DEFINE_TEST(test_write_disk_secure746b)
 	assertTextFileContents("unmodified", "../target/foo");
 
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_FATAL, archive_write_free(a));
 #endif
 }

--- a/libarchive/test/test_write_filter_b64encode.c
+++ b/libarchive/test/test_write_filter_b64encode.c
@@ -147,13 +147,13 @@ DEFINE_TEST(test_write_filter_b64encode)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -161,7 +161,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_bzip2.c
+++ b/libarchive/test/test_write_filter_bzip2.c
@@ -241,7 +241,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	else
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_write_add_filter_bzip2(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -252,7 +252,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	else
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_write_add_filter_bzip2(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -265,7 +265,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 		    archive_write_add_filter_bzip2(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_gzip.c
+++ b/libarchive/test/test_write_filter_gzip.c
@@ -280,14 +280,14 @@ DEFINE_TEST(test_write_filter_gzip)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -295,7 +295,7 @@ DEFINE_TEST(test_write_filter_gzip)
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lrzip.c
+++ b/libarchive/test/test_write_filter_lrzip.c
@@ -106,13 +106,13 @@ DEFINE_TEST(test_write_filter_lrzip)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -120,7 +120,7 @@ DEFINE_TEST(test_write_filter_lrzip)
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 		archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lz4.c
+++ b/libarchive/test/test_write_filter_lz4.c
@@ -247,14 +247,14 @@ DEFINE_TEST(test_write_filter_lz4)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lz4(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lz4(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -263,7 +263,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	    archive_write_add_filter_lz4(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzip.c
+++ b/libarchive/test/test_write_filter_lzip.c
@@ -230,20 +230,20 @@ DEFINE_TEST(test_write_filter_lzip)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzma.c
+++ b/libarchive/test/test_write_filter_lzma.c
@@ -234,20 +234,20 @@ DEFINE_TEST(test_write_filter_lzma)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzop.c
+++ b/libarchive/test/test_write_filter_lzop.c
@@ -239,14 +239,14 @@ DEFINE_TEST(test_write_filter_lzop)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lzop(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lzop(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -255,7 +255,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	    archive_write_add_filter_lzop(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_program.c
+++ b/libarchive/test/test_write_filter_program.c
@@ -58,7 +58,7 @@ DEFINE_TEST(test_write_filter_program)
 	if (r == ARCHIVE_FATAL) {
 		skipping("Write compression via external "
 		    "program unsupported on this platform");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertA(0 == archive_write_set_bytes_per_block(a, blocksize));
@@ -103,7 +103,7 @@ DEFINE_TEST(test_write_filter_program)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
 
 	if (!assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae))) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 

--- a/libarchive/test/test_write_filter_uuencode.c
+++ b/libarchive/test/test_write_filter_uuencode.c
@@ -147,13 +147,13 @@ DEFINE_TEST(test_write_filter_uuencode)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -161,7 +161,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_xz.c
+++ b/libarchive/test/test_write_filter_xz.c
@@ -240,20 +240,20 @@ DEFINE_TEST(test_write_filter_xz)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -340,20 +340,20 @@ DEFINE_TEST(test_write_filter_zstd)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_format_7zip.c
+++ b/libarchive/test/test_write_format_7zip.c
@@ -181,7 +181,7 @@ test_basic(const char *compression_type)
 	assertEqualIntA(a, 0, archive_write_data(a, "12345678", 9));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -310,7 +310,7 @@ test_basic(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -425,7 +425,7 @@ test_basic2(const char *compression_type)
 	assertEqualIntA(a, 0, archive_write_data(a, "12345678", 9));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -517,7 +517,7 @@ test_basic2(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_7zip_empty.c
+++ b/libarchive/test/test_write_format_7zip_empty.c
@@ -46,7 +46,7 @@ DEFINE_TEST(test_write_format_7zip_empty_archive)
 	    archive_write_open_memory(a, buff, buffsize, &used));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the archive file size. */
@@ -105,7 +105,7 @@ test_only_empty_file(void)
 	archive_entry_free(ae);
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the archive file size. */
@@ -148,7 +148,7 @@ test_only_empty_file(void)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -224,7 +224,7 @@ test_only_empty_files(void)
 	archive_entry_free(ae);
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -284,7 +284,7 @@ test_only_empty_files(void)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_7zip_large.c
+++ b/libarchive/test/test_write_format_7zip_large.c
@@ -126,7 +126,7 @@ test_large(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_7zip_large.c
+++ b/libarchive/test/test_write_format_7zip_large.c
@@ -44,7 +44,7 @@ test_large(const char *compression_type)
 	/* Create a new archive in memory. */
 	assert((a = archive_write_new()) != NULL);
 	if (a == NULL || buff == NULL || filedata == NULL || filedata2 == NULL) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		free(filedata);
 		free(filedata2);

--- a/libarchive/test/test_write_format_cpio.c
+++ b/libarchive/test/test_write_format_cpio.c
@@ -183,7 +183,7 @@ test_format(int	(*set_format)(struct archive *))
 	assertA(0 == archive_read_open_memory(a, buff, used));
 
 	if (!assertEqualIntA(a, 0, archive_read_next_header(a, &ae))) {
-		archive_read_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
 

--- a/libarchive/test/test_write_format_gnutar.c
+++ b/libarchive/test/test_write_format_gnutar.c
@@ -199,7 +199,7 @@ DEFINE_TEST(test_write_format_gnutar)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Some basic verification of the low-level format.
@@ -274,7 +274,7 @@ DEFINE_TEST(test_write_format_gnutar)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_gnutar_filenames.c
+++ b/libarchive/test/test_write_format_gnutar_filenames.c
@@ -68,7 +68,7 @@ DEFINE_TEST(test_write_format_gnutar_filenames)
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, template));
 		assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 		/* Read back and verify the filename. */
@@ -81,7 +81,7 @@ DEFINE_TEST(test_write_format_gnutar_filenames)
 		assertEqualString(filename, archive_entry_pathname(ae));
 		assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 
 	archive_entry_free(template);
@@ -127,7 +127,7 @@ DEFINE_TEST(test_write_format_gnutar_linknames)
 		assertA(0 == archive_write_open_memory(a, buff, buffsize, &used));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, template));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 		/* Read back and verify the filename. */
@@ -141,7 +141,7 @@ DEFINE_TEST(test_write_format_gnutar_linknames)
 		assertEqualString(filename, archive_entry_symlink(ae));
 		assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 
 	archive_entry_free(template);

--- a/libarchive/test/test_write_format_iso9660.c
+++ b/libarchive/test/test_write_format_iso9660.c
@@ -195,7 +195,7 @@ DEFINE_TEST(test_write_format_iso9660)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -502,7 +502,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -790,7 +790,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -1103,7 +1103,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_boot.c
+++ b/libarchive/test/test_write_format_iso9660_boot.c
@@ -130,7 +130,7 @@ _test_write_format_iso9660_boot(int write_info_tbl)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert(used == 2048 * 38);
 	/* Check System Area. */
@@ -263,7 +263,7 @@ _test_write_format_iso9660_boot(int write_info_tbl)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_empty.c
+++ b/libarchive/test/test_write_format_iso9660_empty.c
@@ -131,7 +131,7 @@ DEFINE_TEST(test_write_format_iso9660_empty)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert(used == 2048 * 181);
 	/* Check System Area. */
@@ -198,7 +198,7 @@ DEFINE_TEST(test_write_format_iso9660_empty)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_filename.c
+++ b/libarchive/test/test_write_format_iso9660_filename.c
@@ -194,7 +194,7 @@ verify(unsigned char *buff, size_t used, enum vtype type, struct fns *fns)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static int
@@ -297,7 +297,7 @@ create_iso_image(unsigned char *buff, size_t buffsize, size_t *used,
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	return (fcnt);
 }

--- a/libarchive/test/test_write_format_iso9660_joliet_id.c
+++ b/libarchive/test/test_write_format_iso9660_joliet_id.c
@@ -65,7 +65,7 @@ DEFINE_TEST(test_write_format_iso9660_joliet_id)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Read ISO image.
@@ -107,7 +107,7 @@ DEFINE_TEST(test_write_format_iso9660_joliet_id)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_zisofs.c
+++ b/libarchive/test/test_write_format_iso9660_zisofs.c
@@ -186,7 +186,7 @@ test_write_format_iso9660_zisofs_1(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 71680 bytes.");
 	assertEqualInt(used, 2048 * 35);
@@ -318,7 +318,7 @@ test_write_format_iso9660_zisofs_1(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }
@@ -433,7 +433,7 @@ test_write_format_iso9660_zisofs_2(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 110592 bytes.");
 	assertEqualInt(used, 2048 * 54);
@@ -567,7 +567,7 @@ test_write_format_iso9660_zisofs_2(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }
@@ -656,7 +656,7 @@ test_write_format_iso9660_zisofs_3(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 81920 bytes.");
 	assertEqualInt(used, 2048 * 40);
@@ -815,7 +815,7 @@ test_write_format_iso9660_zisofs_3(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_mtree_null_deref.c
+++ b/libarchive/test/test_write_format_mtree_null_deref.c
@@ -78,19 +78,19 @@ DEFINE_TEST(test_write_format_mtree_null_deref)
 
 	out_buf = malloc(256 * 1024);
 	if (!assert(out_buf != NULL)) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	if (archive_write_open_memory(a, out_buf, 256 * 1024, &used)
 	    != ARCHIVE_OK) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(out_buf);
 		return;
 	}
 
 	entry = archive_entry_new();
 	if (!assert(entry != NULL)) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(out_buf);
 		return;
 	}
@@ -168,6 +168,6 @@ DEFINE_TEST(test_write_format_mtree_null_deref)
 	archive_entry_free(entry);
 	/* Close triggers tree traversal; must not crash. */
 	archive_write_close(a);
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(out_buf);
 }

--- a/libarchive/test/test_write_format_mtree_null_deref.c
+++ b/libarchive/test/test_write_format_mtree_null_deref.c
@@ -167,7 +167,7 @@ DEFINE_TEST(test_write_format_mtree_null_deref)
 
 	archive_entry_free(entry);
 	/* Close triggers tree traversal; must not crash. */
-	archive_write_close(a);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(out_buf);
 }

--- a/libarchive/test/test_write_format_mtree_preset_digests.c
+++ b/libarchive/test/test_write_format_mtree_preset_digests.c
@@ -99,7 +99,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -130,7 +130,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
@@ -189,7 +189,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -220,7 +220,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
@@ -280,7 +280,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
 	archive_write_data(a, data, 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -311,7 +311,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
@@ -370,7 +370,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -399,7 +399,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -463,7 +463,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -498,7 +498,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -562,7 +562,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -597,7 +597,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support MD5");
 	return;
@@ -658,7 +658,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -687,7 +687,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -751,7 +751,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -786,7 +786,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -850,7 +850,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -885,7 +885,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support RMD160");
 	return;
@@ -948,7 +948,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -977,7 +977,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1041,7 +1041,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1076,7 +1076,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1140,7 +1140,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1175,7 +1175,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA1");
 	return;
@@ -1240,7 +1240,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1269,7 +1269,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1335,7 +1335,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1370,7 +1370,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1436,7 +1436,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1471,7 +1471,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA256");
 	return;
@@ -1537,7 +1537,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1566,7 +1566,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_no_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1633,7 +1633,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1668,7 +1668,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1735,7 +1735,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1770,7 +1770,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_non_empty_data)
 #ifdef ARCHIVE_HAS_SHA512
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 #endif
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA384");
 	return;
@@ -1838,7 +1838,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1868,7 +1868,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_no_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA512");
 	return;
@@ -1937,7 +1937,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1973,7 +1973,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_empty_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA512");
 	return;
@@ -2042,7 +2042,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -2078,7 +2078,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_non_empty_data)
 
 	assert(memcmp(archive_entry_digest(entry, ARCHIVE_ENTRY_DIGEST_SHA512), ed.sha512, sizeof(ed.sha512)) == 0);
 
-	archive_read_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #else
 	skipping("This platform does not support SHA512");
 	return;

--- a/libarchive/test/test_write_format_pax.c
+++ b/libarchive/test/test_write_format_pax.c
@@ -133,7 +133,7 @@ DEFINE_TEST(test_write_format_pax)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 *
@@ -248,7 +248,7 @@ DEFINE_TEST(test_write_format_pax)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -44,14 +44,14 @@ test_xar(const char *option)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertA(0 == archive_write_add_filter_none(a));
 	if (option != NULL &&
 	    archive_write_set_options(a, option) != ARCHIVE_OK) {
 		skipping("option `%s` is not supported on this platform", option);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 
@@ -170,7 +170,7 @@ test_xar(const char *option)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 *
@@ -298,7 +298,7 @@ test_xar(const char *option)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_xar_bugs.c
+++ b/libarchive/test/test_write_format_xar_bugs.c
@@ -154,7 +154,7 @@ replay_xar_writer(const char *refname)
 	}
 
 	archive_entry_free(entry);
-	archive_write_close(a);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(out_buf);
 }

--- a/libarchive/test/test_write_format_xar_bugs.c
+++ b/libarchive/test/test_write_format_xar_bugs.c
@@ -76,19 +76,19 @@ replay_xar_writer(const char *refname)
 
 	out_buf = (char *)malloc(512 * 1024);
 	if (!assert(out_buf != NULL)) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	if (archive_write_open_memory(a, out_buf, 512 * 1024, &used)
 	    != ARCHIVE_OK) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(out_buf);
 		return;
 	}
 
 	entry = archive_entry_new();
 	if (!assert(entry != NULL)) {
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(out_buf);
 		return;
 	}
@@ -155,7 +155,7 @@ replay_xar_writer(const char *refname)
 
 	archive_entry_free(entry);
 	archive_write_close(a);
-	archive_write_free(a);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(out_buf);
 }
 

--- a/libarchive/test/test_write_format_xar_empty.c
+++ b/libarchive/test/test_write_format_xar_empty.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_write_format_xar_empty)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));

--- a/libarchive/test/test_write_format_xar_fflags.c
+++ b/libarchive/test/test_write_format_xar_fflags.c
@@ -35,7 +35,7 @@ DEFINE_TEST(test_write_format_xar_fflags)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
@@ -74,5 +74,5 @@ DEFINE_TEST(test_write_format_xar_fflags)
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_write_format_zip.c
+++ b/libarchive/test/test_write_format_zip.c
@@ -262,7 +262,7 @@ write_contents(struct archive *a)
 
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
@@ -550,7 +550,7 @@ verify_contents(struct archive *a, int seeking, int content)
 
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_write_format_zip.c
+++ b/libarchive/test/test_write_format_zip.c
@@ -700,7 +700,7 @@ DEFINE_TEST(test_write_format_zip_traditional_pkware_encryption)
 	if (ARCHIVE_OK != archive_write_set_options(a,
 		    "zip:encryption=zipcrypt")) {
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		return;
 	}
@@ -780,7 +780,7 @@ DEFINE_TEST(test_write_format_zip_winzip_aes128_encryption)
 	if (ARCHIVE_OK != archive_write_set_options(a, "zip:encryption=aes128"))
 	{
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		return;
 	}
@@ -860,7 +860,7 @@ DEFINE_TEST(test_write_format_zip_winzip_aes256_encryption)
 	if (ARCHIVE_OK != archive_write_set_options(a, "zip:encryption=aes256"))
 	{
 		skipping("This system does not have cryptographic library");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		free(buff);
 		return;
 	}

--- a/libarchive/test/test_write_format_zip_compression_bzip2.c
+++ b/libarchive/test/test_write_format_zip_compression_bzip2.c
@@ -296,7 +296,7 @@ static void verify_bzip2_contents(const char *buff, size_t used)
 	assertEqualMem(q, "PK\001\002", 4); /* Signature */
 
 	/* Close archive, in case. */
-	archive_read_free(zip_archive);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(zip_archive));
 }
 
 #endif /* HAVE_BZLIB_H */

--- a/libarchive/test/test_write_format_zip_compression_lzmaxz.c
+++ b/libarchive/test/test_write_format_zip_compression_lzmaxz.c
@@ -297,7 +297,7 @@ static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
 	assertEqualMem(q, "PK\001\002", 4); /* Signature */
 
 	/* Close archive, in case. */
-	archive_read_free(zip_archive);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(zip_archive));
 }
 
 static void verify_xz_contents(const char *buff, size_t used)

--- a/libarchive/test/test_write_format_zip_compression_zstd.c
+++ b/libarchive/test/test_write_format_zip_compression_zstd.c
@@ -296,7 +296,7 @@ static void verify_zstd_contents(const char *buff, size_t used)
 	assertEqualMem(q, "PK\001\002", 4); /* Signature */
 
 	/* Close archive, in case. */
-	archive_read_free(zip_archive);
+	assertEqualInt(ARCHIVE_OK, archive_read_free(zip_archive));
 }
 
 #endif /* HAVE_ZSTD_H */

--- a/libarchive/test/test_write_format_zip_empty_pathname.c
+++ b/libarchive/test/test_write_format_zip_empty_pathname.c
@@ -54,7 +54,7 @@ DEFINE_TEST(test_write_format_zip_empty_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Directory entry with empty pathname */
@@ -70,6 +70,6 @@ DEFINE_TEST(test_write_format_zip_empty_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }

--- a/libarchive/test/test_write_format_zip_long_pathname.c
+++ b/libarchive/test/test_write_format_zip_long_pathname.c
@@ -62,7 +62,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_OK, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 
@@ -84,7 +84,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 
@@ -106,7 +106,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 

--- a/libarchive/test/test_write_format_zip_windows_path.c
+++ b/libarchive/test/test_write_format_zip_windows_path.c
@@ -60,7 +60,7 @@ test_with_hdrcharset(const char *charset)
 	archive_entry_free(ae);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	dumpfile("constructed.zip", buff, used);
 
 	/*

--- a/libarchive/test/test_write_format_zip_zip64.c
+++ b/libarchive/test/test_write_format_zip_zip64.c
@@ -51,7 +51,7 @@ verify_zip_filesize(uint64_t size, int expected)
 	archive_entry_free(ae);
 
 	/* Don't actually write 4GB! ;-) */
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_write_format_zip_zip64_oversize)

--- a/libarchive/test/test_write_read_format_zip.c
+++ b/libarchive/test/test_write_read_format_zip.c
@@ -259,7 +259,7 @@ write_contents(struct archive *a)
 
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
@@ -568,7 +568,7 @@ verify_contents(struct archive *a, int seeking, int improved_streaming)
 
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_zip_filename_encoding.c
+++ b/libarchive/test/test_zip_filename_encoding.c
@@ -47,7 +47,7 @@ DEFINE_TEST(test_zip_filename_encoding_UTF8)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " for UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -137,7 +137,7 @@ DEFINE_TEST(test_zip_filename_encoding_KOI8R)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -193,7 +193,7 @@ DEFINE_TEST(test_zip_filename_encoding_KOI8R)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from KOI8-R to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -281,7 +281,7 @@ DEFINE_TEST(test_zip_filename_encoding_Russian_Russia)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from Russian_Russia.CP1251 to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -349,7 +349,7 @@ DEFINE_TEST(test_zip_filename_encoding_EUCJP)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -406,7 +406,7 @@ DEFINE_TEST(test_zip_filename_encoding_EUCJP)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from eucJP to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -449,7 +449,7 @@ DEFINE_TEST(test_zip_filename_encoding_CP932)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from CP932/SJIS to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -506,7 +506,7 @@ DEFINE_TEST(test_zip_filename_encoding_CP932)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from CP932/SJIS to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -551,7 +551,7 @@ DEFINE_TEST(test_zip_filename_encoding_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to UTF-8.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,
@@ -642,7 +642,7 @@ DEFINE_TEST(test_zip_filename_encoding_fail_UTF16_win)
 	if (archive_write_set_options(a, "hdrcharset=CP437") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
 		    " from UTF-16 to CP437.");
-		archive_write_free(a);
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualInt(ARCHIVE_OK,


### PR DESCRIPTION
The test suites use different ways of checking results of
- `archive_read_close`
- `archive_read_free`
- `archive_write_close`
- `archive_write_free`

While the close functions profit from `assertEqualIntA`'s extended archive errno output in case of issues, the free functions would trigger a use after free bug, because even in case of errors, the memory is released.

Always check results (if possible) with the proper assert function.

Looked easier than it is, since our support for external programs makes this difficult. Will take more work, so I'll keep it on hold here.