### PR TITLE
read_disk: Check if off_t can overflow size_t

### DIFF
--- a/libarchive/archive_read_disk_entry_from_file.c
+++ b/libarchive/archive_read_disk_entry_from_file.c
@@ -256,6 +256,11 @@ archive_read_disk_entry_from_file(struct archive *_a,
 		char *linkbuffer;
 		ssize_t lnklen;
 
+		if (st->st_size >= SSIZE_MAX) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "Couldn't read link data");
+			return (ARCHIVE_FAILED);
+		}
 		linkbuffer = malloc(linkbuffer_len + 1);
 		if (linkbuffer == NULL) {
 			archive_set_error(&a->archive, ENOMEM,


### PR DESCRIPTION
Make sure that the content of the link can fit into a size_t. This should be always true, but be cautious with 32 bit systems and very weird filesystems (possibly through fuse).

I took SSIZE_MAX as upper limit due to signedness and eventual readlink calls which would fail with larger values anyway.