### PR TITLE
rpm: Refactor filter

### DIFF
--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -38,20 +38,7 @@
 #include "archive_read_private.h"
 
 struct rpm {
-	int64_t		 total_in;
-	uint64_t	 hpos;
-	uint64_t	 hlen;
-	unsigned char	 header[16];
-	enum {
-		ST_LEAD,	/* Skipping 'Lead' section. */
-		ST_HEADER,	/* Reading 'Header' section;
-				 * first 16 bytes. */
-		ST_HEADER_DATA,	/* Skipping 'Header' section. */
-		ST_PADDING,	/* Skipping padding data after the
-				 * 'Header' section. */
-		ST_ARCHIVE	/* Reading 'Archive' section. */
-	}		 state;
-	int		 first_header;
+	int data_reached;
 };
 #define RPM_LEAD_SIZE		96	/* Size of 'Lead' section. */
 #define RPM_MIN_HEAD_SIZE	16	/* Minimum size of 'Head'. */
@@ -63,8 +50,6 @@ static int	rpm_bidder_init(struct archive_read_filter *);
 static ssize_t	rpm_filter_read(struct archive_read_filter *,
 		    const void **);
 static int	rpm_filter_close(struct archive_read_filter *);
-
-static inline size_t rpm_limit_bytes(uint64_t, size_t);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 /* Deprecated; remove in libarchive 4.0 */
@@ -152,133 +137,107 @@ rpm_bidder_init(struct archive_read_filter *self)
 	}
 
 	self->data = rpm;
-	rpm->state = ST_LEAD;
+	rpm->data_reached = 0;
 	self->vtable = &rpm_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
