### PR TITLE
tests: Fix memory leaks when skipping

### DIFF
--- a/libarchive/test/test_compat_bzip2.c
+++ b/libarchive/test/test_compat_bzip2.c
@@ -48,6 +48,7 @@ compat_bzip2(const char *name)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("Unsupported bzip2");
+		archive_read_free(a);
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_read_format_cpio_bin_bz2.c
+++ b/libarchive/test/test_read_format_cpio_bin_bz2.c
@@ -41,7 +41,7 @@ DEFINE_TEST(test_read_format_cpio_bin_bz2)
 	r = archive_read_support_filter_bzip2(a);
 	if (r != ARCHIVE_OK) {
 		skipping("bzip2 support unavailable");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_read_format_pax_bz2.c
+++ b/libarchive/test/test_read_format_pax_bz2.c
@@ -48,8 +48,8 @@ DEFINE_TEST(test_read_format_pax_bz2)
 	assert((a = archive_read_new()) != NULL);
 	r = archive_read_support_filter_bzip2(a);
 	if (r != ARCHIVE_OK) {
-		archive_read_close(a);
 		skipping("Bzip2 unavailable");
+		archive_read_free(a);
 		return;
 	}
 	assertEqualIntA(a,ARCHIVE_OK, archive_read_support_format_all(a));

--- a/libarchive/test/test_read_format_zip.c
+++ b/libarchive/test/test_read_format_zip.c
@@ -619,7 +619,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	extract_reference_file(refname);
@@ -644,7 +644,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_one_file_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	extract_reference_file(refname);
@@ -669,7 +669,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	extract_reference_file(refname);
@@ -706,7 +706,7 @@ DEFINE_TEST(test_read_format_zip_bzip2_multi_blockread)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	extract_reference_file(refname);
@@ -968,7 +968,7 @@ DEFINE_TEST(test_read_format_zip_bz2_hang_on_invalid)
 	assert((a = archive_read_new()) != NULL);
 	if (ARCHIVE_OK != archive_read_support_filter_bzip2(a)) {
 		skipping("bzip2 is not fully supported on this platform");
-		archive_read_close(a);
+		archive_read_free(a);
 		return;
 	}
 	extract_reference_file(refname);

--- a/libarchive/test/test_write_filter_lz4.c
+++ b/libarchive/test/test_write_filter_lz4.c
@@ -100,6 +100,8 @@ DEFINE_TEST(test_write_filter_lz4)
 		skipping("Can't verify lz4 writing by reading back;"
 		    " lz4 reading not fully supported on this platform");
 		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		free(data);
+		free(buff);
 		return;
 	}
 


### PR DESCRIPTION
Release all resources when skipping to avoid ASAN memory leak warnings.

Tested with a setup disabling all optional features, i.e.
```
CFLAGS="-fsanitize=address,ubsan" ./configure \
--without-zlib --without-bz2lib --without-libb2 \
--without-iconv --without-lz4 --without-zstd \
--without-lzma --without-cng --without-openssl \
--without-xml2 --without-expat
```