### PR TITLE
tests: Avoid assertEqualIntA with archive_*_free

### DIFF
--- a/libarchive/test/test_compat_zip.c
+++ b/libarchive/test/test_compat_zip.c
@@ -140,7 +140,7 @@ DEFINE_TEST(test_compat_zip_3)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 /**
@@ -188,7 +188,7 @@ DEFINE_TEST(test_compat_zip_4)
 	assertEqualInt(0644, archive_entry_perm(ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Try reading without seek support and watch it fail. */
 	assert((a = archive_read_new()) != NULL);
@@ -196,7 +196,7 @@ DEFINE_TEST(test_compat_zip_4)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_FATAL, read_open_memory(a, p, s, 3));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 /**
@@ -273,7 +273,7 @@ DEFINE_TEST(test_compat_zip_5)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Try reading without seek support. */
 	assert((a = archive_read_new()) != NULL);
@@ -332,7 +332,7 @@ DEFINE_TEST(test_compat_zip_5)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 
@@ -376,14 +376,14 @@ DEFINE_TEST(test_compat_zip_6)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory_seek(a, p, s, 7));
 	compat_zip_6_verify(a);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, p, s, 7));
 	compat_zip_6_verify(a);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 
@@ -417,7 +417,7 @@ DEFINE_TEST(test_compat_zip_7)
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_data_skip(a));
 
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(p);
 }
@@ -444,6 +444,6 @@ DEFINE_TEST(test_compat_zip_8)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 	/* This file is in the archive as arc\test */
 	assertEqualString("arc/test", archive_entry_pathname(ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_pax_xattr_header.c
+++ b/libarchive/test/test_pax_xattr_header.c
@@ -67,7 +67,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test1.tar","test_pax_xattr_header_all.tar");
 
@@ -86,7 +86,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test2.tar","test_pax_xattr_header_schily.tar");
 
@@ -105,7 +105,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test3.tar","test_pax_xattr_header_libarchive.tar");
 
@@ -123,7 +123,7 @@ DEFINE_TEST(test_pax_xattr_header)
         assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assertEqualFile("test4.tar","test_pax_xattr_header_all.tar");
 }

--- a/libarchive/test/test_read_files_compressed.c
+++ b/libarchive/test/test_read_files_compressed.c
@@ -44,5 +44,5 @@ DEFINE_TEST(test_read_files_compressed)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &entry));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip_malformed.c
+++ b/libarchive/test/test_read_format_7zip_malformed.c
@@ -39,7 +39,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -56,7 +56,7 @@ test_malformed2(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 
@@ -72,7 +72,7 @@ test_malformed3(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_open_filename(a, refname, 10240));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_7zip_malformed)

--- a/libarchive/test/test_read_format_rar.c
+++ b/libarchive/test/test_read_format_rar.c
@@ -3807,7 +3807,7 @@ DEFINE_TEST(test_read_format_rar_multivolume_uncompressed_files)
   assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
   assertEqualIntA(a, 16, archive_file_count(a));
   assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-  assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_rar_endarc_huge)

--- a/libarchive/test/test_read_format_tar_mac_metadata.c
+++ b/libarchive/test/test_read_format_tar_mac_metadata.c
@@ -79,7 +79,7 @@ DEFINE_TEST(test_read_format_tar_mac_metadata)
 	/* ... and nothing else */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -305,7 +305,7 @@ verify_extract_length_at_end(struct archive *a, int seek_checks)
 	}
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -368,7 +368,7 @@ test_symlink(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }
@@ -398,7 +398,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_one_file_blockread)
@@ -418,7 +418,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_multi)
@@ -450,7 +450,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd_multi_blockread)
@@ -482,7 +482,7 @@ DEFINE_TEST(test_read_format_zip_ppmd_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_one_file)
@@ -507,7 +507,7 @@ DEFINE_TEST(test_read_format_zip_lzma_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_one_file_blockread)
@@ -532,7 +532,7 @@ DEFINE_TEST(test_read_format_zip_lzma_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_multi)
@@ -569,7 +569,7 @@ DEFINE_TEST(test_read_format_zip_lzma_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_multi_blockread)
@@ -606,7 +606,7 @@ DEFINE_TEST(test_read_format_zip_lzma_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 
@@ -632,7 +632,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
@@ -657,7 +657,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_multi)
@@ -694,7 +694,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
@@ -731,7 +731,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_one_file)
@@ -757,7 +757,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
@@ -783,7 +783,7 @@ DEFINE_TEST(test_read_format_zip_zstd_one_file_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_multi)
@@ -821,7 +821,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
@@ -859,7 +859,7 @@ DEFINE_TEST(test_read_format_zip_zstd_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_xz_multi)
@@ -896,7 +896,7 @@ DEFINE_TEST(test_read_format_zip_xz_multi)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_xz_multi_blockread)
@@ -933,7 +933,7 @@ DEFINE_TEST(test_read_format_zip_xz_multi_blockread)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
@@ -955,7 +955,7 @@ DEFINE_TEST(test_read_format_zip_ppmd8_crash_1)
 	 * proper fix, the unpacker was entering an unlimited loop. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 1));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
