### PR TITLE
build: fetch config.guess/config.sub over HTTPS

### DIFF
--- a/build/makerelease.sh
+++ b/build/makerelease.sh
@@ -50,8 +50,8 @@ export MAKE_LIBARCHIVE_RELEASE="1"
 /bin/sh build/autogen.sh
 
 # Get the newest config.guess/config.sub from savannah.gnu.org
-curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' > build/autoconf/config.guess
-curl 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' > build/autoconf/config.sub
+curl -fsSL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' > build/autoconf/config.guess
+curl -fsSL 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' > build/autoconf/config.sub
 
 ./configure
 make distcheck

--- a/build/release/Dockerfile
+++ b/build/release/Dockerfile
@@ -3,8 +3,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 RUN apt-get update && apt-get install -y build-essential autoconf automake libtool pkg-config cmake zlib1g-dev libssl-dev libacl1-dev libbz2-dev liblzma-dev liblz4-dev libzstd-dev lzop groff ghostscript bsdmainutils zip
 ADD . $HOME/libarchive/
-ADD "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" $HOME/libarchive/build/autoconf/config.guess
-ADD "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" $HOME/libarchive/build/autoconf/config.sub
+ADD "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" $HOME/libarchive/build/autoconf/config.guess
+ADD "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" $HOME/libarchive/build/autoconf/config.sub
 WORKDIR $HOME/libarchive
 RUN /bin/sh build/clean.sh
 RUN /bin/sh build/autogen.sh


### PR DESCRIPTION
Following up on a private report, switch the release-time config.guess/config.sub fetches in build/makerelease.sh and the release Dockerfile from http:// to https://, closing the on-path tampering window (CWE-494). Added -fsSL to the curl invocations so a failed fetch errors out instead of silently writing an error page into the helper script.
