### PR TITLE
Extend Windows legacy support

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -1372,7 +1372,7 @@ free_sconv_object(struct archive_string_conv *sc)
 }
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-# if defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+# if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #  define GetOEMCP() CP_OEMCP
 # endif
 

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -219,7 +219,7 @@ la_CreateFile(const char *path, DWORD dwDesiredAccess, DWORD dwShareMode,
 	CREATEFILE2_EXTENDED_PARAMETERS createExParams;
 #endif
 
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
 	handle = CreateFileA(path, dwDesiredAccess, dwShareMode,
 	    lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes,
 	    hTemplateFile);
@@ -307,7 +307,7 @@ __la_open(const char *path, int flags, ...)
 		 * "Permission denied" error.
 		 */
 		attr = GetFileAttributesA(path);
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
 		if (attr == (DWORD)-1 && GetLastError() == ERROR_PATH_NOT_FOUND)
 #endif
 		{
@@ -325,7 +325,7 @@ __la_open(const char *path, int flags, ...)
 		}
 		if (attr & FILE_ATTRIBUTE_DIRECTORY) {
 			HANDLE handle;
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
 			if (ws != NULL)
 				handle = CreateFileW(ws, 0, 0, NULL,
 				    OPEN_EXISTING,
@@ -420,7 +420,7 @@ __la_wopen(const wchar_t *path, int flags, ...)
 		 * "Permission denied" error.
 		 */
 		attr = GetFileAttributesW(path);
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
 		if (attr == (DWORD)-1 && GetLastError() == ERROR_PATH_NOT_FOUND)
 #endif
 		{
@@ -439,7 +439,7 @@ __la_wopen(const wchar_t *path, int flags, ...)
 		}
 		if (attr & FILE_ATTRIBUTE_DIRECTORY) {
 			HANDLE handle;
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
 			if (fullpath != NULL)
 				handle = CreateFileW(fullpath, 0, 0, NULL,
 				    OPEN_EXISTING,

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -307,6 +307,10 @@ size_t wcrtomb(char *, wchar_t, mbstate_t *);
 #define WINAPI_PARTITION_DESKTOP 1
 #endif
 
+#ifndef WINAPI_PARTITION_SYSTEM
+#define WINAPI_PARTITION_SYSTEM 1
+#endif
+
 #ifndef NTDDI_VERSION
 #define NTDDI_VERSION  0x05020000
 #endif

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -299,6 +299,22 @@ typedef int mbstate_t;
 size_t wcrtomb(char *, wchar_t, mbstate_t *);
 #endif
 
+#ifndef WINAPI_FAMILY_PARTITION
+#define WINAPI_FAMILY_PARTITION(x) (x)
+#endif
+
+#ifndef WINAPI_PARTITION_DESKTOP
+#define WINAPI_PARTITION_DESKTOP 1
+#endif
+
+#ifndef NTDDI_VERSION
+#define NTDDI_VERSION  0x05020000
+#endif
+
+#ifndef NTDDI_WIN10_VB
+#define NTDDI_WIN10_VB 0x0A000008
+#endif
+
 #if !WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP) && NTDDI_VERSION < NTDDI_WIN10_VB
 // not supported in UWP SDK before 20H1
 #define GetVolumePathNameW(f, v, c)   (0)

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -667,7 +667,7 @@ la_CreateSymbolicLinkW(const wchar_t *linkname, const wchar_t *target,
 		f = la_GetFunctionKernel32("CreateSymbolicLinkW");
 	}
 #else
-# if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+# if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 	f = CreateSymbolicLinkW;
 # else
 	f = NULL;

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -667,7 +667,7 @@ la_CreateSymbolicLinkW(const wchar_t *linkname, const wchar_t *target,
 		f = la_GetFunctionKernel32("CreateSymbolicLinkW");
 	}
 #else
-# if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+# if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 	f = CreateSymbolicLinkW;
 # else
 	f = NULL;

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -31,7 +31,7 @@
 
 #include "filter_fork.h"
 
-#if !defined(WINAPI_FAMILY_PARTITION) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 /* There are some editions of Windows ("nano server," for example) that
  * do not host user32.dll. If we want to keep running on those editions,
  * we need to delay-load WaitForInputIdle. */


### PR DESCRIPTION
Support compilation on old but still supported systems like Windows XP by defining macros and other preprocesser definitions if they are missing.