### PR TITLE
rar5: Skip correct amount of bytes

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2347,7 +2347,7 @@ static int process_base_block(struct archive_read* a,
 	}
 
 	/* If the checksum is OK, we proceed with parsing. */
-	if(ARCHIVE_OK != consume(a, hdr_size_len)) {
+	if(ARCHIVE_OK != consume(a, hdr_size)) {
 		return ARCHIVE_EOF;
 	}
 


### PR DESCRIPTION
The variable hdr_size_len specifies the length of the header size field, not the header size itself.

Consume the correct amount of bytes (hdr_size), i.e. pass the same value to consume() which was passed to read_ahead().