### PR TITLE
filters: Simplify `__archive_read_filter_ahead` use

### DIFF
--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -116,13 +116,12 @@ static int
 bzip2_reader_bid(struct archive_read_filter_bidder *self, struct archive_read_filter *filter)
 {
 	const unsigned char *buffer;
-	ssize_t avail;
 	int bits_checked;
 
 	(void)self; /* UNUSED */
 
 	/* Minimal bzip2 archive is 14 bytes. */
-	buffer = __archive_read_filter_ahead(filter, 14, &avail);
+	buffer = __archive_read_filter_ahead(filter, 14, NULL);
 	if (buffer == NULL)
 		return (0);
 

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -173,13 +173,12 @@ compress_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *buffer;
-	ssize_t avail;
 	int bits_checked;
 
 	(void)self; /* UNUSED */
 
 	/* Shortest valid compress file is 3 bytes. */
-	buffer = __archive_read_filter_ahead(filter, 3, &avail);
+	buffer = __archive_read_filter_ahead(filter, 3, NULL);
 
 	if (buffer == NULL)
 		return (0);
@@ -441,7 +440,7 @@ getbits(struct archive_read_filter *self, int n)
 				1, &ret);
 			if (ret == 0)
 				return (-1);
-			if (ret < 0 || state->next_in == NULL)
+			if (state->next_in == NULL)
 				return (ARCHIVE_FATAL);
 			state->consume_unnotified = state->avail_in = ret;
 		}

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -80,12 +80,11 @@ grzip_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *p;
-	ssize_t avail;
 
 	(void)self; /* UNUSED */
 
-	p = __archive_read_filter_ahead(filter, sizeof(grzip_magic), &avail);
-	if (p == NULL || avail == 0)
+	p = __archive_read_filter_ahead(filter, sizeof(grzip_magic), NULL);
+	if (p == NULL)
 		return (0);
 
 	if (memcmp(p, grzip_magic, sizeof(grzip_magic)))

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -145,7 +145,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 	 * is all fixed layout. */
 	len = 10;
 	p = __archive_read_filter_ahead(filter, len, &avail);
-	if (p == NULL || avail == 0)
+	if (p == NULL)
 		return (0);
 	/* We only support deflation- third byte must be 0x08. */
 	if (memcmp(p, "\x1F\x8B\x08", 3) != 0)
@@ -411,7 +411,6 @@ consume_trailer(struct archive_read_filter *self)
 {
 	struct private_data *state;
 	const unsigned char *p;
-	ssize_t avail;
 
 	state = (struct private_data *)self->data;
 
@@ -427,8 +426,8 @@ consume_trailer(struct archive_read_filter *self)
 	}
 
 	/* GZip trailer is a fixed 8 byte structure. */
-	p = __archive_read_filter_ahead(self->upstream, 8, &avail);
-	if (p == NULL || avail == 0)
+	p = __archive_read_filter_ahead(self->upstream, 8, NULL);
+	if (p == NULL)
 		return (ARCHIVE_FATAL);
 
 	/* XXX TODO: Verify the length and CRC. */

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -79,15 +79,15 @@ lrzip_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *p;
-	ssize_t avail, len;
+	ssize_t len;
 	int i;
 
 	(void)self; /* UNUSED */
 	/* Start by looking at the first six bytes of the header, which
 	 * is all fixed layout. */
 	len = 6;
-	p = __archive_read_filter_ahead(filter, len, &avail);
-	if (p == NULL || avail == 0)
+	p = __archive_read_filter_ahead(filter, len, NULL);
+	if (p == NULL)
 		return (0);
 
 	if (memcmp(p, LRZIP_HEADER_MAGIC, LRZIP_HEADER_MAGIC_LEN))

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -530,7 +530,6 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	struct private_data *state = (struct private_data *)self->data;
 	ssize_t compressed_size;
 	const char *read_buf;
-	ssize_t bytes_remaining;
 	int checksum_size;
 	ssize_t uncompressed_size;
 	size_t prefix64k;
@@ -538,8 +537,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	*p = NULL;
 
 	/* Make sure we have 4 bytes for a block size. */
