### PR TITLE
lz4: Check `XXH32_init` result

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -512,8 +512,11 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	/* Make sure we have a large enough buffer for uncompressed data. */
 	if (lz4_allocate_out_block(self) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
-	if (state->flags.stream_checksum)
+	if (state->flags.stream_checksum) {
 		state->xxh32_state = __archive_xxhash.XXH32_init(0);
+		if (state->xxh32_state == NULL)
+			return (ARCHIVE_FATAL);
+	}
 
 	state->decoded_size = 0;
 	/* Success */

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -417,9 +417,11 @@ lz4_write_stream_descriptor(struct archive_write_filter *f)
 	sd[5] = (data->block_maximum_size << 4);
 	sd[6] = (__archive_xxhash.XXH32(&sd[4], 2, 0) >> 8) & 0xff;
 	data->out += 7;
-	if (data->stream_checksum)
+	if (data->stream_checksum) {
 		data->xxh32_state = __archive_xxhash.XXH32_init(0);
-	else
+		if (data->xxh32_state == NULL)
+			return (ARCHIVE_FATAL);
+	} else
 		data->xxh32_state = NULL;
 	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
The `XXH32_init` function allocates memory. Check if the allocation was successful and return `ARCHIVE_FATAL` on error.