### PR TITLE
Reject empty pax extended headers

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1757,7 +1757,6 @@ header_pax_global(struct archive_read *a, struct tar *tar,
 	const struct archive_entry_header_ustar *header;
 	int64_t size, to_consume;
 
-	(void)a; /* UNUSED */
 	(void)tar; /* UNUSED */
 	(void)entry; /* UNUSED */
 
@@ -1767,6 +1766,11 @@ header_pax_global(struct archive_read *a, struct tar *tar,
 		archive_set_error(&a->archive, EINVAL,
 		    "Special header has invalid size: %lld",
 		    (long long)size);
+		return (ARCHIVE_FATAL);
+	}
+	if (size == 0) {
+		archive_set_error(&a->archive, EINVAL,
+		    "Invalid empty pax global extended header");
 		return (ARCHIVE_FATAL);
 	}
 	to_consume = ((size + 511) & ~511);
@@ -1914,6 +1918,11 @@ header_pax_extension(struct archive_read *a, struct tar *tar,
 			    "pax extension header has invalid size: %lld",
 			    (long long)ext_size);
 	  return (ARCHIVE_FATAL);
+	}
+	if (ext_size == 0) {
+		archive_set_error(&a->archive, EINVAL,
+		    "Invalid empty pax extended header");
+		return (ARCHIVE_FATAL);
 	}
 
 	ext_padding = 0x1ff & (-ext_size);

--- a/libarchive/test/test_read_format_tar_empty_pax.c
+++ b/libarchive/test/test_read_format_tar_empty_pax.c
@@ -24,6 +24,71 @@
  */
 #include "test.h"
 
+#define TAR_BLOCK_SIZE 512
+
+static void
+format_octal(char *p, size_t s, unsigned long long v)
+{
+	memset(p, 0, s);
+	snprintf(p, s, "%0*llo", (int)s - 1, v);
+}
+
+static void
+build_tar_header(char *p, const char *name, char typeflag,
+    unsigned long long size)
+{
+	unsigned int checksum;
+	size_t i;
+
+	memset(p, 0, TAR_BLOCK_SIZE);
+	snprintf(p, 100, "%s", name);
+	format_octal(p + 100, 8, 0644);
+	format_octal(p + 108, 8, 0);
+	format_octal(p + 116, 8, 0);
+	format_octal(p + 124, 12, size);
+	format_octal(p + 136, 12, 0);
+	memset(p + 148, ' ', 8);
+	p[156] = typeflag;
+	memcpy(p + 257, "ustar", 5);
+	memcpy(p + 263, "00", 2);
+
+	checksum = 0;
+	for (i = 0; i < TAR_BLOCK_SIZE; ++i)
+		checksum += (unsigned char)p[i];
+	snprintf(p + 148, 8, "%06o", checksum);
+	p[154] = '\0';
+	p[155] = ' ';
+}
+
+static void
+build_empty_pax_archive(char *buff, char typeflag)
+{
+	memset(buff, 0, TAR_BLOCK_SIZE * 4);
+	build_tar_header(buff,
+	    typeflag == 'g' ? "pax_global_header" : "./PaxHeaders/file",
+	    typeflag, 0);
+	build_tar_header(buff + TAR_BLOCK_SIZE, "file", '0', 0);
+}
+
+static void
+assert_empty_pax_rejected(char typeflag, const char *error)
+{
+	char archive[TAR_BLOCK_SIZE * 4];
+	struct archive_entry *ae;
+	struct archive *a;
+
+	build_empty_pax_archive(archive, typeflag);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive, sizeof(archive)));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualString(error, archive_error_string(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 /*
  * A "usual" empty tar archive contains only zero bytes
  * and gets handled by the 'empty' format, not by the 'tar'
@@ -54,4 +119,8 @@ DEFINE_TEST(test_read_format_tar_empty_pax)
 	assertEqualInt(ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE, archive_format(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Empty pax extension headers are invalid: they contain no records. */
+	assert_empty_pax_rejected('x', "Invalid empty pax extended header");
+	assert_empty_pax_rejected('g', "Invalid empty pax global extended header");
 }


### PR DESCRIPTION
## Summary

Fixes #3151.

This rejects zero-length pax extended headers (`x`/`X`) and global pax headers (`g`) instead of accepting them as valid pax records. The existing non-empty pax archive regression remains covered, and the new test adds explicit in-memory invalid local/global empty pax cases.

## Test plan

```sh
cmake --build build --target libarchive_test --parallel 2
./build/bin/libarchive_test -r /tmp/oss-pr-pipeline/libarchive-3151/libarchive/test \
  test_read_format_tar_empty_pax \
  test_read_format_tar_pax_g_large \
  test_read_format_tar_pax_large_attr \
  test_read_pax_empty_val_no_nl \
  test_read_pax_truncated
git diff --check HEAD~1..HEAD
```
