### PR TITLE
tests: Skip checks on low memory systems

### DIFF
--- a/libarchive/test/test_write_filter_lzma.c
+++ b/libarchive/test/test_write_filter_lzma.c
@@ -129,43 +129,53 @@ DEFINE_TEST(test_write_filter_lzma)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "99"));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_set_filter_option(a, NULL, "compression-level", "9"));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	for (i = 0; i < 100; i++) {
-		snprintf(path, sizeof(path), "file%03d", i);
-		assert((ae = archive_entry_new()) != NULL);
-		archive_entry_copy_pathname(ae, path);
-		archive_entry_set_size(ae, datasize);
-		archive_entry_set_filetype(ae, AE_IFREG);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
-		assertA(datasize == (size_t)archive_write_data(a, data, datasize));
-		archive_entry_free(ae);
-	}
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
-
-
-	assert((a = archive_read_new()) != NULL);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
-	r = archive_read_support_filter_lzma(a);
-	if (r == ARCHIVE_WARN) {
-		skipping("lzma reading not fully supported on this platform");
+	r = archive_write_open_memory(a, buff, buffsize, &used2);
+	if (r == ARCHIVE_FATAL && archive_errno(a) == ENOMEM) {
+		skipping("Not enough memory available");
+		archive_write_free(a);
 	} else {
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_read_support_filter_all(a));
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_read_open_memory(a, buff, used2));
+		assertEqualIntA(a, ARCHIVE_OK, r);
 		for (i = 0; i < 100; i++) {
 			snprintf(path, sizeof(path), "file%03d", i);
-			failure("Trying to read %s", path);
-			if (!assertEqualIntA(a, ARCHIVE_OK,
-				archive_read_next_header(a, &ae)))
-				break;
-			assertEqualString(path, archive_entry_pathname(ae));
-			assertEqualInt((int)datasize, archive_entry_size(ae));
+			assert((ae = archive_entry_new()) != NULL);
+			archive_entry_copy_pathname(ae, path);
+			archive_entry_set_size(ae, datasize);
+			archive_entry_set_filetype(ae, AE_IFREG);
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_write_header(a, ae));
+			assertA(datasize ==
+			    (size_t)archive_write_data(a, data, datasize));
+			archive_entry_free(ae);
 		}
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+		assert((a = archive_read_new()) != NULL);
+		assertEqualIntA(a, ARCHIVE_OK,
+		    archive_read_support_format_all(a));
+		r = archive_read_support_filter_lzma(a);
+		if (r == ARCHIVE_WARN) {
+			skipping("lzma reading not fully supported on this platform");
+		} else {
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_read_support_filter_all(a));
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_read_open_memory(a, buff, used2));
+			for (i = 0; i < 100; i++) {
+				snprintf(path, sizeof(path), "file%03d", i);
+				failure("Trying to read %s", path);
+				if (!assertEqualIntA(a, ARCHIVE_OK,
+					archive_read_next_header(a, &ae)))
+					break;
+				assertEqualString(path,
+				    archive_entry_pathname(ae));
+				assertEqualInt((int)datasize,
+				    archive_entry_size(ae));
+			}
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		}
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
-	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * Repeat again, with much lower compression.

