### PR TITLE
Add archive_write_header_position() symmetric to archive_read_header_position()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -719,6 +719,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_zip_windows_path.c \
 	libarchive/test/test_write_format_zip_zip64.c \
 	libarchive/test/test_write_open_memory.c \
+	libarchive/test/test_write_position.c \
 	libarchive/test/test_write_read_format_zip.c \
 	libarchive/test/test_xattr_clear.c \
 	libarchive/test/test_xattr_platform.c \

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -611,6 +611,12 @@ __LA_DECL int archive_read_next_header2(struct archive *,
 __LA_DECL la_int64_t		 archive_read_header_position(struct archive *);
 
 /*
+ * Retrieve the byte offset in the format output stream where the
+ * last-written header started.
+ */
+__LA_DECL la_int64_t		 archive_write_header_position(struct archive *);
+
+/*
  * Returns 1 if the archive contains at least one encrypted entry.
  * If the archive format not support encryption at all
  * ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED is returned.

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -778,6 +778,9 @@ _archive_write_header(struct archive *_a, struct archive_entry *entry)
 	if (r2 < ret)
 		ret = r2;
 
+	/* Record start-of-header offset in format output stream. */
+	a->header_position = a->filter_first->bytes_written;
+
 	/* Format and write header. */
 	r2 = ((a->format_write_header)(a, entry));
 	if (r2 == ARCHIVE_FAILED) {
@@ -870,4 +873,17 @@ _archive_filter_bytes(struct archive *_a, int n)
 {
 	struct archive_write_filter *f = filter_lookup(_a, n);
 	return f == NULL ? -1 : f->bytes_written;
+}
+
+/*
+ * Return the byte offset in the format output stream where the
+ * last-written header started.  Symmetric with archive_read_header_position().
+ */
+la_int64_t
+archive_write_header_position(struct archive *_a)
+{
+	struct archive_write *a = (struct archive_write *)_a;
+	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	    ARCHIVE_STATE_ANY, "archive_write_header_position");
+	return (a->header_position);
 }

--- a/libarchive/archive_write_private.h
+++ b/libarchive/archive_write_private.h
@@ -124,6 +124,9 @@ struct archive_write {
 	int	(*format_free)(struct archive_write *);
 
 
+	/* Byte offset in format stream where last-written header started. */
+	int64_t		  header_position;
+
 	/*
 	 * Encryption passphrase.
 	 */

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -350,6 +350,7 @@ IF(ENABLE_TEST)
     test_write_format_zip_windows_path.c
     test_write_format_zip_zip64.c
     test_write_open_memory.c
+    test_write_position.c
     test_write_read_format_zip.c
     test_xattr_clear.c
     test_xattr_platform.c

--- a/libarchive/test/test_write_position.c
+++ b/libarchive/test/test_write_position.c
@@ -1,0 +1,88 @@
+/*-
+ * Copyright (c) 2003-2007 Tim Kientzle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+static unsigned char nulls[1000];
+static unsigned char buff[32768];
+static size_t data_sizes[] = {0, 5, 511, 512, 513};
+
+/* Check that archive_write_header_position() tracks correctly on write. */
+DEFINE_TEST(test_write_position)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	size_t write_pos;
+	size_t i;
+	int64_t expected_pos;
+	int64_t write_positions[sizeof(data_sizes)/sizeof(data_sizes[0])];
+
+	assert(sizeof(nulls) + 512 <= sizeof(buff));
+
+	/* Create an archive and record positions at each archive_write_header(). */
+	assert(NULL != (a = archive_write_new()));
+	assertA(0 == archive_write_set_format_pax_restricted(a));
+	assertA(0 == archive_write_set_bytes_per_block(a, 512));
+	assertA(0 == archive_write_open_memory(a, buff, sizeof(buff), &write_pos));
+
+	expected_pos = 0;
+	for (i = 0; i < sizeof(data_sizes)/sizeof(data_sizes[0]); ++i) {
+		assert((ae = archive_entry_new()) != NULL);
+		archive_entry_set_pathname(ae, "testfile");
+		archive_entry_set_mode(ae, S_IFREG);
+		archive_entry_set_size(ae, data_sizes[i]);
+		assertA(0 == archive_write_header(a, ae));
+		archive_entry_free(ae);
+
+		/* Position captured after archive_write_header() should equal
+		 * expected byte offset of this header in the format stream. */
+		assertEqualInt(expected_pos,
+		    (intmax_t)archive_write_header_position(a));
+		write_positions[i] = archive_write_header_position(a);
+
+		assertA(data_sizes[i]
+		    == (size_t)archive_write_data(a, nulls, sizeof(nulls)));
+
+		expected_pos += 512; /* header block */
+		expected_pos += (data_sizes[i] + 511) & ~511; /* data blocks */
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/*
+	 * Read the archive back and verify write positions match read positions.
+	 */
+	assert(NULL != (a = archive_read_new()));
+	assertA(0 == archive_read_support_format_tar(a));
+	assertA(0 == read_open_memory(a, buff, sizeof(buff), 512));
+
+	for (i = 0; i < sizeof(data_sizes)/sizeof(data_sizes[0]); ++i) {
+		assertA(0 == archive_read_next_header(a, &ae));
+		assertEqualInt(write_positions[i],
+		    (intmax_t)archive_read_header_position(a));
+		assertA(0 == archive_read_data_skip(a));
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	archive_read_free(a);
+}


### PR DESCRIPTION
When writing an archive, there is currently no way to know the byte offset of a header in the format output stream at the time it is written. This makes it impossible to build an index of header positions during a write pass — for example, to record block offsets for use in tape positioning, sparse archive indexing, or LTFS-style catalogues.

This patch adds archive_write_header_position(), which returns the byte offset in the uncompressed format stream where the last-written header started. It is the write-side counterpart to the existing archive_read_header_position()

# Implementation:

struct archive_write gains an int64_t header_position field. In _archive_write_header(), it is captured from filter_first->bytes_written after finish_entry() has flushed the previous entry's trailing padding and before format_write_header() emits the new header bytes — the precise moment the value equals the new header's offset in the stream.

This correctly handles PAX extended headers automatically (it measures emitted bytes rather than reconstructing from entry sizes), and matches the semantics of archive_read_header_position() on read-back of the same archive.

Under a compression filter the value is the position in the uncompressed format stream, consistent with the read-side behaviour.

# Testing:

A new test test_write_position writes a multi-entry tar archive with varying data sizes, asserts that archive_write_header_position() returns the expected offset after each archive_write_header(), then reads the archive back and cross-validates each write-side position against archive_read_header_position().