### PR TITLE
gzip: Support more large in-memory archives

### DIFF
--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -341,7 +341,7 @@ static int
 consume_header(struct archive_read_filter *self)
 {
 	struct private_data *state;
-	ssize_t avail;
+	ssize_t avail, max_in;
 	size_t len;
 	int ret;
 
@@ -359,6 +359,18 @@ consume_header(struct archive_read_filter *self)
 	/* Initialize compression library. */
 	state->stream.next_in = (unsigned char *)(uintptr_t)
 	    __archive_read_filter_ahead(self->upstream, 1, &avail);
+	if (avail < 0) {
+		archive_set_error(&self->archive->archive,
+		    ARCHIVE_ERRNO_MISC,
+		    "Failed to read gzip input");
+		return (ARCHIVE_FATAL);
+	}
+	if (UINT_MAX >= SSIZE_MAX)
+		max_in = SSIZE_MAX;
+	else
+		max_in = UINT_MAX;
+	if (avail > max_in)
+		avail = max_in;
 	state->stream.avail_in = (uInt)avail;
 	ret = inflateInit2(&(state->stream),
 	    -15 /* Don't check for zlib header */);


### PR DESCRIPTION
Apply same logic of gzip_filter_read from commit
256c71ad4eee22a7dac2f13df1e20d85717cbdf6
to consumer_header, which contains the identical issue.