### PR TITLE
Fix minor non-functional issues

### DIFF
--- a/doc/WRITING_TESTS.md
+++ b/doc/WRITING_TESTS.md
@@ -172,7 +172,7 @@ And assertions that verify particular file properties, such as:
 - `assertFileSize(path, expected_size)`
 - `assertTextFileContents(expected_text, path)`
 
-The full set of asertions is listed in `test_utils/test_common.h`.
+The full set of assertions is listed in `test_utils/test_common.h`.
 You can search the existing tests to find examples of their usage.
 
 ---

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -1235,7 +1235,7 @@ __LA_DECL int	archive_match_exclude_entry(struct archive *,
 		    int _flag, struct archive_entry *);
 
 /*
- * Test if a file is excluded by its uid ,gid, uname or gname.
+ * Test if a file is excluded by its uid, gid, uname or gname.
  * The conditions are set by following functions.
  */
 __LA_DECL int	archive_match_owner_excluded(struct archive *,

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -415,8 +415,8 @@ archive_read_add_callback_data(struct archive *_a, void *client_data,
 	}
 
 	if (a->client.nodes == UINT_MAX ||
-    	(size_t)a->client.nodes + 1 >
-        SIZE_MAX / sizeof(*a->client.dataset)) {
+	    (size_t)a->client.nodes + 1 >
+	    SIZE_MAX / sizeof(*a->client.dataset)) {
 		archive_set_error(&a->archive, ENOMEM,
 			"No memory");
 		return ARCHIVE_FATAL;

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -264,7 +264,7 @@ struct cfheader {
 };
 
 struct cab {
-	/* entry_bytes_remaining is the number of bytes we expect.	    */
+	/* entry_bytes_remaining is the number of bytes we expect. */
 	int64_t			 entry_offset;
 	int64_t			 entry_bytes_remaining;
 	int64_t			 entry_unconsumed;
@@ -773,7 +773,7 @@ cab_read_header(struct archive_read *a)
 	 */
 	/* Seek read pointer to the offset of CFFILE if needed. */
 	skip = (int64_t)hd->files_offset - cab->cab_offset;
-	if (skip <  0) {
+	if (skip < 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 		    "Invalid offset of CFFILE %jd < %jd",
 		    (intmax_t)hd->files_offset, (intmax_t)cab->cab_offset);

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -112,8 +112,8 @@ struct lzx_dec {
 		unsigned char	*bitlen;
 
 		/*
-		 * Use a index table. It's faster than searching a huffman
-		 * coding tree, which is a binary tree. But a use of a large
+		 * Use an index table. It's faster than searching a huffman
+		 * coding tree, which is a binary tree. But usage of a large
 		 * index table causes L1 cache read miss many times.
 		 */
 		int		 max_bits;
@@ -279,7 +279,7 @@ struct cab {
 	struct cfheader		 cfheader;
 	struct archive_wstring	 ws;
 
-	/* Flag to mark progress that an archive was read their first header.*/
+	/* Flag to mark progress that first header of an archive was read.*/
 	char			 found_header;
 	char			 end_of_archive;
 	char			 end_of_entry;
@@ -433,7 +433,7 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 	/*
 	 * Attempt to handle self-extracting archives
 	 * by noting a PE header and searching forward
-	 * up to 128k for a 'MSCF' marker.
+	 * up to 128k for an 'MSCF' marker.
 	 */
 	if (p[0] == 'M' && p[1] == 'Z') {
 		offset = 0;
@@ -501,7 +501,7 @@ cab_skip_sfx(struct archive_read *a)
 	for (;;) {
 		const char *h = __archive_read_ahead(a, window, &bytes);
 		if (h == NULL) {
-			/* Remaining size are less than window. */
+			/* Remaining size is less than window. */
 			window >>= 1;
 			if (window < 128) {
 				archive_set_error(&a->archive,

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -1127,8 +1127,8 @@ record_hardlink(struct archive_read *a,
 	const char *pathname = archive_entry_pathname(entry);
 	if (pathname == NULL) {
 		archive_set_error(&a->archive,
-			ARCHIVE_ERRNO_FILE_FORMAT,
-           "Invalid hardlink entry with no pathname");
+		    ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Invalid hardlink entry with no pathname");
 		free(le);
 		return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -1072,7 +1072,7 @@ atol16u(const char *p, unsigned char_cnt)
 		else if (*p >= '0' && *p <= '9')
 			digit = *p - '0';
 		else
-			return ((int64_t)l);
+			return (l);
 		p++;
 		l <<= 4;
 		l |= digit;

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -107,8 +107,8 @@ struct lzh_dec {
 		unsigned char	*bitlen;
 
 		/*
-		 * Use a index table. It's faster than searching a huffman
-		 * coding tree, which is a binary tree. But a use of a large
+		 * Use an index table. It's faster than searching a huffman
+		 * coding tree, which is a binary tree. But usage of a large
 		 * index table causes L1 cache read miss many times.
 		 */
 #define HTBL_BITS	10

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -104,8 +104,7 @@ archive_errno(struct archive *a)
 const char *
 archive_error_string(struct archive *a)
 {
-
-	if (a->error != NULL  &&  *a->error != '\0')
+	if (a->error != NULL && *a->error != '\0')
 		return (a->error);
 	else
 		return (NULL);

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -172,7 +172,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 
 	/*
 	 * If we are now at the beginning of the archive,
-	 * we need first write the ar global header.
+	 * we have to write the ar global header first.
 	 */
 	if (!ar->wrote_global_header) {
 		__archive_write_output(a, "!<arch>\n", 8);

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -961,7 +961,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	}
 	filename_length = path_length(zip->entry);
 
-  /* Reject empty or overlong pathnames */
+	/* Reject empty or overlong pathnames */
 	path = archive_entry_pathname(zip->entry);
 	if (path == NULL || path[0] == '\0') {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,

--- a/libarchive/test/test_archive_string_conversion.c
+++ b/libarchive/test/test_archive_string_conversion.c
@@ -338,13 +338,13 @@ test_archive_string_normalization_nfc(const char *testdata)
 		nfd[sizeof(nfd)-1] = '\0';
 
 		/*
-		 * Get an NFC patterns.
+		 * Get an NFC pattern.
 		 */
 		scan_unicode_pattern(utf8_nfc, wc_nfc, utf16be_nfc, utf16le_nfc,
 		    nfc, 0);
 
 		/*
-		 * Get an NFD patterns.
+		 * Get an NFD pattern.
 		 */
 		scan_unicode_pattern(utf8_nfd, wc_nfd, utf16be_nfd, utf16le_nfd,
 		    nfd, 0);
@@ -550,7 +550,7 @@ test_archive_string_normalization_mac_nfd(const char *testdata)
 		nfd[sizeof(nfd)-1] = '\0';
 
 		/*
-		 * Get an NFC patterns.
+		 * Get an NFC pattern.
 		 */
 		should_be_nfc = scan_unicode_pattern(utf8_nfc, wc_nfc,
 			utf16be_nfc, utf16le_nfc, nfc, 1);

--- a/libarchive/test/test_write_filter_lzma.c
+++ b/libarchive/test/test_write_filter_lzma.c
@@ -55,7 +55,7 @@ DEFINE_TEST(test_write_filter_lzma)
 	memset(data, 0, datasize);
 
 	/*
-	 * Write a 100 files and read them all back.
+	 * Write 100 files and read them all back.
 	 */
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));


### PR DESCRIPTION
Fixes mostly typos and white space issues.

It also removes an unneeded cast (uint64_t -> int64_t -> uint64_t).