### PR TITLE
bzip2: Remove dead code

### DIFF
--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -298,14 +298,6 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 		if (ret > max_in)
 			ret = max_in;
 		state->stream.avail_in = (uint32_t)ret;
-		/* There is no more data, return whatever we have. */
-		if (ret == 0) {
-			state->eof = 1;
-			*p = state->out_block;
-			decompressed = state->stream.next_out
-			    - state->out_block;
-			return (decompressed);
-		}
 
 		/* Decompress as much as we can in one pass. */
 		ret = BZ2_bzDecompress(&(state->stream));


### PR DESCRIPTION
The check for end of file (`avail == 0`) happens after the check for a `NULL` return value of `__archive_read_filter_ahead`.

Remove it, because at this stage, it's definitely truncated, not just end of file.