### PR TITLE
Drop total_out tracking from read filters

### DIFF
--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -56,7 +56,6 @@ struct private_data {
 	char		 in_stream;
 	unsigned char	*out_block;
 	size_t		 out_block_size;
-	int64_t		 total_out;
 	unsigned long	 crc;
 	uint32_t	 mtime;
 	char		*name;
@@ -502,7 +501,6 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 
 	/* We've read as much as we can. */
 	decompressed = state->stream.next_out - state->out_block;
-	state->total_out += decompressed;
 	if (decompressed == 0)
 		*p = NULL;
 	else

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -71,7 +71,6 @@
 struct read_lzop {
 	unsigned char	*out_block;
 	size_t		 out_block_size;
-	int64_t		 total_out;
 	int		 flags;
 	uint32_t	 compressed_cksum;
 	uint32_t	 uncompressed_cksum;
@@ -434,7 +433,6 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	 */
 	if (state->uncompressed_size == state->compressed_size) {
 		*p = b;
-		state->total_out += state->compressed_size;
 		state->unconsumed_bytes = state->compressed_size;
 		return ((ssize_t)state->uncompressed_size);
 	}
@@ -478,7 +476,6 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 
 	__archive_read_filter_consume(self->upstream, state->compressed_size);
 	*p = state->out_block;
-	state->total_out += out_size;
 	return ((ssize_t)out_size);
 }
 

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -54,7 +54,6 @@ struct private_data {
 	lzma_stream	 stream;
 	unsigned char	*out_block;
 	size_t		 out_block_size;
-	int64_t		 total_out;
 	char		 eof; /* True = found end of compressed data. */
 	char		 in_stream;
 
@@ -706,7 +705,6 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 	}
 
 	decompressed = state->stream.next_out - state->out_block;
-	state->total_out += decompressed;
 	state->member_out += decompressed;
 	if (decompressed == 0) {
 		if (member_in != state->member_in &&

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -57,7 +57,6 @@ struct private_data {
 	ZSTD_DStream	*dstream;
 	unsigned char	*out_block;
 	size_t		 out_block_size;
-	int64_t		 total_out;
 	char		 in_frame; /* True = in the middle of a zstd frame. */
 	char		 eof; /* True = found end of compressed data. */
 };
@@ -310,7 +309,6 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 	}
 
 	decompressed = out.pos;
-	state->total_out += decompressed;
 	if (decompressed == 0)
 		*p = NULL;
 	else


### PR DESCRIPTION
The variable is never read and it only allows a very unlikely integer overflow if more than INT64_MAX bytes are read.