### PR TITLE
Miscellaneous fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1378,9 +1378,8 @@ AC_SUBST(LIBSREQUIRED)
 
 # Probe libmd AFTER OpenSSL/libcrypto.
 # The two are incompatible and OpenSSL is more complete.
-AC_CHECK_HEADERS([md5.h ripemd.h sha.h sha256.h sha512.h])
 saved_LIBS=$LIBS
-AC_CHECK_LIB(md,MD5Init)
+AC_CHECK_LIB(md, MD5Init)
 CRYPTO_CHECK(MD5, LIBMD, md5)
 CRYPTO_CHECK(RMD160, LIBMD, rmd160)
 CRYPTO_CHECK(SHA1, LIBMD, sha1)

--- a/libarchive/archive_integer.h
+++ b/libarchive/archive_integer.h
@@ -49,6 +49,9 @@
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -243,5 +246,22 @@ archive_ckd_sub_i64(int64_t *result, int64_t a, int64_t b)
 	return 0;
 #endif
 }
+
+#if !defined(TIME_MAX)
+#define TIME_MAX (((time_t)0 < (time_t)-1) ? (time_t)~0 :		\
+	    sizeof(time_t) == sizeof(long long) ? (time_t)LLONG_MAX :	\
+	    sizeof(time_t) == sizeof(long) ? (time_t)LONG_MAX :		\
+	    sizeof(time_t) == sizeof(int) ? (time_t)INT_MAX :		\
+	    sizeof(time_t) == sizeof(short) ? (time_t)SHRT_MAX :	\
+	    1 /* I give up */)
+#endif
+#if !defined(TIME_MIN)
+#define TIME_MIN (((time_t)0 < (time_t)-1) ? (time_t)0 :		\
+	    sizeof(time_t) == sizeof(long long) ? (time_t)LLONG_MIN :	\
+	    sizeof(time_t) == sizeof(long) ? (time_t)LONG_MIN :		\
+	    sizeof(time_t) == sizeof(int) ? (time_t)INT_MIN :		\
+	    sizeof(time_t) == sizeof(short) ? (time_t)SHRT_MIN :	\
+	    -1 /* I give up */)
+#endif
 
 #endif

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -141,56 +141,6 @@ static int64_t	mtree_atol(char **, int base);
 static size_t	mtree_strnlen(const char *, size_t);
 #endif
 
-/*
- * There's no standard for TIME_T_MAX/TIME_T_MIN.  So we compute them
- * here.  TODO: Move this to configure time, but be careful
- * about cross-compile environments.
- */
-static int64_t
-get_time_t_max(void)
-{
-#if defined(TIME_T_MAX)
-	return TIME_T_MAX;
-#else
-	/* ISO C allows time_t to be a floating-point type,
-	   but POSIX requires an integer type.  The following
-	   should work on any system that follows the POSIX
-	   conventions. */
-	if (((time_t)0) < ((time_t)-1)) {
-		/* Time_t is unsigned */
-		return (~(time_t)0);
-	} else {
-		/* Time_t is signed. */
-		/* Assume it's the same as int64_t or int32_t */
-		if (sizeof(time_t) == sizeof(int64_t)) {
-			return (time_t)INT64_MAX;
-		} else {
-			return (time_t)INT32_MAX;
-		}
-	}
-#endif
-}
-
-static int64_t
-get_time_t_min(void)
-{
-#if defined(TIME_T_MIN)
-	return TIME_T_MIN;
-#else
-	if (((time_t)0) < ((time_t)-1)) {
-		/* Time_t is unsigned */
-		return (time_t)0;
-	} else {
-		/* Time_t is signed. */
-		if (sizeof(time_t) == sizeof(int64_t)) {
-			return (time_t)INT64_MIN;
-		} else {
-			return (time_t)INT32_MIN;
-		}
-	}
-#endif
-}
-
 #ifdef HAVE_STRNLEN
 #define mtree_strnlen(a,b) strnlen(a,b)
 #else
@@ -1781,8 +1731,6 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 		}
 		if (strcmp(key, "time") == 0) {
 			int64_t m;
-			int64_t my_time_t_max = get_time_t_max();
-			int64_t my_time_t_min = get_time_t_min();
 			long ns = 0;
 
 			*parsed_kws |= MTREE_HAS_MTIME;
@@ -1802,10 +1750,10 @@ parse_keyword(struct archive_read *a, struct mtree *mtree,
 				else
 					ns = (long)v;
 			}
-			if (m > my_time_t_max)
-				m = my_time_t_max;
-			else if (m < my_time_t_min)
-				m = my_time_t_min;
+			if (m > TIME_MAX)
+				m = TIME_MAX;
+			else if (m < TIME_MIN)
+				m = TIME_MIN;
 			archive_entry_set_mtime(entry, (time_t)m, ns);
 			return (ARCHIVE_OK);
 		}

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -251,36 +251,6 @@ static const size_t fflags_limit = 512; /* Longest fflags */
 static const size_t acl_limit = 131072; /* Longest textual ACL: 128kiB */
 static const int64_t entry_limit = 0xfffffffffffffffLL; /* 2^60 bytes = 1 ExbiByte */
 
