### PR TITLE
tar: avoid temporary pathname buffer for ustar names

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1816,32 +1816,42 @@ header_ustar(struct archive_read *a, struct tar *tar,
     struct archive_entry *entry, const void *h)
 {
 	const struct archive_entry_header_ustar	*header;
-	struct archive_string as;
 	int err = ARCHIVE_OK, r;
 
 	header = (const struct archive_entry_header_ustar *)h;
 
-	/* Copy name into an internal buffer to ensure null-termination. */
+	/*
+	 * The name field is fixed-width and may not be NUL-terminated.
+	 * Use a temporary string only when prefix/name joining is required.
+	 */
 	const char *existing_pathname = archive_entry_pathname(entry);
 	const wchar_t *existing_wcs_pathname = archive_entry_pathname_w(entry);
 	if ((existing_pathname == NULL || existing_pathname[0] == '\0')
 	    && (existing_wcs_pathname == NULL || existing_wcs_pathname[0] == '\0')) {
+		struct archive_string as;
+		const char *pathname;
+		size_t pathname_length;
+
 		archive_string_init(&as);
 		if (header->prefix[0]) {
 			archive_strncpy(&as, header->prefix, sizeof(header->prefix));
 			if (as.s[archive_strlen(&as) - 1] != '/')
 				archive_strappend_char(&as, '/');
 			archive_strncat(&as, header->name, sizeof(header->name));
+			pathname = as.s;
+			pathname_length = archive_strlen(&as);
 		} else {
-			archive_strncpy(&as, header->name, sizeof(header->name));
+			pathname = header->name;
+			pathname_length = sizeof(header->name);
 		}
-		if (archive_entry_copy_pathname_l(entry, as.s, archive_strlen(&as),
-		    tar->sconv) != 0) {
+		r = archive_entry_copy_pathname_l(entry, pathname,
+		    pathname_length, tar->sconv);
+		archive_string_free(&as);
+		if (r != 0) {
 			err = set_conversion_failed_error(a, tar->sconv, "Pathname");
 			if (err == ARCHIVE_FATAL)
 				return (err);
 		}
-		archive_string_free(&as);
 	}
 
 	/* Handle rest of common fields. */


### PR DESCRIPTION
Avoid building a temporary pathname buffer for the common POSIX ustar case where the prefix field is empty. In that path, header_ustar() can copy the fixed-width name field directly into the archive entry instead of first copying it through a temporary archive_string.

The benchmark builds used CMake Release mode with -DCMAKE_C_FLAGS="-O2 -g -Wno-error" and no explicit -march or -mtune flags.

On a 300,000-entry POSIX ustar archive, measured over 80 runs after 10 warmups, the patch improved listing performance with both GCC and Clang:

GCC:
wall time: 2.78% faster
user CPU: 2.71% lower
total CPU: 2.55% lower

Clang:
wall time: 1.67% faster
user CPU: 2.18% lower
total CPU: 1.69% lower

Peak RSS was effectively unchanged.

A true prefix-heavy ustar workload with 100,000 entries showed no regression; patched listing time was within noise of the unpatched build.

This keeps the existing prefixed-name path for entries that need prefix/name joining. While touching that path, also free the temporary pathname string before returning on a fatal pathname-conversion error.