### PR TITLE
7zip: fix a number of issues in zstd detection

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -335,7 +335,7 @@ struct _7zip {
 	int			 stream_valid;
 #endif
 	/* Decoding Zstandard data. */
-#if HAVE_ZSTD_H
+#if HAVE_ZSTD_H && HAVE_LIBZSTD
 	ZSTD_DStream		 *zstd_dstream;
 	int		         zstdstream_valid;
 #endif
@@ -1581,7 +1581,7 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 #endif
 	case _7Z_ZSTD:
 	{
-#if defined(HAVE_ZSTD_H)
+#if HAVE_ZSTD_H && HAVE_LIBZSTD
 		if (zip->zstdstream_valid) {
 			ZSTD_freeDStream(zip->zstd_dstream);
 			zip->zstdstream_valid = 0;
@@ -1863,7 +1863,7 @@ decompress(struct archive_read *a, struct _7zip *zip,
 		t_avail_out = zip->stream.avail_out;
 		break;
 #endif
-#ifdef HAVE_ZSTD_H
+#if HAVE_ZSTD_H && HAVE_LIBZSTD
 	case _7Z_ZSTD:
 	{
 		ZSTD_inBuffer input = { t_next_in, t_avail_in, 0 }; // src, size, pos
@@ -2050,7 +2050,7 @@ free_decompression(struct archive_read *a, struct _7zip *zip)
 		zip->stream_valid = 0;
 	}
 #endif
-#ifdef HAVE_ZSTD_H
+#if HAVE_ZSTD_H && HAVE_LIBZSTD
 	if (zip->zstdstream_valid)
 		ZSTD_freeDStream(zip->zstd_dstream);
 #endif

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -314,7 +314,7 @@ static int	_7z_compression_init_encoder(struct archive_write *, unsigned,
 		    int);
 static int	compression_init_encoder_zstd(struct archive *,
 		    struct la_zstream *, int, int);
-#if defined(HAVE_ZSTD_H)
+#if HAVE_ZSTD_H && HAVE_ZSTD_compressStream
 static int	compression_code_zstd(struct archive *,
 		    struct la_zstream *, enum la_zaction);
 static int	compression_end_zstd(struct archive *, struct la_zstream *);

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -379,7 +379,7 @@ archive_write_set_format_7zip(struct archive *_a)
 	zip->opt_compression = _7Z_BZIP2;
 #elif defined(HAVE_ZLIB_H)
 	zip->opt_compression = _7Z_DEFLATE;
-#elif HAVE_ZSTD_H
+#elif HAVE_ZSTD_H && HAVE_ZSTD_compressStream
 	zip->opt_compression = _7Z_ZSTD;
 #else
 	zip->opt_compression = _7Z_COPY;


### PR DESCRIPTION
While working on #3090, I discovered that if zstd's headers are present but it cannot be linked, the build will fail with `-Werror=unused-function`, and 7zip compression will fall back to zstd even when it is not actually usable.