### PR TITLE
Fix the bsdtar tests on mingw (when built with expat)

### DIFF
--- a/tar/test/test_option_mtime.c
+++ b/tar/test/test_option_mtime.c
@@ -6,23 +6,6 @@
  */
 #include "test.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
-/* system() on Windows runs its arguments through CMD.EXE, which has
- * notoriously unfriendly quoting rules. The current best documented way around
- * them is to wrap your *entire commandline* in sacrificial quotes.
- *
- * See CMD.EXE /? for more information. Excerpted here:
- * | Otherwise, old behavior is to see if the first character is
- * | a quote character and if so, strip the leading character and
- * | remove the last quote character on the command line, preserving
- * | any text after the last quote character.
- *
- * Since this test makes heavy use of systemf() with quoted arguments inside
- * the commandline, this macro is unfortunately an easier workaround.
- */
-#define systemf(command, ...) systemf("\"" command "\"", __VA_ARGS__)
-#endif
-
 DEFINE_TEST(test_option_mtime)
 {
 	/* Create three files with different mtimes. */

--- a/tar/test/test_option_s.c
+++ b/tar/test/test_option_s.c
@@ -46,9 +46,9 @@ DEFINE_TEST(test_option_s)
 	systemf("%s -xf test1_3.tar -C test1", testprog);
 	assertFileContents("foo", 3, "test1/in/d1/f##");
 	// For the 0-length pattern check, remember that "test1/" isn't part of the string affected by the regexp
-	systemf("%s -cf test1_4.tar -s /f*/\\<~\\>/g in/d1/foo", testprog);
+	systemf("%s -cf test1_4.tar -s /f*/[~]/g in/d1/foo", testprog);
 	systemf("%s -xf test1_4.tar -C test1", testprog);
-	assertFileContents("foo", 3, "test1/<>i<>n<>/<>d<>1<>/<f><>o<>o<>");
+	assertFileContents("foo", 3, "test1/[]i[]n[]/[]d[]1[]/[f][]o[]o[]");
 	/*
 	 * Test 2: Basic substitution when extracting archive.
 	 */

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3056,11 +3056,41 @@ systemf(const char *fmt, ...)
 	pid_t pid;
 #endif
 	va_list ap;
+	size_t off = 0, avail = sizeof(buff);
 	int r;
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	/* system() on Windows runs its arguments through CMD.EXE, which has
+	 * notoriously unfriendly quoting rules. The current best documented way around
+	 * them is to wrap your *entire commandline* in sacrificial quotes.
+	 *
+	 * See CMD.EXE /? for more information. Excerpted here:
+	 * | Otherwise, old behavior is to see if the first character is
+	 * | a quote character and if so, strip the leading character and
+	 * | remove the last quote character on the command line, preserving
+	 * | any text after the last quote character.
+	 *
+	 * Since these tests often make use of systemf() with quoted arguments inside
+	 * the commandline, wrap every formatted commandline in quotes.
+	 */
+	avail -= 2;
+	off++;
+	buff[0] = '"';
+#endif
+
 	va_start(ap, fmt);
-	vsnprintf(buff, sizeof(buff), fmt, ap);
+	r = vsnprintf(buff + off, avail, fmt, ap);
 	va_end(ap);
+
+	if (r < 0 || (size_t)r > avail) {
+		return (-1);
+	}
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	buff[off + r] = '"';
+	buff[off + r + 1] = '\0';
+#endif
+
 	if (verbosity > VERBOSITY_FULL)
 		logprintf("Cmd: %s\n", buff);
 #if USE_POSIX_SPAWN


### PR DESCRIPTION
The substitution tests would have failed on MinGW if tar had been built with expat (or another library that affords support for `-s` substitution) for two reasons:

- They were using invalid characters in filesystem paths (on Windows)
- The call to `system` was producing unexpected results (on Windows, also)

A fix for `systemf` was introduced in #2601 (see https://github.com/libarchive/libarchive/pull/2601#issuecomment-2882030686); this pull request generalizes it for _all_ invocations of `systemf` in the test harness. It also switches the substitution test to use characters guaranteed to work on more filesystems.