### PR TITLE
Add SPDX license identifiers for libarchive-subdir

### DIFF
--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * Copyright (c) 2016 Martin Matuska
  * All rights reserved.

--- a/libarchive/archive_acl_private.h
+++ b/libarchive/archive_acl_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_blake2.h
+++ b/libarchive/archive_blake2.h
@@ -1,4 +1,6 @@
 /*
+   SPDX-License-Identifier: CC0-1.0 OR OpenSSL OR Apache-2.0
+
    BLAKE2 reference source code package - reference C implementations
 
    Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the

--- a/libarchive/archive_blake2_impl.h
+++ b/libarchive/archive_blake2_impl.h
@@ -1,4 +1,6 @@
 /*
+   SPDX-License-Identifier: CC0-1.0 OR OpenSSL OR Apache-2.0
+
    BLAKE2 reference source code package - reference C implementations
 
    Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the

--- a/libarchive/archive_blake2s_ref.c
+++ b/libarchive/archive_blake2s_ref.c
@@ -1,4 +1,6 @@
 /*
+   SPDX-License-Identifier: CC0-1.0 OR OpenSSL OR Apache-2.0
+
    BLAKE2 reference source code package - reference C implementations
 
    Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the

--- a/libarchive/archive_blake2sp_ref.c
+++ b/libarchive/archive_blake2sp_ref.c
@@ -1,4 +1,6 @@
 /*
+   SPDX-License-Identifier: CC0-1.0 OR OpenSSL OR Apache-2.0
+
    BLAKE2 reference source code package - reference C implementations
 
    Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the

--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_cmdline.c
+++ b/libarchive/archive_cmdline.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA 
  * All rights reserved.
  *

--- a/libarchive/archive_cmdline_private.h
+++ b/libarchive/archive_cmdline_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_crc32.h
+++ b/libarchive/archive_crc32.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009 Joerg  Sonnenberger
  * All rights reserved.
  *

--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2014 Michihiro NAKAJIMA
 * All rights reserved.
 *

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2014 Michihiro NAKAJIMA
 * All rights reserved.
 *

--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2003-2007 Tim Kientzle
 * Copyright (c) 2011 Andres Mejia
 * Copyright (c) 2011 Michihiro NAKAJIMA

--- a/libarchive/archive_digest_private.h
+++ b/libarchive/archive_digest_private.h
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2003-2007 Tim Kientzle
 * Copyright (c) 2011 Andres Mejia
 * All rights reserved.

--- a/libarchive/archive_disk_acl_darwin.c
+++ b/libarchive/archive_disk_acl_darwin.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_disk_acl_freebsd.c
+++ b/libarchive/archive_disk_acl_freebsd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * Copyright (c) 2017 Martin Matuska

--- a/libarchive/archive_disk_acl_linux.c
+++ b/libarchive/archive_disk_acl_linux.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * Copyright (c) 2017 Martin Matuska

--- a/libarchive/archive_disk_acl_sunos.c
+++ b/libarchive/archive_disk_acl_sunos.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_endian.h
+++ b/libarchive/archive_endian.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2002 Thomas Moestl <tmm@FreeBSD.org>
  * All rights reserved.
  *

--- a/libarchive/archive_entry.3
+++ b/libarchive/archive_entry.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2016 Martin Matuska
  * All rights reserved.

--- a/libarchive/archive_entry.h
+++ b/libarchive/archive_entry.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2008 Tim Kientzle
  * Copyright (c) 2016 Martin Matuska
  * All rights reserved.

--- a/libarchive/archive_entry_acl.3
+++ b/libarchive/archive_entry_acl.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" Copyright (c) 2016 Martin Matuska
 .\" All rights reserved.

--- a/libarchive/archive_entry_copy_bhfi.c
+++ b/libarchive/archive_entry_copy_bhfi.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_copy_stat.c
+++ b/libarchive/archive_entry_copy_stat.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_link_resolver.c
+++ b/libarchive/archive_entry_link_resolver.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_linkify.3
+++ b/libarchive/archive_entry_linkify.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_entry_locale.h
+++ b/libarchive/archive_entry_locale.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_entry_misc.3
+++ b/libarchive/archive_entry_misc.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2019 Martin Matuska
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_entry_paths.3
+++ b/libarchive/archive_entry_paths.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_entry_perms.3
+++ b/libarchive/archive_entry_perms.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.

--- a/libarchive/archive_entry_private.h
+++ b/libarchive/archive_entry_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_sparse.c
+++ b/libarchive/archive_entry_sparse.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2010-2011 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_entry_stat.3
+++ b/libarchive/archive_entry_stat.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_entry_stat.c
+++ b/libarchive/archive_entry_stat.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_strmode.c
+++ b/libarchive/archive_entry_strmode.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_entry_time.3
+++ b/libarchive/archive_entry_time.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" Copyright (c) 2010 Joerg Sonnenberger
 .\" All rights reserved.

--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2014 Michihiro NAKAJIMA
 * All rights reserved.
 *

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2014 Michihiro NAKAJIMA
 * All rights reserved.
 *

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_openssl_evp_private.h
+++ b/libarchive/archive_openssl_evp_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_openssl_hmac_private.h
+++ b/libarchive/archive_openssl_hmac_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_options.c
+++ b/libarchive/archive_options.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_options_private.h
+++ b/libarchive/archive_options_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -1,6 +1,8 @@
 /*	$NetBSD: pack_dev.c,v 1.12 2013/06/14 16:28:20 tsutsui Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 1998, 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/libarchive/archive_pack_dev.h
+++ b/libarchive/archive_pack_dev.h
@@ -1,6 +1,8 @@
 /*	$NetBSD: pack_dev.h,v 1.8 2013/06/14 16:28:20 tsutsui Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 1998, 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/libarchive/archive_parse_date.c
+++ b/libarchive/archive_parse_date.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: LicenseRef-PublicDomain
+ *
  * This code is in the public domain and has no copyright.
  *
  * This is a plain C recursive-descent translation of an old

--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_pathmatch.h
+++ b/libarchive/archive_pathmatch.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_platform.h
+++ b/libarchive/archive_platform.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_platform_acl.h
+++ b/libarchive/archive_platform_acl.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_platform_xattr.h
+++ b/libarchive/archive_platform_xattr.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_ppmd7.c
+++ b/libarchive/archive_ppmd7.c
@@ -1,4 +1,5 @@
-/* Ppmd7.c -- PPMdH codec
+/* SPDX-License-Identifier: LicenseRef-PublicDomain
+Ppmd7.c -- PPMdH codec
 2010-03-12 : Igor Pavlov : Public domain
 This code is based on PPMd var.H (2001): Dmitry Shkarin : Public domain */
 

