### PR TITLE
Extend `archive_endian.h` usage

### DIFF
--- a/libarchive/archive_endian.h
+++ b/libarchive/archive_endian.h
@@ -71,6 +71,22 @@ archive_be16dec(const void *pp)
 }
 
 static inline uint32_t
+archive_be24dec(const void *pp)
+{
+	unsigned char const *p = (unsigned char const *)pp;
+
+	/* Store into unsigned temporaries before left shifting, to avoid
+	promotion to signed int and then left shifting into the sign bit,
+	which is undefined behaviour. */
+	unsigned int p2 = p[2];
+	unsigned int p1 = p[1];
+	unsigned int p0 = p[0];
+
+	return ((p0 << 16) | (p1 << 8) | p2);
+}
+
+
+static inline uint32_t
 archive_be32dec(const void *pp)
 {
 	unsigned char const *p = (unsigned char const *)pp;
@@ -106,6 +122,21 @@ archive_le16dec(const void *pp)
 	unsigned int p0 = p[0];
 
 	return ((p1 << 8) | p0);
+}
+
+static inline uint32_t
+archive_le24dec(const void *pp)
+{
+	unsigned char const *p = (unsigned char const *)pp;
+
+	/* Store into unsigned temporaries before left shifting, to avoid
+	promotion to signed int and then left shifting into the sign bit,
+	which is undefined behaviour. */
+	unsigned int p2 = p[2];
+	unsigned int p1 = p[1];
+	unsigned int p0 = p[0];
+
+	return ((p2 << 16) | (p1 << 8) | p0);
 }
 
 static inline uint32_t
@@ -168,6 +199,16 @@ archive_le16enc(void *pp, uint16_t u)
 
 	p[0] = u & 0xff;
 	p[1] = (u >> 8) & 0xff;
+}
+
+static inline void
+archive_le24enc(void *pp, uint32_t u)
+{
+	unsigned char *p = (unsigned char *)pp;
+
+	p[0] = u & 0xff;
+	p[1] = (u >> 8) & 0xff;
+	p[2] = (u >> 16) & 0xff;
 }
 
 static inline void

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -165,7 +165,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 		p = __archive_read_filter_ahead(filter, len + 2, &avail);
 		if (p == NULL)
 			return (0);
