### PR TITLE
rar5: reject streams that exceed the declared unpacked size

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1050,6 +1050,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_stored_manyfiles.rar.uu \
 	libarchive/test/test_read_format_rar5_symlink.rar.uu \
 	libarchive/test/test_read_format_rar5_truncated_huff.rar.uu \
+	libarchive/test/test_read_format_rar5_unpacked_size_exceeds_declared.rar.uu \
 	libarchive/test/test_read_format_rar5_unicode.rar.uu \
 	libarchive/test/test_read_format_rar5_win32.rar.uu \
 	libarchive/test/test_read_format_rar5_arm_filter_on_window_boundary.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3160,6 +3160,13 @@ static int copy_string(struct archive_read* a, int len, int dist) {
 	if (rar->cstate.window_buf == NULL)
 		return ARCHIVE_FATAL;
 
+	if (rar->cstate.write_ptr > rar->file.unpacked_size ||
+	    len > rar->file.unpacked_size - rar->cstate.write_ptr) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Uncompressed data exceeds declared size");
+		return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+	}
+
 	/* The unpacker spends most of the time in this function. It would be
 	 * a good idea to introduce some optimizations here.
 	 *
@@ -3228,7 +3235,17 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 
 		if(num < 256) {
 			/* Directly store the byte. */
-			int64_t write_idx = rar->cstate.solid_offset +
+			int64_t write_idx;
+
+			/* A literal write emits one byte; copy_string() checks len. */
+			if(rar->cstate.write_ptr >= rar->file.unpacked_size) {
+				archive_set_error(&a->archive,
+				    ARCHIVE_ERRNO_FILE_FORMAT,
+				    "Uncompressed data exceeds declared size");
+				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+			}
+
+			write_idx = rar->cstate.solid_offset +
 			    rar->cstate.write_ptr++;
 
 			rar->cstate.window_buf[write_idx & cmask] =
@@ -3344,8 +3361,9 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 			dist_cache_push(rar, dist);
 			rar->cstate.last_len = len;
 
-			if(ARCHIVE_OK != copy_string(a, len, dist))
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+			ret = copy_string(a, len, dist);
+			if(ret != ARCHIVE_OK)
+				return ret;
 
 			continue;
 		} else if(num == 256) {
@@ -3357,12 +3375,11 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 			continue;
 		} else if(num == 257) {
 			if(rar->cstate.last_len != 0) {
-				if(ARCHIVE_OK != copy_string(a,
+				ret = copy_string(a,
 				    rar->cstate.last_len,
-				    rar->cstate.dist_cache[0]))
-				{
-					return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
-				}
+				    rar->cstate.dist_cache[0]);
+				if(ret != ARCHIVE_OK)
+					return ret;
 			}
 
 			continue;
@@ -3386,8 +3403,9 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 
 			rar->cstate.last_len = len;
 
-			if(ARCHIVE_OK != copy_string(a, len, dist))
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+			ret = copy_string(a, len, dist);
+			if(ret != ARCHIVE_OK)
+				return ret;
 
 			continue;
 		}

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1572,3 +1572,17 @@ DEFINE_TEST(test_read_format_rar5_bytes_remaining_underflow)
 
 	EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_unpacked_size_exceeds_declared)
+{
+	PROLOGUE("test_read_format_rar5_unpacked_size_exceeds_declared.rar");
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("seed", archive_entry_pathname(ae));
+	assertEqualInt(109, archive_entry_size(ae));
+
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertA(archive_error_string(a) != NULL);
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_rar5_unpacked_size_exceeds_declared.rar.uu
+++ b/libarchive/test/test_read_format_rar5_unpacked_size_exceeds_declared.rar.uu
@@ -1,0 +1,10 @@
+begin 644 test_read_format_rar5_unpacked_size_exceeds_declared.rar
+M4F%R(1H'`0!S'-%&"@$%+`8`!0$!@(``PJ.']B("`POG``3M`*2#`E0DF'B`
+M`P$$<V5E9`H#$V0JGU[VYTHYP?]D-50S+Y,[YA3P`1@)46%!68"P&$$H2)$8
+M,V_"7`<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'!P<'
+M!P<0R!KGS?_Y1ZGJ/]5[V/WGQV3QS(RALJQ[H%.N$.-9EH-4R%#&),\=!'V$
+MXR:QWL0$Z0'%XQY*.<$4(I44Z>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GI
+MZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GIZ>GI
+;Z>GIZ>G)%78/_6H4^?O2+65;@!UW5E$#!00`
+`
+end


### PR DESCRIPTION
## Summary

Reject malformed RAR5 streams when decompression would write more bytes than the current entry's declared unpacked size.

The check is applied at both output write sites:

- direct literal writes
- match-copy writes through `copy_string()`

For solid streams, exceeding the declared size returns `ARCHIVE_FATAL`, matching the existing convention for decoder errors that make the shared solid stream state untrustworthy. For non-solid streams, the error remains entry-local.

This prevents a malformed RAR5 archive from making `bsdtar -tf` continue processing indefinitely after the first listed entry.

Fixes #3186.

## Regression test

Adds `test_read_format_rar5_unpacked_size_exceeds_declared`, using a small RAR5 fixture that previously caused the archive listing path to hang until killed by an external timeout.

The fixture is included in this PR:

```text
libarchive/test/test_read_format_rar5_unpacked_size_exceeds_declared.rar.uu
```

## Manual verification

Affected behavior before the patch:

```text
bsdtar -tf rar5-unpacked-size-exceeds-declared.rar
status=124 under timeout
stdout: seed
stderr: empty
```

After applying this PR, the manual input can be recreated from the included fixture:

```bash
uudecode -o rar5-unpacked-size-exceeds-declared.rar \
  libarchive/test/test_read_format_rar5_unpacked_size_exceeds_declared.rar.uu
```

Behavior after the patch:

```text
bsdtar -tf  rar5-unpacked-size-exceeds-declared.rar: status=1, prints seed, then "Uncompressed data exceeds declared size"
bsdtar -tvf rar5-unpacked-size-exceeds-declared.rar: status=1, prints seed metadata, then "Uncompressed data exceeds declared size"
```

## Tests

```bash
cmake -S . -B build-test \
  -DCMAKE_BUILD_TYPE=Debug \
  -DENABLE_TEST=ON \
  -DENABLE_WERROR=OFF
cmake --build build-test --target libarchive_test bsdtar -j6
build-test/bin/libarchive_test -q \
  -r "$PWD/libarchive/test" \
  test_read_format_rar5_unpacked_size_exceeds_declared
ctest --test-dir build-test \
  -R 'libarchive_test_read_format_rar5' \
  --output-on-failure --timeout 60 -j6
```

Result:

```text
new regression test: passed
focused RAR5 suite: 65 passed, 1 skipped, 0 failed
```

Sanitizer smoke test:

```bash
cmake -S . -B build-asan \
  -DCMAKE_BUILD_TYPE=Debug \
  -DENABLE_TEST=OFF \
  -DENABLE_WERROR=OFF \
  -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' \
  -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined' \
  -DCMAKE_SHARED_LINKER_FLAGS='-fsanitize=address,undefined'
cmake --build build-asan --target bsdtar -j6
ASAN_OPTIONS='detect_leaks=0:abort_on_error=0:symbolize=1' \
UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=0' \
timeout 10s build-asan/bin/bsdtar -tf rar5-unpacked-size-exceeds-declared.rar
```

Result:

```text
status=1
stdout: seed
stderr: Uncompressed data exceeds declared size
no ASAN/UBSAN diagnostics observed
```