--- a/libarchive/archive_ppmd7_private.h
+++ b/libarchive/archive_ppmd7_private.h
@@ -1,4 +1,5 @@
-/* Ppmd7.h -- PPMdH compression codec
+/* SPDX-License-Identifier: LicenseRef-PublicDomain
+Ppmd7.h -- PPMdH compression codec
 2010-03-12 : Igor Pavlov : Public domain
 This code is based on PPMd var.H (2001): Dmitry Shkarin : Public domain */
 

--- a/libarchive/archive_ppmd8.c
+++ b/libarchive/archive_ppmd8.c
@@ -1,4 +1,5 @@
-/* Ppmd8.c -- PPMdI codec
+/* SPDX-License-Identifier: LicenseRef-PublicDomain
+Ppmd8.c -- PPMdI codec
 2016-05-21 : Igor Pavlov : Public domain
 This code is based on PPMd var.I (2002): Dmitry Shkarin : Public domain */
 

--- a/libarchive/archive_ppmd8_private.h
+++ b/libarchive/archive_ppmd8_private.h
@@ -1,4 +1,5 @@
-/* Ppmd8.h -- PPMdI codec
+/* SPDX-License-Identifier: LicenseRef-PublicDomain
+Ppmd8.h -- PPMdI codec
 2011-01-27 : Igor Pavlov : Public domain
 This code is based on:
   PPMd var.I (2002): Dmitry Shkarin : Public domain

--- a/libarchive/archive_ppmd_private.h
+++ b/libarchive/archive_ppmd_private.h
@@ -1,4 +1,5 @@
-/* Ppmd.h -- PPMD codec common code
+/* SPDX-License-Identifier: LicenseRef-PublicDomain
+Ppmd.h -- PPMD codec common code
 2010-03-12 : Igor Pavlov : Public domain
 This code is based on PPMd var.H (2001): Dmitry Shkarin : Public domain */
 

