### PR TITLE
cab: Improve truncation detection

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1574,11 +1574,9 @@ cab_read_ahead_cfdata_deflate(struct archive_read *a, ssize_t *avail)
 	 * correctly compute the sum of CFDATA accordingly.
 	 */
 	if (cfdata->compressed_bytes_remaining > 0) {
-		ssize_t bytes_avail;
-
 		d = __archive_read_ahead(a, cfdata->compressed_bytes_remaining,
-		    &bytes_avail);
-		if (bytes_avail <= 0) {
+		    NULL);
+		if (d == NULL) {
 			*avail = truncated_error(a);
 			return (NULL);
 		}
@@ -1746,11 +1744,9 @@ cab_read_ahead_cfdata_lzx(struct archive_read *a, ssize_t *avail)
 	 * Make sure a read pointer advances to next CFDATA.
 	 */
 	if (cfdata->compressed_bytes_remaining > 0) {
-		ssize_t bytes_avail;
-
 		d = __archive_read_ahead(a, cfdata->compressed_bytes_remaining,
-		    &bytes_avail);
-		if (bytes_avail <= 0) {
+		    NULL);
+		if (d == NULL) {
 			*avail = truncated_error(a);
 			return (NULL);
 		}


### PR DESCRIPTION
If not enough bytes are available, `__archive_read_ahead` will return the amount of bytes still available, which can be larger than 0. Only in error cases, a negative value is returned.

Check the return pointer instead. It simplifies the error handling, allows a `NULL` argument, and covers more truncation issues.

Right now, a `NULL` pointer with a non-zero size could be further processed, which just asks for more technical or logical issues to arise.