### PR TITLE
rar: Add missing bound check for staticdata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -981,6 +981,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar_sfx.exe.uu \
 	libarchive/test/test_read_format_rar_subblock.rar.uu \
 	libarchive/test/test_read_format_rar_symlink_huge.rar.uu \
+	libarchive/test/test_read_format_rar_unbound_staticdata.rar.uu \
 	libarchive/test/test_read_format_rar_unicode.rar.uu \
 	libarchive/test/test_read_format_rar_windows.rar.uu \
 	libarchive/test/test_read_format_rar4_encrypted.rar.uu \

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3550,7 +3550,13 @@ compile_program(const uint8_t *bytes, size_t length)
 
   if (membr_bits(&br, 1))
   {
-    prog->staticdatalen = membr_next_rarvm_number(&br) + 1;
+    uint32_t staticdatalen = membr_next_rarvm_number(&br);
+    if (staticdatalen >= VM_MEMORY_SIZE)
+    {
+      delete_program_code(prog);
+      return NULL;
+    }
+    prog->staticdatalen = staticdatalen + 1;
     prog->staticdata = malloc(prog->staticdatalen);
     if (!prog->staticdata)
     {

--- a/libarchive/test/test_read_format_rar.c
+++ b/libarchive/test/test_read_format_rar.c
@@ -3958,3 +3958,24 @@ DEFINE_TEST(test_read_format_rar_symlink_huge)
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 #endif
 }
+
+DEFINE_TEST(test_read_format_rar_unbound_staticdata)
+{
+  const char* reffile = "test_read_format_rar_unbound_staticdata.rar";
+
+  struct archive_entry *ae;
+  struct archive *a;
+  char buf[64];
+
+  extract_reference_file(reffile);
+  assert((a = archive_read_new()) != NULL);
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, reffile, 1024));
+
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+  assertEqualIntA(a, ARCHIVE_FAILED, archive_read_data(a, buf, 64));
+
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_rar_unbound_staticdata.rar.uu
+++ b/libarchive/test/test_read_format_rar_unbound_staticdata.rar.uu
@@ -1,0 +1,6 @@
+begin 644 test_read_format_rar_unbound_staticdata.rar
+M4F%R(1H'`,^0<P``#0`````````D>W0@`"L`-P````0````#'-]$(0`````=
+M,0L`I($``'!O8U]B-S8N='AT`$```````````&V?]4_(#3#0``B.IW.YK)_P
+C`````````````````````````)5`M\R`2$`0``2P>P``!P``
+`
+end


### PR DESCRIPTION
## Problem

A crafted RAR archive can encode an arbitrarily large `staticdatalen` value in the RAR VM bytecode header, causing `compile_program` to call `malloc(staticdatalen)` and then iterate over every byte in the following loop.

## Proposed Fix

Check against `VM_MEMORY_SIZE` and reject any larger size because a static data size larger than the VM memory makes no sense. For reference, `globaldata` already has a check before allocation.

Actually, libarchive doesn't come with the implementation of RAR VM, and thus `prog->staticdata` is never used.

## Code

https://github.com/libarchive/libarchive/blob/1b080e9c2a127515cb3cffa64800db07884037da/libarchive/archive_read_support_format_rar.c#L3552-L3563

https://github.com/libarchive/libarchive/blob/1b080e9c2a127515cb3cffa64800db07884037da/libarchive/archive_read_support_format_rar.c#L3364-L3374