### PR TITLE
7-Zip: Account for seekability in format bidding

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -486,7 +486,7 @@ archive_read_open1(struct archive *_a)
 	filter->name = "none";
 	filter->code = ARCHIVE_FILTER_NONE;
 	filter->can_skip = 1;
-	filter->can_seek = 1;
+	filter->can_seek = (a->client.seeker != NULL);
 
 	a->client.dataset[0].begin_position = 0;
 	if (!a->filter || !a->bypass_filter_bidding)

--- a/libarchive/archive_read_open_fd.c
+++ b/libarchive/archive_read_open_fd.c
@@ -105,7 +105,7 @@ archive_read_open_fd(struct archive *a, int fd, size_t block_size)
 
 	archive_read_set_read_callback(a, file_read);
 	archive_read_set_skip_callback(a, file_skip);
-	archive_read_set_seek_callback(a, file_seek);
+	if (S_ISREG(st.st_mode)) archive_read_set_seek_callback(a, file_seek);
 	archive_read_set_close_callback(a, file_close);
 	archive_read_set_callback_data(a, mine);
 	return (archive_read_open1(a));

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -600,6 +600,9 @@ fail:
 static int
 archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 {
+	if (a->filter->can_seek == 0)
+		return (0);
+
 	int64_t data_offset;
 
 	/* If someone has already bid more than 32, then avoid

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -1656,3 +1656,53 @@ DEFINE_TEST(test_read_format_7zip_lzma2_powerpc)
   
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+/*
+ * Test that 7-Zip bidder accounts for seekability.
+ * Issue #3068.
+ */
+DEFINE_TEST(test_read_format_7zip_bid)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	/* 7z signature */
+	unsigned char data[] = {'7', 'z', 0xbc, 0xaf, 0x27, 0x1c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+	/* 1. Seekable stream: 7-Zip should win. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_7zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, data, sizeof(data)));
+	/* Since the data is truncated, reading header should fail, 
+	   but the format SHOULD be identified as 7z. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(archive_format(a) & ARCHIVE_FORMAT_BASE_MASK, ARCHIVE_FORMAT_7ZIP);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* 2. Non-seekable stream: 7-Zip should NOT win. */
+#if !defined(_WIN32) || defined(__CYGWIN__)
+	{
+		int pipefd[2];
+		if (pipe(pipefd) == 0) {
+			if (write(pipefd[1], data, sizeof(data)) != (ssize_t)sizeof(data)) {
+				/* Handle error if needed */
+			}
+			close(pipefd[1]);
+
+			assert((a = archive_read_new()) != NULL);
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_7zip(a));
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_open_fd(a, pipefd[0], 512));
+
+			/* 7-Zip should have abstained, allowing 'raw' to win. */
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+			assertEqualInt(archive_format(a) & ARCHIVE_FORMAT_BASE_MASK, ARCHIVE_FORMAT_RAW);
+
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+			assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+			close(pipefd[0]);
+		}
+	}
+#endif
+}
+


### PR DESCRIPTION
Several archive formats, such as 7-Zip, strictly require random access to the archive file to read their central directory. They should not bid on non-seekable streams (like pipes or filtered streams) to avoid hijacking them and failing later with a seek error.

This commit:
1. Improves core seekability detection in `archive_read_open_fd()` by only registering a seek callback for regular files.
2. Updates the initial filter initialization in `archive_read_open1()` to accurately set the `can_seek` flag.
3. Modifies the 7-Zip bidder to abstain if the stream is non-seekable.
4. Adds a unit test `test_read_format_7zip_bid` to verify that 7-Zip correctly yields to fallback handlers like the 'raw' reader on non-seekable streams.

Bug: https://github.com/libarchive/libarchive/issues/3068