--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_random_private.h
+++ b/libarchive/archive_random_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_rb.c
+++ b/libarchive/archive_rb.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/libarchive/archive_rb.h
+++ b/libarchive/archive_rb.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/libarchive/archive_read.3
+++ b/libarchive/archive_read.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_add_passphrase.3
+++ b/libarchive/archive_read_add_passphrase.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 Michihiro NAKAJIMA
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_add_passphrase.c
+++ b/libarchive/archive_read_add_passphrase.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2012 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_data.3
+++ b/libarchive/archive_read_data.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_data_into_fd.c
+++ b/libarchive/archive_read_data_into_fd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2009 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * Copyright (c) 2016 Martin Matuska

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_read_disk_private.h
+++ b/libarchive/archive_read_disk_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_read_extract.3
+++ b/libarchive/archive_read_extract.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_extract.c
+++ b/libarchive/archive_read_extract.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_extract2.c
+++ b/libarchive/archive_read_extract2.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_filter.3
+++ b/libarchive/archive_read_filter.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_format.3
+++ b/libarchive/archive_read_format.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_free.3
+++ b/libarchive/archive_read_free.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_header.3
+++ b/libarchive/archive_read_header.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_new.3
+++ b/libarchive/archive_read_new.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_open.3
+++ b/libarchive/archive_read_open.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_open_fd.c
+++ b/libarchive/archive_read_open_fd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_open_file.c
+++ b/libarchive/archive_read_open_file.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_open_filename.c
+++ b/libarchive/archive_read_open_filename.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_open_memory.c
+++ b/libarchive/archive_read_open_memory.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_set_format.c
+++ b/libarchive/archive_read_set_format.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2012 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_set_options.3
+++ b/libarchive/archive_read_set_options.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_read_set_options.c
+++ b/libarchive/archive_read_set_options.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_all.c
+++ b/libarchive/archive_read_support_filter_all.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_by_code.c
+++ b/libarchive/archive_read_support_filter_by_code.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2020 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_read_support_filter_none.c
+++ b/libarchive/archive_read_support_filter_none.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2007 Joerg Sonnenberger
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2011 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2011 Michihiro NAKAJIMA
  * Copyright (c) 2003-2008 Tim Kientzle and Miklos Vajna
  * All rights reserved.

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2011 Sean Purcell
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_all.c
+++ b/libarchive/archive_read_support_format_all.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2007 Kai Wang
  * Copyright (c) 2007 Tim Kientzle
  * All rights reserved.

