### PR TITLE
Add bsdtar --xattrs-include / --xattrs-exclude name filtering

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1331,6 +1331,7 @@ bsdtar_test_SOURCES= \
 	tar/test/test_option_uid_uname.c \
 	tar/test/test_option_uuencode.c \
 	tar/test/test_option_xattrs.c \
+	tar/test/test_option_xattrs_filter.c \
 	tar/test/test_option_xz.c \
 	tar/test/test_option_z.c \
 	tar/test/test_option_zstd.c \

--- a/tar/CMakeLists.txt
+++ b/tar/CMakeLists.txt
@@ -20,6 +20,8 @@ IF(ENABLE_TAR)
     write.c
     ../libarchive_fe/lafe_err.c
     ../libarchive_fe/lafe_err.h
+    ../libarchive_fe/lafe_fnmatch.c
+    ../libarchive_fe/lafe_fnmatch.h
     ../libarchive_fe/lafe_platform.h
     ../libarchive_fe/line_reader.c
     ../libarchive_fe/line_reader.h

--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -1012,6 +1012,31 @@ This is the reverse of
 and the default behavior in c, r, and u modes or if
 .Nm
 is run in x mode as root.
+.It Fl Fl xattrs-exclude Ar pattern
+(c, r, u, x modes only)
+Do not archive or extract extended attributes whose name matches the
+shell-style
+.Ar pattern .
+May be specified more than once.
+The pattern is matched against the whole attribute name, so
+.Dq Li security.selinux
+excludes exactly that attribute while
+.Dq Li security.\&*
+excludes the whole namespace.
+This is useful to keep host-specific attributes such as SELinux labels
+out of an archive while preserving others such as
+.Dq Li security.capability .
+Exclusion takes precedence over
+.Fl Fl xattrs-include .
+.It Fl Fl xattrs-include Ar pattern
+(c, r, u, x modes only)
+Only archive or extract extended attributes whose name matches the
+shell-style
+.Ar pattern .
+May be specified more than once.
+When no include pattern is given, all attributes (subject to
+.Fl Fl xattrs-exclude )
+are processed.
 .It Fl y
 (c mode only)
 Compress the resulting archive with

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -104,6 +104,7 @@ need_report(void)
 static __LA_NORETURN void		 long_help(void);
 static void		 only_mode(struct bsdtar *, const char *opt,
 			     const char *valid);
+static void		 add_xattr_match(struct xattr_match **, const char *);
 static void		 set_mode(struct bsdtar *, int opt);
 static __LA_NORETURN void		 version(void);
 
@@ -830,6 +831,14 @@ main(int argc, char **argv)
 			bsdtar->readdisk_flags &= ~ARCHIVE_READDISK_NO_XATTR;
 			bsdtar->flags |= OPTFLAG_XATTRS;
 			break;
+		case OPTION_XATTRS_EXCLUDE: /* GNU tar */
+			add_xattr_match(&bsdtar->xattr_exclude,
+			    bsdtar->argument);
+			break;
+		case OPTION_XATTRS_INCLUDE: /* GNU tar */
+			add_xattr_match(&bsdtar->xattr_include,
+			    bsdtar->argument);
+			break;
 		case 'y': /* FreeBSD version of GNU tar */
 			if (compression != '\0')
 				lafe_errc(1, 0,
@@ -1037,6 +1046,26 @@ set_mode(struct bsdtar *bsdtar, int opt)
 		lafe_errc(1, 0,
 		    "Can't specify both -%c and -%c", opt, bsdtar->mode);
 	bsdtar->mode = opt;
+}
+
+/*
+ * Append a --xattrs-include / --xattrs-exclude pattern.  The pattern points
+ * into argv, which outlives the lists, so it is stored without copying; the
+ * lists are applied to the read/write-disk objects in write.c and read.c.
+ */
+static void
+add_xattr_match(struct xattr_match **list, const char *pattern)
+{
+	struct xattr_match *m, **tail;
+
+	m = malloc(sizeof(*m));
+	if (m == NULL)
+		lafe_errc(1, 0, "Out of memory");
+	m->pattern = pattern;
+	m->next = NULL;
+	for (tail = list; *tail != NULL; tail = &(*tail)->next)
+		;
+	*tail = m;
 }
 
 /*

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -31,6 +31,12 @@ struct creation_set;
  * pointer to this structure is passed to most bsdtar internal
  * functions.
  */
