### PR TITLE
formats: Simplify `__archive_read_ahead` use

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -755,7 +755,6 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset, int compat)
 	int64_t r;
 	const char *h;
 	char big_endian, format_64;
-	ssize_t bytes;
 	size_t request;
 	uint64_t e_shoff, strtab_offset, strtab_size;
 	uint16_t e_shentsize, e_shnum, e_shstrndx;
@@ -772,7 +771,7 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset, int compat)
 		/*
 		 * Read Elf header to find bitness & endianness
 		 */
-		h = __archive_read_ahead(a, ELF_HDR_MIN_LEN, &bytes);
+		h = __archive_read_ahead(a, ELF_HDR_MIN_LEN, NULL);
 		if (h == NULL) {
 			return (ARCHIVE_FATAL);
 		}
@@ -830,7 +829,7 @@ get_elf_sfx_offset(struct archive_read *a, int64_t *sfx_offset, int compat)
 		if (request > SFX_MAX_SEEK) {
 			return (ARCHIVE_FATAL);
 		}
-		h = __archive_read_ahead(a, request, &bytes);
+		h = __archive_read_ahead(a, request, NULL);
 		if (h == NULL) {
 			return (ARCHIVE_FATAL);
 		}

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -907,11 +907,10 @@ static inline int get_archive_read(struct archive* a,
 static int read_ahead(struct archive_read* a, size_t how_many,
     const uint8_t** ptr)
 {
-	ssize_t avail = -1;
 	if(!ptr)
 		return 0;
 
-	*ptr = __archive_read_ahead(a, how_many, &avail);
+	*ptr = __archive_read_ahead(a, how_many, NULL);
 	if(*ptr == NULL) {
 		return 0;
 	}

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -2399,7 +2399,6 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 	int64_t t;
 	long n;
 	const char *p;
-	ssize_t bytes_read;
 	int err = ARCHIVE_OK;
 
 	switch (key[0]) {
@@ -2483,7 +2482,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 								  (unsigned long long)sparse_map_limit);
 						err = ARCHIVE_FAILED;
 					} else {
-						p = __archive_read_ahead(a, value_length, &bytes_read);
+						p = __archive_read_ahead(a, value_length, NULL);
 						if (p == NULL) {
 							archive_set_error(&a->archive, EINVAL,
 									  "Truncated archive"
@@ -2571,7 +2570,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 			else if (key_length == 11 && memcmp(key, "symlinktype", 11) == 0) {
 				/* LIBARCHIVE.symlinktype */
 				if (value_length < 16) {
-					p = __archive_read_ahead(a, value_length, &bytes_read);
+					p = __archive_read_ahead(a, value_length, NULL);
 					if (p == NULL) {
 						archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 								  "Truncated tar archive "
@@ -2605,7 +2604,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 				if (value_length > xattr_limit) {
 					err = ARCHIVE_WARN;
 				} else {
-					p = __archive_read_ahead(a, value_length, &bytes_read);
+					p = __archive_read_ahead(a, value_length, NULL);
 					if (p == NULL) {
 						archive_set_error(&a->archive, EINVAL,
 								  "Truncated archive"
@@ -2635,7 +2634,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 				/* TODO: Should this be FAILED instead? */
 				err = ARCHIVE_WARN;
 			} else {
-				p = __archive_read_ahead(a, value_length, &bytes_read);
+				p = __archive_read_ahead(a, value_length, NULL);
 				if (p == NULL) {
 					archive_set_error(&a->archive, EINVAL,
 							  "Truncated archive"
@@ -2688,7 +2687,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 			}
 			else if (key_length == 6 && memcmp(key, "fflags", 6) == 0) {
 				if (value_length < fflags_limit) {
-					p = __archive_read_ahead(a, value_length, &bytes_read);
+					p = __archive_read_ahead(a, value_length, NULL);
 					if (p == NULL) {
 						/* Truncated archive */
 						archive_set_error(&a->archive, EINVAL,
@@ -2735,7 +2734,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 				key_length -= 6;
 				key += 6;
 				if (value_length < xattr_limit) {
-					p = __archive_read_ahead(a, value_length, &bytes_read);
+					p = __archive_read_ahead(a, value_length, NULL);
 					if (p == NULL) {
 						archive_set_error(&a->archive, EINVAL,
 								  "Truncated archive"
@@ -2765,7 +2764,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 			if (key_length == 9 && memcmp(key, "holesdata", 9) == 0) {
 				/* SUN.holesdata */
 				if (value_length < sparse_map_limit) {
-					p = __archive_read_ahead(a, value_length, &bytes_read);
+					p = __archive_read_ahead(a, value_length, NULL);
 					if (p == NULL) {
 						archive_set_error(&a->archive, EINVAL,
 								  "Truncated archive"
@@ -2839,7 +2838,7 @@ pax_attribute(struct archive_read *a, struct tar *tar, struct archive_entry *ent
 	case 'h':
 		if (key_length == 10 && memcmp(key, "hdrcharset", 10) == 0) {
 			if (value_length < 64) {
-				p = __archive_read_ahead(a, value_length, &bytes_read);
+				p = __archive_read_ahead(a, value_length, NULL);
 				if (p == NULL) {
 					archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 							  "Truncated tar archive "
@@ -3210,7 +3209,6 @@ static int
 gnu_sparse_old_read(struct archive_read *a, struct tar *tar,
     const struct archive_entry_header_gnutar *header, int64_t *unconsumed)
 {
-	ssize_t bytes_read;
 	const void *data;
 	struct extended {
 		struct gnu_sparse sparse[21];
@@ -3228,7 +3226,7 @@ gnu_sparse_old_read(struct archive_read *a, struct tar *tar,
 		if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
 			return (ARCHIVE_FATAL);
 		}
-		data = __archive_read_ahead(a, 512, &bytes_read);
+		data = __archive_read_ahead(a, 512, NULL);
 		if (data == NULL) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated tar archive "

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -285,11 +285,10 @@ ppmd_read(void* p) {
 	/* Get the handle to current decompression context. */
 	struct archive_read *a = ((IByteIn*)p)->a;
 	struct zip *zip = (struct zip*) a->format->data;
-	ssize_t bytes_avail = 0;
 
 	/* Fetch next byte. */
-	const uint8_t* data = __archive_read_ahead(a, 1, &bytes_avail);
-	if(bytes_avail < 1) {
+	const uint8_t* data = __archive_read_ahead(a, 1, NULL);
+	if(data == NULL) {
 		zip->ppmd8_stream_failed = 1;
 		return 0;
 	}
@@ -2421,7 +2420,6 @@ zip_read_data_zipx_ppmd(struct archive_read *a, const void **buff,
 	struct zip* zip = (struct zip *)(a->format->data);
 	int ret;
 	size_t consumed_bytes = 0;
-	ssize_t bytes_avail = 0;
 
 	(void) offset; /* UNUSED */
 
@@ -2435,8 +2433,7 @@ zip_read_data_zipx_ppmd(struct archive_read *a, const void **buff,
 
 	/* Fetch for more data. We're reading 1 byte here, but libarchive
 	 * should prefetch more bytes. */
-	(void) __archive_read_ahead(a, 1, &bytes_avail);
-	if(bytes_avail < 0) {
+	if(__archive_read_ahead(a, 1, NULL) == NULL) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Truncated PPMd8 file body");
 		return (ARCHIVE_FATAL);


### PR DESCRIPTION
Set the third argument to `NULL` if the amount of actually read bytes is not needed. This simplifies code audits.

Pretty much continuation of https://github.com/libarchive/libarchive/pull/3098, but for formats this time.