### PR TITLE
Harden code against future changes

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -643,11 +643,12 @@ add_pattern_from_file(struct archive_match *a, struct match_list *mlist,
 	}
 	r = archive_read_next_header(ar, &ae);
 	if (r != ARCHIVE_OK) {
-		archive_read_free(ar);
 		if (r == ARCHIVE_EOF) {
+			archive_read_free(ar);
 			return (ARCHIVE_OK);
 		} else {
 			archive_copy_error(&(a->archive), ar);
+			archive_read_free(ar);
 			return (r);
 		}
 	}

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -524,6 +524,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	free(state->out_block);
 	free(state);
 	self->data = NULL;
+	self->vtable = NULL;
 	return (ARCHIVE_FATAL);
 }
 


### PR DESCRIPTION
This PR does not fix any reachable issue, but fixes the code in question nonetheless to prevent regressions in the future:

- Do not call `archive_copy_error` after `archive_read_free` to prevent a user after free bug
- Reset `vtable` to `NULL` to prevent `close` from being called after filter initialization error, since `data` is already freed and set to `NULL`, preventing a `NULL` pointer dereference