### PR TITLE
Use checked size_t arithmetic

### DIFF
--- a/libarchive/archive_integer.h
+++ b/libarchive/archive_integer.h
@@ -112,6 +112,24 @@ archive_ckd_add_i64(int64_t *result, int64_t a, int64_t b)
 
 /* Returns 0 on success, a non-zero value otherwise. */
 static inline int
+archive_ckd_add_size(size_t *result, size_t a, size_t b)
+{
+#if USE_STDCKDINT
+	return ckd_add(result, a, b);
+#elif USE_BUILTIN
+	return __builtin_add_overflow(a, b, result);
+#elif USE_INTSAFE
+	return SizeTAdd(a, b, result);
+#else
+	if (a > SIZE_MAX - b)
+		return 1;
+	*result = a + b;
+	return 0;
+#endif
+}
+
+/* Returns 0 on success, a non-zero value otherwise. */
+static inline int
 archive_ckd_add_u64(uint64_t *result, uint64_t a, uint64_t b)
 {
 #if USE_STDCKDINT
@@ -155,6 +173,24 @@ archive_ckd_mul_i64(int64_t *result, int64_t a, int64_t b)
 	    (a < 0 && b < 0 && a < INT64_MAX / b))
 		return 1;
 
+	*result = a * b;
+	return 0;
+#endif
+}
+
+/* Returns 0 on success, a non-zero value otherwise. */
+static inline int
+archive_ckd_mul_size(size_t *result, size_t a, size_t b)
+{
+#if USE_STDCKDINT
+	return ckd_mul(result, a, b);
+#elif USE_BUILTIN
+	return __builtin_mul_overflow(a, b, result);
+#elif USE_INTSAFE
+	return SizeTMult(a, b, result);
+#else
+	if (b != 0 && a > SIZE_MAX / b)
+		return 1;
 	*result = a * b;
 	return 0;
 #endif

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -40,6 +40,7 @@
 #endif
 
 #include "archive.h"
+#include "archive_integer.h"
 #include "archive_private.h"
 #include "archive_entry.h"
 #include "archive_pathmatch.h"
@@ -1699,18 +1700,18 @@ add_owner_id(struct archive_match *a, struct id_array *ids, int64_t id)
 
 	if (ids->count + 1 >= ids->size) {
 		void *p;
-		size_t new_size;
+		size_t alloc_size, new_size;
 
 		if (ids->size == 0)
 			new_size = 8;
 		else {
-			if (ids->size > SIZE_MAX / 2)
+			if (archive_ckd_mul_size(&new_size, ids->size, 2))
 				return (error_nomem(a));
-			new_size = ids->size * 2;
 		}
-		if (new_size > SIZE_MAX / sizeof(*ids->ids))
+		if (archive_ckd_mul_size(&alloc_size,
+		    new_size, sizeof(*ids->ids)))
 			return (error_nomem(a));
-		p = realloc(ids->ids, sizeof(*ids->ids) * new_size);
+		p = realloc(ids->ids, alloc_size);
 		if (p == NULL)
 			return (error_nomem(a));
 		ids->ids = (int64_t *)p;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -52,6 +52,7 @@
 
 #include "archive.h"
 #include "archive_entry.h"
+#include "archive_integer.h"
 #include "archive_private.h"
 #include "archive_read_private.h"
 
@@ -403,6 +404,7 @@ archive_read_add_callback_data(struct archive *_a, void *client_data,
 {
 	struct archive_read *a = (struct archive_read *)_a;
 	void *p;
+	size_t alloc_size;
 	unsigned int i;
 	unsigned int nodes;
 
@@ -415,15 +417,15 @@ archive_read_add_callback_data(struct archive *_a, void *client_data,
 	}
 
 	if (a->client.nodes == UINT_MAX ||
-	    (size_t)a->client.nodes + 1 >
-	    SIZE_MAX / sizeof(*a->client.dataset)) {
+	    archive_ckd_mul_size(&alloc_size,
+	    (size_t)a->client.nodes + 1, sizeof(*a->client.dataset))) {
 		archive_set_error(&a->archive, ENOMEM,
 			"No memory");
 		return ARCHIVE_FATAL;
 	}
 
 	nodes = a->client.nodes + 1;
-	p = realloc(a->client.dataset, sizeof(*a->client.dataset) * nodes);
+	p = realloc(a->client.dataset, alloc_size);
 	if (p == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 			"No memory");

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -44,6 +44,7 @@
 
 #include "archive.h"
 #include "archive_endian.h"
+#include "archive_integer.h"
 #include "archive_private.h"
 #include "archive_read_private.h"
 #include "archive_xxhash.h"
@@ -175,6 +176,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 	magic_number = archive_le32dec(buffer);
 
 	while ((magic_number & LZ4_SKIPPABLE_MASK) == LZ4_SKIPPABLE_START) {
+		size_t min;
 		uint32_t frame_data_size;
 
 		/* Skip over the magic number */
@@ -194,24 +196,24 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 		offset_in_buffer += 4;
 
 		/* Skip over the value stored there. */
-		if (frame_data_size > SIZE_MAX - offset_in_buffer)
+		if (archive_ckd_add_size(&offset_in_buffer,
+		    offset_in_buffer, frame_data_size))
 			return (0);
-		offset_in_buffer += frame_data_size;
 
 		/*
 		 * There should be at least one more frame
 		 * if this is LZ4 data.
 		 */
-		if (min_lz4_frame_size > SIZE_MAX - offset_in_buffer)
+		if (archive_ckd_add_size(&min,
+		    offset_in_buffer, min_lz4_frame_size))
 			return (0);
 		/* TODO: should this be >= ? */
-		if (offset_in_buffer + min_lz4_frame_size > (size_t)avail) {
-			if (offset_in_buffer + min_lz4_frame_size >
-			    max_lookahead)
+		if (min > (size_t)avail) {
+			if (min > max_lookahead)
 				return (0); 
 
 			buffer = __archive_read_filter_ahead(filter,
-			    offset_in_buffer + min_lz4_frame_size, &avail);
+			    min, &avail);
 			if (buffer == NULL)
 				return (0); 
 		}

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -48,6 +48,7 @@
 
 #include "archive.h"
 #include "archive_endian.h"
+#include "archive_integer.h"
 #include "archive_private.h"
 #include "archive_read_private.h"
 
@@ -142,6 +143,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 
 	while ((magic_number & zstd_magic_skippable_mask) ==
 	    zstd_magic_skippable_start) {
+		size_t min;
 		uint32_t frame_data_size;
 
 		/* Skip over the magic number */
@@ -161,23 +163,23 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 		offset_in_buffer += 4;
 
 		/* Skip over the value stored there. */
-		if (frame_data_size > SIZE_MAX - offset_in_buffer)
+		if (archive_ckd_add_size(&offset_in_buffer,
+		    offset_in_buffer, frame_data_size))
 			return (0);
-		offset_in_buffer += frame_data_size;
 
 		/*
 		 * There should be at least one more frame
 		 * if this is zstd data.
 		 */
-		if (min_zstd_frame_size > SIZE_MAX - offset_in_buffer)
+		if (archive_ckd_add_size(&min,
+		    offset_in_buffer, min_zstd_frame_size))
 			return (0);
-		if (offset_in_buffer + min_zstd_frame_size > (size_t)avail) {
-			if (offset_in_buffer + min_zstd_frame_size >
-			    max_lookahead)
+		if (min > (size_t)avail) {
+			if (min > max_lookahead)
 				return (0);
 
 			buffer = __archive_read_filter_ahead(filter,
-			    offset_in_buffer + min_zstd_frame_size, &avail);
+			    min, &avail);
 			if (buffer == NULL)
 				return (0);
 		}

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -40,6 +40,7 @@
 #include "archive.h"
 #include "archive_entry.h"
 #include "archive_entry_locale.h"
+#include "archive_integer.h"
 #include "archive_private.h"
 #include "archive_write_private.h"
 #include "archive_write_set_format_private.h"
@@ -1935,17 +1936,17 @@ url_encode(const char *in)
 
 	for (s = in; *s != '\0'; s++) {
 		if (*s < 33 || *s > 126 || *s == '%' || *s == '=') {
-			if (SIZE_MAX - out_len < 4)
+			if (archive_ckd_add_size(&out_len, out_len, 3))
 				return (NULL);
-			out_len += 3;
 		} else {
-			if (SIZE_MAX - out_len < 2)
+			if (archive_ckd_add_size(&out_len, out_len, 1))
 				return (NULL);
-			out_len++;
 		}
 	}
 
-	out = malloc(out_len + 1);
+	if (archive_ckd_add_size(&out_len, out_len, 1))
+		return (NULL);
+	out = malloc(out_len);
 	if (out == NULL)
 		return (NULL);
 


### PR DESCRIPTION
Add `archive_ckd_add_size` and `archive_ckd_mul_size`. Use them for checked arithmetic throughout the source code where explicit `SIZE_MAX` checks were performed.

There are more cases in which we check for size overflows (by checking if the result is smaller than one of the used values), but let's start with the very obvious cases here.