### PR TITLE
32 bit: Fix compile warnings and test failure

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1363,8 +1363,9 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 			    coder2->codec != _7Z_SPARC) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_MISC,
-				    "Unsupported filter %lx for %lx",
-				    coder2->codec, coder1->codec);
+				    "Unsupported filter %jx for %jx",
+				    (uintmax_t)coder2->codec,
+				    (uintmax_t)coder1->codec);
 				return (ARCHIVE_FAILED);
 			}
 			zip->codec2 = coder2->codec;

--- a/libarchive/test/test_archive_parse_date.c
+++ b/libarchive/test/test_archive_parse_date.c
@@ -35,6 +35,7 @@
 DEFINE_TEST(test_archive_parse_date)
 {
 	time_t now = time(NULL);
+	long long expected;
 
 	assertEqualInt(archive_parse_date(now, "Jan 1, 1970 UTC"), 0);
 	assertEqualInt(archive_parse_date(now, "7:12:18-0530 4 May 1983"), 420900138);
@@ -97,7 +98,8 @@ DEFINE_TEST(test_archive_parse_date)
 	assertEqualInt(archive_parse_date(now, "@100 tomorrow"), -1);
 
 	/* Verify handling of overlarge numbers */
-	assertEqualInt(archive_parse_date(now, "Jan 1, 9999 UTC"), 253375948800LL);
+	expected = sizeof(time_t) == 4 ? -1 : 253375948800LL;
+	assertEqualInt(archive_parse_date(now, "Jan 1, 9999 UTC"), expected);
 	assertEqualInt(archive_parse_date(now, "Jan 1, 10000 UTC"), -1);
 	assertEqualInt(archive_parse_date(now, "Jan 1, 99999 UTC"), -1);
 	assertEqualInt(archive_parse_date(time(NULL), "2147483647-01-01 00:00:00"), -1);


### PR DESCRIPTION
Compiling libarchive and running tests on a 32 bit Linux system revealed two issues:

1. Use correct format modifier (uint64_t is not unsigned long on i686)
2. Fix a failing test due to time_t being 32 bit (if configured with autotools)