### PR TITLE
fix: windows filter argument quoting

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ BUILT_SOURCES= libarchive/test/list.h tar/test/list.h cpio/test/list.h cat/test/
 # What to test: We always test libarchive, test bsdtar and bsdcpio only
 # if we built them.
 #
-check_PROGRAMS= libarchive_test $(bsdtar_test_programs) $(bsdcpio_test_programs) $(bsdcat_test_programs) $(bsdunzip_test_programs)
+check_PROGRAMS= libarchive_test libarchive_test_argvfilter $(bsdtar_test_programs) $(bsdcpio_test_programs) $(bsdcat_test_programs) $(bsdunzip_test_programs)
 TESTS= libarchive_test $(bsdtar_test_programs) $(bsdcpio_test_programs) $(bsdcat_test_programs) $(bsdunzip_test_programs)
 TESTS_ENVIRONMENT= $(libarchive_TESTS_ENVIRONMENT) $(bsdtar_TESTS_ENVIRONMENT) $(bsdcpio_TESTS_ENVIRONMENT) $(bsdcat_TESTS_ENVIRONMENT) $(bsdunzip_TESTS_ENVIRONMENT)
 # Uncomment the following to enable verbose test output:
@@ -735,6 +735,9 @@ libarchive_test_CPPFLAGS= \
 
 libarchive_test_LDADD= $(LTLIBICONV)
 
+libarchive_test_argvfilter_SOURCES= \
+	libarchive/test/test_read_filter_program_argvfilter.c
+
 # The "list.h" file just lists all of the tests defined in all of the sources.
 # Building it automatically provides a sanity-check on libarchive_test_SOURCES
 # above.
@@ -742,7 +745,9 @@ libarchive/test/list.h: $(libarchive_test_SOURCES)
 	$(MKDIR_P) libarchive/test
 	grep -h '^DEFINE_TEST(' $^ | LC_COLLATE=C sort > $@
 
-libarchive_TESTS_ENVIRONMENT= LIBARCHIVE_TEST_FILES=`cd $(top_srcdir);/bin/pwd`/libarchive/test LRZIP=NOCONFIG
+libarchive_TESTS_ENVIRONMENT= \
+	LIBARCHIVE_TEST_FILES=`cd $(top_srcdir);/bin/pwd`/libarchive/test \
+	LRZIP=NOCONFIG
 
 libarchive_test_EXTRA_DIST=\
 	libarchive/test/list.h \

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -105,8 +105,7 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
 	struct archive_string cmdline;
 	struct archive_string fullpath;
 	struct archive_cmdline *acmd;
-	char *arg0, *ext;
-	int i, l;
+	char *ext;
 	DWORD fl, fl_old;
 	HANDLE child;
 
@@ -142,49 +141,13 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
 			goto fail;
 		fl_old = fl;
 		fl = SearchPathA(NULL, acmd->path, ext, fl, fullpath.s,
-			&arg0);
+			NULL);
 	} while (fl != 0 && fl > fl_old);
 	if (fl == 0)
 		goto fail;
 
-	/*
-	 * Make a command line.
-	 */
-	for (l = 0, i = 0;  acmd->argv[i] != NULL; i++) {
-		if (i == 0)
-			continue;
-		l += (int)strlen(acmd->argv[i]) + 1;
-	}
-	if (archive_string_ensure(&cmdline, l + 1) == NULL)
+	if (archive_strcpy(&cmdline, cmd) == NULL)
 		goto fail;
-	for (i = 0;  acmd->argv[i] != NULL; i++) {
-		if (i == 0) {
-			const char *p, *sp;
-
-			if ((p = strchr(acmd->argv[i], '/')) != NULL ||
-			    (p = strchr(acmd->argv[i], '\\')) != NULL)
-				p++;
-			else
-				p = acmd->argv[i];
-			if ((sp = strchr(p, ' ')) != NULL)
-				archive_strappend_char(&cmdline, '"');
-			archive_strcat(&cmdline, p);
-			if (sp != NULL)
-				archive_strappend_char(&cmdline, '"');
-		} else {
-			archive_strappend_char(&cmdline, ' ');
-			archive_strcat(&cmdline, acmd->argv[i]);
-		}
-	}
-	if (i <= 1) {
-		const char *sp;
-
-		if ((sp = strchr(arg0, ' ')) != NULL)
-			archive_strappend_char(&cmdline, '"');
-		archive_strcat(&cmdline, arg0);
-		if (sp != NULL)
-			archive_strappend_char(&cmdline, '"');
-	}
 
 	secAtts.nLength = sizeof(SECURITY_ATTRIBUTES);
 	secAtts.bInheritHandle = TRUE;