+/* A --xattrs-include / --xattrs-exclude pattern (points into argv). */
+struct xattr_match {
+	struct xattr_match	*next;
+	const char		*pattern;
+};
+
 struct bsdtar {
 	/* Options */
 	const char	 *filename; /* -f filename */
@@ -42,6 +48,8 @@ struct bsdtar {
 	unsigned int	  flags; /* Bitfield of boolean options */
 	int		  extract_flags; /* Flags for extract operation */
 	int		  readdisk_flags; /* Flags for read disk operation */
+	struct xattr_match *xattr_include; /* --xattrs-include patterns */
+	struct xattr_match *xattr_exclude; /* --xattrs-exclude patterns */
 	int		  strip_components; /* Remove this many leading dirs */
 	int		  gid;  /* --gid */
 	const char	 *gname; /* --gname */
@@ -183,6 +191,8 @@ enum {
 	OPTION_UUENCODE,
 	OPTION_VERSION,
 	OPTION_XATTRS,
+	OPTION_XATTRS_EXCLUDE,
+	OPTION_XATTRS_INCLUDE,
 	OPTION_ZSTD,
 	OPTION_MTIME,
 	OPTION_CLAMP_MTIME,
@@ -192,6 +202,7 @@ int	bsdtar_getopt(struct bsdtar *);
 void	do_chdir(struct bsdtar *);
 int	edit_pathname(struct bsdtar *, struct archive_entry *);
 void	edit_mtime(struct bsdtar *, struct archive_entry *);
+void	edit_xattrs(struct bsdtar *, struct archive_entry *);
 int	need_report(void);
 int	pathcmp(const char *a, const char *b);
 void	safe_fprintf(FILE * ARCHIVE_RESTRICT, const char * ARCHIVE_RESTRICT fmt, ...) __LA_PRINTF(2, 3);

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -149,6 +149,8 @@ static const struct bsdtar_option {
 	{ "verbose",              0, 'v' },
 	{ "version",              0, OPTION_VERSION },
 	{ "xattrs",               0, OPTION_XATTRS },
+	{ "xattrs-exclude",       1, OPTION_XATTRS_EXCLUDE },
+	{ "xattrs-include",       1, OPTION_XATTRS_INCLUDE },
 	{ "xz",                   0, 'J' },
 	{ "zstd",                 0, OPTION_ZSTD },
 	{ NULL, 0, 0 }

--- a/tar/read.c
+++ b/tar/read.c
@@ -336,6 +336,9 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 			if (edit_pathname(bsdtar, entry))
 				continue; /* Excluded by a rewrite failure. */
 
+			/* Apply --xattrs-include / --xattrs-exclude masks. */
+			edit_xattrs(bsdtar, entry);
+
 			if ((bsdtar->flags & OPTFLAG_INTERACTIVE) &&
 			    !yes("extract '%s'", archive_entry_pathname(entry)))
 				continue;

--- a/tar/test/CMakeLists.txt
+++ b/tar/test/CMakeLists.txt
@@ -73,6 +73,7 @@ IF(ENABLE_TAR AND ENABLE_TEST)
     test_option_uid_uname.c
     test_option_uuencode.c
     test_option_xattrs.c
+    test_option_xattrs_filter.c
     test_option_xz.c
     test_option_z.c
     test_option_zstd.c

--- a/tar/test/test_option_xattrs_filter.c
+++ b/tar/test/test_option_xattrs_filter.c
@@ -1,0 +1,81 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Nikolay Bryskin
+ * All rights reserved.
+ */
+#include "test.h"
+
+/*
+ * Exercise --xattrs-exclude / --xattrs-include name filtering on both the
+ * create (read-disk) and extract (write-disk) sides.  Two user.* attributes
+ * are used so the test needs no special privileges; the filtering code path
+ * is namespace-agnostic (the motivating case is dropping security.selinux
+ * while keeping security.capability).
+ */
+DEFINE_TEST(test_option_xattrs_filter)
+{
+#if !ARCHIVE_XATTR_SUPPORT
+	skipping("Extended attributes are not supported on this platform");
+#else	/* ARCHIVE_XATTR_SUPPORT */
+	const char *keep = "user.libarchive.keep";
+	const char *drop = "user.libarchive.drop";
+	const char *val = "v";
+	void *readval;
+	size_t size;
+	int r;
+
+	assertMakeFile("f", 0644, "a");
+	if (!setXattr("f", keep, val, strlen(val) + 1) ||
+	    !setXattr("f", drop, val, strlen(val) + 1)) {
+		skipping("Can't set user extended attributes on this "
+		    "filesystem");
+		return;
+	}
+
+	/* Create side: --xattrs-exclude drops just the matching name. */
+	r = systemf("%s -c --no-mac-metadata --xattrs "
+	    "--xattrs-exclude %s -f excl.tar f >excl.out 2>excl.err",
+	    testprog, drop);
+	assertEqualInt(r, 0);
+	assertMakeDir("excl", 0755);
+	r = systemf("%s -x -C excl --no-same-permissions --xattrs "
+	    "-f excl.tar >excl_x.out 2>excl_x.err", testprog);
+	assertEqualInt(r, 0);
+	readval = getXattr("excl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("excl/f", drop, &size) == NULL);
+
+	/* Create side: --xattrs-include keeps only the matching name. */
+	r = systemf("%s -c --no-mac-metadata --xattrs "
+	    "--xattrs-include %s -f incl.tar f >incl.out 2>incl.err",
+	    testprog, keep);
+	assertEqualInt(r, 0);
+	assertMakeDir("incl", 0755);
+	r = systemf("%s -x -C incl --no-same-permissions --xattrs "
+	    "-f incl.tar >incl_x.out 2>incl_x.err", testprog);
+	assertEqualInt(r, 0);
+	readval = getXattr("incl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("incl/f", drop, &size) == NULL);
+
+	/* Extract side: archive carries both, extraction drops one. */
+	r = systemf("%s -c --no-mac-metadata --xattrs -f both.tar f "
+	    ">both.out 2>both.err", testprog);
+	assertEqualInt(r, 0);
+	assertMakeDir("xexcl", 0755);
+	r = systemf("%s -x -C xexcl --no-same-permissions --xattrs "
+	    "--xattrs-exclude %s -f both.tar >xexcl.out 2>xexcl.err",
+	    testprog, drop);
+	assertEqualInt(r, 0);
+	readval = getXattr("xexcl/f", keep, &size);
+	if (assertEqualInt(size, strlen(val) + 1) != 0)
+		assertEqualMem(readval, val, size);
+	free(readval);
+	assert(getXattr("xexcl/f", drop, &size) == NULL);
+#endif	/* ARCHIVE_XATTR_SUPPORT */
+}

--- a/tar/util.c
+++ b/tar/util.c
@@ -17,6 +17,9 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
+#ifdef HAVE_FNMATCH_H
+#include <fnmatch.h>
+#endif
 #ifdef HAVE_IO_H
 #include <io.h>
 #endif
@@ -42,6 +45,7 @@
 
 #include "bsdtar.h"
 #include "lafe_err.h"
+#include "lafe_fnmatch.h"
 #include "passphrase.h"
 
 static size_t	bsdtar_expand_char(char *, size_t, size_t, char);
@@ -582,6 +586,91 @@ edit_mtime(struct bsdtar *bsdtar, struct archive_entry *entry)
 	__LA_TIME_T entry_mtime = archive_entry_mtime(entry);
 	if (!bsdtar->clamp_mtime || entry_mtime > bsdtar->mtime)
 		archive_entry_set_mtime(entry, bsdtar->mtime, 0);
+}
+
+/*
+ * Decide whether an extended-attribute name survives the
+ * --xattrs-include / --xattrs-exclude masks.  The name is matched as a
+ * whole string with shell-style globbing (no path splitting), so
+ * "security.selinux" matches exactly that key while "security.*" matches
+ * the namespace.  Exclusion wins; when an include list is present a name
+ * must match it to be kept; empty lists impose no restriction.
+ */
+static int
+xattr_name_kept(struct bsdtar *bsdtar, const char *name)
+{
+	struct xattr_match *m;
+
+	for (m = bsdtar->xattr_exclude; m != NULL; m = m->next)
+		if (fnmatch(m->pattern, name, 0) == 0)
+			return 0;
+	if (bsdtar->xattr_include != NULL) {
+		for (m = bsdtar->xattr_include; m != NULL; m = m->next)
+			if (fnmatch(m->pattern, name, 0) == 0)
+				return 1;
+		return 0;
+	}
+	return 1;
+}
+
+/*
+ * Apply the --xattrs-include / --xattrs-exclude masks to an entry,
+ * dropping any extended attribute whose name does not survive.  Used on
+ * both the create side (entries read from disk) and the extract side
+ * (entries read from the archive).  archive_entry has no per-name remove,
+ * so the surviving attributes are copied out, the list is cleared and the
+ * survivors are re-added (in reverse, since add_entry prepends, to keep
+ * the original order).
+ */
+void
+edit_xattrs(struct bsdtar *bsdtar, struct archive_entry *entry)
+{
+	struct kept_xattr {
+		char	*name;
+		void	*value;
+		size_t	 size;
+	} *kept;
+	const char *name;
+	const void *value;
+	size_t size;
+	int count, n, i;
+
+	if (bsdtar->xattr_include == NULL && bsdtar->xattr_exclude == NULL)
+		return;
+
+	count = archive_entry_xattr_reset(entry);
+	if (count <= 0)
+		return;
+
+	kept = calloc((size_t)count, sizeof(*kept));
+	if (kept == NULL)
+		lafe_errc(1, 0, "Out of memory");
+
+	n = 0;
+	while (archive_entry_xattr_next(entry, &name, &value, &size)
+	    == ARCHIVE_OK) {
+		if (name == NULL || !xattr_name_kept(bsdtar, name))
+			continue;
+		if ((kept[n].name = strdup(name)) == NULL)
+			lafe_errc(1, 0, "Out of memory");
+		if (size > 0) {
+			if ((kept[n].value = malloc(size)) == NULL)
+				lafe_errc(1, 0, "Out of memory");
+			memcpy(kept[n].value, value, size);
+		} else
+			kept[n].value = NULL;
+		kept[n].size = size;
+		n++;
+	}
+
+	archive_entry_xattr_clear(entry);
+	for (i = n - 1; i >= 0; i--) {
+		archive_entry_xattr_add_entry(entry, kept[i].name,
+		    kept[i].value, kept[i].size);
+		free(kept[i].name);
+		free(kept[i].value);
+	}
+	free(kept);
 }
 
 /*

--- a/tar/write.c
+++ b/tar/write.c
@@ -718,6 +718,8 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina)
 		    !yes("copy '%s'", archive_entry_pathname(in_entry)))
 			continue;
 		edit_mtime(bsdtar, in_entry);
+		/* Apply --xattrs-include / --xattrs-exclude masks. */
+		edit_xattrs(bsdtar, in_entry);
 		if (bsdtar->verbose > 1) {
 			safe_fprintf(stderr, "a ");
 			list_item_verbose(bsdtar, stderr, in_entry);
@@ -946,6 +948,9 @@ write_hierarchy(struct bsdtar *bsdtar, struct archive *a, const char *path)
 
 		/* Rewrite the mtime. */
 		edit_mtime(bsdtar, entry);
+
+		/* Apply --xattrs-include / --xattrs-exclude masks. */
+		edit_xattrs(bsdtar, entry);
 
 		/* Display entry as we process it. */
 		if (bsdtar->verbose > 1) {


### PR DESCRIPTION
## Summary

Adds per-key extended-attribute name filtering to bsdtar, bringing it to parity with GNU tar's `--xattrs-include` / `--xattrs-exclude`:

- `bsdtar --xattrs-include <pattern>` / `--xattrs-exclude <pattern>` (GNU tar compatible), valid in c/r/u/x modes.

The masks are matched in the bsdtar front-end with shell-style `fnmatch` globbing, so `libarchive/` itself is untouched — no new public API.

## Motivation

The coarse `--no-xattrs` cannot express "drop *this* attribute but keep the others." The motivating case is SELinux: an archive should not carry the **build host's** `security.selinux` label (the correct label is a property of the **install host's** policy, applied by `restorecon`), but you still want to keep `security.capability` so setcap'd binaries keep working. `--no-xattrs` drops both.

```
bsdtar --xattrs --xattrs-exclude 'security.selinux' -cf pkg.tar .   # archiving
bsdtar --xattrs --xattrs-exclude 'security.selinux' -xf pkg.tar     # extraction
```

## Approach

- **No new libarchive public API** — `libarchive/` is untouched. The masks are applied in the bsdtar front-end (`tar/util.c:edit_xattrs`): each `archive_entry`'s xattr set is rewritten, exclusion wins, an include list restricts to matching names, empty lists are a no-op. The name is matched as a whole string, so `security.selinux` matches exactly that key and `security.*` matches the namespace.
- Hooked into all three entry paths: create traversal (`write.c`), the `-r`/`-u` `@archive` copy path (`write.c`), and extract (`read.c`).
- The globbing currently comes from a small, self-contained byte-oriented BSD `fnmatch(3)` vendored in `libarchive_fe`. **This will be rebased onto #3172**, which factors that import out as a shared foundation (also used by the `bsdunzip` Windows port). Per @stoeckmann's review, the end form is a plain `fnmatch` compat shim used only where the system lacks one — no `lafe_`/`LAFE_FNM_` prefix — so glibc/FreeBSD users get the system implementation.

## Testing

- `tar/test/test_option_xattrs_filter.c`: create-side include/exclude and extract-side exclude, using `user.*` attributes so it needs no privileges.
- Full bsdtar suite: **77 passed, 0 failed, 94,457 assertions**.
- Built with `-Werror` (CMake/Ninja, gcc), clean.
- Manual roundtrip confirms whole-name globbing: `--xattrs-exclude 'user.foo.*'` drops a sub-namespace, `--xattrs-include 'user.foo.a'` keeps exactly that key.

## Note on mask semantics

GNU tar's `--xattrs-*` masks are POSIX extended regexps; here they are shell-style `fnmatch` globs, for portability (no regex dependency) and consistency with the rest of libarchive's globbing. For typical keys this is equivalent (`security.selinux`, `security.*`). Happy to adjust if strict GNU tar parity is preferred.