--- a/libarchive/test/test_write_filter_xz.c
+++ b/libarchive/test/test_write_filter_xz.c
@@ -129,50 +129,61 @@ DEFINE_TEST(test_write_filter_xz)
 	    archive_write_set_filter_option(a, NULL, "compression-level", "99"));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_write_set_filter_option(a, NULL, "compression-level", "9"));
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, buffsize, &used2));
-	for (i = 0; i < 100; i++) {
-		snprintf(path, sizeof(path), "file%03d", i);
-		assert((ae = archive_entry_new()) != NULL);
-		archive_entry_copy_pathname(ae, path);
-		archive_entry_set_size(ae, datasize);
-		archive_entry_set_filetype(ae, AE_IFREG);
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
-		assertA(datasize == (size_t)archive_write_data(a, data, datasize));
-		archive_entry_free(ae);
-	}
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
-	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
-
-	/* Curiously, this test fails; the test data above compresses
-	 * better at default compression than at level 9. */
-	/*
-	failure("compression-level=9 wrote %d bytes, default wrote %d bytes",
-	    (int)used2, (int)used1);
-	assert(used2 < used1);
-	*/
-
-	assert((a = archive_read_new()) != NULL);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
-	r = archive_read_support_filter_xz(a);
-	if (r == ARCHIVE_WARN) {
-		skipping("xz reading not fully supported on this platform");
+	r = archive_write_open_memory(a, buff, buffsize, &used2);
+	if (r == ARCHIVE_FATAL && archive_errno(a) == ENOMEM) {
+		skipping("Not enough memory available");
+		archive_write_free(a);
 	} else {
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_read_support_filter_all(a));
-		assertEqualIntA(a, ARCHIVE_OK,
-		    archive_read_open_memory(a, buff, used2));
+		assertEqualIntA(a, ARCHIVE_OK, r);
 		for (i = 0; i < 100; i++) {
 			snprintf(path, sizeof(path), "file%03d", i);
-			failure("Trying to read %s", path);
-			if (!assertEqualIntA(a, ARCHIVE_OK,
-				archive_read_next_header(a, &ae)))
-				break;
-			assertEqualString(path, archive_entry_pathname(ae));
-			assertEqualInt((int)datasize, archive_entry_size(ae));
+			assert((ae = archive_entry_new()) != NULL);
+			archive_entry_copy_pathname(ae, path);
+			archive_entry_set_size(ae, datasize);
+			archive_entry_set_filetype(ae, AE_IFREG);
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_write_header(a, ae));
+			assertA(datasize ==
+			    (size_t)archive_write_data(a, data, datasize));
+			archive_entry_free(ae);
 		}
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+		/* Curiously, this test fails; the test data above compresses
+		 * better at default compression than at level 9. */
+		/*
+		failure("compression-level=9 wrote %d bytes, default wrote %d bytes",
+		    (int)used2, (int)used1);
+		assert(used2 < used1);
+		*/
+
+		assert((a = archive_read_new()) != NULL);
+		assertEqualIntA(a, ARCHIVE_OK,
+		    archive_read_support_format_all(a));
+		r = archive_read_support_filter_xz(a);
+		if (r == ARCHIVE_WARN) {
+			skipping("xz reading not fully supported on this platform");
+		} else {
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_read_support_filter_all(a));
+			assertEqualIntA(a, ARCHIVE_OK,
+			    archive_read_open_memory(a, buff, used2));
+			for (i = 0; i < 100; i++) {
+				snprintf(path, sizeof(path), "file%03d", i);
+				failure("Trying to read %s", path);
+				if (!assertEqualIntA(a, ARCHIVE_OK,
+					archive_read_next_header(a, &ae)))
+					break;
+				assertEqualString(path,
+				    archive_entry_pathname(ae));
+				assertEqualInt((int)datasize,
+				    archive_entry_size(ae));
+			}
+			assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		}
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	}
-	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 	/*
 	 * Repeat again, with much lower compression.

--- a/libarchive/test/test_write_format_zip_compression_lzmaxz.c
+++ b/libarchive/test/test_write_format_zip_compression_lzmaxz.c
@@ -23,9 +23,10 @@ static const short folder_gid = 40;
 
 static time_t now;
 
-static void verify_write_lzma(struct archive *a)
+static int verify_write_lzma(struct archive *a)
 {
 	struct archive_entry *entry;
+	int r;
 
 	/* Write entries. */
 
@@ -38,7 +39,13 @@ static void verify_write_lzma(struct archive *a)
 	archive_entry_set_gid(entry, file_gid);
 	archive_entry_set_mtime(entry, now, 0);
 	archive_entry_set_atime(entry, now + 3, 0);
-	assertEqualIntA(a, 0, archive_write_header(a, entry));
+	r = archive_write_header(a, entry);
+	if (r == ARCHIVE_FATAL && archive_errno(a) == ENOMEM) {
+		archive_entry_free(entry);
+		archive_free(a);
+		return -1;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, r);
 	assertEqualIntA(a, sizeof(file_data1), archive_write_data(a, file_data1, sizeof(file_data1)));
 	assertEqualIntA(a, sizeof(file_data2), archive_write_data(a, file_data2, sizeof(file_data2)));
 	archive_entry_free(entry);
@@ -54,6 +61,8 @@ static void verify_write_lzma(struct archive *a)
 	archive_entry_set_ctime(entry, now + 5, 0);
 	assertEqualIntA(a, 0, archive_write_header(a, entry));
 	archive_entry_free(entry);
+
+	return 0;
 }
 
 static void verify_xz_lzma(const char *buff, size_t used, uint16_t id,
@@ -361,7 +370,10 @@ DEFINE_TEST(test_write_format_zip_compression_lzmaxz)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_in_last_block(a, 1));
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_open_memory(a, buff, sizeof(buff), &used));
 
-	verify_write_lzma(a);
+	if (verify_write_lzma(a) < 0) {
+		skipping("Not enough memory available");
+		return;
+	}
 
 	/* Close the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));


### PR DESCRIPTION
If not enough memory is available, skip tests. This can happen on 32 bit systems with ASAN enabled. While these tests run perfectly fine if run directly with libarchive_test, the test harness fails with eventual NULL pointer dereferences, since these assert-checks do not stop processing.

Happens with lzma and xz and compression level 9.

This allows us to run tests with ASAN on more "obscure" systems (which i686 by now almost is).