-		len += ((int)p[len + 1] << 8) | (int)p[len];
+		len += archive_le16dec(p + len);
 		len += 2;
 	}
 

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -4159,9 +4159,7 @@ x86_Convert(struct _7zip *zip, uint8_t *data, size_t size)
 		prevPosT = bufferPos;
 
 		if (Test86MSByte(p[4])) {
-			uint32_t src = ((uint32_t)p[4] << 24) |
-				((uint32_t)p[3] << 16) | ((uint32_t)p[2] << 8) |
-				((uint32_t)p[1]);
+			uint32_t src = archive_le32dec(p + 1);
 			uint32_t dest;
 			for (;;) {
 				uint8_t b;
@@ -4221,16 +4219,13 @@ arm_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 	for (i = 0; i + 4 <= size; i += 4) {
 		if (buf[i + 3] == 0xEB) {
 			// Calculate the transformed addr.
-			addr = (uint32_t)buf[i] | ((uint32_t)buf[i + 1] << 8)
-				| ((uint32_t)buf[i + 2] << 16);
+			addr = archive_le24dec(buf + i);
 			addr <<= 2;
 			addr -= zip->bcj_ip + (uint32_t)i;
 			addr >>= 2;
 
 			// Store the transformed addr in buf.
-			buf[i] = (uint8_t)addr;
-			buf[i + 1] = (uint8_t)(addr >> 8);
-			buf[i + 2] = (uint8_t)(addr >> 16);
+			archive_le24enc(buf + i, addr);
 		}
 	}
 
@@ -4261,20 +4256,14 @@ arm64_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 	uint32_t addr;
 
 	for (i = 0; i + 4 <= size; i += 4) {
-		instr = (uint32_t)buf[i]
-			| ((uint32_t)buf[i+1] << 8)
-			| ((uint32_t)buf[i+2] << 16)
-			| ((uint32_t)buf[i+3] << 24);
+		instr = archive_le32dec(buf + i);
 
 		if ((instr >> 26) == 0x25) {
 			/* BL instruction */
 			addr = instr - ((zip->bcj_ip + (uint32_t)i) >> 2);
 			instr = 0x94000000 | (addr & 0x03FFFFFF);
 
-			buf[i]   = (uint8_t)instr;
-			buf[i+1] = (uint8_t)(instr >> 8);
-			buf[i+2] = (uint8_t)(instr >> 16);
-			buf[i+3] = (uint8_t)(instr >> 24);
+			archive_le32enc(buf + i, instr);
 		} else if ((instr & 0x9F000000) == 0x90000000) {
 			/* ADRP instruction */
 			addr = ((instr >> 29) & 3) | ((instr >> 3) & 0x1FFFFC);
@@ -4290,10 +4279,7 @@ arm64_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 			instr |= (addr & 0x03FFFC) << 3;
 			instr |= (0U - (addr & 0x020000)) & 0xE00000;
 
-			buf[i]   = (uint8_t)instr;
-			buf[i+1] = (uint8_t)(instr >> 8);
-			buf[i+2] = (uint8_t)(instr >> 16);
-			buf[i+3] = (uint8_t)(instr >> 24);
+			archive_le32enc(buf + i, instr);
 		}
 	}
 
@@ -4336,10 +4322,7 @@ sparc_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 	size &= ~(size_t)3;
 
 	for (i = 0; i < size; i += 4) {
-		instr = ((uint32_t)buf[i] << 24)
-			| ((uint32_t)buf[i+1] << 16)
-			| ((uint32_t)buf[i+2] << 8)
-			| (uint32_t)buf[i+3];
+		instr = archive_be32dec(buf + i);
 
 		if ((instr >> 22) == 0x100 || (instr >> 22) == 0x1FF) {
 			instr <<= 2;
@@ -4348,10 +4331,7 @@ sparc_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 			instr = ((uint32_t)0x40000000 - (instr & 0x400000))
 			        | 0x40000000 | (instr & 0x3FFFFF);
 
-			buf[i] = (uint8_t)(instr >> 24);
-			buf[i+1] = (uint8_t)(instr >> 16);
-			buf[i+2] = (uint8_t)(instr >> 8);
-			buf[i+3] = (uint8_t)instr;
+			archive_be32enc(buf + i, instr);
 		}
 	}
 
@@ -4562,15 +4542,10 @@ Bcj2_Decode(struct _7zip *zip, uint8_t *outBuf, size_t outSize)
 				buf2 += 4;
 				size2 -= 4;
 			}
-			dest = (((uint32_t)v[0] << 24) |
-			    ((uint32_t)v[1] << 16) |
-			    ((uint32_t)v[2] << 8) |
-			    ((uint32_t)v[3])) -
+			dest = archive_be32dec(v) -
 			    ((uint32_t)zip->bcj2_outPos + (uint32_t)outPos + 4);
-			out[0] = (uint8_t)dest;
-			out[1] = (uint8_t)(dest >> 8);
-			out[2] = (uint8_t)(dest >> 16);
-			out[3] = zip->bcj2_prevByte = (uint8_t)(dest >> 24);
+			archive_le32enc(out, dest);
+			zip->bcj2_prevByte = out[3];
 
 			for (i = 0; i < 4 && outPos < outSize; i++)
 				outBuf[outPos++] = out[i];

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -38,6 +38,7 @@
 #endif
 
 #include "archive.h"
+#include "archive_endian.h"
 #include "archive_entry.h"
 #include "archive_entry_locale.h"
 #include "archive_private.h"
@@ -202,7 +203,7 @@ static int	archive_read_format_cpio_read_data(struct archive_read *,
 static int	archive_read_format_cpio_read_header(struct archive_read *,
 		    struct archive_entry *);
 static int	archive_read_format_cpio_skip(struct archive_read *);
-static int64_t	be4(const unsigned char *);
+static int64_t	be32dec(const unsigned char *);
 static int	find_odc_header(struct archive_read *);
 static int	find_newc_header(struct archive_read *);
 static int	header_bin_be(struct archive_read *, struct cpio *,
@@ -217,7 +218,7 @@ static int	header_afiol(struct archive_read *, struct cpio *,
 		    struct archive_entry *, size_t *, size_t *);
 static int	is_octal(const char *, size_t);
 static int	is_hex(const char *, size_t);
-static int64_t	le4(const unsigned char *);
+static int64_t	le32dec(const unsigned char *);
 static int	record_hardlink(struct archive_read *a,
 		    struct cpio *cpio, struct archive_entry *entry);
 
@@ -305,12 +306,12 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		 * XXX TODO:  More verification; Could check that only hex
 		 * digits appear in appropriate header locations. XXX
 		 */
-	} else if (p[0] * 256 + p[1] == 070707) {
+	} else if (archive_be16dec(p) == 070707) {
 		/* big-endian binary cpio archives */
 		cpio->read_header = header_bin_be;
 		bid += 16;
 		/* Is more verification possible here? */
-	} else if (p[0] + p[1] * 256 == 070707) {
+	} else if (archive_le16dec(p) == 070707) {
 		/* little-endian binary cpio archives */
 		cpio->read_header = header_bin_le;
 		bid += 16;
@@ -926,24 +927,24 @@ header_bin_le(struct archive_read *a, struct cpio *cpio,
 	/* Parse out binary fields. */
 	header = (const unsigned char *)h;
 
-	archive_entry_set_dev(entry, header[bin_dev_offset] + header[bin_dev_offset + 1] * 256);
-	archive_entry_set_ino(entry, header[bin_ino_offset] + header[bin_ino_offset + 1] * 256);
-	archive_entry_set_mode(entry, header[bin_mode_offset] + header[bin_mode_offset + 1] * 256);
+	archive_entry_set_dev(entry, archive_le16dec(header + bin_dev_offset));
+	archive_entry_set_ino(entry, archive_le16dec(header + bin_ino_offset));
+	archive_entry_set_mode(entry, archive_le16dec(header + bin_mode_offset));
 	if (cpio->option_pwb) {
 		/* turn off random bits left over from V6 inode */
 		archive_entry_set_mode(entry, archive_entry_mode(entry) & 067777);
 		if ((archive_entry_mode(entry) & AE_IFMT) == 0)
 			archive_entry_set_mode(entry, archive_entry_mode(entry) | AE_IFREG);
 	}
-	archive_entry_set_uid(entry, header[bin_uid_offset] + header[bin_uid_offset + 1] * 256);
-	archive_entry_set_gid(entry, header[bin_gid_offset] + header[bin_gid_offset + 1] * 256);
-	archive_entry_set_nlink(entry, header[bin_nlink_offset] + header[bin_nlink_offset + 1] * 256);
-	archive_entry_set_rdev(entry, header[bin_rdev_offset] + header[bin_rdev_offset + 1] * 256);
-	archive_entry_set_mtime(entry, le4(header + bin_mtime_offset), 0);
-	*namelength = header[bin_namesize_offset] + header[bin_namesize_offset + 1] * 256;
+	archive_entry_set_uid(entry, archive_le16dec(header + bin_uid_offset));
+	archive_entry_set_gid(entry, archive_le16dec(header + bin_gid_offset));
+	archive_entry_set_nlink(entry, archive_le16dec(header + bin_nlink_offset));
+	archive_entry_set_rdev(entry, archive_le16dec(header + bin_rdev_offset));
+	archive_entry_set_mtime(entry, le32dec(header + bin_mtime_offset), 0);
+	*namelength = archive_le16dec(header + bin_namesize_offset);
 	*name_pad = *namelength & 1; /* Pad to even. */
 
-	cpio->entry_bytes_remaining = le4(header + bin_filesize_offset);
+	cpio->entry_bytes_remaining = le32dec(header + bin_filesize_offset);
 	archive_entry_set_size(entry, cpio->entry_bytes_remaining);
 	cpio->entry_padding = cpio->entry_bytes_remaining & 1; /* Pad to even. */
 	__archive_read_consume(a, bin_header_size);
@@ -971,24 +972,24 @@ header_bin_be(struct archive_read *a, struct cpio *cpio,
 	/* Parse out binary fields. */
 	header = (const unsigned char *)h;
 
-	archive_entry_set_dev(entry, header[bin_dev_offset] * 256 + header[bin_dev_offset + 1]);
-	archive_entry_set_ino(entry, header[bin_ino_offset] * 256 + header[bin_ino_offset + 1]);
-	archive_entry_set_mode(entry, header[bin_mode_offset] * 256 + header[bin_mode_offset + 1]);
+	archive_entry_set_dev(entry, archive_be16dec(header + bin_dev_offset));
+	archive_entry_set_ino(entry, archive_be16dec(header + bin_ino_offset));
+	archive_entry_set_mode(entry, archive_be16dec(header + bin_mode_offset));
 	if (cpio->option_pwb) {
 		/* turn off random bits left over from V6 inode */
 		archive_entry_set_mode(entry, archive_entry_mode(entry) & 067777);
 		if ((archive_entry_mode(entry) & AE_IFMT) == 0)
 			archive_entry_set_mode(entry, archive_entry_mode(entry) | AE_IFREG);
 	}
-	archive_entry_set_uid(entry, header[bin_uid_offset] * 256 + header[bin_uid_offset + 1]);
-	archive_entry_set_gid(entry, header[bin_gid_offset] * 256 + header[bin_gid_offset + 1]);
-	archive_entry_set_nlink(entry, header[bin_nlink_offset] * 256 + header[bin_nlink_offset + 1]);
-	archive_entry_set_rdev(entry, header[bin_rdev_offset] * 256 + header[bin_rdev_offset + 1]);
-	archive_entry_set_mtime(entry, be4(header + bin_mtime_offset), 0);
-	*namelength = header[bin_namesize_offset] * 256 + header[bin_namesize_offset + 1];
+	archive_entry_set_uid(entry, archive_be16dec(header + bin_uid_offset));
+	archive_entry_set_gid(entry, archive_be16dec(header + bin_gid_offset));
+	archive_entry_set_nlink(entry, archive_be16dec(header + bin_nlink_offset));
+	archive_entry_set_rdev(entry, archive_be16dec(header + bin_rdev_offset));
+	archive_entry_set_mtime(entry, be32dec(header + bin_mtime_offset), 0);
+	*namelength = archive_be16dec(header + bin_namesize_offset);
 	*name_pad = *namelength & 1; /* Pad to even. */
 
-	cpio->entry_bytes_remaining = be4(header + bin_filesize_offset);
+	cpio->entry_bytes_remaining = be32dec(header + bin_filesize_offset);
 	archive_entry_set_size(entry, cpio->entry_bytes_remaining);
 	cpio->entry_padding = cpio->entry_bytes_remaining & 1; /* Pad to even. */
 	    __archive_read_consume(a, bin_header_size);
@@ -1015,16 +1016,15 @@ archive_read_format_cpio_cleanup(struct archive_read *a)
 }
 
 static int64_t
-le4(const unsigned char *p)
+le32dec(const unsigned char *p)
 {
-	return ((p[0] << 16) | (((int64_t)p[1]) << 24) | (p[2] << 0) | (p[3] << 8));
+	return ((int64_t)archive_le16dec(p) << 16) | archive_le16dec(p + 2);
 }
 
-
 static int64_t
-be4(const unsigned char *p)
+be32dec(const unsigned char *p)
 {
-	return ((((int64_t)p[0]) << 24) | (p[1] << 16) | (p[2] << 8) | (p[3]));
+	return ((int64_t)archive_be16dec(p) << 16) | archive_be16dec(p + 2);
 }
 
 /*

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -436,7 +436,6 @@ static void	parse_rockridge_ZF1(struct file_info *,
 		    const unsigned char *, int);
 static void	register_file(struct iso9660 *, struct file_info *);
 static void	release_files(struct iso9660 *);
-static unsigned	toi(const void *p, int n);
 static inline void re_add_entry(struct iso9660 *, struct file_info *);
 static inline struct file_info * re_get_entry(struct iso9660 *);
 static inline int rede_add_entry(struct file_info *);
@@ -1865,7 +1864,7 @@ parse_file_info(struct archive_read *a, struct file_info *parent,
 	}
 	name_len = (size_t)isodirrec[DR_name_len_offset];
 	location = archive_le32dec(isodirrec + DR_extent_offset);
-	fsize = toi(isodirrec + DR_size_offset, DR_size_size);
+	fsize = archive_le32dec(isodirrec + DR_size_offset);
 	/* Sanity check that name_len doesn't exceed dr_len. */
 	if (dr_len - 33 < name_len || name_len == 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
@@ -2162,7 +2161,7 @@ parse_file_info(struct archive_read *a, struct file_info *parent,
 		fprintf(stderr, "\n ** Unrecognized flag: ");
 		dump_isodirrec(stderr, isodirrec);
 		fprintf(stderr, "\n");
-	} else if (toi(isodirrec + DR_volume_sequence_number_offset, 2) != 1) {
+	} else if (archive_le16dec(isodirrec + DR_volume_sequence_number_offset) != 1) {
 		fprintf(stderr, "\n ** Unrecognized sequence number: ");
 		dump_isodirrec(stderr, isodirrec);
 		fprintf(stderr, "\n");
@@ -2255,9 +2254,10 @@ parse_rockridge(struct archive_read *a, struct file_info *file,
 			 */
 			if (p[1] == 'N') {
 				if (version == 1 && data_length == 16) {
-					file->rdev = toi(data,4);
+					file->rdev = archive_le32dec(data);
 					file->rdev <<= 32;
-					file->rdev |= toi(data + 8, 4);
+					file->rdev |=
+					    archive_le32dec(data + 8);
 					iso9660->seenRockridge = 1;
 				}
 			}
@@ -2272,20 +2272,20 @@ parse_rockridge(struct archive_read *a, struct file_info *file,
 				 */
 				if (version == 1) {
 					if (data_length >= 8)
-						file->mode
-						    = (__LA_MODE_T)toi(data, 4);
+						file->mode = (__LA_MODE_T)
+						    archive_le32dec(data);
 					if (data_length >= 16)
-						file->nlinks
-						    = toi(data + 8, 4);
+						file->nlinks =
+						    archive_le32dec(data + 8);
 					if (data_length >= 24)
-						file->uid
-						    = toi(data + 16, 4);
+						file->uid =
+						    archive_le32dec(data + 16);
 					if (data_length >= 32)
-						file->gid
-						    = toi(data + 24, 4);
+						file->gid =
+						    archive_le32dec(data + 24);
 					if (data_length >= 40)
-						file->number
-						    = toi(data + 32, 4);
+						file->number =
+						    archive_le32dec(data + 32);
 					iso9660->seenRockridge = 1;
 				}
 			}
@@ -3238,17 +3238,6 @@ heap_get_entry(struct heap_queue *heap)
 	}
 }
 
-static unsigned int
-toi(const void *p, int n)
-{
-	const unsigned char *v = (const unsigned char *)p;
-	if (n > 1)
-		return v[0] + 256 * toi(v + 1, n - 1);
-	if (n == 1)
-		return v[0];
-	return (0);
-}
-
 /*
  * ECMA119/ISO9660 stores multi-byte integers in one of
  * three different formats:
@@ -3519,26 +3508,24 @@ static void
 dump_isodirrec(FILE *out, const unsigned char *isodirrec)
 {
 	fprintf(out, " l %d,",
-	    toi(isodirrec + DR_length_offset, DR_length_size));
+	    isodirrec[DR_length_offset]);
 	fprintf(out, " a %d,",
-	    toi(isodirrec + DR_ext_attr_length_offset, DR_ext_attr_length_size));
+	    isodirrec[DR_ext_attr_length_offset]);
 	fprintf(out, " ext 0x%x,",
-	    toi(isodirrec + DR_extent_offset, DR_extent_size));
+	    archive_le32dec(isodirrec + DR_extent_offset));
 	fprintf(out, " s %d,",
-	    toi(isodirrec + DR_size_offset, DR_extent_size));
+	    archive_le32dec(isodirrec + DR_size_offset));
 	fprintf(out, " f 0x%x,",
-	    toi(isodirrec + DR_flags_offset, DR_flags_size));
+	    isodirrec[DR_flags_offset]);
 	fprintf(out, " u %d,",
-	    toi(isodirrec + DR_file_unit_size_offset, DR_file_unit_size_size));
+	    isodirrec[DR_file_unit_size_offset]);
 	fprintf(out, " ilv %d,",
-	    toi(isodirrec + DR_interleave_offset, DR_interleave_size));
+	    isodirrec[DR_interleave_offset]);
 	fprintf(out, " seq %d,",
-	    toi(isodirrec + DR_volume_sequence_number_offset,
-		DR_volume_sequence_number_size));
+	    archive_le16dec(isodirrec + DR_volume_sequence_number_offset));
 	fprintf(out, " nl %d:",
-	    toi(isodirrec + DR_name_len_offset, DR_name_len_size));
+	    isodirrec[DR_name_len_offset]);
 	fprintf(out, " `%.*s'",
-	    toi(isodirrec + DR_name_len_offset, DR_name_len_size),
-		isodirrec + DR_name_offset);
+	    isodirrec[DR_name_len_offset], isodirrec + DR_name_offset);
 }
 #endif

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1048,10 +1048,7 @@ static int read_bits_32(struct archive_read* a, struct rar5* rar,
 		return ARCHIVE_FATAL;
 	}
 
-	uint32_t bits = ((uint32_t) p[rar->bits.in_addr]) << 24;
-	bits |= p[rar->bits.in_addr + 1] << 16;
-	bits |= p[rar->bits.in_addr + 2] << 8;
-	bits |= p[rar->bits.in_addr + 3];
+	uint32_t bits = archive_be32dec(p + rar->bits.in_addr);
 	bits <<= rar->bits.bit_addr;
 	bits |= p[rar->bits.in_addr + 4] >> (8 - rar->bits.bit_addr);
 	*value = bits;
@@ -1068,9 +1065,7 @@ static int read_bits_16(struct archive_read* a, struct rar5* rar,
 		return ARCHIVE_FATAL;
 	}
 
-	int bits = (int) ((uint32_t) p[rar->bits.in_addr]) << 16;
-	bits |= (int) p[rar->bits.in_addr + 1] << 8;
-	bits |= (int) p[rar->bits.in_addr + 2];
+	uint32_t bits = archive_be24dec(p + (unsigned)rar->bits.in_addr);
 	bits >>= (8 - rar->bits.bit_addr);
 	*value = bits & 0xffff;
 	return ARCHIVE_OK;

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -40,6 +40,7 @@
 #endif
 
 #include "archive.h"
+#include "archive_endian.h"
 #include "archive_private.h"
 #include "archive_string.h"
 #include "archive_write_private.h"
@@ -230,11 +231,8 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	data->compressed[2] = 0x08; /* "Deflate" compression */
 	data->compressed[3] = 0x00; /* Flags */
 	if (data->timestamp >= 0) {
-		time_t t = time(NULL);
-		data->compressed[4] = (uint8_t)(t)&0xff;  /* Timestamp */
-		data->compressed[5] = (uint8_t)(t>>8)&0xff;
-		data->compressed[6] = (uint8_t)(t>>16)&0xff;
-		data->compressed[7] = (uint8_t)(t>>24)&0xff;
+		uint32_t t = (uint32_t)time(NULL);
+		archive_le32enc(data->compressed + 4, t); /* Timestamp */
 	} else {
 		memset(&data->compressed[4], 0, 4);
 	}
@@ -358,14 +356,8 @@ archive_compressor_gzip_close(struct archive_write_filter *f)
 	}
 	if (ret == ARCHIVE_OK) {
 		/* Build and write out 8-byte trailer. */
-		trailer[0] = (uint8_t)(data->crc)&0xff;
-		trailer[1] = (uint8_t)(data->crc >> 8)&0xff;
-		trailer[2] = (uint8_t)(data->crc >> 16)&0xff;
-		trailer[3] = (uint8_t)(data->crc >> 24)&0xff;
-		trailer[4] = (uint8_t)(data->total_in)&0xff;
-		trailer[5] = (uint8_t)(data->total_in >> 8)&0xff;
-		trailer[6] = (uint8_t)(data->total_in >> 16)&0xff;
-		trailer[7] = (uint8_t)(data->total_in >> 24)&0xff;
+		archive_le32enc(trailer, data->crc);
+		archive_le32enc(trailer + 4, data->total_in);
 		ret = __archive_write_filter(f->next_filter, trailer, 8);
 	}
 

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -38,6 +38,7 @@
 #endif
 
 #include "archive.h"
+#include "archive_endian.h"
 #include "archive_entry.h"
 #include "archive_private.h"
 #include "archive_write_private.h"
@@ -408,9 +409,9 @@ static void
 uuencode_group(const char _in[3], char out[4])
 {
 	const unsigned char *in = (const unsigned char *)_in;
-	int t;
+	uint32_t t;
 
-	t = (in[0] << 16) | (in[1] << 8) | in[2];
+	t = archive_be24dec(in);
 	out[0] = UUENC( 0x3f & (t >> 18) );
 	out[1] = UUENC( 0x3f & (t >> 12) );
 	out[2] = UUENC( 0x3f & (t >> 6) );


### PR DESCRIPTION
1. Add 24 bit operations to `archive_endian.h`
2. Use all `archive_endian.h` functions more often across formats and filters

While 1) sounds a bit awkward, multiple occasions exist that it's worth it to move these operations into the header file.

Otherwise this unifies the bit operations into a single header file which simplifies reviewing and also improves readability of its users.

Note: Compiling leads to different output. At least gcc uses different optimizations, which lead to smaller output.