### PR TITLE
7zip/rar5: Simplify file attribute handling

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1016,29 +1016,19 @@ archive_read_format_7zip_read_header(struct archive_read *a,
 	const int supported_attrs = FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM;
 
 	if (zip_entry->attr & supported_attrs) {
-		char *fflags_text, *ptr;
-		/* allocate for ",rdonly,hidden,system" */
-		fflags_text = malloc(22 * sizeof(*fflags_text));
-		if (fflags_text != NULL) {
-			ptr = fflags_text;
-			if (zip_entry->attr & FILE_ATTRIBUTE_READONLY) {
-				strcpy(ptr, ",rdonly");
-				ptr = ptr + 7;
-			}
-			if (zip_entry->attr & FILE_ATTRIBUTE_HIDDEN) {
-				strcpy(ptr, ",hidden");
-				ptr = ptr + 7;
-			}
-			if (zip_entry->attr & FILE_ATTRIBUTE_SYSTEM) {
-				strcpy(ptr, ",system");
-				ptr = ptr + 7;
-			}
-			if (ptr > fflags_text) {
-				archive_entry_copy_fflags_text(entry,
-				    fflags_text + 1);
-			}
-			free(fflags_text);
-		}
+		char buf[sizeof(",rdonly,hidden,system")];
+		char *fflags[3] = { "", "", "" };
+		char **flag = fflags;
+
+		if (zip_entry->attr & FILE_ATTRIBUTE_READONLY)
+			*flag++ = ",rdonly";
+		if (zip_entry->attr & FILE_ATTRIBUTE_HIDDEN)
+			*flag++ = ",hidden";
+		if (zip_entry->attr & FILE_ATTRIBUTE_SYSTEM)
+			*flag++ = ",system";
+
+		snprintf(buf, sizeof(buf), "%s%s%s", fflags[0], fflags[1], fflags[2]);
+		archive_entry_copy_fflags_text(entry, buf + 1);
 	}
 
 	/* If there's no body, force read_data() to return EOF immediately. */

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1948,29 +1948,20 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 		archive_entry_set_mode(entry, mode);
 
 		if (file_attr & (ATTR_READONLY | ATTR_HIDDEN | ATTR_SYSTEM)) {
-			char *fflags_text, *ptr;
-			/* allocate for ",rdonly,hidden,system" */
-			fflags_text = malloc(22 * sizeof(*fflags_text));
-			if (fflags_text != NULL) {
-				ptr = fflags_text;
-				if (file_attr & ATTR_READONLY) {
-					strcpy(ptr, ",rdonly");
-					ptr = ptr + 7;
-				}
-				if (file_attr & ATTR_HIDDEN) {
-					strcpy(ptr, ",hidden");
-					ptr = ptr + 7;
-				}
-				if (file_attr & ATTR_SYSTEM) {
-					strcpy(ptr, ",system");
-					ptr = ptr + 7;
-				}
-				if (ptr > fflags_text) {
-					archive_entry_copy_fflags_text(entry,
-					    fflags_text + 1);
-				}
-				free(fflags_text);
-			}
+			char buf[sizeof(",rdonly,hidden,system")];
+			char *fflags[3] = { "", "", "" };
+			char **flag = fflags;
+
+			if (file_attr & ATTR_READONLY)
+				*flag++ = ",rdonly";
+			if (file_attr & ATTR_HIDDEN)
+				*flag++ = ",hidden";
+			if (file_attr & ATTR_SYSTEM)
+				*flag++ = ",system";
+
+			snprintf(buf, sizeof(buf), "%s%s%s",
+			    fflags[0], fflags[1], fflags[2]);
+			archive_entry_copy_fflags_text(entry, buf + 1);
 		}
 	} else if(host_os == HOST_UNIX) {
 		/* Host OS is Unix */


### PR DESCRIPTION
- Use a stack array for 22 bytes
- Entering the if-branch already implies that we will add data
- Use `snprintf` instead of `strcpy`

Even though `snprintf` is slower than `strcpy`, it's easier to verify and since nobody complained so far about the `malloc` overhead, this should be okay (for now).

As a bonus, this code cannot fail anymore, which previously meant that file attributes were silently ignored.