### PR TITLE
ci: pin acj/freebsd-firecracker-action to full commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         bs: [autotools, cmake]
     steps:
     - name: Build and test on a FreeBSD 15 firecracker VM
-      uses: acj/freebsd-firecracker-action@v0.9.1
+      uses: acj/freebsd-firecracker-action@bab3e77871573c7943b80816f1641b6c1ce36896 # v0.9.1
       with:
         run-in-vm: |
           chflags -R noschg / && \


### PR DESCRIPTION
`ci.yml` uses `acj/freebsd-firecracker-action@v0.9.1` — a mutable tag that can be silently re-pointed to a different commit.

Pin to full SHA (tag kept as comment):
- `acj/freebsd-firecracker-action`: `@v0.9.1` → `@bab3e77871573c7943b80816f1641b6c1ce36896`

~~Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).~~ Does not qualify, as `freebsd-firecracker-action` is using Immutable Releases which prevents tag manipulation. Pull request merged for consistency.