### PR TITLE
7zip: Support streamable reading again

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3260,7 +3260,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 
 	if (get_data_offset(a, &data_offset) < 0)
 		return (ARCHIVE_FATAL);
-	if (__archive_read_seek(a, data_offset, SEEK_SET) < 0)
+	if (__archive_read_consume(a, data_offset) < 0)
 		return (ARCHIVE_FATAL);
 	if ((p = __archive_read_ahead(a, 32, &bytes_avail)) == NULL)
 		return (ARCHIVE_FATAL);


### PR DESCRIPTION
The `slurp_central_directory` function has been changed to always use seek, which is not needed and also breaks streamable 7-Zip archives.

Resolves an issue observed in #3068.

Fixes: 71ef1c385249 ("7zip: Merge skip_sfx into get_data_offset")