### PR TITLE
xar: Fix infinite loop caused by redundant counter decrement

### DIFF
--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -819,9 +819,7 @@ xar_finish_entry(struct archive_write *a)
 		if (s > a->null_length)
 			s = a->null_length;
 		w = xar_write_data(a, a->nulls, s);
-		if (w > 0)
-			xar->bytes_remaining -= w;
-		else
+		if (w <= 0)
 			return ((int)w);
 	}
 	file = xar->cur_file;

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -351,3 +351,32 @@ DEFINE_TEST(test_write_format_xar)
 	test_xar("compression=xz,compression-level=1");
 	test_xar("compression=xz,compression-level=9");
 }
+
+DEFINE_TEST(test_write_format_xar_entry_trunc)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	unsigned char buff[1024];
+	size_t used = 0;
+
+	assert((a = archive_write_new()) != NULL);
+	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
+		skipping("xar is not supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "foo");
+	archive_entry_set_mode(ae, S_IFREG | 0644);
+	archive_entry_set_size(ae, 1028);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+	assertEqualIntA(a, 3, archive_write_data(a, "foo", 3));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}


### PR DESCRIPTION
When `archive_write_data()` writes fewer bytes than the entry size declared by `archive_entry_set_size()`, the xar writer fills the remaining space with null bytes.

`xar_finish_entry()` decrements `xar->bytes_remaining` after calling `xar_write_data()`, but `xar_write_data()` already decrements it internally. The double-decrement causes a `uint64_t` underflow, causing the while loop to run forever.

https://github.com/libarchive/libarchive/blob/6a8af66e641f2c9c4ae5daa3ec31427b57b4e1aa/libarchive/archive_write_set_format_xar.c#L817-L826

https://github.com/libarchive/libarchive/blob/6a8af66e641f2c9c4ae5daa3ec31427b57b4e1aa/libarchive/archive_write_set_format_xar.c#L798-L802