### PR TITLE
lz4: Improve truncated input stream detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -472,6 +472,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_filter_grzip.c \
 	libarchive/test/test_read_filter_gzip_recursive.c \
 	libarchive/test/test_read_filter_lrzip.c \
+	libarchive/test/test_read_filter_lz4_raw.c \
 	libarchive/test/test_read_filter_lzop.c \
 	libarchive/test/test_read_filter_lzop_multiple_parts.c \
 	libarchive/test/test_read_filter_program.c \
@@ -826,6 +827,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_filter_grzip.tar.grz.uu \
 	libarchive/test/test_read_filter_gzip_recursive.gz.uu \
 	libarchive/test/test_read_filter_lrzip.tar.lrz.uu \
+	libarchive/test/test_read_filter_lz4_raw_skip.uu \
 	libarchive/test/test_read_filter_lzop.tar.lzo.uu \
 	libarchive/test/test_read_filter_lzop_multiple_parts.tar.lzo.uu \
 	libarchive/test/test_read_filter_uudecode_raw.uu \

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -408,7 +408,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 				    "Malformed lz4 data");
 				return (ARCHIVE_FATAL);
 			}
-			uint32_t skip_bytes = archive_le32dec(read_buf);
+			int64_t skip_bytes = archive_le32dec(read_buf);
 			__archive_read_filter_consume(self->upstream,
 				4 + skip_bytes);
 		} else {

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -409,8 +409,14 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 				return (ARCHIVE_FATAL);
 			}
 			int64_t skip_bytes = archive_le32dec(read_buf);
-			__archive_read_filter_consume(self->upstream,
-				4 + skip_bytes);
+			if (__archive_read_filter_consume(self->upstream,
+			    4 + skip_bytes) < 0) {
+				archive_set_error(
+				    &self->archive->archive,
+				    ARCHIVE_ERRNO_MISC,
+				    "Malformed lz4 data");
+				return (ARCHIVE_FATAL);
+			}
 		} else {
 			/* Ignore following unrecognized data. */
 			state->eof = 1;

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -104,6 +104,7 @@ IF(ENABLE_TEST)
     test_read_filter_grzip.c
     test_read_filter_gzip_recursive.c
     test_read_filter_lrzip.c
+    test_read_filter_lz4_raw.c
     test_read_filter_lzop.c
     test_read_filter_lzop_multiple_parts.c
     test_read_filter_program.c

--- a/libarchive/test/test_read_filter_lz4_raw.c
+++ b/libarchive/test/test_read_filter_lz4_raw.c
@@ -1,0 +1,40 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+DEFINE_TEST(test_read_filter_lz4_raw_skip)
+{
+	struct archive *a;
+
+	const char *name = "test_read_filter_lz4_raw_skip";
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
+	extract_reference_file(name);
+	assertEqualIntA(a, ARCHIVE_FATAL,
+	    archive_read_open_filename(a, name, 200));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_filter_lz4_raw_skip.uu
+++ b/libarchive/test/test_read_filter_lz4_raw_skip.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_filter_lz4_raw_skip.uu
+<!")-&&1`IP$``(`*`````%+3R8%0*DT8_/___P``
+`
+end


### PR DESCRIPTION
While https://github.com/libarchive/libarchive/pull/3073 is specific to 32 bit, this PR improves detection of truncated input streams which also affects 64 bit systems.

The same integer promotion issue exists within the reader. Skipping the initial bidding issue is possible by concatenating two different stream types. The latter would trigger the bidding issue, but since it's not detected in bidding phase, the reader tries to skip a specific amount of bytes (integer overflow) but fails to check if these bytes were actually skipped.

Added unit test to highlight the issue.