### PR TITLE
Add --xattrs-include / --xattrs-exclude name filtering

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1294,6 +1294,7 @@ bsdtar_test_SOURCES= \
 	tar/test/test_option_uid_uname.c \
 	tar/test/test_option_uuencode.c \
 	tar/test/test_option_xattrs.c \
+	tar/test/test_option_xattrs_filter.c \
 	tar/test/test_option_xz.c \
 	tar/test/test_option_z.c \
 	tar/test/test_option_zstd.c \

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -973,6 +973,17 @@ __LA_DECL int archive_write_disk_set_skip_file(struct archive *,
 __LA_DECL int		 archive_write_disk_set_options(struct archive *,
 		     int flags);
 /*
+ * Restrict which extended-attribute names are restored on extraction.  Each
+ * call appends a shell-style pattern matched against the whole xattr name
+ * (e.g. "security.selinux", or "security.*").  With an include list set, only
+ * matching names are restored; exclude always wins.  May be called repeatedly.
+ * Requires ARCHIVE_EXTRACT_XATTR to have any effect.
+ */
+__LA_DECL int		 archive_write_disk_set_xattr_include(struct archive *,
+		     const char *_pattern);
+__LA_DECL int		 archive_write_disk_set_xattr_exclude(struct archive *,
+		     const char *_pattern);
+/*
  * The lookup functions are given uname/uid (or gname/gid) pairs and
  * return a uid (gid) suitable for this system.  These are used for
  * restoring ownership and for setting ACLs.  The default functions
@@ -1094,6 +1105,17 @@ __LA_DECL int	archive_read_disk_set_matching(struct archive *,
 __LA_DECL int	archive_read_disk_set_metadata_filter_callback(struct archive *,
 		    int (*_metadata_filter_func)(struct archive *, void *,
 		    	struct archive_entry *), void *_client_data);
+
+/*
+ * Restrict which extended-attribute names are archived.  Each call appends a
+ * shell-style pattern matched against the whole xattr name (e.g.
+ * "security.selinux", or "security.*").  With an include list set, only
+ * matching names are archived; exclude always wins.  May be called repeatedly.
+ */
+__LA_DECL int	archive_read_disk_set_xattr_include(struct archive *,
+		    const char *_pattern);
+__LA_DECL int	archive_read_disk_set_xattr_exclude(struct archive *,
+		    const char *_pattern);
 
 /* Simplified cleanup interface;
  * This calls archive_read_free() or archive_write_free() as needed. */

--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -33,6 +33,11 @@
 #include <wchar.h>
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#include "archive.h"
 #include "archive_pathmatch.h"
 
 #define MAX_RECURSION	100
@@ -477,4 +482,74 @@ __archive_pathmatch_w(const wchar_t *p, const wchar_t *s, int flags)
 
 	/* Default: Match from beginning. */
 	return (pm_w(p, s, flags, 0));
+}
+
+/*
+ * Extended-attribute name filtering (see archive_pathmatch.h).  An xattr
+ * name is matched against shell-style patterns as a whole string (no path
+ * splitting), so a literal pattern like "security.selinux" matches only that
+ * key, while "security.*" matches the namespace.
+ */
+struct archive_xattr_filter {
+	struct archive_xattr_filter	*next;
+	char				*pattern;
+};
+
+int
+__archive_xattr_filter_add(struct archive_xattr_filter **list,
+    const char *pattern)
+{
+	struct archive_xattr_filter *f;
+
+	if (pattern == NULL)
+		return (ARCHIVE_OK);
+	if ((f = malloc(sizeof(*f))) == NULL)
+		return (ARCHIVE_FATAL);
+	if ((f->pattern = strdup(pattern)) == NULL) {
+		free(f);
+		return (ARCHIVE_FATAL);
+	}
+	/* Append, preserving the order patterns were supplied. */
+	f->next = NULL;
+	while (*list != NULL)
+		list = &(*list)->next;
+	*list = f;
+	return (ARCHIVE_OK);
+}
+
+void
+__archive_xattr_filter_free(struct archive_xattr_filter **list)
+{
+	struct archive_xattr_filter *f;
+
+	while ((f = *list) != NULL) {
+		*list = f->next;
+		free(f->pattern);
+		free(f);
+	}
+}
+
+int
+__archive_xattr_name_excluded(struct archive_xattr_filter *include,
+    struct archive_xattr_filter *exclude, const char *name)
+{
+	struct archive_xattr_filter *f;
+
+	/* Anchor patterns at both ends: a whole-name match, not a substring. */
+	const int flags = 0;
+
+	/* Exclusion takes precedence over inclusion. */
+	for (f = exclude; f != NULL; f = f->next) {
+		if (__archive_pathmatch(f->pattern, name, flags))
+			return (1);
+	}
+	/* With an inclusion list present, a name must match it to be kept. */
+	if (include != NULL) {
+		for (f = include; f != NULL; f = f->next) {
+			if (__archive_pathmatch(f->pattern, name, flags))
+				return (0);
+		}
+		return (1);
+	}
+	return (0);
 }