@@ -981,7 +981,7 @@ DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
 	 * But it shouldn't crash. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_ppmd8_crash_2)
@@ -1002,7 +1002,7 @@ DEFINE_TEST(test_read_format_zip_ppmd8_crash_2)
 	 * But it shouldn't crash. */
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, 64));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
@@ -1037,7 +1037,7 @@ DEFINE_TEST(test_read_format_zip_lzma_alone_leak)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* This testcase shouldn't produce any memory leaks. When running test
 	 * suite under Valgrind or ASan, the test runner won't return with
@@ -1066,7 +1066,7 @@ DEFINE_TEST(test_read_format_zip_lzma_stream_end)
 	assertEqualIntA(a, 0, extract_one(a, ae, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_lzma_stream_end_blockread)
@@ -1091,7 +1091,7 @@ DEFINE_TEST(test_read_format_zip_lzma_stream_end_blockread)
 	assertEqualIntA(a, 0, extract_one_using_blocks(a, 13, 0xBA8E3BAA));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_7z_lzma)
@@ -1123,7 +1123,7 @@ DEFINE_TEST(test_read_format_zip_7z_lzma)
 		"/src/abc_measurement_analysis_sample.py",
 		archive_entry_symlink(ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_7z_deflate)
@@ -1169,5 +1169,5 @@ DEFINE_TEST(test_read_format_zip_7z_deflate)
 	}
 	assertEqualInt(AE_IFLNK, archive_entry_filetype(ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_7075_utf8_paths.c
+++ b/libarchive/test/test_read_format_zip_7075_utf8_paths.c
@@ -86,7 +86,7 @@ DEFINE_TEST(test_read_format_zip_utf8_paths)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	verify(a);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Verify with streaming reader. */
 	p = slurpfile(&s, "%s", refname);

--- a/libarchive/test/test_read_format_zip_comment_stored.c
+++ b/libarchive/test/test_read_format_zip_comment_stored.c
@@ -61,7 +61,7 @@ verify(const char *refname)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), 0);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_jar.c
+++ b/libarchive/test/test_read_format_zip_jar.c
@@ -53,6 +53,6 @@ DEFINE_TEST(test_read_format_zip_jar)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_mac_metadata.c
+++ b/libarchive/test/test_read_format_zip_mac_metadata.c
@@ -110,7 +110,7 @@ DEFINE_TEST(test_read_format_zip_mac_metadata)
 	}
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_malformed.c
+++ b/libarchive/test/test_read_format_zip_malformed.c
@@ -42,7 +42,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/* Verify with streaming reader. */
 	p = slurpfile(&s, "%s", refname);
@@ -51,7 +51,7 @@ test_malformed1(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, p, s, 31));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }
 

--- a/libarchive/test/test_read_format_zip_nested.c
+++ b/libarchive/test/test_read_format_zip_nested.c
@@ -62,7 +62,7 @@ DEFINE_TEST(test_read_format_zip_nested)
 	/* Close outer Zip */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 
@@ -80,7 +80,7 @@ DEFINE_TEST(test_read_format_zip_nested)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(inner);
 }

--- a/libarchive/test/test_read_format_zip_nofiletype.c
+++ b/libarchive/test/test_read_format_zip_nofiletype.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_format_zip_nofiletype)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_padded.c
+++ b/libarchive/test/test_read_format_zip_padded.c
@@ -51,7 +51,7 @@ verify_padded_archive(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_sfx.c
+++ b/libarchive/test/test_read_format_zip_sfx.c
@@ -58,7 +58,7 @@ DEFINE_TEST(test_read_format_zip_sfx)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_with_invalid_traditional_eocd.c
+++ b/libarchive/test/test_read_format_zip_with_invalid_traditional_eocd.c
@@ -53,6 +53,6 @@ DEFINE_TEST(test_read_format_zip_with_invalid_traditional_eocd)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(p);
 }

--- a/libarchive/test/test_read_format_zip_zip64.c
+++ b/libarchive/test/test_read_format_zip_zip64.c
@@ -47,7 +47,7 @@ verify_file0_seek(struct archive *a)
 #endif
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void
@@ -76,7 +76,7 @@ verify_file0_stream(struct archive *a, int size_known)
 #endif
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_format_zip_zip64a)