@@ -218,7 +181,7 @@ __archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
 
 	*child_stdout = _open_osfhandle((intptr_t)childStdout[0], _O_RDONLY);
 	*child_stdin = _open_osfhandle((intptr_t)childStdin[1], _O_WRONLY);
-	
+
 	child = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE,
 		childInfo.dwProcessId);
 	if (child == NULL) // INVALID_HANDLE_VALUE ?

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -360,7 +360,10 @@ IF(ENABLE_TEST)
   #
   # Register target
   #
+  ADD_EXECUTABLE(libarchive_test_argvfilter
+    test_read_filter_program_argvfilter.c)
   ADD_EXECUTABLE(libarchive_test ${libarchive_test_SOURCES})
+  ADD_DEPENDENCIES(libarchive_test libarchive_test_argvfilter)
   TARGET_LINK_LIBRARIES(libarchive_test archive_static ${ADDITIONAL_LIBS})
   SET_PROPERTY(TARGET libarchive_test PROPERTY COMPILE_DEFINITIONS
     LIBARCHIVE_STATIC LIST_H)
@@ -382,6 +385,6 @@ IF(ENABLE_TEST)
   # Experimental new test handling
   ADD_CUSTOM_TARGET(run_libarchive_test
 	COMMAND	libarchive_test -r ${CMAKE_CURRENT_SOURCE_DIR} -vv)
+  ADD_DEPENDENCIES(run_libarchive_test libarchive_test libarchive_test_argvfilter)
   ADD_DEPENDENCIES(run_all_tests run_libarchive_test)
 ENDIF(ENABLE_TEST)
-

--- a/libarchive/test/test_read_filter_program.c
+++ b/libarchive/test/test_read_filter_program.c
@@ -32,6 +32,57 @@ static unsigned char archive[] = {
 148,'d',230,226,'U','G','H',30,234,15,'8','=',10,'F',193,'(',24,5,131,28,
 0,0,29,172,5,240,0,6,0,0};
 