--- a/libarchive/archive_pathmatch.h
+++ b/libarchive/archive_pathmatch.h
@@ -47,4 +47,26 @@ int __archive_pathmatch_w(const wchar_t *p, const wchar_t *s, int flags);
 #define archive_pathmatch(p, s, f)	__archive_pathmatch(p, s, f)
 #define archive_pathmatch_w(p, s, f)	__archive_pathmatch_w(p, s, f)
 
+/*
+ * A name filter: ordered lists of shell-style patterns used to decide
+ * whether an extended-attribute name should be processed.  Shared by the
+ * read-disk (archiving) and write-disk (extraction) xattr code so that
+ * bsdtar's --xattrs-include / --xattrs-exclude can drop individual keys
+ * (e.g. security.selinux) while keeping the rest (e.g. security.capability).
+ */
+struct archive_xattr_filter;
+
+/* Append `pattern` to a filter list (allocating it on first use). */
+int  __archive_xattr_filter_add(struct archive_xattr_filter **list,
+	const char *pattern);
+/* Free a filter list and reset it to NULL. */
+void __archive_xattr_filter_free(struct archive_xattr_filter **list);
+/*
+ * Return non-zero if an xattr named `name` must be skipped given the
+ * include/exclude lists.  Exclusion wins; when an include list is present a
+ * name must match it to be kept; empty lists impose no restriction.
+ */
+int  __archive_xattr_name_excluded(struct archive_xattr_filter *include,
+	struct archive_xattr_filter *exclude, const char *name);
+
 #endif

--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -93,6 +93,7 @@
 
 #include "archive.h"
 #include "archive_entry.h"
+#include "archive_pathmatch.h"
 #include "archive_private.h"
 #include "archive_read_disk_private.h"
 
@@ -633,6 +634,9 @@ setup_xattrs(struct archive_read_disk *a,
 		if (strncmp(p, "xfsroot.", 8) == 0)
 			continue;
 #endif
+		if (__archive_xattr_name_excluded(a->xattr_include,
+		    a->xattr_exclude, p))
+			continue;
 		setup_xattr(a, entry, p, *fd, path);
 	}
 
@@ -777,6 +781,11 @@ setup_xattrs_namespace(struct archive_read_disk *a,
 		name = buff + strlen(buff);
 		memcpy(name, p + 1, len);
 		name[len] = '\0';
+		if (__archive_xattr_name_excluded(a->xattr_include,
+		    a->xattr_exclude, buff)) {
+			p += 1 + len;
+			continue;
+		}
 		setup_xattr(a, entry, namespace, name, buff, *fd, path);
 		p += 1 + len;
 	}

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -95,6 +95,7 @@
 #include "archive_string.h"
 #include "archive_entry.h"
 #include "archive_private.h"
+#include "archive_pathmatch.h"
 #include "archive_read_disk_private.h"
 
 #ifndef HAVE_FCHDIR
