### PR TITLE
Fix integer overflow in __archive_read_filter_ahead

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1378,7 +1378,7 @@ __archive_read_filter_ahead(struct archive_read_filter *filter,
 
 		/* Move data forward in copy buffer if necessary. */
 		if (filter->next > filter->buffer &&
-		    filter->next + min > filter->buffer + filter->buffer_size) {
+		    min > filter->buffer_size - (filter->next - filter->buffer)) {
 			if (filter->avail > 0)
 				memmove(filter->buffer, filter->next,
 				    filter->avail);


### PR DESCRIPTION
The pointer arithmetic could overflow with a large `min` value. Prevent this by using subtraction instead of addition.

Resolves #3025.