+DEFINE_TEST(test_read_filter_program_windows_quoted_argument)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	const char input[] = "x";
+	char *cmd;
+	const char *sep;
+	size_t cmdsize;
+	size_t testprogdir_len;
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+
+	if (!assert(testprogdir != NULL))
+		return;
+	testprogdir_len = strlen(testprogdir);
+	sep = "";
+	if (testprogdir_len > 0 &&
+	    testprogdir[testprogdir_len - 1] != '/' &&
+	    testprogdir[testprogdir_len - 1] != '\\')
+		sep = "/";
+
+	cmdsize = testprogdir_len + strlen(sep) +
+	    sizeof("\"libarchive_test_argvfilter.exe\" \"safe value\"");
+	cmd = malloc(cmdsize);
+	if (!assert(cmd != NULL))
+		return;
+	r = snprintf(cmd, cmdsize, "\"%s%slibarchive_test_argvfilter.exe\" "
+	    "\"safe value\"", testprogdir, sep);
+	if (!assert(r >= 0 && (size_t)r < cmdsize)) {
+		free(cmd);
+		return;
+	}
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_filter_program_signature(a,
+		cmd, "x", 1));
+	free(cmd);
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, input, sizeof(input) - 1));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	assertTextFileContents("ok\n", "argvfilter.out");
+#else
+	skipping("Windows-specific CreateProcess argument quoting test");
+#endif
+}
+
 DEFINE_TEST(test_read_filter_program)
 {
 	int r;

--- a/libarchive/test/test_read_filter_program_argvfilter.c
+++ b/libarchive/test/test_read_filter_program_argvfilter.c
@@ -1,0 +1,48 @@
+/*-
+ * Copyright (c) 2026 ysf
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdio.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+	FILE *f;
+	int c;
+
+	f = fopen("argvfilter.out", "wb");
+	if (f != NULL) {
+		if (argc == 2 && strcmp(argv[1], "safe value") == 0)
+			fputs("ok\n", f);
+		else
+			fprintf(f, "argc=%d argv1=%s\n", argc,
+			    argc > 1 ? argv[1] : "");
+		fclose(f);
+	}
+
+	while ((c = getchar()) != EOF)
+		putchar(c == 'x' ? 'y' : c);
+
+	return (0);
+}

--- a/test_utils/test_common.h
+++ b/test_utils/test_common.h
@@ -416,6 +416,8 @@ mode_t umasked(mode_t expected_mode);
 
 /* Path to working directory for current test */
 extern const char *testworkdir;
+/* Path to directory containing the test program */
+extern const char *testprogdir;
 
 #ifndef PROGRAM
 /*

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -177,6 +177,8 @@ mode_t umasked(mode_t expected_mode)
 
 /* Path to working directory for current test */
 const char *testworkdir;
+/* Path to directory containing the test program */
+const char *testprogdir;
 #ifdef PROGRAM
 /* Pathname of exe to be tested. */
 const char *testprogfile;
@@ -4028,7 +4030,7 @@ main(int argc, char **argv)
 #else
 	char tmpdir[256];
 #endif
-	char *pwd, *testprogdir, *tmp2 = NULL, *vlevel = NULL;
+	char *pwd, *testprogdir_alloc, *tmp2 = NULL, *vlevel = NULL;
 	char tmpdir_timestamp[32];
 #ifdef RUN_TEST_UNPRIV
 	struct passwd *pw;
@@ -4058,12 +4060,12 @@ main(int argc, char **argv)
 	 */
 	progname = p = argv[0];
 	testprogdir_len = strlen(progname) + 1;
-	if ((testprogdir = malloc(testprogdir_len)) == NULL)
+	if ((testprogdir_alloc = malloc(testprogdir_len)) == NULL)
 	{
 		fprintf(stderr, "ERROR: Out of memory.");
 		exit(1);
 	}
-	strncpy(testprogdir, progname, testprogdir_len);
+	strncpy(testprogdir_alloc, progname, testprogdir_len);
 	while (*p != '\0') {
 		/* Support \ or / dir separators for Windows compat. */
 		if (*p == '/' || *p == '\\')
@@ -4074,29 +4076,30 @@ main(int argc, char **argv)
 		++p;
 		j++;
 	}
-	testprogdir[i] = '\0';
+	testprogdir_alloc[i] = '\0';
 #if defined(_WIN32) && !defined(__CYGWIN__)
-	if (testprogdir[0] != '/' && testprogdir[0] != '\\' &&
-	    !(((testprogdir[0] >= 'a' && testprogdir[0] <= 'z') ||
-	       (testprogdir[0] >= 'A' && testprogdir[0] <= 'Z')) &&
-		testprogdir[1] == ':' &&
-		(testprogdir[2] == '/' || testprogdir[2] == '\\')))
+	if (testprogdir_alloc[0] != '/' && testprogdir_alloc[0] != '\\' &&
+	    !(((testprogdir_alloc[0] >= 'a' && testprogdir_alloc[0] <= 'z') ||
+	       (testprogdir_alloc[0] >= 'A' && testprogdir_alloc[0] <= 'Z')) &&
+		testprogdir_alloc[1] == ':' &&
+		(testprogdir_alloc[2] == '/' || testprogdir_alloc[2] == '\\')))
 #else
-	if (testprogdir[0] != '/')
+	if (testprogdir_alloc[0] != '/')
 #endif
 	{
 		/* Fixup path for relative directories. */
-		if ((testprogdir = realloc(testprogdir,
-			strlen(pwd) + 1 + strlen(testprogdir) + 1)) == NULL)
+		if ((testprogdir_alloc = realloc(testprogdir_alloc,
+			strlen(pwd) + 1 + strlen(testprogdir_alloc) + 1)) == NULL)
 		{
 			fprintf(stderr, "ERROR: Out of memory.");
 			exit(1);
 		}
-		memmove(testprogdir + strlen(pwd) + 1, testprogdir,
-		    strlen(testprogdir) + 1);
-		memcpy(testprogdir, pwd, strlen(pwd));
-		testprogdir[strlen(pwd)] = '/';
+		memmove(testprogdir_alloc + strlen(pwd) + 1, testprogdir_alloc,
+		    strlen(testprogdir_alloc) + 1);
+		memcpy(testprogdir_alloc, pwd, strlen(pwd));
+		testprogdir_alloc[strlen(pwd)] = '/';
 	}
+	testprogdir = testprogdir_alloc;
 
 #ifdef PROGRAM
 	/* Get the target program from environment, if available. */
@@ -4380,7 +4383,7 @@ main(int argc, char **argv)
 			if (test_num < 0) {
 				printf("*** INVALID Test %s\n", *argv);
 				free(refdir_alloc);
-				free(testprogdir);
+				free(testprogdir_alloc);
 				usage(progname);
 			}
 			for (i = 0; i < test_num; i++) {
@@ -4399,7 +4402,7 @@ main(int argc, char **argv)
 finish:
 	/* Must be freed after all tests run */
 	free(tmp2);
-	free(testprogdir);
+	free(testprogdir_alloc);
 	free(pwd);
 
 	/*


### PR DESCRIPTION
This fix adds Windows/MSVCRT-style quoting when reconstructing the command line. Before, `filter_fork_windows.c` parsed the filter command into `argv`, but rebuilt the `CreateProcessA()` commandline by appending arguments after `argv[0]` without quoting. Unfortunately arguments with spaces would be split again in the child  process, which could be cme a security issue if an application builds filter commands from an untrusted input.