--- a/libarchive/test/test_write_disk_appledouble.c
+++ b/libarchive/test/test_write_disk_appledouble.c
@@ -151,7 +151,7 @@ DEFINE_TEST(test_write_disk_appledouble)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -210,7 +210,7 @@ DEFINE_TEST(test_write_disk_appledouble)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -296,7 +296,7 @@ DEFINE_TEST(test_write_disk_appledouble_zip)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test test_file */
 	assertEqualInt(0, stat("apple_double_dir/test_file", &st));

--- a/libarchive/test/test_write_disk_hfs_compression.c
+++ b/libarchive/test/test_write_disk_hfs_compression.c
@@ -146,7 +146,7 @@ DEFINE_TEST(test_write_disk_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));
@@ -229,7 +229,7 @@ DEFINE_TEST(test_write_disk_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));

--- a/libarchive/test/test_write_disk_mac_metadata.c
+++ b/libarchive/test/test_write_disk_mac_metadata.c
@@ -144,7 +144,7 @@ DEFINE_TEST(test_write_disk_mac_metadata)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));
@@ -195,7 +195,7 @@ DEFINE_TEST(test_write_disk_mac_metadata)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file3. */
 	assertEqualInt(0, stat("file3", &st));

--- a/libarchive/test/test_write_disk_no_hfs_compression.c
+++ b/libarchive/test/test_write_disk_no_hfs_compression.c
@@ -120,7 +120,7 @@ DEFINE_TEST(test_write_disk_no_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));
@@ -190,7 +190,7 @@ DEFINE_TEST(test_write_disk_no_hfs_compression)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-	assertEqualIntA(ad, ARCHIVE_OK, archive_write_free(ad));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(ad));
 
 	/* Test file1. */
 	assertEqualInt(0, stat("file1", &st));

--- a/libarchive/test/test_write_format_gnutar.c
+++ b/libarchive/test/test_write_format_gnutar.c
@@ -199,7 +199,7 @@ DEFINE_TEST(test_write_format_gnutar)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Some basic verification of the low-level format.
@@ -274,7 +274,7 @@ DEFINE_TEST(test_write_format_gnutar)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_gnutar_filenames.c
+++ b/libarchive/test/test_write_format_gnutar_filenames.c
@@ -68,7 +68,7 @@ DEFINE_TEST(test_write_format_gnutar_filenames)
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, template));
 		assertEqualIntA(a, 8, archive_write_data(a, "12345678", 9));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 		/* Read back and verify the filename. */
@@ -81,7 +81,7 @@ DEFINE_TEST(test_write_format_gnutar_filenames)
 		assertEqualString(filename, archive_entry_pathname(ae));
 		assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 
 	archive_entry_free(template);
@@ -127,7 +127,7 @@ DEFINE_TEST(test_write_format_gnutar_linknames)
 		assertA(0 == archive_write_open_memory(a, buff, buffsize, &used));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, template));
 		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 
 		/* Read back and verify the filename. */
@@ -141,7 +141,7 @@ DEFINE_TEST(test_write_format_gnutar_linknames)
 		assertEqualString(filename, archive_entry_symlink(ae));
 		assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 
 	archive_entry_free(template);

--- a/libarchive/test/test_write_format_iso9660.c
+++ b/libarchive/test/test_write_format_iso9660.c
@@ -195,7 +195,7 @@ DEFINE_TEST(test_write_format_iso9660)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -502,7 +502,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -790,7 +790,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * -----------------------------------------------------------
@@ -1103,7 +1103,7 @@ DEFINE_TEST(test_write_format_iso9660)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_boot.c
+++ b/libarchive/test/test_write_format_iso9660_boot.c
@@ -130,7 +130,7 @@ _test_write_format_iso9660_boot(int write_info_tbl)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert(used == 2048 * 38);
 	/* Check System Area. */
@@ -263,7 +263,7 @@ _test_write_format_iso9660_boot(int write_info_tbl)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_empty.c
+++ b/libarchive/test/test_write_format_iso9660_empty.c
@@ -131,7 +131,7 @@ DEFINE_TEST(test_write_format_iso9660_empty)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert(used == 2048 * 181);
 	/* Check System Area. */
@@ -198,7 +198,7 @@ DEFINE_TEST(test_write_format_iso9660_empty)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_filename.c
+++ b/libarchive/test/test_write_format_iso9660_filename.c
@@ -194,7 +194,7 @@ verify(unsigned char *buff, size_t used, enum vtype type, struct fns *fns)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static int
@@ -297,7 +297,7 @@ create_iso_image(unsigned char *buff, size_t buffsize, size_t *used,
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	return (fcnt);
 }