-	read_buf = __archive_read_filter_ahead(self->upstream, 4,
-	    &bytes_remaining);
+	read_buf = __archive_read_filter_ahead(self->upstream, 4, NULL);
 	if (read_buf == NULL)
 		goto truncated_error;
 	compressed_size = archive_le32dec(read_buf);
@@ -565,7 +563,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	  a huge buffer used for decoded data.
 	*/
 	read_buf = __archive_read_filter_ahead(self->upstream,
-	    4 + compressed_size + checksum_size, &bytes_remaining);
+	    4 + compressed_size + checksum_size, NULL);
 	if (read_buf == NULL)
 		goto truncated_error;
 
@@ -673,7 +671,6 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 {
 	struct private_data *state = (struct private_data *)self->data;
 	const char *read_buf;
-	ssize_t bytes_remaining;
 	ssize_t ret;
 
 	if (state->stage == SELECT_STREAM) {
@@ -697,7 +694,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 			unsigned int checksum;
 			unsigned int checksum_stream;
 			read_buf = __archive_read_filter_ahead(self->upstream,
-			    4, &bytes_remaining);
+			    4, NULL);
 			if (read_buf == NULL) {
 				archive_set_error(&self->archive->archive,
 				    ARCHIVE_ERRNO_MISC, "truncated lz4 input");

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -132,12 +132,11 @@ lzop_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *p;
-	ssize_t avail;
 
 	(void)self; /* UNUSED */
 
-	p = __archive_read_filter_ahead(filter, LZOP_HEADER_MAGIC_LEN, &avail);
-	if (p == NULL || avail == 0)
+	p = __archive_read_filter_ahead(filter, LZOP_HEADER_MAGIC_LEN, NULL);
+	if (p == NULL)
 		return (0);
 
 	if (memcmp(p, LZOP_HEADER_MAGIC, LZOP_HEADER_MAGIC_LEN))

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -95,12 +95,11 @@ rpm_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *b;
-	ssize_t avail;
 	int bits_checked;
 
 	(void)self; /* UNUSED */
 
-	b = __archive_read_filter_ahead(filter, 8, &avail);
+	b = __archive_read_filter_ahead(filter, 8, NULL);
 	if (b == NULL)
 		return (0);
 

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -202,11 +202,10 @@ xz_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *buffer;
-	ssize_t avail;
 
 	(void)self; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, 6, &avail);
+	buffer = __archive_read_filter_ahead(filter, 6, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -236,14 +235,13 @@ lzma_bidder_bid(struct archive_read_filter_bidder *self,
     struct archive_read_filter *filter)
 {
 	const unsigned char *buffer;
-	ssize_t avail;
 	uint32_t dicsize;
 	uint64_t uncompressed_size;
 	int bits_checked;
 
 	(void)self; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, 14, &avail);
+	buffer = __archive_read_filter_ahead(filter, 14, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -342,11 +340,10 @@ static int
 lzip_has_member(struct archive_read_filter *filter)
 {
 	const unsigned char *buffer;
-	ssize_t avail;
 	int bits_checked;
 	int log2dic;
 
-	buffer = __archive_read_filter_ahead(filter, 6, &avail);
+	buffer = __archive_read_filter_ahead(filter, 6, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -535,12 +532,11 @@ lzip_init(struct archive_read_filter *self)
 	const unsigned char *h;
 	lzma_filter filters[2];
 	unsigned char props[5];
-	ssize_t avail_in;
 	uint32_t dicsize;
 	int log2dic, ret;
 
 	state = (struct private_data *)self->data;
-	h = __archive_read_filter_ahead(self->upstream, 6, &avail_in);
+	h = __archive_read_filter_ahead(self->upstream, 6, NULL);
 	if (h == NULL)
 		return (ARCHIVE_FATAL);
 


### PR DESCRIPTION
The third argument (available bytes) is not always evaluated. It is perfectly fine to pass a `NULL` argument if it's not needed.

Also, some checks of the third argument can be removed, because in case of an error (`< 0`) or in case of end of stream (`0`) the return value is `NULL` anyway. If a `NULL` check is already in place, just use it.

Simplifies code audits because it's obvious that the available bytes are not needed within the function if they are never stored.