### PR TITLE
rar: Simplify FILE_ATTRIBUTE_DIRECTORY check

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -155,7 +155,7 @@
 #define UNP_BUFFER_SIZE   (128 * 1024)
 
 /* Define this here for non-Windows platforms */
-#if !((defined(__WIN32__) || defined(_WIN32) || defined(__WIN32)) && !defined(__CYGWIN__))
+#ifndef FILE_ATTRIBUTE_DIRECTORY
 #define FILE_ATTRIBUTE_DIRECTORY 0x10
 #endif
 


### PR DESCRIPTION
Just check if the definition exists. If not, create it. Fixes Cygwin build.

I have merged this PR and https://github.com/libarchive/libarchive/pull/3079 into https://github.com/stoeckmann/libarchive/tree/cygwin where the Cygwin build passes.