### PR TITLE
unzip: Skip another test if zlib unavailable

### DIFF
--- a/unzip/test/test_P_encryption.c
+++ b/unzip/test/test_P_encryption.c
@@ -9,6 +9,7 @@
 /* Test P arg - password protected */
 DEFINE_TEST(test_P_encryption)
 {
+#ifdef HAVE_LIBZ
 	const char *reffile = "test_encrypted.zip";
 	int r;
 
@@ -23,4 +24,7 @@ DEFINE_TEST(test_P_encryption)
 
 		assertTextFileContents("plaintext\n", "encrypted/file.txt");
 	}
+#else
+	skipping("zlib not available");
+#endif
 }


### PR DESCRIPTION
The input file in `test_P_encryption` uses deflate, which is only available if zlib is available. Skip the test if built without zlib.

This previously slipped through because I basically disabled everything, including cryptography libraries -- which the test properly checks.