--- a/libarchive/archive_read_support_format_by_code.c
+++ b/libarchive/archive_read_support_format_by_code.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2011 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_read_support_format_empty.c
+++ b/libarchive/archive_read_support_format_empty.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2009 Andreas Henriksson <andreas@fatal.se>
  * Copyright (c) 2009-2012 Michihiro NAKAJIMA

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2008-2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2008 Joerg Sonnenberger
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2003-2007 Tim Kientzle
 * Copyright (c) 2011 Andres Mejia
 * All rights reserved.

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1,4 +1,6 @@
 /*-
+* SPDX-License-Identifier: BSD-2-Clause
+*
 * Copyright (c) 2018 Grzegorz Antoniak (http://antoniak.org)
 * All rights reserved.
 *

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2009 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2023 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * Copyright (c) 2016 Martin Matuska

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Sebastian Freundt
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2004-2013 Tim Kientzle
  * Copyright (c) 2011-2012,2014 Michihiro NAKAJIMA
  * Copyright (c) 2013 Konrad Kleine

--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2011 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_string.h
+++ b/libarchive/archive_string.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_string_composition.h
+++ b/libarchive/archive_string_composition.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011-2012 libarchive Project
  * All rights reserved.
  *

--- a/libarchive/archive_string_sprintf.c
+++ b/libarchive/archive_string_sprintf.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_time.c
+++ b/libarchive/archive_time.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright © 2025 ARJANEN Loïc Jean David
  * All rights reserved.
  *

--- a/libarchive/archive_time_private.h
+++ b/libarchive/archive_time_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright © 2025 ARJANEN Loïc Jean David
  * All rights reserved.
  *

--- a/libarchive/archive_util.3
+++ b/libarchive/archive_util.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2012,2014 Michihiro NAKAJIMA
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.

--- a/libarchive/archive_version_details.c
+++ b/libarchive/archive_version_details.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2012,2014 Michihiro NAKAJIMA
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.

--- a/libarchive/archive_virtual.c
+++ b/libarchive/archive_virtual.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2011 Michihiro NAKAJIMA
  * Copyright (c) 2003-2007 Kees Zeelenberg
  * All rights reserved.

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2009-2011 Michihiro NAKAJIMA
  * Copyright (c) 2003-2006 Tim Kientzle
  * All rights reserved.

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter.c
+++ b/libarchive/archive_write_add_filter.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Ondrej Holy
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_by_name.c
+++ b/libarchive/archive_write_add_filter_by_name.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2008 Joerg Sonnenberger
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_none.c
+++ b/libarchive/archive_write_add_filter_none.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2007 Joerg Sonnenberger
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * Copyright (c) 2009-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2017 Sean Purcell
  * Copyright (c) 2023-2024 Klara, Inc.
  * All rights reserved.

--- a/libarchive/archive_write_data.3
+++ b/libarchive/archive_write_data.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_disk.3
+++ b/libarchive/archive_write_disk.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_disk_private.h
+++ b/libarchive/archive_write_disk_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_filter.3
+++ b/libarchive/archive_write_filter.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_finish_entry.3
+++ b/libarchive/archive_write_finish_entry.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_format.3
+++ b/libarchive/archive_write_format.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_free.3
+++ b/libarchive/archive_write_free.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_header.3
+++ b/libarchive/archive_write_header.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_new.3
+++ b/libarchive/archive_write_new.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_open.3
+++ b/libarchive/archive_write_open.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_open_fd.c
+++ b/libarchive/archive_write_open_fd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_open_file.c
+++ b/libarchive/archive_write_open_file.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_open_filename.c
+++ b/libarchive/archive_write_open_filename.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_open_memory.c
+++ b/libarchive/archive_write_open_memory.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_private.h
+++ b/libarchive/archive_write_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format.c
+++ b/libarchive/archive_write_set_format.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: LicenseRef-scancode-bsd-unchanged
+ *
  * Copyright (c) 2007 Kai Wang
  * Copyright (c) 2007 Tim Kientzle
  * All rights reserved.

--- a/libarchive/archive_write_set_format_by_name.c
+++ b/libarchive/archive_write_set_format_by_name.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2006 Rudolf Marek SYSGO s.r.o.
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_set_format_filter_by_ext.c
+++ b/libarchive/archive_write_set_format_filter_by_ext.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2015 Okhotnikov Kirill
  * All rights reserved.

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2010 Nokia Corporation and/or its subsidiary(-ies).
  * Author: Jonas Gastal <jgastal@profusion.mobi>
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2008 Joerg Sonnenberger
  * Copyright (c) 2009-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * Copyright (c) 2016 Martin Matuska

--- a/libarchive/archive_write_set_format_private.h
+++ b/libarchive/archive_write_set_format_private.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2020 Martin Matuska
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_raw.c
+++ b/libarchive/archive_write_set_format_raw.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2013 Marek Kubica
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2008 Joerg Sonnenberger
  * All rights reserved.

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * Copyright (c) 2011-2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Sebastian Freundt
  * Author: Sebastian Freundt  <devel@fresse.org>
  *

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2010-2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2008 Anselm Strauss
  * Copyright (c) 2009 Joerg Sonnenberger
  * Copyright (c) 2011-2012,2014 Michihiro NAKAJIMA

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2010 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_set_options.c
+++ b/libarchive/archive_write_set_options.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2010 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/archive_write_set_passphrase.3
+++ b/libarchive/archive_write_set_passphrase.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2014 Michihiro NAKAJIMA
 .\" All rights reserved.
 .\"

--- a/libarchive/archive_write_set_passphrase.c
+++ b/libarchive/archive_write_set_passphrase.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/archive_xxhash.h
+++ b/libarchive/archive_xxhash.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2014 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/config_freebsd.h
+++ b/libarchive/config_freebsd.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.
  *

--- a/libarchive/filter_fork.h
+++ b/libarchive/filter_fork.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2007 Joerg Sonnenberger
  * All rights reserved.
  *

--- a/libarchive/filter_fork_posix.c
+++ b/libarchive/filter_fork_posix.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2007 Joerg Sonnenberger
  * Copyright (c) 2012 Michihiro NAKAJIMA
  * All rights reserved.

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2009-2012 Michihiro NAKAJIMA
  * All rights reserved.
  *

--- a/libarchive/libarchive.3
+++ b/libarchive/libarchive.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/libarchive_changes.3
+++ b/libarchive/libarchive_changes.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2011 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/libarchive_internals.3
+++ b/libarchive/libarchive_internals.3
@@ -1,3 +1,5 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
+.\"
 .\" Copyright (c) 2003-2007 Tim Kientzle
 .\" All rights reserved.
 .\"

--- a/libarchive/xxhash.c
+++ b/libarchive/xxhash.c
@@ -1,4 +1,6 @@
 /*
+SPDX-License-Identifier: BSD-2-Clause
+
 xxHash - Fast Hash algorithm
 Copyright (C) 2012-2014, Yann Collet.
 BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)


### PR DESCRIPTION
 Add SPDX license identifier to libarchive-subdir. There is several licenses under libarchive-dir:

- CC0-1.0 OR OpenSSL OR Apache-2.0
- BSD-2-Clause
- LicenseRef-PublicDomain
- LicenseRef-scancode-bsd-unchanged (As I have used Scantool-toolkit to determine licenses [this can be found here)](https://scancode-licensedb.aboutcode.org/bsd-unchanged.html)

Separated licenses have separated commits to help review. 

This is not fixing #2298 but towards to fixing it