-static inline size_t
-rpm_limit_bytes(uint64_t bytes, size_t max)
+static ssize_t
+skip_padding(struct archive_read_filter *self)
 {
-	return (bytes > max ? max : (size_t)bytes);
+	const unsigned char *h;
+	ssize_t avail, count, r;
+
+	do {
+		h = __archive_read_filter_ahead(self->upstream, 1, &avail);
+		if (h == NULL)
+			return (ARCHIVE_FATAL);
+		for (count = 0; count < avail && *h++ == '\0'; count++)
+			;
+		r = __archive_read_filter_consume(self->upstream, count);
+		if (r < 0)
+			return (r);
+	} while (count == avail);
+
+	return (ARCHIVE_OK);
+}
+
+static ssize_t
+skip_prologue(struct archive_read_filter *self)
+{
+	const unsigned char *h;
+	ssize_t r;
+	int header, seen_header = 0;
+
+	/* Skip lead size. */
+	r = __archive_read_filter_consume(self->upstream, RPM_LEAD_SIZE);
+	if (r < 0)
+		return (r);
+
+	do {
+		/* Read header intro. */
+		h = __archive_read_filter_ahead(self->upstream,
+		    RPM_MIN_HEAD_SIZE, NULL);
+		if (h == NULL)
+			return (ARCHIVE_FATAL);
+
+		header = (memcmp(h, "\x8E\xAD\xE8\x01", 4) == 0);
+		if (header) {
+			int64_t bytes, length, section;
+
+			seen_header = 1;
+
+			/* Calculate header length. */
+			section = archive_be32dec(h + 8);
+			bytes = archive_be32dec(h + 12);
+			length = RPM_MIN_HEAD_SIZE + section * 16 + bytes;
+
+			/* Skip header. */
+			r = __archive_read_filter_consume(self->upstream,
+			     length);
+			if (r < 0)
+				return (r);
+
+			/* Skip padding. */
+			r = skip_padding(self);
+			if (r != ARCHIVE_OK)
+				return (r);
+		}
+	} while (header);
+
+	/* At least one header must have been encountered. */
+	if (!seen_header) {
+		archive_set_error(
+		    &self->archive->archive,
+		    ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Unrecognized rpm header");
+		return (ARCHIVE_FATAL);
+	}
+
+	return (ARCHIVE_OK);
 }
 
 static ssize_t
 rpm_filter_read(struct archive_read_filter *self, const void **buff)
 {
 	struct rpm *rpm;
-	const unsigned char *b;
-	ssize_t avail_in, total, used;
-	size_t n;
-	uint64_t section;
-	uint64_t bytes;
+	ssize_t r;
 
 	rpm = (struct rpm *)self->data;
-	*buff = NULL;
-	total = avail_in = 0;
-	b = NULL;
-	used = 0;
-	do {
-		if (b == NULL) {
-			b = __archive_read_filter_ahead(self->upstream, 1,
-			    &avail_in);
-			if (b == NULL) {
-				if (avail_in < 0)
-					return (ARCHIVE_FATAL);
-				else
-					break;
-			}
-		}
 
-		switch (rpm->state) {
-		case ST_LEAD:
-			if (rpm->total_in + avail_in < RPM_LEAD_SIZE)
-				used += avail_in;
-			else {
-				n = (size_t)(RPM_LEAD_SIZE - rpm->total_in);
-				used += n;
-				b += n;
-				rpm->state = ST_HEADER;
-				rpm->hpos = 0;
-				rpm->hlen = 0;
-				rpm->first_header = 1;
-			}
-			break;
-		case ST_HEADER:
-			n = rpm_limit_bytes(RPM_MIN_HEAD_SIZE - rpm->hpos,
-			    avail_in - used);
-			memcpy(rpm->header+rpm->hpos, b, n);
-			b += n;
-			used += n;
-			rpm->hpos += n;
-
-			if (rpm->hpos == RPM_MIN_HEAD_SIZE) {
-				if (rpm->header[0] != 0x8e ||
-				    rpm->header[1] != 0xad ||
-				    rpm->header[2] != 0xe8 ||
-				    rpm->header[3] != 0x01) {
-					if (rpm->first_header) {
-						archive_set_error(
-						    &self->archive->archive,
-						    ARCHIVE_ERRNO_FILE_FORMAT,
-						    "Unrecognized rpm header");
-						return (ARCHIVE_FATAL);
-					}
-					rpm->state = ST_ARCHIVE;
-					*buff = rpm->header;
-					total = RPM_MIN_HEAD_SIZE;
-					break;
-				}
-				/* Calculate 'Header' length. */
-				section = archive_be32dec(rpm->header+8);
-				bytes = archive_be32dec(rpm->header+12);
-				rpm->hlen = rpm->hpos + section * 16 + bytes;
-				rpm->state = ST_HEADER_DATA;
-				rpm->first_header = 0;
-			}
-			break;
-		case ST_HEADER_DATA:
-			n = rpm_limit_bytes(rpm->hlen - rpm->hpos,
-			    avail_in - used);
-			b += n;
-			used += n;
-			rpm->hpos += n;
-			if (rpm->hpos == rpm->hlen)
-				rpm->state = ST_PADDING;
-			break;
-		case ST_PADDING:
-			while (used < avail_in) {
-				if (*b != 0) {
-					/* Read next header. */
-					rpm->state = ST_HEADER;
-					rpm->hpos = 0;
-					rpm->hlen = 0;
-					break;
-				}
-				b++;
-				used++;
-			}
-			break;
-		case ST_ARCHIVE:
-			*buff = b;
-			total = avail_in;
-			used = avail_in;
-			break;
-		}
-		if (used == avail_in) {
-			rpm->total_in += used;
-			__archive_read_filter_consume(self->upstream, used);
-			b = NULL;
-			used = 0;
-		}
-	} while (total == 0 && avail_in > 0);
-
-	if (used > 0 && b != NULL) {
-		rpm->total_in += used;
-		__archive_read_filter_consume(self->upstream, used);
+	if (!rpm->data_reached) {
+		r = skip_prologue(self);
+		if (r != ARCHIVE_OK)
+			return (r);
+		rpm->data_reached = 1;
 	}
-	return (total);
+
+	*buff = __archive_read_filter_ahead(self->upstream, 1, &r);
+	if (r > 0)
+		__archive_read_filter_consume(self->upstream, r);
+
+	return r;
 }
 
 static int

--- a/libarchive/test/test_read_format_huge_rpm.c
+++ b/libarchive/test/test_read_format_huge_rpm.c
@@ -26,7 +26,6 @@
 
 DEFINE_TEST(test_read_format_huge_rpm)
 {
-	struct archive_entry *ae;
 	struct archive *a;
 	const char *name = "test_read_format_huge_rpm.rpm";
 
@@ -34,15 +33,11 @@ DEFINE_TEST(test_read_format_huge_rpm)
         assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
 	extract_reference_file(name);
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, name, 2));
-
-	/* This archive should have no entries -- if it has entries, the bid has screwed up */
-	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
-
-	/* Verify that the format detection worked. */
-	assertEqualInt(ARCHIVE_FILTER_RPM, archive_filter_code(a, 0));
-	assertEqualString("rpm", archive_filter_name(a, 0));
-	assertEqualInt(ARCHIVE_FORMAT_EMPTY, archive_format(a));
+	/* This archive is truncated -- if it has data, the bid has screwed up */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_open_filename(a, name, 2));
+	assertEqualStringA(a, "Truncated input file "
+	    "(needed 34359738384 bytes, only 10256 available)",
+	    archive_error_string(a));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));


### PR DESCRIPTION
The current finite state machine carefully handles short reads, i.e. the loop can enter as often as needed until enough bytes arrive for the current state to perform its actions.

This can be simplified by relying on `__archive_filter_read_ahead` to return the amount of bytes actually needed. I assume that this did not happen in the original code due to its age (2009) and evolution of libarchive's internals over time.

Also, headers are only skipped at the beginning. As soon as the reader starts returning data (ST_ARCHIVE reached), the filter pretty much becomes a pass-through filter.

Split the initial lead and header skipping into its own function and only keep track if the initial skipping was performed or not. This greatly simplifies the reader function.

Also, it avoids book keeping of internal states and `total_in` tracking, which I don't have to properly audit for edge cases anymore.

This refactoring properly reports truncated streams now.

Also, it's roughly 5 % faster than before with large archives, e.g. fedora's chromium rpm.