### PR TITLE
ci: migrate Windows Cygwin to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        be: [mingw-gcc, msvc]
+        be: [mingw-gcc, cygwin-gcc, msvc]
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: Install Cygwin
+      uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6
+      if:  ${{ matrix.be=='cygwin-gcc' }}
+      with:
+        install-dir: "D:\\cygwin"
+        packages: |-
+          make autoconf automake cmake
+          gcc-core binutils libtool pkg-config
+          bison zlib-devel libbz2-devel liblzma-devel
+          liblz4-devel libiconv-devel libxml2-devel
+          libzstd-devel libssl-devel
     - name: Install mingw
       if:  ${{ matrix.be=='mingw-gcc' }}
       run: choco install mingw
@@ -166,4 +177,4 @@ jobs:
     - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: libarchive-windows-${{ matrix.be }}-${{ github.sha }}
-        path: libarchive.zip
+        path: ${{ matrix.be=='cygwin-gcc' && 'libarchive.tar.xz' || 'libarchive.zip' }}

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -4,8 +4,10 @@ SET BZIP2_VERSION=1ea1ac188ad4b9cb662e3f8314673c63df95a589
 SET XZ_VERSION=5.6.3
 IF NOT "%BE%"=="mingw-gcc" (
   IF NOT "%BE%"=="msvc" (
-    ECHO Environment variable BE must be mingw-gcc or msvc
-    EXIT /b 1
+    IF NOT "%BE%"=="cygwin-gcc"  (
+      ECHO Environment variable BE must be cygwin-gcc, mingw-gcc or msvc
+      EXIT /b 1
+    )
   )
 )
 
@@ -24,6 +26,11 @@ IF "%BE%"=="mingw-gcc" (
 )
 
 IF "%1"=="deplibs" (
+  IF "%BE%"=="cygwin-gcc" (
+    ECHO Library dependencies satisfied by Cygwin install
+    EXIT /b 0
+  )
+
   IF NOT EXIST build_ci\libs (
     MKDIR build_ci\libs
   )
@@ -121,6 +128,10 @@ IF "%1"=="deplibs" (
     MKDIR build_ci\cmake
     CD build_ci\cmake
     cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" -D ZLIB_LIBRARY="C:/Program Files (x86)/zlib/lib/zlibstatic.lib" -D ZLIB_INCLUDE_DIR="C:/Program Files (x86)/zlib/include" -D BZIP2_LIBRARIES="C:/Program Files (x86)/bzip2/lib/bz2_static.lib" -D BZIP2_INCLUDE_DIR="C:/Program Files (x86)/bzip2/include" -D LIBLZMA_LIBRARY="C:/Program Files (x86)/xz/lib/lzma.lib" -D LIBLZMA_INCLUDE_DIR="C:/Program Files (x86)/xz/include" -D ZSTD_LIBRARY="C:/Program Files (x86)/zstd/lib/zstd_static.lib" -D ZSTD_INCLUDE_DIR="C:/Program Files (x86)/zstd/include" ..\.. || EXIT /b 1
+  ) ELSE IF "%BE%"=="cygwin-gcc" (
+    SET BS=cmake
+    SET CYGWIN_NOWINPATH=1
+    D:\cygwin\bin\bash.exe --login -c "cd '%cd%'; ./build/ci/build.sh -a configure" || EXIT /b 1
   )
 ) ELSE IF "%1%"=="build" (
   IF "%BE%"=="mingw-gcc" (
@@ -130,6 +141,11 @@ IF "%1"=="deplibs" (
   ) ELSE IF "%BE%"=="msvc" (
     CD build_ci\cmake
     cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
+  ) ELSE IF "%BE%"=="cygwin-gcc" (
+    SET BS=cmake
+    SET MAKE_ARGS=-j
+    SET CYGWIN_NOWINPATH=1
+    D:\cygwin\bin\bash.exe --login -c "cd '%cd%'; ./build/ci/build.sh -a build" || EXIT /b 1
   )
 ) ELSE IF "%1%"=="test" (
   IF "%BE%"=="mingw-gcc" (
@@ -140,6 +156,13 @@ IF "%1"=="deplibs" (
   ) ELSE IF "%BE%"=="msvc" (
     CD build_ci\cmake
     cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
+  ) ELSE IF "%BE%"=="cygwin-gcc" (
+    REM SET BS=cmake
+    REM SET CYGWIN_NOWINPATH=1
+    REM SET SKIP_TEST_SPARSE=1
+    ECHO "Skipping tests on this platform"
+    REM D:\cygwin\bin\bash.exe --login -c "cd '%cd%'; ./build/ci/build.sh -a test" || EXIT /b 1
+    EXIT /b 0
   )
 ) ELSE IF "%1%"=="install" (
   IF "%BE%"=="mingw-gcc" (
@@ -149,10 +172,23 @@ IF "%1"=="deplibs" (
   ) ELSE IF "%BE%"=="msvc" (
     CD build_ci\cmake
     cmake --build . --target INSTALL --config Release || EXIT /b 1
+  ) ELSE IF "%BE%"=="cygwin-gcc" (
+    SET BS=cmake
+    SET CYGWIN_NOWINPATH=1
+    D:\cygwin\bin\bash.exe --login -c "cd '%cd%'; ./build/ci/build.sh -a install" || EXIT /b 1
+    REM Exit early here; the build.sh install step for Cygwin prints the version.
+    EXIT /b 0
   )
   "C:\Program Files (x86)\libarchive\bin\bsdtar.exe" --version
 ) ELSE IF "%1"=="artifact" (
-    C:\windows\system32\tar.exe -c -C "C:\Program Files (x86)" --format=zip -f libarchive.zip libarchive
+  IF "%BE%"=="cygwin-gcc" (
+    SET BS=cmake
+    SET CYGWIN_NOWINPATH=1
+    D:\cygwin\bin\bash.exe --login -c "cd '%cd%'; ./build/ci/build.sh -a artifact" || EXIT /b 1
+    EXIT /b 0
+  )
+
+  C:\windows\system32\tar.exe -c -C "C:\Program Files (x86)" --format=zip -f libarchive.zip libarchive
 ) ELSE (
   ECHO "Usage: %0% deplibs|configure|build|test|install|artifact"
   @EXIT /b 0


### PR DESCRIPTION
Cirrus went away on June 1st.

I have kept the tests disabled as they were in Cirrus, but I've made sure to retain the fix from #3079.