### PR TITLE
Fix typos in comments and error message

### DIFF
--- a/libarchive/archive_read_open_filename.c
+++ b/libarchive/archive_read_open_filename.c
@@ -315,7 +315,7 @@ file_open(struct archive *a, void *client_data)
 		}
 #else
 		archive_set_error(a, ARCHIVE_ERRNO_MISC,
-		    "Unexpedted operation in archive_read_open_filename");
+		    "Unexpected operation in archive_read_open_filename");
 		goto fail;
 #endif
 	}

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -283,7 +283,7 @@ gzip_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 
 	state = (struct private_data *)self->data;
 
-	/* A mtime of 0 is considered invalid/missing. */
+	/* An mtime of 0 is considered invalid/missing. */
 	if (state->mtime != 0)
 		archive_entry_set_mtime(entry, state->mtime, 0);
 

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -361,7 +361,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 		break;
 	case READ_DEFAULT_STREAM:
 	case READ_LEGACY_STREAM:
-		/* Reading a lz4 stream already failed. */
+		/* Reading an lz4 stream already failed. */
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Invalid sequence");
 		return (ARCHIVE_FATAL);

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -428,7 +428,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	}
 
 	/*
-	 * If the both uncompressed size and compressed size are the same,
+	 * If both uncompressed size and compressed size are the same,
 	 * we do not decompress this block.
 	 */
 	if (state->uncompressed_size == state->compressed_size) {

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -838,7 +838,7 @@ header_odc(struct archive_read *a, struct cpio *cpio,
  * NOTE: if a filename suffix is ".z", it is a file gzipped by afio.
  * it would be nice if we could show uncompressed file size and
  * uncompress file contents automatically, unfortunately we have nothing
- * to get a uncompressed file size while reading each header. It means
+ * to get an uncompressed file size while reading each header. It means
  * we also cannot uncompress file contents under our framework.
  */
 static int

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -88,7 +88,7 @@ static int archive_filter_lz4_write(struct archive_write_filter *,
 		    const void *, size_t);
 
 /*
- * Add a lz4 compression filter to this write handle.
+ * Add an lz4 compression filter to this write handle.
  */
 int
 archive_write_add_filter_lz4(struct archive *_a)
@@ -243,7 +243,7 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 		free(data->out_buffer);
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
-			 * the of bytes per block for performance. */
+			 * the bytes per block for performance. */
 			bpb = archive_write_get_bytes_per_block(f->archive);
 			if (bpb > bs)
 				bs = bpb;

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -766,7 +766,7 @@ struct iso9660 {
 #ifdef HAVE_ZLIB_H
 		/*
 		 * Copy a compressed file to iso9660.zisofs.temp_fd
-		 * and also copy a uncompressed file(original file) to
+		 * and also copy an uncompressed file(original file) to
 		 * iso9660.temp_fd . If the number of logical block
 		 * of the compressed file is less than the number of
 		 * logical block of the uncompressed file, use it and

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1439,7 +1439,7 @@ make_file_entry(struct archive_write *a, struct xml_writer *writer,
 	}
 
 	/*
-	 * Make a mtime entry, "<mtime>".
+	 * Make an mtime entry, "<mtime>".
 	 */
 	if (archive_entry_mtime_is_set(file->entry)) {
 		r = xmlwrite_time(a, writer, "mtime",

--- a/libarchive/libarchive-formats.5
+++ b/libarchive/libarchive-formats.5
@@ -210,7 +210,7 @@ values of varying byte order and length.
 .Bl -tag -width indent
 .It Cm binary
 The libarchive library transparently reads both big-endian and
-little-endian variants of the the two binary cpio formats; the
+little-endian variants of the two binary cpio formats; the
 original one from PWB/UNIX, and the later, more widely used, variant.
 This format used 32-bit binary values for file size and mtime, and
 16-bit binary values for the other fields.  The formats support only

--- a/libarchive/test/test_compat_lz4.c
+++ b/libarchive/test/test_compat_lz4.c
@@ -31,7 +31,7 @@
  * In particular:
  *  * lz4 -d will read multiple lz4 streams, concatenating the output
  *  * lz4 -d will stop at the end of a stream if the following data
- *    doesn't start with a lz4 signature.
+ *    doesn't start with an lz4 signature.
  */
 
 /*


### PR DESCRIPTION
Collection of unrelated (and otherwise harmless) typos.