### PR TITLE
iso9660: Fix null dereference in set_directory_record_rr

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -3039,8 +3039,8 @@ set_directory_record_rr(unsigned char *bp, int dr_len,
 		const char *sl;
 		char sl_last;
 
-		if (extra_space(&ctl) < 7)
-			bp = extra_next_record(&ctl, 7);
+		if (extra_space(&ctl) < 12)
+			bp = extra_next_record(&ctl, 12);
 		sl = file->symlink.s;
 		sl_last = '\0';
 		if (bp != NULL) {

--- a/libarchive/test/test_write_format_iso9660_bugs.c
+++ b/libarchive/test/test_write_format_iso9660_bugs.c
@@ -246,3 +246,60 @@ DEFINE_TEST(test_write_format_iso9660_duplicate_identifier_truncation)
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 	free(buff);
 }
+
+
+DEFINE_TEST(test_write_format_iso9660_symlink)
+{
+	const size_t buffsize = 512 * 1024;
+	unsigned char *buff;
+	size_t used = 0;
+	char name[1024];
+	struct archive *a;
+	struct archive_entry *ae;
+
+	assert((buff = malloc(buffsize)) != NULL);
+	for (size_t i = 0; i + 1 < sizeof(name); i++) {
+		/* Write the archive */
+		assert((a = archive_write_new()) != NULL);
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_iso9660(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+		assertEqualIntA(a, ARCHIVE_OK,
+			archive_write_open_memory(a, buff, buffsize, &used));
+		assert((ae = archive_entry_new()) != NULL);
+		name[i] = 'A';
+		name[i + 1] = '\0';
+		archive_entry_copy_pathname(ae, name);
+		archive_entry_set_filetype(ae, AE_IFLNK);
+		archive_entry_set_symlink(ae, "B");
+		archive_entry_set_size(ae, 0);
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+		archive_entry_free(ae);
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+		/* Read the archive back */
+		assert((a = archive_read_new()) != NULL);
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+		assertEqualIntA(a, ARCHIVE_OK,
+			archive_read_open_memory(a, buff, used));
+
+		/* First entry: the root directory '.' */
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+		assertEqualStringA(a, ".", archive_entry_pathname(ae));
+		assertEqualIntA(a, AE_IFDIR, archive_entry_filetype(ae));
+
+		/* Second entry: the symbolic link */
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+		assertEqualStringA(a, name, archive_entry_pathname(ae));
+		assertEqualIntA(a, AE_IFLNK, archive_entry_filetype(ae));
+		assertEqualStringA(a, "B", archive_entry_symlink(ae));
+		assertEqualIntA(a, 0, archive_entry_size(ae));
+
+		/* End of archive */
+		assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	}
+	free(buff);
+}


### PR DESCRIPTION
## Bug

A null dereference bug can be triggered when writing an ISO9660 archive containing a symbolic-link entry
with Rock Ridge extensions enabled.

[L3062](https://github.com/libarchive/libarchive/blob/cda40b999b46cdc019b34f1c2e88dfdd51bf915f/libarchive/archive_write_set_format_iso9660.c#L3062) sets `cf` to `NULL`. If `slmax <= 11`, the subsequent loop is never entered and [L3164](https://github.com/libarchive/libarchive/blob/cda40b999b46cdc019b34f1c2e88dfdd51bf915f/libarchive/archive_write_set_format_iso9660.c#L3164) dereferences the `NULL` pointer.

https://github.com/libarchive/libarchive/blob/cda40b999b46cdc019b34f1c2e88dfdd51bf915f/libarchive/archive_write_set_format_iso9660.c#L3042-L3066
https://github.com/libarchive/libarchive/blob/cda40b999b46cdc019b34f1c2e88dfdd51bf915f/libarchive/archive_write_set_format_iso9660.c#L3158-L3166

## Fix

https://github.com/libarchive/libarchive/blob/cda40b999b46cdc019b34f1c2e88dfdd51bf915f/libarchive/archive_write_set_format_iso9660.c#L3042-L3043

Raising `7` to `12` to make sure the `while` loop body executes. 
If the bug is triggered, it implies that `bp != NULL` (L3160), and guarantees `nc != NULL` (L3058) when entering the loop.
There is `cl = NULL` at L3062, so the first pass of the while loop should enter L3137 or one of the `if`-blocks before the line. All paths include `if (nc != NULL) cf = nc++;`, proving that making the loop body executes at least once suffices to fix the bug.



