### PR TITLE
gnutar: fix stack buffer overflow writing the gname header field

### DIFF
--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -652,7 +652,7 @@ archive_format_gnutar_header(struct archive_write *a, char h[512],
 		copy_length = gnutar->gname_length;
 	}
 	if (copy_length > 0) {
-		if (strlen(p) > GNUTAR_gname_size)
+		if (copy_length > GNUTAR_gname_size)
 			copy_length = GNUTAR_gname_size;
 		memcpy(h + GNUTAR_gname_offset, p, copy_length);
 	}

--- a/libarchive/test/test_gnutar_filename_encoding.c
+++ b/libarchive/test/test_gnutar_filename_encoding.c
@@ -389,6 +389,55 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP932_UTF8)
 	assertEqualMem(buff, "\xE8\xA1\xA8.txt", 7);
 }
 
+/*
+ * A group name whose converted byte length exceeds the 32-byte gname
+ * field used to clamp on strlen() of the converted string instead of its
+ * byte length.  With a header charset that embeds NUL bytes (UTF-16),
+ * strlen() stops at the first NUL while the memcpy still used the full
+ * byte length, writing past the 512-byte header buffer.
+ */
+DEFINE_TEST(test_gnutar_filename_encoding_long_gname_utf16)
+{
+	struct archive *a;
+	struct archive_entry *entry;
+	char buff[4096];
+	char gname[256];
+	size_t used;
+
+	a = archive_write_new();
+	assertEqualInt(ARCHIVE_OK, archive_write_set_format_gnutar(a));
+	if (archive_write_set_options(a, "hdrcharset=UTF-16LE") != ARCHIVE_OK) {
+		skipping("This system cannot convert character-set"
+		    " to UTF-16LE.");
+		archive_write_free(a);
+		return;
+	}
+	assertEqualInt(ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	memset(gname, 'A', sizeof(gname) - 1);
+	gname[sizeof(gname) - 1] = '\0';
+
+	entry = archive_entry_new2(a);
+	archive_entry_set_pathname(entry, "file");
+	archive_entry_set_filetype(entry, AE_IFREG);
+	archive_entry_set_size(entry, 0);
+	archive_entry_set_gname(entry, gname);
+	assertEqualInt(ARCHIVE_OK, archive_write_header(a, entry));
+	archive_entry_free(entry);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/* The archive is still well-formed; the gname field is truncated to
+	 * the 32-byte field, which reads back as "A" (the first UTF-16 unit
+	 * before the embedded NUL). */
+	a = archive_read_new();
+	assertEqualInt(ARCHIVE_OK, archive_read_support_format_tar(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+	assertEqualInt(ARCHIVE_OK, archive_read_next_header(a, &entry));
+	assertEqualString("A", archive_entry_gname(entry));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_gnutar_filename_encoding_UTF16_win)
 {
 #if !defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
AddressSanitizer, gnutar writer with `hdrcharset=UTF-16LE` and a long group name:

    archive_write_set_format_gnutar.c:657: stack-buffer-overflow
    WRITE of size 798 at 0x... in archive_format_gnutar_header
      frame object 'buff' (line 275) is 512 bytes; gname field is at offset 297

The gname copy clamps on `strlen(p)` but the memcpy length is `copy_length`,
the converted byte length. With a header charset that embeds NUL bytes
(UTF-16), `strlen(p)` stops at the first NUL while `copy_length` is the full
byte count, so a long gname slips past the clamp and overruns the 512-byte
header buffer. The uname block just above already clamps `copy_length`; gname
was the only field still keyed on `strlen`.

Test is in its own commit ahead of the fix; it overflows under ASan on the
current tree and passes after.