### PR TITLE
Fix OOB in `archive_read_open_filenames_w` on some systems

### DIFF
--- a/libarchive/archive_read_open_filename.c
+++ b/libarchive/archive_read_open_filename.c
@@ -40,6 +40,9 @@
 #ifdef HAVE_IO_H
 #include <io.h>
 #endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
@@ -181,7 +184,7 @@ archive_read_open_filenames_w(struct archive *a, const wchar_t **wfilenames,
 		if (wfilename == NULL)
 			wfilename = L"";
 		mine = calloc(1,
-			sizeof(*mine) + wcslen(wfilename) * sizeof(wchar_t));
+			sizeof(*mine) + wcslen(wfilename) * MB_LEN_MAX);
 		if (mine == NULL)
 			goto no_memory;
 		mine->block_size = block_size;

--- a/libarchive/test/test_open_filename.c
+++ b/libarchive/test/test_open_filename.c
@@ -24,6 +24,8 @@
  */
 #include "test.h"
 
+#include <locale.h>
+
 static void
 test_open_filename_mbs(void)
 {
@@ -196,4 +198,25 @@ DEFINE_TEST(test_open_filename)
 {
 	test_open_filename_mbs();
 	test_open_filename_wcs();
+}
+
+DEFINE_TEST(test_open_filename_wcs_oob)
+{
+	struct archive *a;
+
+	/* Continue even if not available for best test coverage. */
+	setlocale(LC_ALL, "en_US.UTF-8");
+
+	/*
+	 * Try to open file with filename which might use more bytes in
+	 * MBS representation than in wchar_t if platform uses 16 bit wchar_t,
+	 * e.g. Cygwin (3 times a Euro sign, i.e. 3*2+2=8 vs 3*3+1=10 bytes).
+	 */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_FATAL,
+	    archive_read_open_filename_w(a, L"\u20AC\u20AC\u20AC", 512));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }


### PR DESCRIPTION
Systems except Windows with `sizeof(wchar_t) = 2`, e.g. Cygwin on Windows, are vulnerable to an out of boundary write when converting filenames to multi byte strings if the target representation takes more bytes than before.

An example would be `€€€` (6 in `wchar_t` but 9 in `char`), see added unit test.

Always allocate enough bytes by using `MB_LEN_MAX` instead.

Resolves GHSA-crm5-q56g-xw29.