### PR TITLE
build: windows: get all CI dependencies from a package manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,18 @@ jobs:
           bison zlib-devel libbz2-devel liblzma-devel
           liblz4-devel libiconv-devel libxml2-devel
           libzstd-devel libssl-devel
-    - name: Install mingw
+    - name: Install MinGW (msys2)
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
       if:  ${{ matrix.be=='mingw-gcc' }}
-      run: choco install mingw
-      shell: cmd
+      with:
+        location: "D:\\"
+        install: |-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-binutils
+          mingw-w64-x86_64-pkgconf
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-make
     - name: Install library dependencies
       run: ./build/ci/github_actions/ci.cmd deplibs
       shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,10 @@ jobs:
           mingw-w64-x86_64-pkgconf
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-make
+          mingw-w64-x86_64-zlib
+          mingw-w64-x86_64-bzip2
+          mingw-w64-x86_64-xz
+          mingw-w64-x86_64-zstd
     - name: Install library dependencies
       run: ./build/ci/github_actions/ci.cmd deplibs
       shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,6 @@ jobs:
           mingw-w64-x86_64-bzip2
           mingw-w64-x86_64-xz
           mingw-w64-x86_64-zstd
-    - name: Install library dependencies
-      run: ./build/ci/github_actions/ci.cmd deplibs
-      shell: cmd
-      env:
-        BE: ${{ matrix.be }}
     - name: Configure
       run: ./build/ci/github_actions/ci.cmd configure
       shell: cmd

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -22,7 +22,7 @@ IF "%BE%"=="msvc" (
 
 SET ORIGPATH=%PATH%
 IF "%BE%"=="mingw-gcc" (
-  SET MINGWPATH=C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\cmake\bin;C:\ProgramData\mingw64\mingw64\bin
+  SET MINGWPATH=C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;D:\msys64\mingw64\bin;C:\Program Files\cmake\bin
 )
 
 IF "%1"=="deplibs" (

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -1,7 +1,4 @@
 @ECHO OFF
-SET ZLIB_VERSION=1.3
-SET BZIP2_VERSION=1ea1ac188ad4b9cb662e3f8314673c63df95a589
-SET XZ_VERSION=5.6.3
 IF NOT "%BE%"=="mingw-gcc" (
   IF NOT "%BE%"=="msvc" (
     IF NOT "%BE%"=="cygwin-gcc"  (
@@ -11,84 +8,12 @@ IF NOT "%BE%"=="mingw-gcc" (
   )
 )
 
-REM v1.5.6 has a bug with the CMake files & MSVC
-REM https://github.com/facebook/zstd/issues/3999
-REM Fall back to 1.5.5 for MSVC until fixed
-IF "%BE%"=="msvc" (
-  SET ZSTD_VERSION=1.5.5
-) ELSE (
-  SET ZSTD_VERSION=1.5.6
-)
-
 SET ORIGPATH=%PATH%
 IF "%BE%"=="mingw-gcc" (
   SET MINGWPATH=C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;D:\msys64\mingw64\bin;C:\Program Files\cmake\bin
 )
 
-IF "%1"=="deplibs" (
-  IF NOT "%BE%"=="msvc" (
-    ECHO Library dependencies satisfied by Cygwin or MinGW install
-    EXIT /b 0
-  )
-
-  IF NOT EXIST build_ci\libs (
-    MKDIR build_ci\libs
-  )
-  CD build_ci\libs
-  IF NOT EXIST zlib-%ZLIB_VERSION%.zip (
-    ECHO Downloading https://github.com/libarchive/zlib/archive/v%ZLIB_VERSION%.zip
-    curl -L -o zlib-%ZLIB_VERSION%.zip https://github.com/libarchive/zlib/archive/v%ZLIB_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST zlib-%ZLIB_VERSION% (
-    ECHO Unpacking zlib-%ZLIB_VERSION%.zip
-    C:\windows\system32\tar.exe -x -f zlib-%ZLIB_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST bzip2-%BZIP2_VERSION%.zip (
-    echo Downloading https://github.com/libarchive/bzip2/archive/%BZIP2_VERSION%.zip
-    curl -L -o bzip2-%BZIP2_VERSION%.zip https://github.com/libarchive/bzip2/archive/%BZIP2_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST bzip2-%BZIP2_VERSION% (
-    echo Unpacking bzip2-%BZIP2_VERSION%.zip
-    C:\windows\system32\tar.exe -x -f bzip2-%BZIP2_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST xz-%XZ_VERSION%.zip (
-    echo Downloading https://github.com/libarchive/xz/archive/%XZ_VERSION%.zip
-    curl -L -o xz-%XZ_VERSION%.zip https://github.com/libarchive/xz/archive/v%XZ_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST xz-%XZ_VERSION% (
-    echo Unpacking xz-%XZ_VERSION%.zip
-    C:\windows\system32\tar.exe -x -f xz-%XZ_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST zstd-%ZSTD_VERSION%.zip (
-    echo Downloading https://github.com/facebook/zstd/archive/refs/tags/v%ZSTD_VERSION%.zip
-    curl -L -o zstd-%ZSTD_VERSION%.zip https://github.com/facebook/zstd/archive/refs/tags/v%ZSTD_VERSION%.zip || EXIT /b 1
-  )
-  IF NOT EXIST zstd-%ZSTD_VERSION% (
-    echo Unpacking zstd-%ZSTD_VERSION%.zip
-    C:\windows\system32\tar.exe -x -f zstd-%ZSTD_VERSION%.zip || EXIT /b 1
-  )
-  CD zlib-%ZLIB_VERSION%
-  cmake -G "Visual Studio 17 2022" . || EXIT /b 1
-  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-  cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
-  cmake --build . --target INSTALL --config Release || EXIT /b 1
-  CD ..
-  CD bzip2-%BZIP2_VERSION%
-  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
-  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-  REM cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
-  cmake --build . --target INSTALL --config Release || EXIT /b 1
-  CD ..
-  CD xz-%XZ_VERSION%
-  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-  cmake --build . --target INSTALL --config Release || EXIT /b 1
-  CD ..
-  CD zstd-%ZSTD_VERSION%\build\cmake
-  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-  cmake --build . --target INSTALL --config Release || EXIT /b 1
-) ELSE IF "%1%"=="configure" (
+IF "%1%"=="configure" (
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
     MKDIR build_ci\cmake
@@ -97,7 +22,7 @@ IF "%1"=="deplibs" (
   ) ELSE IF "%BE%"=="msvc" (
     MKDIR build_ci\cmake
     CD build_ci\cmake
-    cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" -D ZLIB_LIBRARY="C:/Program Files (x86)/zlib/lib/zlibstatic.lib" -D ZLIB_INCLUDE_DIR="C:/Program Files (x86)/zlib/include" -D BZIP2_LIBRARIES="C:/Program Files (x86)/bzip2/lib/bz2_static.lib" -D BZIP2_INCLUDE_DIR="C:/Program Files (x86)/bzip2/include" -D LIBLZMA_LIBRARY="C:/Program Files (x86)/xz/lib/lzma.lib" -D LIBLZMA_INCLUDE_DIR="C:/Program Files (x86)/xz/include" -D ZSTD_LIBRARY="C:/Program Files (x86)/zstd/lib/zstd_static.lib" -D ZSTD_INCLUDE_DIR="C:/Program Files (x86)/zstd/include" ..\.. || EXIT /b 1
+    cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" --toolchain "%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" -D VCPKG_TARGET_TRIPLET=x64-windows-static -D VCPKG_MANIFEST_DIR=%GITHUB_WORKSPACE%\build\ci\github_actions ..\.. || EXIT /b 1
   ) ELSE IF "%BE%"=="cygwin-gcc" (
     SET BS=cmake
     SET CYGWIN_NOWINPATH=1

--- a/build/ci/github_actions/ci.cmd
+++ b/build/ci/github_actions/ci.cmd
@@ -26,8 +26,8 @@ IF "%BE%"=="mingw-gcc" (
 )
 
 IF "%1"=="deplibs" (
-  IF "%BE%"=="cygwin-gcc" (
-    ECHO Library dependencies satisfied by Cygwin install
+  IF NOT "%BE%"=="msvc" (
+    ECHO Library dependencies satisfied by Cygwin or MinGW install
     EXIT /b 0
   )
 
@@ -68,62 +68,32 @@ IF "%1"=="deplibs" (
     C:\windows\system32\tar.exe -x -f zstd-%ZSTD_VERSION%.zip || EXIT /b 1
   )
   CD zlib-%ZLIB_VERSION%
-  IF "%BE%"=="mingw-gcc" (
-    SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-    mingw32-make -j %NUMBER_OF_PROCESSORS% || EXIT /b 1
-    mingw32-make test || EXIT /b 1
-    mingw32-make install || EXIT /b 1
-  ) ELSE IF "%BE%"=="msvc" (
-    cmake -G "Visual Studio 17 2022" . || EXIT /b 1
-    cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-    cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
-    cmake --build . --target INSTALL --config Release || EXIT /b 1
-  )
+  cmake -G "Visual Studio 17 2022" . || EXIT /b 1
+  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
+  cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
+  cmake --build . --target INSTALL --config Release || EXIT /b 1
   CD ..
   CD bzip2-%BZIP2_VERSION%
-  IF "%BE%"=="mingw-gcc" (
-    SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
-    mingw32-make -j %NUMBER_OF_PROCESSORS% || EXIT /b 1
-    REM mingw32-make test || EXIT /b 1
-    mingw32-make install || EXIT /b 1
-  ) ELSE IF "%BE%"=="msvc" (
-    cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
-    cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-    REM cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
-    cmake --build . --target INSTALL --config Release || EXIT /b 1
-  )
+  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" -D ENABLE_LIB_ONLY=ON -D ENABLE_SHARED_LIB=OFF -D ENABLE_STATIC_LIB=ON . || EXIT /b 1
+  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
+  REM cmake --build . --target RUN_TESTS --config Release || EXIT /b 1
+  cmake --build . --target INSTALL --config Release || EXIT /b 1
   CD ..
   CD xz-%XZ_VERSION%
-  IF "%BE%"=="mingw-gcc" (
-    SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-    mingw32-make -j %NUMBER_OF_PROCESSORS% || EXIT /b 1
-    mingw32-make install || EXIT /b 1
-  ) ELSE IF "%BE%"=="msvc" (
-    cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-    cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-    cmake --build . --target INSTALL --config Release || EXIT /b 1
-  )
+  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
+  cmake --build . --target INSTALL --config Release || EXIT /b 1
   CD ..
   CD zstd-%ZSTD_VERSION%\build\cmake
-  IF "%BE%"=="mingw-gcc" (
-    SET PATH=%MINGWPATH%
-    cmake -G "MinGW Makefiles" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-    mingw32-make -j %NUMBER_OF_PROCESSORS% || EXIT /b 1
-    mingw32-make install || EXIT /b 1
-  ) ELSE IF "%BE%"=="msvc" (
-    cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
-    cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
-    cmake --build . --target INSTALL --config Release || EXIT /b 1
-  )
+  cmake -G "Visual Studio 17 2022" -D CMAKE_BUILD_TYPE="Release" . || EXIT /b 1
+  cmake --build . --target ALL_BUILD --config Release || EXIT /b 1
+  cmake --build . --target INSTALL --config Release || EXIT /b 1
 ) ELSE IF "%1%"=="configure" (
   IF "%BE%"=="mingw-gcc" (
     SET PATH=%MINGWPATH%
     MKDIR build_ci\cmake
     CD build_ci\cmake
-    cmake -G "MinGW Makefiles" -D ZLIB_LIBRARY="C:/Program Files (x86)/zlib/lib/libzlibstatic.a" -D ZLIB_INCLUDE_DIR="C:/Program Files (x86)/zlib/include" -D BZIP2_LIBRARIES="C:/Program Files (x86)/bzip2/lib/libbz2_static.a" -D BZIP2_INCLUDE_DIR="C:/Program Files (x86)/bzip2/include" -D LIBLZMA_LIBRARY="C:/Program Files (x86)/xz/lib/liblzma.a" -D LIBLZMA_INCLUDE_DIR="C:/Program Files (x86)/xz/include" -D ZSTD_LIBRARY="C:/Program Files (x86)/zstd/lib/libzstd.a" -D ZSTD_INCLUDE_DIR="C:/Program Files (x86)/zstd/include" ..\.. || EXIT /b 1
+    cmake -G "MinGW Makefiles" ..\.. || EXIT /b 1
   ) ELSE IF "%BE%"=="msvc" (
     MKDIR build_ci\cmake
     CD build_ci\cmake

--- a/build/ci/github_actions/vcpkg.json
+++ b/build/ci/github_actions/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": [
+    "zlib",
+    "bzip2",
+    "liblzma",
+    "zstd"
+  ],
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "baseline": "44819aa2a6c10e56065e2b0330e7d6c89d1d2574"
+    }
+  }
+}


### PR DESCRIPTION
Right now, the libarchive organization has mirrors of bzip2, zlib, zstd and xz which it seems to use exclusively for the Windows CI builds.

By switching the mingw build to packages from the msys2-mingw64 repository and the MSVC build to source packages from Microsoft's vcpkg, we may be able to shed our vendored copies of these dependencies. This also brings the other two Windows build environments in line with Cygwin, as well as the Ubuntu and macOS builds.

It should also make it significantly easier in the future to build against new dependencies.

The vcpkg manifest is scoped to the CI build only; it does not convey any indirect dependencies through libarchive when it is consumed as a dependency itself.