### PR TITLE
gzip: Fix OOB in writer with huge filename

### DIFF
--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -61,7 +61,7 @@ struct private_data {
 	char	*original_filename;
 #ifdef HAVE_ZLIB_H
 	z_stream	 stream;
-	int64_t		 total_in;
+	uint64_t	 total_in;
 	unsigned char	*compressed;
 	size_t		 compressed_buffer_size;
 	unsigned long	 crc;

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -253,9 +253,9 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 		/* Limit "original filename" to 32k or the
 		 * remaining space in the buffer, whichever is smaller.
 		 */
-		int ofn_length = strlen(data->original_filename);
-		int ofn_max_length = 32768;
-		int ofn_space_available = data->compressed
+		size_t ofn_length = strlen(data->original_filename);
+		size_t ofn_max_length = 32768;
+		size_t ofn_space_available = data->compressed
 			+ data->compressed_buffer_size
 			- data->stream.next_out
 			- 1;

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -178,7 +178,7 @@ archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
 		if (value) {
 			data->original_filename = strdup(value);
 			if (data->original_filename == NULL)
-				return (ARCHIVE_WARN);
+				return (ARCHIVE_FAILED);
 		}
 		return (ARCHIVE_OK);
 	}


### PR DESCRIPTION
It is possible to trigger an out of boundary write when supplying a huge original filename on 64 bit systems. Storing the string length in an int could overflow the type, eventually leading to a huge positive value while copying memory.

Fix this by using correct data types.

While at it, turn `total_in` into an unsigned type to never trigger another integer overflow and properly treat out of memory conditions while duplicating the original filename.

Proof of Concept:

1. Create proof of concept binary (> INT_MAX chars in original filename)
```
cat > poc.c << EOF
#include <archive.h>
#include <archive_entry.h>
#include <err.h>
#include <limits.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main(void) {
        struct archive *a;
        char *buf;

        buf = malloc((unsigned)INT_MAX + 3);
        if (buf == NULL)
                err(1, "malloc");
        memset(buf, 'A', (unsigned)INT_MAX + 1);
        buf[(unsigned)INT_MAX + 2] = '\0';

        if ((a = archive_write_new()) == NULL)
                errx(1, "archive_writE_new");
        archive_write_set_format_raw(a);
        archive_write_add_filter_gzip(a);
        if (archive_write_set_filter_option(a, NULL, "original-filename", buf) != ARCHIVE_OK)
                errx(1, "archive_write_set_filteR_option");

        if (archive_write_open_filename(a, "poc.gz") < ARCHIVE_WARN)
                errx(1, "archive_write_open_filename");

        if (archive_write_close(a) != ARCHIVE_OK)
                errx(1, "archive_write_close");
        archive_write_free(a);

        free(buf);

        return 0;
}
EOF
cc -larchive -o poc poc.c
```
2. Run proof of concept
```
./poc
```