### PR TITLE
xattr/sparse: Fix UAF by nullifying pointer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -708,6 +708,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_zip_zip64.c \
 	libarchive/test/test_write_open_memory.c \
 	libarchive/test/test_write_read_format_zip.c \
+	libarchive/test/test_xattr_clear.c \
 	libarchive/test/test_xattr_platform.c \
 	libarchive/test/test_zip_filename_encoding.c
 libarchive_test_CPPFLAGS= \

--- a/libarchive/archive_entry_sparse.c
+++ b/libarchive/archive_entry_sparse.c
@@ -46,6 +46,7 @@ archive_entry_sparse_clear(struct archive_entry *entry)
 		entry->sparse_head = sp;
 	}
 	entry->sparse_tail = NULL;
+	entry->sparse_p = NULL;
 }
 
 void

--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -82,6 +82,7 @@ archive_entry_xattr_clear(struct archive_entry *entry)
 	}
 
 	entry->xattr_head = NULL;
+	entry->xattr_p = NULL;
 }
 
 void

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -340,6 +340,7 @@ IF(ENABLE_TEST)
     test_write_format_zip_zip64.c
     test_write_open_memory.c
     test_write_read_format_zip.c
+    test_xattr_clear.c
     test_xattr_platform.c
     test_zip_filename_encoding.c
   )

--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -721,3 +721,28 @@ DEFINE_TEST(test_sparse_iterator)
 
 	archive_entry_free(entry);
 }
+
+DEFINE_TEST(test_sparse_clear)
+{
+	struct archive_entry *entry;
+	la_int64_t offset, length;
+
+	entry = archive_entry_new();
+	archive_entry_set_size(entry, 1024);
+
+	/* Add two sparse blocks */
+	archive_entry_sparse_add_entry(entry, 0, 16);
+	archive_entry_sparse_add_entry(entry, 123, 16);
+
+	/* Set iterator to head */
+	archive_entry_sparse_reset(entry);
+
+	/* Clear the two blocks */
+	archive_entry_sparse_clear(entry);
+
+	assertEqualInt(0, archive_entry_sparse_count(entry));
+	assertEqualInt(ARCHIVE_WARN,
+		archive_entry_sparse_next(entry, &offset, &length));
+
+	archive_entry_free(entry);
+}

--- a/libarchive/test/test_xattr_clear.c
+++ b/libarchive/test/test_xattr_clear.c
@@ -1,0 +1,60 @@
+/*-
+ * Copyright (c) 2003-2007 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+DEFINE_TEST(test_xattr_clear)
+{
+	struct archive_entry *entry;
+	const char *xname;
+	const void *xval;
+	size_t xsize;
+
+	assert((entry = archive_entry_new()) != NULL);
+
+	/* Add an entry */
+	archive_entry_xattr_add_entry(entry, "xattr1", "value1", 7);
+
+	/* Set iterator to head */
+	assertEqualInt(1, archive_entry_xattr_reset(entry));
+
+	assertEqualInt(ARCHIVE_OK,
+		archive_entry_xattr_next(entry, &xname, &xval, &xsize));
+	assertEqualString(xname, "xattr1");
+	assertEqualString(xval, "value1");
+	assertEqualInt((int)xsize, 7);
+
+	/* Reset iterator to head */
+	assertEqualInt(1, archive_entry_xattr_reset(entry));
+
+	/* Clear xattr list */
+	archive_entry_xattr_clear(entry);
+
+	assertEqualInt(ARCHIVE_WARN,
+		archive_entry_xattr_next(entry, &xname, &xval, &xsize));
+	assertEqualString(xname, NULL);
+	assertEqualString(xval, NULL);
+	assertEqualInt((int)xsize, 0);
+	archive_entry_free(entry);
+}


### PR DESCRIPTION
Migrated from GHSA-276x-h974-wm2f, as GitHub is experiencing a partial outage in mergeability for advisory branches.