### PR TITLE
rar5: fix signed integer underflow in bytes_remaining

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -998,6 +998,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_solid_encrypted_filenames.rar.uu \
 	libarchive/test/test_read_format_rar5_arm.rar.uu \
 	libarchive/test/test_read_format_rar5_blake2.rar.uu \
+	libarchive/test/test_read_format_rar5_bytes_remaining_underflow.rar.uu \
 	libarchive/test/test_read_format_rar5_compressed.rar.uu \
 	libarchive/test/test_read_format_rar5_different_window_size.rar.uu \
 	libarchive/test/test_read_format_rar5_different_solid_window_size.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1792,6 +1792,13 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 		if(!read_var_sized(a, &data_size, NULL))
 			return ARCHIVE_EOF;
 
+		if(data_size > SSIZE_MAX) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "File data size is too large");
+			return ARCHIVE_FATAL;
+		}
+
 		rar->file.bytes_remaining = data_size;
 	} else {
 		rar->file.bytes_remaining = 0;
@@ -3575,12 +3582,13 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 		cur_block_size = rar5_min(rar->file.bytes_remaining,
 		    block_size - partial_offset);
 
-		if(cur_block_size == 0) {
-			/* bytes_remaining is 0 at the wrong point in the merge
-			 * loop, indicating corrupt volume accounting. */
+		if(cur_block_size < 1) {
+			/* bytes_remaining is less than 1 at the wrong point in
+			 * the merge loop, indicating corrupt volume
+			 * accounting. */
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
-			    "Encountered block size == 0 during block merge");
+			    "Encountered invalid block size during block merge");
 			rar->cstate.switch_multivolume = 0;
 			return ARCHIVE_FATAL;
 		}
@@ -3688,6 +3696,15 @@ static int process_block(struct archive_read* a) {
 		 * if present. */
 		to_skip = sizeof(struct compressed_block_header) +
 			bf_byte_count(&rar->last_block_hdr) + 1;
+
+		/* If the block header's to_skip value exceeds the declared
+		 * remaining data, the archive is malformed. */
+		if(to_skip > rar->file.bytes_remaining) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Block header size exceeds remaining file data");
+			return ARCHIVE_FATAL;
+		}
 
 		if(ARCHIVE_OK != consume(a, to_skip))
 			return ARCHIVE_EOF;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1543,3 +1543,32 @@ DEFINE_TEST(test_read_format_rar5_skip_block_extra_bytes)
 
 	EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_bytes_remaining_underflow)
+{
+	/* GH #2986 — CWE-191 signed integer underflow on
+	 * rar->file.bytes_remaining in process_block(). A malformed RAR5
+	 * archive whose compressed-block to_skip value exceeds the declared
+	 * remaining file data drives bytes_remaining negative; the negative
+	 * ssize_t later reaches read_ahead() and is implicitly converted to
+	 * a near-SIZE_MAX malloc request (CWE-122).
+	 *
+	 * The patched reader must reject the malformed archive with
+	 * ARCHIVE_FATAL before the negative value is reached. */
+
+	char buf[4096];
+	la_ssize_t r;
+	PROLOGUE("test_read_format_rar5_bytes_remaining_underflow.rar");
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("poc.txt", archive_entry_pathname(ae));
+
+	do {
+		r = archive_read_data(a, buf, sizeof(buf));
+	} while (r > 0);
+
+	assertEqualIntA(a, ARCHIVE_FATAL, r);
+	assertA(archive_error_string(a) != NULL);
+
+	EPILOGUE();
+}

--- a/libarchive/test/test_read_format_rar5_bytes_remaining_underflow.rar.uu
+++ b/libarchive/test/test_read_format_rar5_bytes_remaining_underflow.rar.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_rar5_bytes_remaining_underflow.rar
+M4F%R(1H' 0!3*C1% P$  =ANJWT1 A(!  H @ $!!W!O8RYT>'1 '@0Y^;*!
+# @4 
+ 
+end


### PR DESCRIPTION
Cleaned up version of https://github.com/libarchive/libarchive/pull/2986 which also fixes the same issue described and tested in https://github.com/libarchive/libarchive/pull/2920

@00redbeer, let me know if this works for you. These are your changes (thus, authorship is kept) without modifying the error messages which are not relevant to the security fix and properly separated test and fixes.

Closes #2986
Closes #2920