@@ -479,6 +480,8 @@ _archive_read_free(struct archive *_a)
 		r = ARCHIVE_OK;
 
 	tree_free(a->tree);
+	__archive_xattr_filter_free(&a->xattr_include);
+	__archive_xattr_filter_free(&a->xattr_exclude);
 	if (a->cleanup_gname != NULL && a->lookup_gname_data != NULL)
 		(a->cleanup_gname)(a->lookup_gname_data);
 	if (a->cleanup_uname != NULL && a->lookup_uname_data != NULL)
@@ -505,6 +508,24 @@ _archive_read_close(struct archive *_a)
 	tree_close(a->tree);
 
 	return (ARCHIVE_OK);
+}
+
+int
+archive_read_disk_set_xattr_include(struct archive *_a, const char *pattern)
+{
+	struct archive_read_disk *a = (struct archive_read_disk *)_a;
+	archive_check_magic(_a, ARCHIVE_READ_DISK_MAGIC,
+	    ARCHIVE_STATE_ANY, "archive_read_disk_set_xattr_include");
+	return (__archive_xattr_filter_add(&a->xattr_include, pattern));
+}
+
+int
+archive_read_disk_set_xattr_exclude(struct archive *_a, const char *pattern)
+{
+	struct archive_read_disk *a = (struct archive_read_disk *)_a;
+	archive_check_magic(_a, ARCHIVE_READ_DISK_MAGIC,
+	    ARCHIVE_STATE_ANY, "archive_read_disk_set_xattr_exclude");
+	return (__archive_xattr_filter_add(&a->xattr_exclude, pattern));
 }
 
 static void

--- a/libarchive/archive_read_disk_private.h
+++ b/libarchive/archive_read_disk_private.h
@@ -35,6 +35,7 @@
 
 struct tree;
 struct archive_entry;
