### PR TITLE
cab: Properly limit maximum name length

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -554,14 +554,16 @@ cab_strnlen(const unsigned char *p, size_t maxlen)
 	return ((ssize_t)i);
 }
 
-/* Read bytes as much as remaining. */
+/* Read up to max remaining bytes. */
 static const void *
-cab_read_ahead_remaining(struct archive_read *a, size_t min, ssize_t *avail)
+cab_read_ahead_remaining(struct archive_read *a, size_t max, ssize_t *avail)
 {
-	const void *p = __archive_read_ahead(a, min, avail);
+	const void *p = __archive_read_ahead(a, max, avail);
 
 	if (p == NULL && *avail > 0)
 		p = __archive_read_ahead(a, *avail, avail);
+	if (p != NULL && (size_t)*avail > max)
+		*avail = max;
 
 	return (p);
 }


### PR DESCRIPTION
The `cab_read_ahead_remaining` function might return more bytes through `avail` than initially asked for. The given limit is `255+1`, i.e. the maximum file name length.

While it's not a big deal for libarchive to handle file names longer than that, the CAB format does not allow longer names.

Limit the amount of available bytes to the given argument for proper checking.