### PR TITLE
cpio: Improve afio header detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -897,6 +897,8 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_cab_filename_cp932.cab.uu \
 	libarchive/test/test_read_format_cab_lzx_oob.cab.uu \
 	libarchive/test/test_read_format_cab_skip_malformed.cab.uu \
+	libarchive/test/test_read_format_cpio_afio_header.part1.cpio.uu \
+	libarchive/test/test_read_format_cpio_afio_header.part2.cpio.uu \
 	libarchive/test/test_read_format_cpio_bin_be.cpio.uu \
 	libarchive/test/test_read_format_cpio_bin_le.cpio.uu \
 	libarchive/test/test_read_format_cpio_filename_cp866.cpio.uu \

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -718,9 +718,19 @@ find_odc_header(struct archive_read *a)
 	ssize_t bytes;
 
 	for (;;) {
-		h = __archive_read_ahead(a, odc_header_size, &bytes);
-		if (h == NULL)
-			return (ARCHIVE_FATAL);
+		size_t header_size;
+
+		header_size = afiol_header_size;
+		h = __archive_read_ahead(a, afiol_header_size, &bytes);
+		if (h == NULL) {
+			if (bytes >= odc_header_size) {
+				header_size = odc_header_size;
+				h = __archive_read_ahead(a, odc_header_size,
+				    &bytes);
+			}
+			if (h == NULL)
+				return (ARCHIVE_FATAL);
+		}
 		p = h;
 		q = p + bytes;
 
@@ -736,7 +746,7 @@ find_odc_header(struct archive_read *a)
 		 * Scan ahead until we find something that looks
 		 * like an odc header.
 		 */
-		while (p + odc_header_size <= q) {
+		while (p + header_size <= q) {
 			switch (p[5]) {
 			case '7':
 				if ((memcmp("070707", p, 6) == 0

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -713,7 +713,8 @@ find_odc_header(struct archive_read *a)
 {
 	const void *h;
 	const char *p, *q;
-	size_t skip, skipped = 0;
+	int64_t skip;
+	uintmax_t skipped = 0;
 	ssize_t bytes;
 
 	for (;;) {
@@ -751,9 +752,9 @@ find_odc_header(struct archive_read *a)
 					if (skipped > 0) {
 						archive_set_error(&a->archive,
 						    0,
-						    "Skipped %d bytes before "
+						    "Skipped %ju bytes before "
 						    "finding valid header",
-						    (int)skipped);
+						    skipped);
 						return (ARCHIVE_WARN);
 					}
 					return (ARCHIVE_OK);

--- a/libarchive/test/test_read_format_cpio_afio.c
+++ b/libarchive/test/test_read_format_cpio_afio.c
@@ -125,3 +125,27 @@ DEFINE_TEST(test_read_format_cpio_afio_broken)
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_CPIO_AFIO_LARGE);
 	archive_read_free(a);
 }
+
+DEFINE_TEST(test_read_format_cpio_afio_header)
+{
+  const char *reffiles[] =
+  {
+    "test_read_format_cpio_afio_header.part1.cpio",
+    "test_read_format_cpio_afio_header.part2.cpio",
+    NULL
+  };
+  struct archive_entry *ae;
+  struct archive *a;
+
+  extract_reference_files(reffiles);
+  assert((a = archive_read_new()) != NULL);
+  assertA(0 == archive_read_support_format_cpio(a));
+  assertA(0 == archive_read_open_filenames(a, reffiles, 10240));
+
+  /* File "a" */
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+  assertEqualString("a", archive_entry_pathname(ae));
+
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_cpio_afio_header.part1.cpio.uu
+++ b/libarchive/test/test_read_format_cpio_afio_header.part1.cpio.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_cpio_afio_header.part1.cpio
+M,#<P-S(W,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P;3`P,#`P,#`P,#`P,#`P
+?,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,#`P,```
+`
+end

--- a/libarchive/test/test_read_format_cpio_afio_header.part2.cpio.uu
+++ b/libarchive/test/test_read_format_cpio_afio_header.part2.cpio.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_format_cpio_afio_header.part2.cpio
+I,#`P,#`P,#`P;C`P,#$P,#`P,#`P,',P,#`P,#`P,#`P,#`P,#`P.F$`
+`
+end


### PR DESCRIPTION
The cpio reader supports multiple header formats, including `070707` (odc) and `070727` (afio). The odc header requires 76 bytes, while the afio header takes 116. The routine to detect both header formats only requests 76 bytes though. If a filter only returns a part of the afio header, the header detection fails and erroneously states that no header exists.

Request 116 bytes instead. If no more 116 bytes are available, fall back to 76 bytes.

I've simulated such a filter issue by splitting the header into two files for the unit test. This is the most reliable way for our test harness to replicate the issue on different platforms, otherwise it would depend on filter implementations.

While at it, fix a signed integer overflow in a counter for diagnostic purposes and a typo in a comment.