+struct archive_xattr_filter;
 
 struct archive_read_disk {
 	struct archive	archive;
@@ -77,6 +78,10 @@ struct archive_read_disk {
 	int	(*metadata_filter_func)(struct archive *, void *,
 			struct archive_entry *);
 	void	*metadata_filter_data;
+
+	/* Optional extended-attribute name filters (NULL = no filtering). */
+	struct archive_xattr_filter *xattr_include;
+	struct archive_xattr_filter *xattr_exclude;
 
 	/* ARCHIVE_MATCH object. */
 	struct archive	*matching;

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -144,6 +144,7 @@
 #include "archive_string.h"
 #include "archive_endian.h"
 #include "archive_entry.h"
+#include "archive_pathmatch.h"
 #include "archive_private.h"
 #include "archive_write_disk_private.h"
 
@@ -312,6 +313,10 @@ struct archive_write_disk {
     ARCHIVE_XATTR_FREEBSD)
 	int			 warning_done;
 #endif
+
+	/* Optional extended-attribute name filters (NULL = no filtering). */
+	struct archive_xattr_filter *xattr_include;
+	struct archive_xattr_filter *xattr_exclude;
 };
 
 /*
@@ -962,6 +967,24 @@ archive_write_disk_set_skip_file(struct archive *_a, la_int64_t d, la_int64_t i)
 	a->skip_file_dev = d;
 	a->skip_file_ino = i;
 	return (ARCHIVE_OK);
+}
+
+int
+archive_write_disk_set_xattr_include(struct archive *_a, const char *pattern)
+{
+	struct archive_write_disk *a = (struct archive_write_disk *)_a;
+	archive_check_magic(&a->archive, ARCHIVE_WRITE_DISK_MAGIC,
+	    ARCHIVE_STATE_ANY, "archive_write_disk_set_xattr_include");
+	return (__archive_xattr_filter_add(&a->xattr_include, pattern));
+}
+
+int
+archive_write_disk_set_xattr_exclude(struct archive *_a, const char *pattern)
+{
+	struct archive_write_disk *a = (struct archive_write_disk *)_a;
+	archive_check_magic(&a->archive, ARCHIVE_WRITE_DISK_MAGIC,
+	    ARCHIVE_STATE_ANY, "archive_write_disk_set_xattr_exclude");
+	return (__archive_xattr_filter_add(&a->xattr_exclude, pattern));
 }
 
 static ssize_t
@@ -2666,6 +2689,8 @@ _archive_write_disk_free(struct archive *_a)
 	archive_string_free(&a->_tmpname_data);
 	archive_string_free(&a->archive.error_string);
 	archive_string_free(&a->path_safe);
+	__archive_xattr_filter_free(&a->xattr_include);
+	__archive_xattr_filter_free(&a->xattr_exclude);
 	a->archive.magic = 0;
 	__archive_clean(&a->archive);
 	free(a->decmpfs_header_p);
@@ -4543,6 +4568,10 @@ set_xattrs(struct archive_write_disk *a)
 		}
 #endif
 
+		if (__archive_xattr_name_excluded(a->xattr_include,
+		    a->xattr_exclude, name))
+			continue;
+
 		if (a->fd >= 0) {
 #if ARCHIVE_XATTR_LINUX
 			e = fsetxattr(a->fd, name, value, size, 0);
@@ -4611,6 +4640,10 @@ set_xattrs(struct archive_write_disk *a)
 		if (name != NULL) {
 			int e;
 			int namespace;
+
+			if (__archive_xattr_name_excluded(a->xattr_include,
+			    a->xattr_exclude, name))
+				continue;
 
 			namespace = EXTATTR_NAMESPACE_USER;
 

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -1012,6 +1012,31 @@ This is the reverse of
 and the default behavior in c, r, and u modes or if
 .Nm
 is run in x mode as root.
+.It Fl Fl xattrs-exclude Ar pattern
+(c, r, u, x modes only)
+Do not archive or extract extended attributes whose name matches the
+shell-style
+.Ar pattern .
+May be specified more than once.
+The pattern is matched against the whole attribute name, so
+.Dq Li security.selinux
+excludes exactly that attribute while
+.Dq Li security.\&*
+excludes the whole namespace.
+This is useful to keep host-specific attributes such as SELinux labels
+out of an archive while preserving others such as
+.Dq Li security.capability .
+Exclusion takes precedence over
+.Fl Fl xattrs-include .
+.It Fl Fl xattrs-include Ar pattern
+(c, r, u, x modes only)
+Only archive or extract extended attributes whose name matches the
+shell-style
+.Ar pattern .
+May be specified more than once.
+When no include pattern is given, all attributes (subject to
+.Fl Fl xattrs-exclude )
+are processed.
 .It Fl y
 (c mode only)
 Compress the resulting archive with

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -104,6 +104,7 @@ need_report(void)
 static __LA_NORETURN void		 long_help(void);
 static void		 only_mode(struct bsdtar *, const char *opt,
 			     const char *valid);
+static void		 add_xattr_match(struct xattr_match **, const char *);
 static void		 set_mode(struct bsdtar *, int opt);
 static __LA_NORETURN void		 version(void);
 
@@ -830,6 +831,14 @@ main(int argc, char **argv)
 			bsdtar->readdisk_flags &= ~ARCHIVE_READDISK_NO_XATTR;
 			bsdtar->flags |= OPTFLAG_XATTRS;
 			break;
+		case OPTION_XATTRS_EXCLUDE: /* GNU tar */
+			add_xattr_match(&bsdtar->xattr_exclude,
+			    bsdtar->argument);
+			break;
+		case OPTION_XATTRS_INCLUDE: /* GNU tar */
+			add_xattr_match(&bsdtar->xattr_include,
+			    bsdtar->argument);
+			break;
 		case 'y': /* FreeBSD version of GNU tar */
 			if (compression != '\0')
 				lafe_errc(1, 0,
@@ -1037,6 +1046,26 @@ set_mode(struct bsdtar *bsdtar, int opt)
 		lafe_errc(1, 0,
 		    "Can't specify both -%c and -%c", opt, bsdtar->mode);
 	bsdtar->mode = opt;
+}
+
+/*
+ * Append a --xattrs-include / --xattrs-exclude pattern.  The pattern points
+ * into argv, which outlives the lists, so it is stored without copying; the
+ * lists are applied to the read/write-disk objects in write.c and read.c.
+ */
+static void
+add_xattr_match(struct xattr_match **list, const char *pattern)
+{
+	struct xattr_match *m, **tail;
+
+	m = malloc(sizeof(*m));
+	if (m == NULL)
+		lafe_errc(1, 0, "Out of memory");
+	m->pattern = pattern;
+	m->next = NULL;
+	for (tail = list; *tail != NULL; tail = &(*tail)->next)
+		;
+	*tail = m;
 }
 
 /*

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -31,6 +31,12 @@ struct creation_set;
  * pointer to this structure is passed to most bsdtar internal
  * functions.
  */
+/* A --xattrs-include / --xattrs-exclude pattern (points into argv). */
+struct xattr_match {
+	struct xattr_match	*next;
+	const char		*pattern;
+};
+
 struct bsdtar {
 	/* Options */
 	const char	 *filename; /* -f filename */
@@ -42,6 +48,8 @@ struct bsdtar {
 	unsigned int	  flags; /* Bitfield of boolean options */
 	int		  extract_flags; /* Flags for extract operation */
 	int		  readdisk_flags; /* Flags for read disk operation */
+	struct xattr_match *xattr_include; /* --xattrs-include patterns */
+	struct xattr_match *xattr_exclude; /* --xattrs-exclude patterns */
 	int		  strip_components; /* Remove this many leading dirs */
 	int		  gid;  /* --gid */
 	const char	 *gname; /* --gname */
@@ -183,6 +191,8 @@ enum {
 	OPTION_UUENCODE,
 	OPTION_VERSION,
 	OPTION_XATTRS,
+	OPTION_XATTRS_EXCLUDE,
+	OPTION_XATTRS_INCLUDE,
 	OPTION_ZSTD,
 	OPTION_MTIME,
 	OPTION_CLAMP_MTIME,

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -149,6 +149,8 @@ static const struct bsdtar_option {
 	{ "verbose",              0, 'v' },
 	{ "version",              0, OPTION_VERSION },
 	{ "xattrs",               0, OPTION_XATTRS },
+	{ "xattrs-exclude",       1, OPTION_XATTRS_EXCLUDE },
+	{ "xattrs-include",       1, OPTION_XATTRS_INCLUDE },
 	{ "xz",                   0, 'J' },
 	{ "zstd",                 0, OPTION_ZSTD },
 	{ NULL, 0, 0 }

--- a/tar/read.c
+++ b/tar/read.c
@@ -82,6 +82,7 @@ void
 tar_mode_x(struct bsdtar *bsdtar)
 {
 	struct archive *writer;
+	struct xattr_match *xattr_m;
 
 	writer = archive_write_disk_new();
 	if (writer == NULL)
@@ -89,6 +90,13 @@ tar_mode_x(struct bsdtar *bsdtar)
 	if ((bsdtar->flags & OPTFLAG_NUMERIC_OWNER) == 0)
 		archive_write_disk_set_standard_lookup(writer);
 	archive_write_disk_set_options(writer, bsdtar->extract_flags);
+	/* Restrict which xattr names are restored (--xattrs-include/exclude). */
+	for (xattr_m = bsdtar->xattr_include; xattr_m != NULL;
+	    xattr_m = xattr_m->next)
+		archive_write_disk_set_xattr_include(writer, xattr_m->pattern);
+	for (xattr_m = bsdtar->xattr_exclude; xattr_m != NULL;
+	    xattr_m = xattr_m->next)
+		archive_write_disk_set_xattr_exclude(writer, xattr_m->pattern);
 
 	read_archive(bsdtar, 'x', writer);
 

--- a/tar/test/CMakeLists.txt
+++ b/tar/test/CMakeLists.txt
@@ -73,6 +73,7 @@ IF(ENABLE_TAR AND ENABLE_TEST)
     test_option_uid_uname.c
     test_option_uuencode.c
     test_option_xattrs.c
+    test_option_xattrs_filter.c
     test_option_xz.c
     test_option_z.c
     test_option_zstd.c

--- a/tar/test/test_option_xattrs_filter.c
+++ b/tar/test/test_option_xattrs_filter.c
@@ -1,0 +1,81 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Nikolay Bryskin
+ * All rights reserved.
+ */
+#include "test.h"
+
+/*
+ * Exercise --xattrs-exclude / --xattrs-include name filtering on both the
+ * create (read-disk) and extract (write-disk) sides.  Two user.* attributes
+ * are used so the test needs no special privileges; the filtering code path
+ * is namespace-agnostic (the motivating case is dropping security.selinux
+ * while keeping security.capability).
+ */
+DEFINE_TEST(test_option_xattrs_filter)
+{
+#if !ARCHIVE_XATTR_SUPPORT
+	skipping("Extended attributes are not supported on this platform");
+#else	/* ARCHIVE_XATTR_SUPPORT */
+	const char *keep = "user.libarchive.keep";
+	const char *drop = "user.libarchive.drop";
+	const char *val = "v";
+	void *readval;
+	size_t size;
+	int r;
+
+	assertMakeFile("f", 0644, "a");
+	if (!setXattr("f", keep, val, strlen(val) + 1) ||
+	    !setXattr("f", drop, val, strlen(val) + 1)) {
+		skipping("Can't set user extended attributes on this "
+		    "filesystem");
+		return;
+	}
+
+	/* Create side: --xattrs-exclude drops just the matching name. */
+	r = systemf("%s -c --no-mac-metadata --xattrs "
+	    "--xattrs-exclude %s -f excl.tar f >excl.out 2>excl.err",
+	    testprog, drop);
+	assertEqualInt(r, 0);
+	assertMakeDir("excl", 0755);
+	r = systemf("%s -x -C excl --no-same-permissions --xattrs "
+	    "-f excl.tar >excl_x.out 2>excl_x.err", testprog);
+	assertEqualInt(r, 0);
+	readval = getXattr("excl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("excl/f", drop, &size) == NULL);
+
+	/* Create side: --xattrs-include keeps only the matching name. */
+	r = systemf("%s -c --no-mac-metadata --xattrs "
+	    "--xattrs-include %s -f incl.tar f >incl.out 2>incl.err",
+	    testprog, keep);
+	assertEqualInt(r, 0);
+	assertMakeDir("incl", 0755);
+	r = systemf("%s -x -C incl --no-same-permissions --xattrs "
+	    "-f incl.tar >incl_x.out 2>incl_x.err", testprog);
+	assertEqualInt(r, 0);
+	readval = getXattr("incl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("incl/f", drop, &size) == NULL);
+
+	/* Extract side: archive carries both, extraction drops one. */
+	r = systemf("%s -c --no-mac-metadata --xattrs -f both.tar f "
+	    ">both.out 2>both.err", testprog);
+	assertEqualInt(r, 0);
+	assertMakeDir("xexcl", 0755);
+	r = systemf("%s -x -C xexcl --no-same-permissions --xattrs "
+	    "--xattrs-exclude %s -f both.tar >xexcl.out 2>xexcl.err",
+	    testprog, drop);
+	assertEqualInt(r, 0);
+	readval = getXattr("xexcl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("xexcl/f", drop, &size) == NULL);
+#endif	/* ARCHIVE_XATTR_SUPPORT */
+}

--- a/tar/write.c
+++ b/tar/write.c
@@ -447,6 +447,7 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 {
 	const char *arg;
 	struct archive_entry *entry, *sparse_entry;
+	struct xattr_match *xattr_m;
 
 	/* Choose a suitable copy buffer size */
 	bsdtar->buff_size = 64 * 1024;
@@ -488,6 +489,15 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 	archive_read_disk_set_behavior(bsdtar->diskreader,
 	    bsdtar->readdisk_flags);
 	archive_read_disk_set_standard_lookup(bsdtar->diskreader);
+	/* Restrict which xattr names are archived (--xattrs-include/exclude). */
+	for (xattr_m = bsdtar->xattr_include; xattr_m != NULL;
+	    xattr_m = xattr_m->next)
+		archive_read_disk_set_xattr_include(bsdtar->diskreader,
+		    xattr_m->pattern);
+	for (xattr_m = bsdtar->xattr_exclude; xattr_m != NULL;
+	    xattr_m = xattr_m->next)
+		archive_read_disk_set_xattr_exclude(bsdtar->diskreader,
+		    xattr_m->pattern);
 
 	if (bsdtar->names_from_file != NULL)
 		archive_names_from_file(bsdtar, a);


### PR DESCRIPTION
## Summary

Adds per-key extended-attribute name filtering to libarchive and bsdtar:

- `bsdtar --xattrs-include <pattern>` / `--xattrs-exclude <pattern>` (GNU tar compatible)
- Library API: `archive_read_disk_set_xattr_include/exclude` and `archive_write_disk_set_xattr_include/exclude`

Today bsdtar can only handle xattrs all-or-nothing (`--xattrs` / `--no-xattrs`), while GNU tar has had `--xattrs-include` / `--xattrs-exclude` masks for years. This closes that gap.

## Motivation

The coarse `--no-xattrs` cannot express "drop *this* attribute but keep the others." The motivating case is SELinux: a package/archive should not carry the **build host's** `security.selinux` label, because the correct label is a property of the **install host's** policy (applied by `restorecon`). But you still want to keep `security.capability` so setcap'd binaries (e.g. `newuidmap`) keep working. `--no-xattrs` would drop both; there was no way to drop just one.

With this change:

```
bsdtar --xattrs --xattrs-exclude 'security.selinux' -cf pkg.tar .   # archiving
bsdtar --xattrs --xattrs-exclude 'security.selinux' -xf pkg.tar     # extraction
```

It is generally useful for reproducible/portable archives (stripping host-specific attributes) beyond SELinux.

## Implementation

- A small shared name filter in `archive_pathmatch.c`: ordered lists of shell-style patterns (`__archive_xattr_filter_add` / `_free` / `__archive_xattr_name_excluded`). Exclusion takes precedence; when an include list is present a name must match it to be kept; empty lists impose no restriction.
- Wired into both directions and all platform paths:
  - read-disk (archiving): `setup_xattrs()` — Linux/Darwin/AIX and FreeBSD loops
  - write-disk (extraction): `set_xattrs()` — Linux/Darwin/AIX and FreeBSD variants
- The name is matched as a whole string (no path splitting), so `security.selinux` matches exactly that key and `security.*` matches the namespace.
- bsdtar options valid in c/r/u/x modes; patterns applied to the read-disk object in `write.c` (create) and the write-disk object in `read.c` (extract).
- Man page entries and a new `tar/test/test_option_xattrs_filter.c` (create-side include/exclude and extract-side exclude, using `user.*` attributes so it needs no privileges).

No new translation units; the filter lives in the existing `archive_pathmatch.c`.

## Note on mask semantics

GNU tar's `--xattrs-*` masks are POSIX extended regexps. Here the masks are libarchive's own **shell-style** patterns (`__archive_pathmatch`), for consistency with the rest of libarchive and to avoid a regex dependency on platforms without `<regex.h>` (e.g. Windows). For typical keys this is equivalent (`security.selinux`, `security.*`), but it is not regex — happy to adjust the documented semantics or the matcher if you'd prefer strict GNU tar parity.

## Testing

- `test_option_xattrs_filter` passes (31 assertions); `test_option_xattrs`, `test_option_acls`, `test_basic`, `test_copy` unaffected.
- Built with `-Werror` (CMake/Ninja, gcc) clean.
- Manual roundtrip on a permissive-SELinux host confirms `security.selinux` is dropped on both create and extract while a second attribute is preserved, and the extracted file falls back to the directory/policy default label instead of the archived one.
