### PR TITLE
xattr: Treat memory allocation failure as error

### DIFF
--- a/libarchive/archive_entry_xattr.c
+++ b/libarchive/archive_entry_xattr.c
@@ -97,11 +97,11 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 	if ((xp->name = strdup(name)) == NULL)
 		__archive_errx(1, "Out of memory");
 
-	if ((xp->value = malloc(size)) != NULL) {
-		memcpy(xp->value, value, size);
-		xp->size = size;
-	} else
-		xp->size = 0;
+	if ((xp->value = malloc(size)) == NULL)
+		__archive_errx(1, "Out of memory");
+
+	memcpy(xp->value, value, size);
+	xp->size = size;
 
 	xp->next = entry->xattr_head;
 	entry->xattr_head = xp;


### PR DESCRIPTION
Do not silently truncate values if allocation fails.

Reported by @ysf.