--- a/libarchive/test/test_write_format_iso9660_joliet_id.c
+++ b/libarchive/test/test_write_format_iso9660_joliet_id.c
@@ -65,7 +65,7 @@ DEFINE_TEST(test_write_format_iso9660_joliet_id)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Read ISO image.
@@ -107,7 +107,7 @@ DEFINE_TEST(test_write_format_iso9660_joliet_id)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_iso9660_zisofs.c
+++ b/libarchive/test/test_write_format_iso9660_zisofs.c
@@ -186,7 +186,7 @@ test_write_format_iso9660_zisofs_1(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 71680 bytes.");
 	assertEqualInt(used, 2048 * 35);
@@ -318,7 +318,7 @@ test_write_format_iso9660_zisofs_1(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }
@@ -433,7 +433,7 @@ test_write_format_iso9660_zisofs_2(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 110592 bytes.");
 	assertEqualInt(used, 2048 * 54);
@@ -567,7 +567,7 @@ test_write_format_iso9660_zisofs_2(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }
@@ -656,7 +656,7 @@ test_write_format_iso9660_zisofs_3(void)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	failure("The ISO image size should be 81920 bytes.");
 	assertEqualInt(used, 2048 * 40);
@@ -815,7 +815,7 @@ test_write_format_iso9660_zisofs_3(void)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_mtree_preset_digests.c
+++ b/libarchive/test/test_write_format_mtree_preset_digests.c
@@ -99,7 +99,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -189,7 +189,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -280,7 +280,7 @@ DEFINE_TEST(test_write_format_mtree_digests_no_digests_set_non_empty_data)
 	archive_write_data(a, data, 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -370,7 +370,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -463,7 +463,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -562,7 +562,7 @@ DEFINE_TEST(test_write_format_mtree_digests_md5_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -658,7 +658,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -751,7 +751,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -850,7 +850,7 @@ DEFINE_TEST(test_write_format_mtree_digests_rmd160_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -948,7 +948,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1041,7 +1041,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1140,7 +1140,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha1_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1240,7 +1240,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1335,7 +1335,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1436,7 +1436,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha256_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1537,7 +1537,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1633,7 +1633,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1735,7 +1735,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha384_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1838,7 +1838,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_no_data)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -1937,7 +1937,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_empty_data)
 	archive_write_data(a, "", 0);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
@@ -2042,7 +2042,7 @@ DEFINE_TEST(test_write_format_mtree_digests_sha512_digest_set_non_empty_data)
 	archive_write_data(a, "abcd", 4);
 	archive_entry_free(entry);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_write_format_pax.c
+++ b/libarchive/test/test_write_format_pax.c
@@ -133,7 +133,7 @@ DEFINE_TEST(test_write_format_pax)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 *
@@ -248,7 +248,7 @@ DEFINE_TEST(test_write_format_pax)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -44,14 +44,14 @@ test_xar(const char *option)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertA(0 == archive_write_add_filter_none(a));
 	if (option != NULL &&
 	    archive_write_set_options(a, option) != ARCHIVE_OK) {
 		skipping("option `%s` is not supported on this platform", option);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 
@@ -170,7 +170,7 @@ test_xar(const char *option)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 *
@@ -298,7 +298,7 @@ test_xar(const char *option)
 	 */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
 }

--- a/libarchive/test/test_write_format_xar_empty.c
+++ b/libarchive/test/test_write_format_xar_empty.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_write_format_xar_empty)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));

--- a/libarchive/test/test_write_format_xar_fflags.c
+++ b/libarchive/test/test_write_format_xar_fflags.c
@@ -35,7 +35,7 @@ DEFINE_TEST(test_write_format_xar_fflags)
 	assert((a = archive_write_new()) != NULL);
 	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
 		skipping("xar is not supported on this platform");
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
@@ -55,7 +55,7 @@ DEFINE_TEST(test_write_format_xar_fflags)
 
 	/* Close out the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*
 	 * Now, read the data back.
@@ -74,5 +74,5 @@ DEFINE_TEST(test_write_format_xar_fflags)
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_write_format_zip_windows_path.c
+++ b/libarchive/test/test_write_format_zip_windows_path.c
@@ -60,7 +60,7 @@ test_with_hdrcharset(const char *charset)
 	archive_entry_free(ae);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	dumpfile("constructed.zip", buff, used);
 
 	/*

--- a/libarchive/test/test_write_format_zip_zip64.c
+++ b/libarchive/test/test_write_format_zip_zip64.c
@@ -51,7 +51,7 @@ verify_zip_filesize(uint64_t size, int expected)
 	archive_entry_free(ae);
 
 	/* Don't actually write 4GB! ;-) */
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
 DEFINE_TEST(test_write_format_zip_zip64_oversize)


### PR DESCRIPTION
In case of errors, `assertEqualIntA` accesses the given archive and prints diagnostic information about errno and error string.

Since archive_read_free and archive_write_free free the memory of the archive, this would just lead to memory issues in case of errors.

Use `assertEqualInt` instead.

These are the simple cases picked from https://github.com/libarchive/libarchive/pull/3065.