### PR TITLE
Improve `archive_read_data_into_fd` with sparse files

### DIFF
--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -86,6 +86,7 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	const void *buff;
 	size_t size, bytes_to_write;
 	ssize_t bytes_written;
+	int64_t fd_offset;
 	int64_t target_offset;
 	int64_t actual_offset = 0;
 	int can_lseek;
@@ -96,6 +97,11 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	    "archive_read_data_into_fd");
 
 	can_lseek = (fstat(fd, &st) == 0) && S_ISREG(st.st_mode);
+	if (can_lseek) {
+		fd_offset = lseek(fd, 0, SEEK_CUR);
+		if (fd_offset == -1)
+			can_lseek = 0;
+	}
 	if (!can_lseek) {
 		nulls = calloc(1, nulls_size);
 		if (!nulls) {
@@ -141,5 +147,15 @@ cleanup:
 	free(nulls);
 	if (r != ARCHIVE_EOF)
 		return (r);
-	return (ARCHIVE_OK);
+	r = ARCHIVE_OK;
+	if (can_lseek) {
+		int64_t offset = lseek(fd, 0, SEEK_CUR);
+		if (offset - fd_offset != actual_offset) {
+			archive_set_error(a,
+			    offset == -1 ? errno : ARCHIVE_ERRNO_MISC,
+			    "Seek error");
+			r = ARCHIVE_FATAL;
+		}
+	}
+	return (r);
 }

--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -46,9 +46,9 @@
  */
 static int
 pad_to(struct archive *a, int fd, int can_lseek,
-    size_t nulls_size, const char *nulls,
-    int64_t target_offset, int64_t actual_offset)
+    char **nulls, int64_t target_offset, int64_t actual_offset)
 {
+	const size_t nulls_size = 16384;
 	size_t to_write;
 	ssize_t bytes_written;
 
@@ -63,11 +63,19 @@ pad_to(struct archive *a, int fd, int can_lseek,
 		}
 		return (ARCHIVE_OK);
 	}
+	if (*nulls == NULL) {
+		*nulls = calloc(1, nulls_size);
+		if (*nulls == NULL) {
+			archive_set_error(a, errno, "Out of memory");
+			return (ARCHIVE_FATAL);
+		}
+	}
+
 	while (target_offset > actual_offset) {
 		to_write = nulls_size;
 		if (target_offset < actual_offset + (int64_t)nulls_size)
 			to_write = (size_t)(target_offset - actual_offset);
-		bytes_written = write(fd, nulls, to_write);
+		bytes_written = write(fd, *nulls, to_write);
 		if (bytes_written < 0) {
 			archive_set_error(a, errno, "Write error");
 			return (ARCHIVE_FATAL);
@@ -91,7 +99,6 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	int64_t actual_offset = 0;
 	int can_lseek;
 	char *nulls = NULL;
-	size_t nulls_size = 16384;
 
 	archive_check_magic(a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_DATA,
 	    "archive_read_data_into_fd");
@@ -102,19 +109,12 @@ archive_read_data_into_fd(struct archive *a, int fd)
 		if (fd_offset == -1)
 			can_lseek = 0;
 	}
-	if (!can_lseek) {
-		nulls = calloc(1, nulls_size);
-		if (!nulls) {
-			r = ARCHIVE_FATAL;
-			goto cleanup;
-		}
-	}
 
 	while ((r = archive_read_data_block(a, &buff, &size, &target_offset)) ==
 	    ARCHIVE_OK) {
 		const char *p = buff;
 		if (target_offset > actual_offset) {
-			r = pad_to(a, fd, can_lseek, nulls_size, nulls,
+			r = pad_to(a, fd, can_lseek, &nulls,
 			    target_offset, actual_offset);
 			if (r != ARCHIVE_OK)
 				break;
@@ -137,7 +137,7 @@ archive_read_data_into_fd(struct archive *a, int fd)
 	}
 
 	if (r == ARCHIVE_EOF && target_offset > actual_offset) {
-		r2 = pad_to(a, fd, can_lseek, nulls_size, nulls,
+		r2 = pad_to(a, fd, can_lseek, &nulls,
 		    target_offset, actual_offset);
 		if (r2 != ARCHIVE_OK)
 			r = r2;

--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -56,7 +56,9 @@ pad_to(struct archive *a, int fd, int can_lseek,
 		actual_offset = lseek(fd,
 		    target_offset - actual_offset, SEEK_CUR);
 		if (actual_offset != target_offset) {
-			archive_set_error(a, errno, "Seek error");
+			archive_set_error(a,
+			    actual_offset == -1 ? errno : ARCHIVE_ERRNO_MISC,
+			    "Seek error");
 			return (ARCHIVE_FATAL);
 		}
 		return (ARCHIVE_OK);


### PR DESCRIPTION
This primarily focus on an issue when appending sparse-files to regular files. The `lseek` system call forwards the cursor position with a successful return value, but writing data will just be appended at the end of the file. With sparse files, this means that wrong data is written into file descriptor:

Proof of Concept:
1. Create a sparse file
```
dd if=/dev/zero of=poc bs=1 seek=9999 count=1
```
2. Trigger `archive_read_data_into_fd` by writing a sparse file into a regular file with O_APPEND mode
```
bsdtar -c poc | bsdtar -xO >> poc.out
```
3. Compare input and output file
```
sha256sum poc poc.out
```
```
2a90a283e8df326212122fa2982932889df5954f65ec464b8cdbeb8876cda342  poc
e9538c41d6110a72f4002e4fac9a31780f5cadb49fdbba84605b7f827b6a02d6  poc.out
```

With this PR applied, data will still be written, but an error will be shown at the end. This avoids performance penalties in regular use cases:
```
bsdtar -c poc | bsdtar -xO >> poc.out
```
```
poc: Seek error: Unknown error -1
bsdtar: Error exit delayed from previous errors
```

While at it, I have moved the allocation of `nulls` into `pad_to` so it is only done when really needed, i.e. when lseek won't be used and sparse files are encountered. The additional `NULL` check should be negligible in terms of performance since sparse blocks should be rare and write takes already much more time due to I/O.

Surprisingly it's rather hard to write a unit test for all systems when it comes to sparse files and opening files with append mode and making sure that this is a problem ... So it's a proof of concept in this PR description.