### PR TITLE
filters: Update comments

### DIFF
--- a/libarchive/archive_read_support_filter_all.c
+++ b/libarchive/archive_read_support_filter_all.c
@@ -43,34 +43,34 @@ archive_read_support_filter_all(struct archive *a)
 	archive_check_magic(a, ARCHIVE_READ_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_read_support_filter_all");
 
-	/* Bzip falls back to "bunzip2" command-line */
+	/* Bzip falls back to "bzip2 -d" command-line */
 	archive_read_support_filter_bzip2(a);
 	/* The decompress code doesn't use an outside library. */
 	archive_read_support_filter_compress(a);
 	/* Gzip decompress falls back to "gzip -d" command-line. */
 	archive_read_support_filter_gzip(a);
-	/* Lzip falls back to "unlzip" command-line program. */
+	/* Lzip falls back to "lzip -d -q" command-line. */
 	archive_read_support_filter_lzip(a);
 	/* The LZMA file format has a very weak signature, so it
 	 * may not be feasible to keep this here, but we'll try.
 	 * This will come back out if there are problems. */
-	/* Lzma falls back to "unlzma" command-line program. */
+	/* Lzma falls back to "lzma -d -qq" command-line. */
 	archive_read_support_filter_lzma(a);
-	/* Xz falls back to "unxz" command-line program. */
+	/* Xz falls back to "xz -d -qq" command-line. */
 	archive_read_support_filter_xz(a);
 	/* The decode code doesn't use an outside library. */
 	archive_read_support_filter_uu(a);
 	/* The decode code doesn't use an outside library. */
 	archive_read_support_filter_rpm(a);
-	/* The decode code always uses "lrzip -q -d" command-line. */
+	/* The decode code always uses "lrzip -d -q" command-line. */
 	archive_read_support_filter_lrzip(a);
 	/* Lzop decompress falls back to "lzop -d" command-line. */
 	archive_read_support_filter_lzop(a);
 	/* The decode code always uses "grzip -d" command-line. */
 	archive_read_support_filter_grzip(a);
-	/* Lz4 falls back to "lz4 -d" command-line program. */
+	/* Lz4 falls back to "lz4 -d -q" command-line. */
 	archive_read_support_filter_lz4(a);
-	/* Zstd falls back to "zstd -d" command-line program. */
+	/* Zstd falls back to "zstd -d -qq" command-line. */
 	archive_read_support_filter_zstd(a);
 
 	/* Note: We always return ARCHIVE_OK here, even if some of the

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -66,8 +66,7 @@ static int	bzip2_filter_close(struct archive_read_filter *);
 /*
  * Note that we can detect bzip2 archives even if we can't decompress
  * them.  (In fact, we like detecting them because we can give better
- * error messages.)  So the bid framework here gets compiled even
- * if bzlib is unavailable.
+ * error messages.)
  */
 static int	bzip2_reader_bid(struct archive_read_filter_bidder *, struct archive_read_filter *);
 static int	bzip2_reader_init(struct archive_read_filter *);
@@ -153,9 +152,9 @@ bzip2_reader_bid(struct archive_read_filter_bidder *self, struct archive_read_fi
 #if !defined(HAVE_BZLIB_H) || !defined(BZ_CONFIG_ERROR)
 
 /*
- * If we don't have the library on this system, we can't actually do the
- * decompression.  We can, however, still detect compressed archives
- * and emit a useful message.
+ * If we don't have the library on this system, we can't do the
+ * decompression directly.  We can, however, try to run "bzip2 -d"
+ * in case that's available.
  */
 static int
 bzip2_reader_init(struct archive_read_filter *self)

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -70,12 +70,7 @@ static int	gzip_filter_close(struct archive_read_filter *);
 /*
  * Note that we can detect gzip archives even if we can't decompress
  * them.  (In fact, we like detecting them because we can give better
- * error messages.)  So the bid framework here gets compiled even
- * if zlib is unavailable.
- *
- * TODO: If zlib is unavailable, gzip_bidder_init() should
- * use the compress_program framework to try to fire up an external
- * gzip program.
+ * error messages.)
  */
 static int	gzip_bidder_bid(struct archive_read_filter_bidder *,
 		    struct archive_read_filter *);

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -95,8 +95,7 @@ static int	lz4_filter_close(struct archive_read_filter *);
 /*
  * Note that we can detect lz4 archives even if we can't decompress
  * them.  (In fact, we like detecting them because we can give better
- * error messages.)  So the bid framework here gets compiled even
- * if liblz4 is unavailable.
+ * error messages.)
  */
 static int	lz4_reader_bid(struct archive_read_filter_bidder *, struct archive_read_filter *);
 static int	lz4_reader_init(struct archive_read_filter *);
@@ -241,9 +240,9 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 #if !defined(HAVE_LIBLZ4)
 
 /*
- * If we don't have the library on this system, we can't actually do the
- * decompression.  We can, however, still detect compressed archives
- * and emit a useful message.
+ * If we don't have the library on this system, we can't do the
+ * decompression directly.  We can, however, try to run "lz4 -d -q"
+ * in case that's available.
  */
 static int
 lz4_reader_init(struct archive_read_filter *self)

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -117,7 +117,6 @@ archive_read_support_filter_lzop(struct archive *_a)
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	return (ARCHIVE_OK);
 #else
-	/* Return ARCHIVE_WARN since this always uses an external program. */
 	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
 	    "Using external lzop program for lzop decompression");
 	return (ARCHIVE_WARN);

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -82,8 +82,7 @@ static int	xz_lzma_bidder_init(struct archive_read_filter *);
 /*
  * Note that we can detect xz and lzma compressed files even if we
  * can't decompress them.  (In fact, we like detecting them because we
- * can give better error messages.)  So the bid framework here gets
- * compiled even if no lzma library is available.
+ * can give better error messages.)
  */
 static int	xz_bidder_bid(struct archive_read_filter_bidder *,
 		    struct archive_read_filter *);

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -69,8 +69,7 @@ static int	zstd_filter_close(struct archive_read_filter *);
 /*
  * Note that we can detect zstd compressed files even if we can't decompress
  * them.  (In fact, we like detecting them because we can give better error
- * messages.)  So the bid framework here gets compiled even if no zstd library
- * is available.
+ * messages.)
  */
 static int	zstd_bidder_bid(struct archive_read_filter_bidder *,
 		    struct archive_read_filter *);
@@ -178,7 +177,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 
 /*
  * If we don't have the library on this system, we can't do the
- * decompression directly.  We can, however, try to run "zstd -d"
+ * decompression directly.  We can, however, try to run "zstd -d -qq"
  * in case that's available.
  */
 static int


### PR DESCRIPTION
Some filter comments were not updated when the execution of external filter programs was introduced.

Sync them with reality, including the actually performed commands.