### PR TITLE
zip: harden test cleanup assertion

### DIFF
--- a/libarchive/test/test_read_format_zip_7075_utf8_paths.c
+++ b/libarchive/test/test_read_format_zip_7075_utf8_paths.c
@@ -96,6 +96,6 @@ DEFINE_TEST(test_read_format_zip_utf8_paths)
 	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, p, s, 31));
 	verify(a);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_free(a));
+	assertEqualInt(ARCHIVE_OK, archive_free(a));
 	free(p);
 }


### PR DESCRIPTION
assertEqualIntA() uses the archive pointer to print archive error details when the assertion fails. Passing `a` while the asserted expression is `archive_free(a)` can make the failure path inspect the archive after it has already been freed.