### PR TITLE
entry_link_resolver: Improve memory handling

### DIFF
--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -381,6 +381,10 @@ insert_entry(struct archive_entry_linkresolver *res,
 	if (le == NULL)
 		return (NULL);
 	le->canonical = archive_entry_clone(entry);
+	if (le->canonical == NULL) {
+		free(le);
+		return (NULL);
+	}
 
 	/* If the links cache is getting too full, enlarge the hash table. */
 	if (res->number_entries > res->number_buckets * 2)

--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -78,7 +78,7 @@ struct links_entry {
 struct archive_entry_linkresolver {
 	struct links_entry	**buckets;
 	struct links_entry	 *spare;
-	unsigned long		  number_entries;
+	size_t			  number_entries;
 	size_t			  number_buckets;
 	int			  strategy;
 };


### PR DESCRIPTION
- Always check if allocations succeed
- Use `size_t` instead of `unsigned long` for element counter, since LP64 systems like Windows use 32 bit for `unsigned long`