### PR TITLE
7zip: Fix range check in get_pe_sfx_offset

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -711,9 +711,9 @@ get_pe_sfx_offset(struct archive_read *a, int64_t *sfx_offset)
 		}
 		max_offset = offset;
 		while (sec_cnt > 0) {
-			uint32_t sec_end;
+			int64_t sec_end;
 
-			sec_end = archive_le32dec(
+			sec_end = (int64_t)archive_le32dec(
 				      h + offset + PE_SEC_HDR_RAW_SZ_OFFSET) +
 			    archive_le32dec(
 				h + offset + PE_SEC_HDR_RAW_ADDR_OFFSET);


### PR DESCRIPTION
Fix an unsigned integer overflow in get_pe_sfx_offset to properly address the correct section.

Reported by shxz9u.