### PR TITLE
Avoid 0 as error code

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -895,7 +895,8 @@ header_afiol(struct archive_read *a, struct cpio *cpio,
 
 	t = atol16(header + afiol_filesize_offset, afiol_filesize_size);
 	if (t < 0) {
-		archive_set_error(&a->archive, 0, "Nonsensical file size");
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Nonsensical file size");
 		return (ARCHIVE_FATAL);
 	}
 	cpio->entry_bytes_remaining = t;
@@ -919,7 +920,7 @@ header_bin_le(struct archive_read *a, struct cpio *cpio,
 	/* Read fixed-size portion of header. */
 	h = __archive_read_ahead(a, bin_header_size, NULL);
 	if (h == NULL) {
-	    archive_set_error(&a->archive, 0,
+	    archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		"End of file trying to read next cpio header");
 	    return (ARCHIVE_FATAL);
 	}
@@ -964,7 +965,7 @@ header_bin_be(struct archive_read *a, struct cpio *cpio,
 	/* Read fixed-size portion of header. */
 	h = __archive_read_ahead(a, bin_header_size, NULL);
 	if (h == NULL) {
-	    archive_set_error(&a->archive, 0,
+	    archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		"End of file trying to read next cpio header");
 	    return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -761,7 +761,7 @@ _archive_write_header(struct archive *_a, struct archive_entry *entry)
 	    archive_entry_ino_is_set(entry) &&
 	    archive_entry_dev(entry) == (dev_t)a->skip_file_dev &&
 	    archive_entry_ino64(entry) == a->skip_file_ino) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EIO,
 		    "Can't add archive to itself");
 		return (ARCHIVE_FAILED);
 	}

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -976,7 +976,7 @@ write_data_block(struct archive_write_disk *a, const char *buff, size_t size)
 		return (ARCHIVE_OK);
 
 	if (a->filesize == 0 || a->fd < 0) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EIO,
 		    "Attempt to write to an empty file");
 		return (ARCHIVE_WARN);
 	}
@@ -1600,7 +1600,7 @@ hfs_write_data_block(struct archive_write_disk *a, const char *buff,
 		return (ARCHIVE_OK);
 
 	if (a->filesize == 0 || a->fd < 0) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EIO,
 		    "Attempt to write to an empty file");
 		return (ARCHIVE_WARN);
 	}
@@ -1679,7 +1679,7 @@ _archive_write_disk_data_block(struct archive *_a,
 	if (r < ARCHIVE_OK)
 		return (r);
 	if ((size_t)r < size) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EOVERFLOW,
 		    "Too much data: Truncating file at %ju bytes",
 		    (uintmax_t)a->filesize);
 		return (ARCHIVE_WARN);
