### PR TITLE
Remove unneeded counters

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -347,11 +347,9 @@ struct _7zip {
 	struct {
 		const unsigned char	*next_in;
 		int64_t			 avail_in;
-		int64_t			 total_in;
 		int64_t			 stream_in;
 		unsigned char		*next_out;
 		int64_t			 avail_out;
-		int64_t			 total_out;
 		int			 overconsumed;
 	} ppstream;
 	int			 ppmd7_valid;
@@ -1335,7 +1333,6 @@ ppmd_read(void *p)
 		b = *zip->ppstream.next_in++;
 	}
 	zip->ppstream.avail_in--;
-	zip->ppstream.total_in++;
 	zip->ppstream.stream_in++;
 	return (b);
 }
@@ -1645,8 +1642,6 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 		zip->ppmd7_valid = 1;
 		zip->ppmd7_stat = 0;
 		zip->ppstream.overconsumed = 0;
-		zip->ppstream.total_in = 0;
-		zip->ppstream.total_out = 0;
 		break;
 	}
 	case _7Z_X86:
@@ -1929,7 +1924,6 @@ decompress(struct archive_read *a, struct _7zip *zip,
 			}
 			*zip->ppstream.next_out++ = (unsigned char)sym;
 			zip->ppstream.avail_out--;
-			zip->ppstream.total_out++;
 			if (flush_bytes)
 				flush_bytes--;
 		} while (zip->ppstream.avail_out &&

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -142,7 +142,6 @@ struct lzh_stream {
 	int64_t			 total_in;
 	const unsigned char	*ref_ptr;
 	int			 avail_out;
-	int64_t			 total_out;
 	struct lzh_dec		*ds;
 };
 
@@ -1585,7 +1584,6 @@ lha_read_data_lzh(struct archive_read *a, const void **buff,
 		/* We've initialized decompression for this stream. */
 		lha->decompress_init = 1;
 		lha->strm.avail_out = 0;
-		lha->strm.total_out = 0;
 	}
 
 	/*
@@ -2137,7 +2135,6 @@ lzh_emit_window(struct lzh_stream *strm, size_t s)
 {
 	strm->ref_ptr = strm->ds->w_buff;
 	strm->avail_out = (int)s;
-	strm->total_out += s;
 }
 
 static int

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -57,7 +57,6 @@ struct private_data {
 	int		 compression_level;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	bz_stream	 stream;
-	int64_t		 total_in;
 	char		*compressed;
 	size_t		 compressed_buffer_size;
 #else
@@ -238,9 +237,6 @@ archive_compressor_bzip2_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
 	struct private_data *data = (struct private_data *)f->data;
-
-	/* Update statistics */
-	data->total_in += length;
 
 	/* Compress input data to output buffer */
 	SET_NEXT_IN(data, buff);

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -61,7 +61,6 @@ struct private_data {
 	unsigned	 preset_dictionary:1;
 	unsigned	 block_maximum_size:3;
 #if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
-	int64_t		 total_in;
 	char		*out;
 	char		*out_buffer;
 	size_t		 out_buffer_size;
@@ -305,9 +304,6 @@ archive_filter_lz4_write(struct archive_write_filter *f,
 			return (ret);
 		data->header_written = 1;
 	}
-
-	/* Update statistics */
-	data->total_in += length;
 
 	p = (const char *)buff;
 	remaining = length;

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -73,7 +73,6 @@ struct private_data {
 	size_t		 cur_frame;
 	size_t		 cur_frame_in;
 	size_t		 cur_frame_out;
-	size_t		 total_in;
 	ZSTD_CStream	*cstream;
 	ZSTD_outBuffer	 out;
 #else
@@ -505,7 +504,6 @@ drive_compressor(struct archive_write_filter *f,
 			data->state = running;
 			break;
 		}
-		data->total_in += in.pos - ipos;
 		data->cur_frame_in += in.pos - ipos;
 		data->cur_frame_out += data->out.pos - opos;
 		if (data->state == running) {


### PR DESCRIPTION
These counters are written to, but never read. Remove them for easier code audits.