### PR TITLE
lz4: Fix double-free on reallocation failure

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -327,13 +327,15 @@ lz4_allocate_out_block(struct archive_read_filter *self)
 		out_block_size += 64 * 1024;
 	if (state->out_block_size < out_block_size) {
 		free(state->out_block);
+		state->out_block = NULL;
 		out_block = malloc(out_block_size);
-		state->out_block_size = out_block_size;
 		if (out_block == NULL) {
+			state->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
+		state->out_block_size = out_block_size;
 		state->out_block = out_block;
 	}
 	if (!state->flags.block_independence)
@@ -350,13 +352,15 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 
 	if (state->out_block_size < out_block_size) {
 		free(state->out_block);
+		state->out_block = NULL;
 		out_block = malloc(out_block_size);
-		state->out_block_size = out_block_size;
 		if (out_block == NULL) {
+			state->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
+		state->out_block_size = out_block_size;
 		state->out_block = out_block;
 	}
 	return (ARCHIVE_OK);


### PR DESCRIPTION
Alternative version of https://github.com/libarchive/libarchive/pull/2945 which removes the test (which requires a modified malloc to actually fail the 4 MB allocation). While I would like to have a test, @calvinytt timed out adding a copyright to the test, so this is the original commit without the test, thus keeping authorship.