@@ -2201,7 +2201,7 @@ restore_entry(struct archive_write_disk *a)
 		if (a->skip_file_set &&
 		    a->st.st_dev == (dev_t)a->skip_file_dev &&
 		    a->st.st_ino == (ino_t)a->skip_file_ino) {
-			archive_set_error(&a->archive, 0,
+			archive_set_error(&a->archive, EIO,
 			    "Refusing to overwrite archive");
 			return (ARCHIVE_FAILED);
 		}
@@ -3001,7 +3001,7 @@ check_symlinks_fsobj(char *path, int *a_eno, struct archive_string *a_estr,
 				 */
 				/*
 				if (!S_ISLNK(path)) {
-					fsobj_error(a_eno, a_estr, 0,
+					fsobj_error(a_eno, a_estr, -1,
 					    "Removing symlink ", path);
 				}
 				*/
@@ -3017,7 +3017,7 @@ check_symlinks_fsobj(char *path, int *a_eno, struct archive_string *a_estr,
 #endif
 				if (r != 0) {
 					tail[0] = c;
-					fsobj_error(a_eno, a_estr, 0,
+					fsobj_error(a_eno, a_estr, EIO,
 					    "Cannot remove intervening "
 					    "symlink ", path);
 					res = ARCHIVE_FAILED;
@@ -3077,7 +3077,7 @@ check_symlinks_fsobj(char *path, int *a_eno, struct archive_string *a_estr,
 					head = tail + 1;
 				} else {
 					tail[0] = c;
-					fsobj_error(a_eno, a_estr, 0,
+					fsobj_error(a_eno, a_estr, ELOOP,
 					    "Cannot extract through "
 					    "symlink ", path);
 					res = ARCHIVE_FAILED;
@@ -3085,7 +3085,7 @@ check_symlinks_fsobj(char *path, int *a_eno, struct archive_string *a_estr,
 				}
 			} else {
 				tail[0] = c;
-				fsobj_error(a_eno, a_estr, 0,
+				fsobj_error(a_eno, a_estr, ELOOP,
 				    "Cannot extract through symlink ", path);
 				res = ARCHIVE_FAILED;
 				break;

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1049,7 +1049,7 @@ write_data_block(struct archive_write_disk *a, const char *buff, size_t size)
 		return (ARCHIVE_OK);
 
 	if (a->filesize == 0 || a->fh == INVALID_HANDLE_VALUE) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EIO,
 		    "Attempt to write to an empty file");
 		return (ARCHIVE_WARN);
 	}
@@ -1133,7 +1133,7 @@ _archive_write_disk_data_block(struct archive *_a,
 	if (r < ARCHIVE_OK)
 		return (r);
 	if ((size_t)r < size) {
-		archive_set_error(&a->archive, 0,
+		archive_set_error(&a->archive, EOVERFLOW,
 		    "Write request too large");
 		return (ARCHIVE_WARN);
 	}
@@ -1550,7 +1550,7 @@ restore_entry(struct archive_write_disk *a)
 		if (a->skip_file_set &&
 		    bhfi_dev(&a->st) == a->skip_file_dev &&
 		    bhfi_ino(&a->st) == a->skip_file_ino) {
-			archive_set_error(&a->archive, 0,
+			archive_set_error(&a->archive, EIO,
 			    "Refusing to overwrite archive");
 			return (ARCHIVE_FAILED);
 		}
@@ -2141,7 +2141,7 @@ check_symlinks(struct archive_write_disk *a)
 				 * symlink with another symlink.
 				 */
 				if (!S_ISLNK(a->mode)) {
-					archive_set_error(&a->archive, 0,
+					archive_set_error(&a->archive, -1,
 					    "Removing symlink %ls",
 					    a->name);
 				}
@@ -2161,7 +2161,7 @@ check_symlinks(struct archive_write_disk *a)
 					r = disk_unlink(a->name);
 				}
 				if (r != 0) {
-					archive_set_error(&a->archive, 0,
+					archive_set_error(&a->archive, EIO,
 					    "Cannot remove intervening "
 					    "symlink %ls", a->name);
 					pn[0] = c;
@@ -2169,7 +2169,7 @@ check_symlinks(struct archive_write_disk *a)
 				}
 				a->pst = NULL;
 			} else {
-				archive_set_error(&a->archive, 0,
+				archive_set_error(&a->archive, ELOOP,
 				    "Cannot extract through symlink %ls",
 				    a->name);
 				pn[0] = c;

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -841,7 +841,8 @@ copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 			return (ARCHIVE_FATAL);
 		}
 		if (rs == 0) {
-			archive_set_error(&(a->archive), 0,
+			archive_set_error(&(a->archive),
+			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated 7-Zip archive");
 			return (ARCHIVE_FATAL);
 		}

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -1864,7 +1864,8 @@ copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 			return (ARCHIVE_FATAL);
 		}
 		if (rs == 0) {
-			archive_set_error(&(a->archive), 0,
+			archive_set_error(&(a->archive),
+			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Truncated xar archive");
 			return (ARCHIVE_FATAL);
 		}


### PR DESCRIPTION
Do not set 0 as error code, since this will be printed as success. Use proper error codes in various places for better error messages.

Proof of Concept:

1. Create a temporary directory with conflicting symlink
```
BASE=$(mktemp -d)
cd $BASE
mkdir -p dest/c; ln -s c dest/a
```
2. Try to extract an archive into dest
```
mkdir -p a/b
bsdtar -c a/b | bsdtar -xC dest
```
```
a/b/: Cannot extract through symlink a/b: Success
bsdtar: Error exit delayed from previous errors
```