### PR TITLE
cpio: fix OOB read from int pathlength truncation in newc/binary writers

### DIFF
--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -380,12 +380,12 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 {
 	struct cpio *cpio;
 	const char *p, *path;
-	int pathlength, ret, ret_final;
+	int ret, ret_final;
 	int64_t	ino;
 	struct cpio_binary_header h;
 	struct archive_string_conv *sconv;
 	struct archive_entry *entry_main;
-	size_t len;
+	size_t len, pathlength;
 
 	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
@@ -423,7 +423,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		ret_final = ARCHIVE_WARN;
 	}
 	/* Include trailing null */
-	pathlength = (int)len + 1;
+	pathlength = len + 1;
 
 	h.h_magic = la_swap16(070707);
 	h.h_dev = la_swap16(archive_entry_dev(entry));
@@ -472,7 +472,13 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		h.h_majmin = 0;
 
 	h.h_mtime = la_swap32((uint32_t)archive_entry_mtime(entry));
-	h.h_namesize = la_swap16(pathlength);
+	if (pathlength > 0xffff) {
+		archive_set_error(&a->archive, ERANGE,
+		    "Filename is too long for cpio format");
+		ret_final = ARCHIVE_FAILED;
+		goto exit_write_header;
+	}
+	h.h_namesize = la_swap16((uint16_t)pathlength);
 
 	/* Non-regular files don't store bodies. */
 	if (archive_entry_filetype(entry) != AE_IFREG)

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -219,11 +219,11 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	int64_t ino;
 	struct cpio *cpio;
 	const char *p, *path;
-	int pathlength, ret, ret_final;
+	int ret, ret_final;
 	char h[c_header_size];
 	struct archive_string_conv *sconv;
 	struct archive_entry *entry_main;
-	size_t len;
+	size_t len, pathlength;
 	int pad;
 
 	cpio = (struct cpio *)a->format_data;
@@ -261,7 +261,7 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 		    archive_string_conversion_charset_name(sconv));
 		ret_final = ARCHIVE_WARN;
 	}
-	pathlength = (int)len + 1; /* Include trailing null. */
+	pathlength = len + 1; /* Include trailing null. */
 
 	memset(h, 0, c_header_size);
 	format_hex(0x070701, h + c_magic_offset, c_magic_size);
@@ -292,7 +292,12 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	    format_hex(0, h + c_rdevminor_offset, c_rdevminor_size);
 	}
 	format_hex(archive_entry_mtime(entry), h + c_mtime_offset, c_mtime_size);
-	format_hex(pathlength, h + c_namesize_offset, c_namesize_size);
+	if (format_hex(pathlength, h + c_namesize_offset, c_namesize_size)) {
+		archive_set_error(&a->archive, ERANGE,
+		    "Filename is too long for cpio format");
+		ret_final = ARCHIVE_FAILED;
+		goto exit_write_header;
+	}
 	format_hex(0, h + c_checksum_offset, c_checksum_size);
 
 	/* Non-regular files don't store bodies. */


### PR DESCRIPTION
The newc and binary cpio writers size the pathname field as len + 1, where len is the size_t pathname length, but keep the result in an int with pathlength = (int)len + 1. A pathname longer than INT_MAX wraps that int negative, and because __archive_write_output takes a size_t length the negative value widens back into a huge count, so the trailing write of path reads far past the buffer. The same truncated value also feeds the namesize header field, which silently clamps. I noticed it reading 26980cc, which fixed the identical conversion in the odc writer but left these two siblings as they were. Switching pathlength to size_t in both keeps the value correct, and I made the oversize case fail up front: newc now checks the format_hex return the way odc checks format_octal, and binary rejects a name that will not fit its 16-bit namesize field. The existing cpio write tests stay green.