-/*
- * There's no standard for TIME_T_MAX.  So we compute it
- * here.  TODO: Move this to configure time, but be careful
- * about cross-compile environments.
- */
-static time_t
-get_time_t_max(void)
-{
-#if defined(TIME_T_MAX)
-        return TIME_T_MAX;
-#else
-        /* ISO C allows time_t to be a floating-point type,
-           but POSIX requires an integer type.  The following
-           should work on any system that follows the POSIX
-           conventions. */
-        if (((time_t)0) < ((time_t)-1)) {
-                /* Time_t is unsigned */
-                return (~(time_t)0);
-        } else {
-                /* Time_t is signed. */
-                /* Assume it's the same as int64_t or int32_t */
-                if (sizeof(time_t) == sizeof(int64_t)) {
-                        return (time_t)INT64_MAX;
-                } else {
-                        return (time_t)INT32_MAX;
-                }
-        }
-#endif
-}
-
 int
 archive_read_support_format_gnutar(struct archive *a)
 {
@@ -1402,7 +1372,7 @@ header_common(struct archive_read *a, struct tar *tar,
 		int64_t t64 = tar_atol(header->mtime, sizeof(header->mtime));
 		time_t t = (time_t)t64;
 		if ((int64_t)t != t64) { /* time_t overflowed */
-			t = get_time_t_max();
+			t = TIME_MAX;
 		}
 		archive_entry_set_mtime(entry, t, 0);
 	}

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -4350,7 +4350,7 @@ copy_metadata(struct archive_write_disk *a, const char *metadata,
 		 * with at least a writing mode(O_RDWR or O_WRONLY). it
 		 * makes the data fork uncompressed.
 		 */
-		dffd = open(datafork, 0);
+		dffd = open(datafork, O_SYMLINK);
 		if (dffd == -1) {
 			archive_set_error(&a->archive, errno,
 			    "Failed to open the data fork for metadata");
@@ -4459,7 +4459,9 @@ fixup_appledouble(struct archive_write_disk *a, const char *pathname)
 	if (la_stat(datafork.s, &st) == -1)
 		goto skip_appledouble;
 #endif
-	if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
+	if (!S_ISREG(st.st_mode) &&
+	    !S_ISDIR(st.st_mode) &&
+	    !S_ISLNK(st.st_mode))
 		goto skip_appledouble;
 
 	/*

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2375,7 +2375,7 @@ create_filesystem_object(struct archive_write_disk *a)
 #endif
 			if (r != 0)
 				r = errno;
-			else if ((st.st_mode & AE_IFMT) == AE_IFREG) {
+			else if (S_ISREG(st.st_mode)) {
 				a->fd = open(a->name, O_WRONLY | O_TRUNC |
 				    O_BINARY | O_CLOEXEC | O_NOFOLLOW);
 				__archive_ensure_cloexec_flag(a->fd);
@@ -4452,14 +4452,14 @@ fixup_appledouble(struct archive_write_disk *a, const char *pathname)
 	 */
 	archive_strncpy(&datafork, pathname, p - pathname);
 	archive_strcat(&datafork, p + 2);
-	if (
 #ifdef HAVE_LSTAT
-		lstat(datafork.s, &st) == -1 ||
+	if (lstat(datafork.s, &st) == -1)
+		goto skip_appledouble;
 #else
-		la_stat(datafork.s, &st) == -1 ||
+	if (la_stat(datafork.s, &st) == -1)
+		goto skip_appledouble;
 #endif
-	    (((st.st_mode & AE_IFMT) != AE_IFREG) &&
-		((st.st_mode & AE_IFMT) != AE_IFDIR)))
+	if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
 		goto skip_appledouble;
 
 	/*

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -300,7 +300,7 @@ struct archive_write_disk {
 	uint32_t		 compressed_rsrc_position;
 	uint32_t		 compressed_rsrc_position_v;
 	/* Buffer for uncompressed data. */
-	char			*uncompressed_buffer;
+	unsigned char		*uncompressed_buffer;
 	size_t			 block_remaining_bytes;
 	size_t			 file_remaining_bytes;
 #ifdef HAVE_ZLIB_H
@@ -1254,7 +1254,7 @@ static int
 hfs_decompress(struct archive_write_disk *a)
 {
 	uint32_t *block_info;
-	unsigned int block_count;
+	uint32_t block_count;
 	uint32_t data_pos, data_size;
 	ssize_t r;
 	ssize_t bytes_written, bytes_to_write;
@@ -1277,10 +1277,10 @@ hfs_decompress(struct archive_write_disk *a)
 			bytes_to_write = data_size -1;
 			b = a->compressed_buffer + 1;
 		} else {
-			uLong dest_len = MAX_DECMPFS_BLOCK_SIZE;
+			size_t dest_len = MAX_DECMPFS_BLOCK_SIZE;
 			int zr;
 
-			zr = uncompress((Bytef *)a->uncompressed_buffer,
+			zr = uncompress(a->uncompressed_buffer,
 			    &dest_len, a->compressed_buffer, data_size);
 			if (zr != Z_OK) {
 				archive_set_error(&a->archive,
@@ -1289,7 +1289,7 @@ hfs_decompress(struct archive_write_disk *a)
 				return (ARCHIVE_WARN);
 			}
 			bytes_to_write = dest_len;
-			b = (unsigned char *)a->uncompressed_buffer;
+			b = a->uncompressed_buffer;
 		}
 		do {
 			bytes_written = write(a->fd, b, bytes_to_write);
@@ -1472,8 +1472,7 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 
 	if (a->decmpfs_block_count == (unsigned)-1) {
 		void *new_block;
-		size_t new_size;
-		unsigned int block_count;
+		size_t block_count, new_size;
 
 		if (a->decmpfs_header_p == NULL) {
 			new_block = malloc(MAX_DECMPFS_XATTR_SIZE
@@ -1493,13 +1492,20 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		archive_le64enc(&a->decmpfs_header_p[DECMPFS_UNCOMPRESSED_SIZE],
 		    a->filesize);
 
-		/* Calculate a block count of the file. */
-		block_count =
-		    (a->filesize + MAX_DECMPFS_BLOCK_SIZE -1) /
-			MAX_DECMPFS_BLOCK_SIZE;
+		/*
+		 * Calculate block count for the file.
+		 */
+		block_count = (a->filesize + MAX_DECMPFS_BLOCK_SIZE - 1) /
+		    MAX_DECMPFS_BLOCK_SIZE;
+		if (block_count > (SIZE_MAX - RSRC_H_SIZE - 4 - RSRC_F_SIZE) /
+		    (sizeof(uint32_t) * 2) || block_count > UINT32_MAX) {
+			archive_set_error(&a->archive, EFBIG, "File too big");
+			return (ARCHIVE_FATAL);
+		}
+
 		/*
 		 * Allocate buffer for resource fork.
-		 * Set up related pointers;
+		 * Set up related pointers.
 		 */
 		new_size =
 		    RSRC_H_SIZE + /* header */
@@ -1540,7 +1546,7 @@ hfs_write_decmpfs_block(struct archive_write_disk *a, const char *buff,
 		a->decmpfs_block_info =
 		    (uint32_t *)(a->resource_fork + RSRC_H_SIZE);
 		/* Set the block count to the resource fork. */
-		archive_le32enc(a->decmpfs_block_info++, block_count);
+		archive_le32enc(a->decmpfs_block_info++, (uint32_t)block_count);
 		/* Get the position where we are going to set compressed
 		 * data. */
 		a->compressed_rsrc_position =

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -111,7 +111,7 @@ static int xml_writer_start_element(struct xml_writer *ctx,
 static int xml_writer_write_attribute(struct xml_writer *ctx, const char *key,
     const char *value);
 static int xml_writer_write_attributef(struct xml_writer *ctx, const char *key,
-    const char *format, ...);
+    const char *format, ...) __LA_PRINTF(3, 4);
 static int xml_writer_write_string(struct xml_writer *ctx, const char *string);
 static int xml_writer_write_base64(struct xml_writer* ctx,
     const char *data, size_t start, size_t len);
@@ -907,7 +907,7 @@ xmlwrite_string(struct archive_write *a, struct xml_writer *writer,
 	return (ARCHIVE_OK);
 }
 
-static int
+static int __LA_PRINTF(4, 5)
 xmlwrite_fstring(struct archive_write *a, struct xml_writer *writer,
 	const char *key, const char *fmt, ...)
 {
@@ -1333,11 +1333,11 @@ make_file_entry(struct archive_write *a, struct xml_writer *writer,
 			return (ARCHIVE_FATAL);
 		}
 		r = xmlwrite_fstring(a, writer, "major",
-		    "%d", archive_entry_rdevmajor(file->entry));
+		    "%ld", (long)archive_entry_rdevmajor(file->entry));
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 		r = xmlwrite_fstring(a, writer, "minor",
-		    "%d", archive_entry_rdevminor(file->entry));
+		    "%ld", (long)archive_entry_rdevminor(file->entry));
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 		r = xml_writer_end_element(writer);
@@ -1361,7 +1361,7 @@ make_file_entry(struct archive_write *a, struct xml_writer *writer,
 		return (ARCHIVE_FATAL);
 	if (archive_entry_dev(file->entry) != 0) {
 		r = xmlwrite_fstring(a, writer, "deviceno",
-		    "%d", archive_entry_dev(file->entry));
+		    "%ld", (long)archive_entry_dev(file->entry));
 		if (r < 0)
 			return (ARCHIVE_FATAL);
 	}

--- a/libarchive/test/test_read_format_zip_zipx_encrypted.c
+++ b/libarchive/test/test_read_format_zip_zipx_encrypted.c
@@ -56,7 +56,7 @@ static la_ssize_t read_streaming_buffer(struct archive *a, void *_client_data, c
 }
 
 static void
-validate_entry_read(struct archive *a, const char* msg, const int streaming_reader)
+validate_entry_read(struct archive *a, const int streaming_reader)
 {
 	struct archive_entry *ae;
 	size_t total_read;
@@ -76,7 +76,8 @@ validate_entry_read(struct archive *a, const char* msg, const int streaming_read
 		r = archive_read_data(a, readbuf, sizeof(readbuf));
 		if (r <= 0) {
 			if (r < 0) {
-				failure(msg, (int) r, archive_error_string(a));
+				failure("archive_read_data returned %d: %s",
+				    (int)r, archive_error_string(a));
 				assertEqualInt(r > 0, 1);
 			}
 			break;
@@ -114,7 +115,7 @@ test_encrypted_zipx_read_mem(char* buff, size_t used)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, password));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
 
-	validate_entry_read(a, "archive_read_data returned %d: %s", 0);
+	validate_entry_read(a, 0);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
@@ -126,7 +127,7 @@ test_encrypted_zipx_read_mem(char* buff, size_t used)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, password));
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory_seek(a, buff, used, 7));
 
-	validate_entry_read(a, "seek: archive_read_data returned %d: %s", 0);
+	validate_entry_read(a, 0);
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
@@ -144,7 +145,7 @@ test_encrypted_zipx_read_callback(const char* buff, const size_t used)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, password));
 	/* NOTE: archive_read_open2 with read callback only -> NON-seekable. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open2(a, &stream_buffer, NULL, read_streaming_buffer, NULL, NULL));
-	validate_entry_read(a, "archive_read_data returned %d: %s", 1);
+	validate_entry_read(a, 1);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -3082,7 +3082,7 @@ systemf(const char *fmt, ...)
 	r = vsnprintf(buff + off, avail, fmt, ap);
 	va_end(ap);
 
-	if (r < 0 || (size_t)r > avail) {
+	if (r < 0 || (size_t)r >= avail) {
 		return (-1);
 	}
 

--- a/unzip/test/test_symlink.c
+++ b/unzip/test/test_symlink.c
@@ -18,6 +18,7 @@ DEFINE_TEST(test_symlink)
 		return;
 	}
 
+	assertUmask(0);
 	extract_reference_file(reffile1);
 	extract_reference_file(reffile2);
 

--- a/unzip/test/test_symlink_dotdot.c
+++ b/unzip/test/test_symlink_dotdot.c
@@ -21,6 +21,7 @@ DEFINE_TEST(test_symlink_dotdot)
 		return;
 	}
 
+	assertUmask(0);
 	extract_reference_file(reffile);
 
 	r = systemf("%s %s >test.out 2>test.err", testprog, reffile);


### PR DESCRIPTION
Fix issues encountered while integrating 3.8.8 downstream. Some are old issues which I haven't gotten around to submitting before, most are new.

* configure.ac: Remove unused checks

* libarchive: Fix `TIME_MAX` and `TIME_MIN`

* test: Fix off-by-one in bounds check

  Fixes:                0e4fa9ff0d82 ("test: promote the win32-repairing systemf wrapper to all systemf calls")

* bsdunzip_test: Set umask before asserting permissions

  Fixes:                34b3da0013ae ("unzip: Add symlink tests")

* archive_write_disk_posix: Fix type issues

  Fix type issues in the HFS+ (de)compression code, primarily to avoid
  arithmetic overflow when calculating the block count during compression.

* archive_write_disk_posix: Miscellaneous cleanup

  Use `S_IS*()` macros consistently and clean up some `#ifdef`s.

* archive_write_disk_posix: Symlinks can have AppleDouble data

* libarchive: Fix format string issues
