### PR TITLE
tests: Use assertEqualIntA for archive_*_close

### DIFF
--- a/libarchive/test/test_archive_read_close_twice.c
+++ b/libarchive/test/test_archive_read_close_twice.c
@@ -29,11 +29,11 @@ DEFINE_TEST(test_archive_read_close_twice)
 {
 	struct archive* a = archive_read_new();
 
-	assertEqualInt(0, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(0, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_read_close_twice_open_fd.c
+++ b/libarchive/test/test_archive_read_close_twice_open_fd.c
@@ -34,11 +34,11 @@ DEFINE_TEST(test_archive_read_close_twice_open_fd)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_read_close_twice_open_filename.c
+++ b/libarchive/test/test_archive_read_close_twice_open_filename.c
@@ -36,11 +36,11 @@ DEFINE_TEST(test_archive_read_close_twice_open_filename)
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(0, archive_errno(a));
 	assertEqualString(NULL, archive_error_string(a));
 

--- a/libarchive/test/test_archive_write_add_filter.c
+++ b/libarchive/test/test_archive_write_add_filter.c
@@ -131,7 +131,7 @@ test_add_filter_by_code(int filter_code,
 	assertEqualIntA(a, filter_code, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(buff);
 }

--- a/libarchive/test/test_archive_write_add_filter_by_name.c
+++ b/libarchive/test/test_archive_write_add_filter_by_name.c
@@ -129,7 +129,7 @@ test_filter_by_name(const char *filter_name, int filter_code,
 	assertEqualIntA(a, filter_code, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(buff);
 }

--- a/libarchive/test/test_archive_write_set_format_by_name.c
+++ b/libarchive/test/test_archive_write_set_format_by_name.c
@@ -130,7 +130,7 @@ test_format_by_name(const char *format_name, const char *compression_type,
 		    archive_filter_code(a, 0));
 		assertEqualIntA(a, format_id, archive_format(a));
 
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(buff);

--- a/libarchive/test/test_archive_write_set_format_filter_by_ext.c
+++ b/libarchive/test/test_archive_write_set_format_filter_by_ext.c
@@ -137,7 +137,7 @@ test_format_filter_by_ext(const char *output_file,
 		    archive_filter_code(a, 0));
 		assertEqualIntA(a, format_id, archive_format(a) & ARCHIVE_FORMAT_BASE_MASK );
 
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
 	free(buff);

--- a/libarchive/test/test_compat_cpio.c
+++ b/libarchive/test/test_compat_cpio.c
@@ -92,7 +92,7 @@ test_compat_cpio_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_gtar.c
+++ b/libarchive/test/test_compat_gtar.c
@@ -101,7 +101,7 @@ test_compat_gtar_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -141,7 +141,7 @@ test_compat_gtar_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_gtar_large.c
+++ b/libarchive/test/test_compat_gtar_large.c
@@ -218,7 +218,7 @@ DEFINE_TEST(test_compat_gtar_large)
 	/* Verify that the reader actually read to the end of data */
 	assertEqualInt(reader.zero_blocks_remaining, 0);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(reader.zero_block);
 }

--- a/libarchive/test/test_compat_gzip.c
+++ b/libarchive/test/test_compat_gzip.c
@@ -77,7 +77,7 @@ verify(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lz4.c
+++ b/libarchive/test/test_compat_lz4.c
@@ -78,7 +78,7 @@ verify(const char *name, const char *n[])
 	assertEqualString(archive_filter_name(a, 0), "lz4");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lzip.c
+++ b/libarchive/test/test_compat_lzip.c
@@ -124,7 +124,7 @@ compat_lzip(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -165,7 +165,7 @@ compat_lzip_3(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_RAW);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -202,7 +202,7 @@ compat_lzip_4(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lzma.c
+++ b/libarchive/test/test_compat_lzma.c
@@ -133,7 +133,7 @@ compat_lzma(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "lzma");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_lzop.c
+++ b/libarchive/test/test_compat_lzop.c
@@ -70,7 +70,7 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -101,7 +101,7 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -125,6 +125,6 @@ DEFINE_TEST(test_compat_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_mac.c
+++ b/libarchive/test/test_compat_mac.c
@@ -130,7 +130,7 @@ test_compat_mac_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -201,7 +201,7 @@ test_compat_mac_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_perl_archive_tar.c
+++ b/libarchive/test/test_compat_perl_archive_tar.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_compat_perl_archive_tar)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_plexus_archiver_tar.c
+++ b/libarchive/test/test_compat_plexus_archiver_tar.c
@@ -63,6 +63,6 @@ DEFINE_TEST(test_compat_plexus_archiver_tar)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_compat_solaris_pax_sparse.c
+++ b/libarchive/test/test_compat_solaris_pax_sparse.c
@@ -100,7 +100,7 @@ test_compat_solaris_pax_sparse_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -172,7 +172,7 @@ test_compat_solaris_pax_sparse_2(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_tar_directory.c
+++ b/libarchive/test/test_compat_tar_directory.c
@@ -64,7 +64,7 @@ test_compat_tar_directory_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_tar_hardlink.c
+++ b/libarchive/test/test_compat_tar_hardlink.c
@@ -91,7 +91,7 @@ test_compat_tar_hardlink_1(void)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_xz.c
+++ b/libarchive/test/test_compat_xz.c
@@ -72,7 +72,7 @@ compat_xz(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "xz");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_zip.c
+++ b/libarchive/test/test_compat_zip.c
@@ -58,7 +58,7 @@ DEFINE_TEST(test_compat_zip_1)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_ZIP);
 
 finish:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -89,7 +89,7 @@ DEFINE_TEST(test_compat_zip_2)
 	assertEqualString("file2", archive_entry_pathname(ae));
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_compat_zstd.c
+++ b/libarchive/test/test_compat_zstd.c
@@ -67,7 +67,7 @@ compat_zstd(const char *name)
 	assertEqualString(archive_filter_name(a, 0), "zstd");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_disk_directory_traversals.c
+++ b/libarchive/test/test_read_disk_directory_traversals.c
@@ -230,7 +230,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test that call archive_read_disk_open_w, wchar_t version.
@@ -358,7 +358,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test that call archive_read_disk_open with a regular file.
@@ -381,7 +381,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -427,7 +427,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test for a full-path beginning with "//?/"
@@ -458,7 +458,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	free(fullpath);
 
 	/*
@@ -515,7 +515,7 @@ test_basic(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	free(fullpath);
 
 #endif
@@ -658,7 +658,7 @@ test_symlink_hybrid(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Specified file is a directory and it has symbolic files.
@@ -722,7 +722,7 @@ test_symlink_hybrid(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	/* Destroy the disk object. */
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	archive_entry_free(ae);
@@ -827,7 +827,7 @@ test_symlink_logical(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Specified file is a directory and it has symbolic files.
@@ -953,7 +953,7 @@ test_symlink_logical(void)
 	/* There is no entry. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	/* Destroy the disk object. */
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1131,7 +1131,7 @@ test_restore_atime(void)
 	assertFileAtime("at/fe", 886611, 0);
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test2: Traversals with archive_read_disk_set_atime_restored().
@@ -1197,7 +1197,7 @@ test_restore_atime(void)
 	assertFileAtime("at/fe", 886611, 0);
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test3: Traversals with archive_read_disk_set_atime_restored() but
@@ -1254,7 +1254,7 @@ test_restore_atime(void)
 	}
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test4: Traversals with ARCHIVE_READDISK_RESTORE_ATIME and
@@ -1406,7 +1406,7 @@ test_callbacks(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/* Reset name filter */
 	assertEqualIntA(a, ARCHIVE_OK,
@@ -1539,7 +1539,7 @@ test_nodump(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test2: Traversals with ARCHIVE_READDISK_HONOR_NODUMP
@@ -1671,7 +1671,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	assertChdir("../..");
 
@@ -1720,7 +1720,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test3: Traverse lock/dir1/.
@@ -1767,7 +1767,7 @@ test_parent(void)
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header2(a, ae));
 
 	/* Close the disk object. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	/*
 	 * Test4: Traverse lock/lock2/dir1 from inside lock.
@@ -1842,7 +1842,7 @@ test_parent(void)
 		    archive_read_next_header2(a, ae));
 
 		/* Close the disk object. */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	}
 
 	assertChdir("..");

--- a/libarchive/test/test_read_filter_compress.c
+++ b/libarchive/test/test_read_filter_compress.c
@@ -35,7 +35,7 @@ DEFINE_TEST(test_read_filter_compress_truncated)
 	assertEqualIntA(a, ARCHIVE_FATAL,
 	    archive_read_open_memory(a, data, sizeof(data)));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -59,7 +59,7 @@ DEFINE_TEST(test_read_filter_compress_empty2)
 	assertEqualString(archive_filter_name(a, 0), "compress (.Z)");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_EMPTY);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -75,6 +75,6 @@ DEFINE_TEST(test_read_filter_compress_invalid)
 	assertEqualIntA(a, ARCHIVE_FATAL,
 	    archive_read_open_memory(a, data, sizeof(data)));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_grzip.c
+++ b/libarchive/test/test_read_filter_grzip.c
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_grzip)
 	assertEqualString(archive_filter_name(a, 0), "grzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_gzip_recursive.c
+++ b/libarchive/test/test_read_filter_gzip_recursive.c
@@ -45,6 +45,6 @@ DEFINE_TEST(test_read_filter_gzip_recursive)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_GZIP);
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lrzip.c
+++ b/libarchive/test/test_read_filter_lrzip.c
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_lrzip)
 	assertEqualString(archive_filter_name(a, 0), "lrzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lzop.c
+++ b/libarchive/test/test_read_filter_lzop.c
@@ -72,6 +72,6 @@ DEFINE_TEST(test_read_filter_lzop)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_lzop_multiple_parts.c
+++ b/libarchive/test/test_read_filter_lzop_multiple_parts.c
@@ -71,6 +71,6 @@ DEFINE_TEST(test_read_filter_lzop_multiple_parts)
 	assertEqualString(archive_filter_name(a, 0), "lzop");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_filter_uudecode_raw.c
+++ b/libarchive/test/test_read_filter_uudecode_raw.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_read_filter_uudecode_raw)
 	assertEqualInt((AE_IFREG | 0755), archive_entry_mode(ae));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -62,6 +62,6 @@ DEFINE_TEST(test_read_filter_uudecode_base64_raw)
 	assertEqualInt((AE_IFREG | 0600), archive_entry_mode(ae));
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -82,7 +82,7 @@ test_copy(int use_open_fd)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	if (fd != -1)
 		close(fd);
@@ -115,7 +115,7 @@ test_empty_archive(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -156,7 +156,7 @@ test_empty_file(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -199,7 +199,7 @@ test_plain_header(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -284,7 +284,7 @@ test_extract_all_files(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -369,7 +369,7 @@ test_extract_all_files_zstd(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -419,7 +419,7 @@ test_extract_file_zstd_bcj_nobjc(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -498,7 +498,7 @@ test_extract_last_file(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -629,7 +629,7 @@ test_extract_all_files2(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -685,7 +685,7 @@ test_delta_lzma(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -741,7 +741,7 @@ test_bcj(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -798,7 +798,7 @@ test_ppmd(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -847,7 +847,7 @@ test_symname(void)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1081,7 +1081,7 @@ test_arm_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1155,7 +1155,7 @@ test_arm64_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1404,7 +1404,7 @@ DEFINE_TEST(test_read_format_7zip_sfx_elf64trunc)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
 	assertEqualInt(0, archive_file_count(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1486,7 +1486,7 @@ test_riscv_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 #endif
@@ -1546,7 +1546,7 @@ test_sparc_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -1619,7 +1619,7 @@ test_powerpc_filter(const char *refname)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_read_format_7zip_encryption_data.c
+++ b/libarchive/test/test_read_format_7zip_encryption_data.c
@@ -63,7 +63,7 @@ DEFINE_TEST(test_read_format_7zip_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_header.c
+++ b/libarchive/test/test_read_format_7zip_encryption_header.c
@@ -65,7 +65,7 @@ DEFINE_TEST(test_read_format_7zip_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_partially.c
+++ b/libarchive/test/test_read_format_7zip_encryption_partially.c
@@ -76,6 +76,6 @@ DEFINE_TEST(test_read_format_7zip_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip_issue2765.c
+++ b/libarchive/test/test_read_format_7zip_issue2765.c
@@ -46,6 +46,6 @@ DEFINE_TEST(test_read_format_7zip_issue2765)
 	assertEqualInt(0, archive_file_count(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_7zip_packinfo_digests.c
+++ b/libarchive/test/test_read_format_7zip_packinfo_digests.c
@@ -82,7 +82,7 @@ DEFINE_TEST(test_read_format_7zip_packinfo_digests)
 		    archive_format(a));
 
 		/* Close the archive. */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	}
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_cab.c
+++ b/libarchive/test/test_read_format_cab.c
@@ -266,7 +266,7 @@ verify(const char *refname, enum comp_type comp)
 
 	/* Close the archive. */
 finish:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -332,7 +332,7 @@ verify2(const char *refname, enum comp_type comp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CAB, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -387,7 +387,7 @@ verify3(const char *refname, enum comp_type comp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CAB, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cab_filename.c
+++ b/libarchive/test/test_read_format_cab_filename.c
@@ -79,7 +79,7 @@ test_read_format_cab_filename_CP932_eucJP(const char *refname)
 
 	/* Close the archive. */
 cleanup:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -157,7 +157,7 @@ test_read_format_cab_filename_CP932_UTF8(const char *refname)
 
 	/* Close the archive. */
 cleanup:
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_afio.c
+++ b/libarchive/test/test_read_format_cpio_afio.c
@@ -102,7 +102,7 @@ DEFINE_TEST(test_read_format_cpio_afio)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertA(archive_filter_code(a, 0) == ARCHIVE_FILTER_NONE);
 	assertA(archive_format(a) == ARCHIVE_FORMAT_CPIO_AFIO_LARGE);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(p);

--- a/libarchive/test/test_read_format_cpio_bin_gz.c
+++ b/libarchive/test/test_read_format_cpio_bin_gz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_cpio_bin_gz)
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_BIN_LE);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_filename.c
+++ b/libarchive/test/test_read_format_cpio_filename.c
@@ -76,7 +76,7 @@ DEFINE_TEST(test_read_format_cpio_filename_eucJP_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -182,7 +182,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -235,7 +235,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_jp)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }
@@ -288,7 +288,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -340,7 +340,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -393,7 +393,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -445,7 +445,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -498,7 +498,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -551,7 +551,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -603,7 +603,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_UTF8_ru)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }
@@ -654,7 +654,7 @@ DEFINE_TEST(test_read_format_cpio_filename_eucJP_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -706,7 +706,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -759,7 +759,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -812,7 +812,7 @@ DEFINE_TEST(test_read_format_cpio_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -864,7 +864,7 @@ DEFINE_TEST(test_read_format_cpio_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -917,7 +917,7 @@ DEFINE_TEST(test_read_format_cpio_filename_UTF8_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_CPIO_POSIX, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_cpio_svr4_bzip2_rpm.c
+++ b/libarchive/test/test_read_format_cpio_svr4_bzip2_rpm.c
@@ -123,7 +123,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_bzip2_rpm)
 	assertEqualString(archive_filter_name(a, 0), "bzip2");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_svr4_gzip.c
+++ b/libarchive/test/test_read_format_cpio_svr4_gzip.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_gzip)
 	    ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_cpio_svr4_gzip_rpm.c
+++ b/libarchive/test/test_read_format_cpio_svr4_gzip_rpm.c
@@ -123,7 +123,7 @@ DEFINE_TEST(test_read_format_cpio_svr4_gzip_rpm)
 	assertEqualString(archive_filter_name(a, 0), "gzip");
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_SVR4_NOCRC);
  
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_gtar_filename.c
+++ b/libarchive/test/test_read_format_gtar_filename.c
@@ -74,7 +74,7 @@ DEFINE_TEST(test_read_format_gtar_filename_eucJP_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -127,7 +127,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -179,7 +179,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -232,7 +232,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -284,7 +284,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -335,7 +335,7 @@ DEFINE_TEST(test_read_format_gtar_filename_eucJP_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -388,7 +388,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -441,7 +441,7 @@ DEFINE_TEST(test_read_format_gtar_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -493,7 +493,7 @@ DEFINE_TEST(test_read_format_gtar_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_gtar_gz.c
+++ b/libarchive/test/test_read_format_gtar_gz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_gtar_gz)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_gtar_redundant_L.c
+++ b/libarchive/test/test_read_format_gtar_redundant_L.c
@@ -35,6 +35,6 @@ DEFINE_TEST(test_read_format_gtar_redundant_L)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_GNUTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_gtar_sparse_skip_entry.c
+++ b/libarchive/test/test_read_format_gtar_sparse_skip_entry.c
@@ -74,7 +74,7 @@ DEFINE_TEST(test_read_format_gtar_sparse_skip_entry)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -117,7 +117,7 @@ DEFINE_TEST(test_read_format_gtar_sparse_skip_entry)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_huge_rpm.c
+++ b/libarchive/test/test_read_format_huge_rpm.c
@@ -44,7 +44,7 @@ DEFINE_TEST(test_read_format_huge_rpm)
 	assertEqualString("rpm", archive_filter_name(a, 0));
 	assertEqualInt(ARCHIVE_FORMAT_EMPTY, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha.c
+++ b/libarchive/test/test_read_format_lha.c
@@ -266,7 +266,7 @@ verify(const char *refname, int posix)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha_bugfix_0.c
+++ b/libarchive/test/test_read_format_lha_bugfix_0.c
@@ -69,7 +69,7 @@ DEFINE_TEST(test_read_format_lha_bugfix_0)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_lha_filename.c
+++ b/libarchive/test/test_read_format_lha_filename.c
@@ -85,7 +85,7 @@ test_read_format_lha_filename_CP932_eucJP(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -145,7 +145,7 @@ test_read_format_lha_filename_CP932_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -195,7 +195,7 @@ test_read_format_lha_filename_CP932_Windows(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 #else

--- a/libarchive/test/test_read_format_lha_filename_utf16.c
+++ b/libarchive/test/test_read_format_lha_filename_utf16.c
@@ -127,7 +127,7 @@ test_read_format_lha_filename_UTF16_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_LHA, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_mtree.c
+++ b/libarchive/test/test_read_format_mtree.c
@@ -269,7 +269,7 @@ test_read_format_mtree1(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(30, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -299,7 +299,7 @@ test_read_format_mtree2(void)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -348,7 +348,7 @@ test_read_format_mtree3(void)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	assertChdir("..");
@@ -418,7 +418,7 @@ DEFINE_TEST(test_read_format_mtree_filenames_only)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -477,7 +477,7 @@ DEFINE_TEST(test_read_format_mtree_nochange)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -518,7 +518,7 @@ DEFINE_TEST(test_read_format_mtree_nochange)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(3, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -620,7 +620,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v1_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(12, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -687,7 +687,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v2_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -754,7 +754,7 @@ DEFINE_TEST(test_read_format_mtree_nomagic_v2_netbsd_form)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(6, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -785,7 +785,7 @@ DEFINE_TEST(test_read_format_mtree_nonexistent_contents_file)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -811,7 +811,7 @@ DEFINE_TEST(test_read_format_mtree_noprint)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
 	assertEqualString("Can't parse line 3", archive_error_string(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -840,7 +840,7 @@ DEFINE_TEST(test_read_format_mtree_tab)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -875,6 +875,6 @@ DEFINE_TEST(test_read_format_mtree_nano)
 
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 	assertEqualInt(2, archive_file_count(a));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_rar_encryption.c
+++ b/libarchive/test/test_read_format_rar_encryption.c
@@ -81,7 +81,7 @@ static void test_encrypted_rar_archive(const char *filename, int filenamesEncryp
 		assertEqualInt(ARCHIVE_FATAL, archive_read_data(a, buff, sizeof(buff)));
 
 		/* Additional attempts to read headers are futile */
-		assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 		return;
 	}
@@ -126,7 +126,7 @@ static void test_encrypted_rar_archive(const char *filename, int filenamesEncryp
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_rar_encryption_data.c
+++ b/libarchive/test/test_read_format_rar_encryption_data.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_read_format_rar_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_rar_encryption_header.c
+++ b/libarchive/test/test_read_format_rar_encryption_header.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_format_rar_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_rar_encryption_partially.c
+++ b/libarchive/test/test_read_format_rar_encryption_partially.c
@@ -73,6 +73,6 @@ DEFINE_TEST(test_read_format_rar_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_RAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_concatenated.c
+++ b/libarchive/test/test_read_format_tar_concatenated.c
@@ -54,7 +54,7 @@ DEFINE_TEST(test_read_format_tar_concatenated)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -80,6 +80,6 @@ DEFINE_TEST(test_read_format_tar_concatenated)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_empty_filename.c
+++ b/libarchive/test/test_read_format_tar_empty_filename.c
@@ -58,6 +58,6 @@ DEFINE_TEST(test_read_format_tar_empty_filename)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_empty_with_gnulabel.c
+++ b/libarchive/test/test_read_format_tar_empty_with_gnulabel.c
@@ -47,6 +47,6 @@ DEFINE_TEST(test_read_format_tar_empty_with_gnulabel)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_GNUTAR);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_filename.c
+++ b/libarchive/test/test_read_format_tar_filename.c
@@ -100,7 +100,7 @@ test_read_format_tar_filename_KOI8R_CP866(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -150,7 +150,7 @@ next_test:
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -214,7 +214,7 @@ test_read_format_tar_filename_KOI8R_UTF8(const char *refname)
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
@@ -261,7 +261,7 @@ test_read_format_tar_filename_KOI8R_UTF8(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -329,7 +329,7 @@ test_read_format_tar_filename_KOI8R_CP1251(const char *refname)
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -377,7 +377,7 @@ next_test:
 	    archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_tar_pax_g_large.c
+++ b/libarchive/test/test_read_format_tar_pax_g_large.c
@@ -48,6 +48,6 @@ DEFINE_TEST(test_read_format_tar_pax_g_large)
 	assertEqualInt(ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualInt(ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_large_attr.c
+++ b/libarchive/test/test_read_format_tar_pax_large_attr.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_format_tar_pax_large_attr)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_COMPRESS);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_negative_time.c
+++ b/libarchive/test/test_read_format_tar_pax_negative_time.c
@@ -63,6 +63,6 @@ DEFINE_TEST(test_read_format_tar_pax_negative_time)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_pax_timestamps.c
+++ b/libarchive/test/test_read_format_tar_pax_timestamps.c
@@ -59,6 +59,6 @@ DEFINE_TEST(test_read_format_tar_pax_timestamps)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tar_timestamp_overflow.c
+++ b/libarchive/test/test_read_format_tar_timestamp_overflow.c
@@ -50,6 +50,6 @@ DEFINE_TEST(test_read_format_tar_timestamp_overflow)
 	/* Verify the end-of-archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_tgz.c
+++ b/libarchive/test/test_read_format_tgz.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_read_format_tgz)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
 	assertEqualInt(archive_entry_is_encrypted(ae), 0);
 	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_ustar_filename.c
+++ b/libarchive/test/test_read_format_ustar_filename.c
@@ -75,7 +75,7 @@ test_read_format_ustar_filename_eucJP_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -130,7 +130,7 @@ test_read_format_ustar_filename_CP866_KOI8R(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -185,7 +185,7 @@ test_read_format_ustar_filename_CP866_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -241,7 +241,7 @@ test_read_format_ustar_filename_KOI8R_CP866(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -296,7 +296,7 @@ test_read_format_ustar_filename_KOI8R_UTF8(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -350,7 +350,7 @@ test_read_format_ustar_filename_eucJP_CP932(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -406,7 +406,7 @@ test_read_format_ustar_filename_CP866_CP1251(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -462,7 +462,7 @@ test_read_format_ustar_filename_CP866_CP1251_win(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -517,7 +517,7 @@ test_read_format_ustar_filename_KOI8R_CP1251(const char *refname)
 	assertEqualIntA(a, ARCHIVE_FORMAT_TAR_USTAR, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_encryption_data.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_read_format_zip_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_encryption_header.c
+++ b/libarchive/test/test_read_format_zip_encryption_header.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_format_zip_encryption_header)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_encryption_partially.c
+++ b/libarchive/test/test_read_format_zip_encryption_partially.c
@@ -73,6 +73,6 @@ DEFINE_TEST(test_read_format_zip_encryption_partially)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_format_zip_filename.c
+++ b/libarchive/test/test_read_format_zip_filename.c
@@ -81,7 +81,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -159,7 +159,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -234,7 +234,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_eucJP)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -329,7 +329,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -385,7 +385,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -441,7 +441,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -498,7 +498,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -554,7 +554,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_UTF8)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -616,7 +616,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_KOI8R)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -681,7 +681,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP866)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -734,7 +734,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_UTF8_ru)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -792,7 +792,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP932_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -869,7 +869,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP932)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -926,7 +926,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -983,7 +983,7 @@ DEFINE_TEST(test_read_format_zip_filename_CP866_CP1251_win)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -1039,7 +1039,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1103,7 +1103,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_CP1251)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 cleanup:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
@@ -1173,7 +1173,7 @@ DEFINE_TEST(test_read_format_zip_filename_KOI8R_UTF8_2)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 next_test:
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
@@ -1223,7 +1223,7 @@ next_test:
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }

--- a/libarchive/test/test_read_format_zip_traditional_encryption_data.c
+++ b/libarchive/test/test_read_format_zip_traditional_encryption_data.c
@@ -92,7 +92,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -161,7 +161,7 @@ DEFINE_TEST(test_read_format_zip_traditional_encryption_data)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_winzip_aes.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes.c
@@ -78,7 +78,7 @@ test_winzip_aes(const char *refname, int need_libz)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -128,7 +128,7 @@ test_winzip_aes(const char *refname, int need_libz)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_winzip_aes_large.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes_large.c
@@ -110,7 +110,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 
@@ -210,7 +210,7 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 	assertEqualIntA(a, ARCHIVE_FORMAT_ZIP, archive_format(a));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_zip_zipx_lzma_oom.c
+++ b/libarchive/test/test_read_format_zip_zipx_lzma_oom.c
@@ -58,6 +58,6 @@ DEFINE_TEST(test_read_format_zip_zipx_lzma_oom)
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
 	assertEqualInt(ENOMEM, archive_errno(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_empty_val_no_nl.c
+++ b/libarchive/test/test_read_pax_empty_val_no_nl.c
@@ -60,6 +60,6 @@ DEFINE_TEST(test_read_pax_empty_val_no_nl)
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_NONE);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE);
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_xattr_rht_security_selinux.c
+++ b/libarchive/test/test_read_pax_xattr_rht_security_selinux.c
@@ -57,6 +57,6 @@ DEFINE_TEST(test_read_pax_xattr_rht_security_selinux)
 	assertEqualInt((int)xsize, strlen(string));
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_pax_xattr_schily.c
+++ b/libarchive/test/test_read_pax_xattr_schily.c
@@ -65,6 +65,6 @@ DEFINE_TEST(test_read_pax_xattr_schily)
 	assertEqualMem(xval, array, 12);
 
 	/* Close the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -148,7 +148,7 @@ DEFINE_TEST(test_read_append_filter)
   assertEqualInt(1, archive_file_count(a));
   assertEqualInt(archive_filter_code(a, 0), ARCHIVE_COMPRESSION_GZIP);
   assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
-  assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 

--- a/libarchive/test/test_write_disk_secure745.c
+++ b/libarchive/test/test_write_disk_secure745.c
@@ -72,7 +72,7 @@ DEFINE_TEST(test_write_disk_secure745)
 	/* Permission of target dir should not have changed. */
 	assertFileMode("../target", 0700);
 
-	assert(0 == archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	archive_write_free(a);
 #endif
 }

--- a/libarchive/test/test_write_filter_b64encode.c
+++ b/libarchive/test/test_write_filter_b64encode.c
@@ -147,13 +147,13 @@ DEFINE_TEST(test_write_filter_b64encode)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -161,7 +161,7 @@ DEFINE_TEST(test_write_filter_b64encode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_b64encode(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_bzip2.c
+++ b/libarchive/test/test_write_filter_bzip2.c
@@ -241,7 +241,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	else
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_write_add_filter_bzip2(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -252,7 +252,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 	else
 		assertEqualIntA(a, ARCHIVE_OK,
 		    archive_write_add_filter_bzip2(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -265,7 +265,7 @@ DEFINE_TEST(test_write_filter_bzip2)
 		    archive_write_add_filter_bzip2(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_gzip.c
+++ b/libarchive/test/test_write_filter_gzip.c
@@ -280,14 +280,14 @@ DEFINE_TEST(test_write_filter_gzip)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -295,7 +295,7 @@ DEFINE_TEST(test_write_filter_gzip)
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_gzip(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lrzip.c
+++ b/libarchive/test/test_write_filter_lrzip.c
@@ -106,13 +106,13 @@ DEFINE_TEST(test_write_filter_lrzip)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -120,7 +120,7 @@ DEFINE_TEST(test_write_filter_lrzip)
 	assertEqualIntA(a, ARCHIVE_WARN, archive_write_add_filter_lrzip(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 		archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lz4.c
+++ b/libarchive/test/test_write_filter_lz4.c
@@ -247,14 +247,14 @@ DEFINE_TEST(test_write_filter_lz4)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lz4(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lz4(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -263,7 +263,7 @@ DEFINE_TEST(test_write_filter_lz4)
 	    archive_write_add_filter_lz4(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzip.c
+++ b/libarchive/test/test_write_filter_lzip.c
@@ -230,20 +230,20 @@ DEFINE_TEST(test_write_filter_lzip)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzip(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzma.c
+++ b/libarchive/test/test_write_filter_lzma.c
@@ -234,20 +234,20 @@ DEFINE_TEST(test_write_filter_lzma)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_lzma(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_lzop.c
+++ b/libarchive/test/test_write_filter_lzop.c
@@ -239,14 +239,14 @@ DEFINE_TEST(test_write_filter_lzop)
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lzop(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, (use_prog)?ARCHIVE_WARN:ARCHIVE_OK,
 	    archive_write_add_filter_lzop(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -255,7 +255,7 @@ DEFINE_TEST(test_write_filter_lzop)
 	    archive_write_add_filter_lzop(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_uuencode.c
+++ b/libarchive/test/test_write_filter_uuencode.c
@@ -147,13 +147,13 @@ DEFINE_TEST(test_write_filter_uuencode)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
@@ -161,7 +161,7 @@ DEFINE_TEST(test_write_filter_uuencode)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_uuencode(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_xz.c
+++ b/libarchive/test/test_write_filter_xz.c
@@ -240,20 +240,20 @@ DEFINE_TEST(test_write_filter_xz)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_xz(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_filter_zstd.c
+++ b/libarchive/test/test_write_filter_zstd.c
@@ -340,20 +340,20 @@ DEFINE_TEST(test_write_filter_zstd)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_zstd(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/*

--- a/libarchive/test/test_write_format_7zip.c
+++ b/libarchive/test/test_write_format_7zip.c
@@ -181,7 +181,7 @@ test_basic(const char *compression_type)
 	assertEqualIntA(a, 0, archive_write_data(a, "12345678", 9));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -310,7 +310,7 @@ test_basic(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -425,7 +425,7 @@ test_basic2(const char *compression_type)
 	assertEqualIntA(a, 0, archive_write_data(a, "12345678", 9));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -517,7 +517,7 @@ test_basic2(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_7zip_empty.c
+++ b/libarchive/test/test_write_format_7zip_empty.c
@@ -46,7 +46,7 @@ DEFINE_TEST(test_write_format_7zip_empty_archive)
 	    archive_write_open_memory(a, buff, buffsize, &used));
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the archive file size. */
@@ -105,7 +105,7 @@ test_only_empty_file(void)
 	archive_entry_free(ae);
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the archive file size. */
@@ -148,7 +148,7 @@ test_only_empty_file(void)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);
@@ -224,7 +224,7 @@ test_only_empty_files(void)
 	archive_entry_free(ae);
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Verify the initial header. */
@@ -284,7 +284,7 @@ test_only_empty_files(void)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_7zip_large.c
+++ b/libarchive/test/test_write_format_7zip_large.c
@@ -126,7 +126,7 @@ test_large(const char *compression_type)
 	assertEqualIntA(a, ARCHIVE_FILTER_NONE, archive_filter_code(a, 0));
 	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
 
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	free(buff);

--- a/libarchive/test/test_write_format_zip.c
+++ b/libarchive/test/test_write_format_zip.c
@@ -262,7 +262,7 @@ write_contents(struct archive *a)
 
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
@@ -550,7 +550,7 @@ verify_contents(struct archive *a, int seeking, int content)
 
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_write_format_zip_empty_pathname.c
+++ b/libarchive/test/test_write_format_zip_empty_pathname.c
@@ -54,7 +54,7 @@ DEFINE_TEST(test_write_format_zip_empty_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Directory entry with empty pathname */
@@ -70,6 +70,6 @@ DEFINE_TEST(test_write_format_zip_empty_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }

--- a/libarchive/test/test_write_format_zip_long_pathname.c
+++ b/libarchive/test/test_write_format_zip_long_pathname.c
@@ -62,7 +62,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_OK, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 
@@ -84,7 +84,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 
@@ -106,7 +106,7 @@ DEFINE_TEST(test_write_format_zip_long_pathname)
 	assertEqualInt(ARCHIVE_FAILED, archive_write_header(a, ae));
 	archive_entry_free(ae);
 
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(pathname);
 

--- a/libarchive/test/test_write_read_format_zip.c
+++ b/libarchive/test/test_write_read_format_zip.c
@@ -259,7 +259,7 @@ write_contents(struct archive *a)
 
 
 	/* Close out the archive. */
-	assertEqualInt(ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
@@ -568,7 +568,7 @@ verify_contents(struct archive *a, int seeking, int improved_streaming)
 
 	/* Verify the end of the archive. */
 	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-	assertEqualInt(ARCHIVE_OK, archive_read_close(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 


### PR DESCRIPTION
In case of errors, `assertEqualIntA` offers more information by accessing archive's errno and error message.

Another spin-off of easy changes from https://github.com/libarchive/libarchive/pull/3065