### PR TITLE
Remove `archive_read_data_into_buffer` comment

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -655,7 +655,6 @@ __LA_DECL int archive_read_data_block(struct archive *a,
 /*-
  * Some convenience functions that are built on archive_read_data:
  *  'skip': skips entire entry
- *  'into_buffer': writes data into memory buffer that you provide
  *  'into_fd': writes data to specified filedes
  */
 __LA_DECL int archive_read_data_skip(struct archive *);


### PR DESCRIPTION
The function has been removed in 2011 with commit fe9b86254d66411b6bf267a02236d4672258b61b. Remove the comment as well.