### PR TITLE
tar: avoid wide pathname conversion for trailing slash check

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -615,16 +615,16 @@ archive_read_format_tar_read_header(struct archive_read *a,
 		 * directory: This is needed for certain old tar
 		 * variants and even for some broken newer ones.
 		 */
-		if ((wp = archive_entry_pathname_w(entry)) != NULL) {
-			l = wcslen(wp);
-			if (l > 0 && wp[l - 1] == L'/') {
+		if ((p = archive_entry_pathname(entry)) != NULL) {
+			l = strlen(p);
+			if (l > 0 && p[l - 1] == '/') {
 				archive_entry_set_filetype(entry, AE_IFDIR);
 				tar->entry_bytes_remaining = 0;
 				tar->entry_padding = 0;
 			}
-		} else if ((p = archive_entry_pathname(entry)) != NULL) {
-			l = strlen(p);
-			if (l > 0 && p[l - 1] == '/') {
+		} else if ((wp = archive_entry_pathname_w(entry)) != NULL) {
+			l = wcslen(wp);
+			if (l > 0 && wp[l - 1] == L'/') {
 				archive_entry_set_filetype(entry, AE_IFDIR);
 				tar->entry_bytes_remaining = 0;
 				tar->entry_padding = 0;


### PR DESCRIPTION
Avoid requesting the wide-character pathname when the tar reader only needs to check whether a regular entry name ends in `/`.

`archive_entry_pathname_w()` can lazily convert the pathname to WCS. In the common tar read path, the multibyte pathname is already available, so checking it first avoids unnecessary per-entry conversion. The WCS fallback is kept for cases where the multibyte pathname is unavailable.

Benchmarks were run with a CMake `RelWithDebInfo` build:

```
-G Ninja
-DCMAKE_BUILD_TYPE=RelWithDebInfo
-DENABLE_WERROR=OFF
-DENABLE_TEST=ON
```

Workload | Base | Patched | Change
-- | -- | -- | --
1,000,000 empty regular entries | 3.588476s | 3.203626s | 10.72% faster
300,000 empty regular entries | 1.075521s | 0.962154s | 10.54% faster
300,000 entries with longer pathnames | 1.976323s | 1.501097s | 24.05% faster
300,000 mixed directory, symlink, prefix, and trailing-slash entries | 1.146964s | 1.049142s | 8.53% faster
50,000 entries with 1 KiB payloads | 0.210933s | 0.188106s | 10.82% faster
200,000 entries with 64-byte payloads | 0.768982s | 0.680057s | 11.56% faster
300,000 prefix-heavy entries | 1.568270s | 1.299198s | 17.16% faster
300,000 regular entries with trailing / names | 1.164957s | 1.016962s | 12.70% faster
300,000 entries with varying user/group names | 1.049889s | 0.948133s | 9.69% faster