### PR TITLE
mtree: Fix integer overflow on 32 bit systems

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -337,7 +337,7 @@ next_line(struct archive_read *a,
 	 */
 	while (*nl == 0 && len == *avail && !quit) {
 		ssize_t diff = *ravail - *avail;
-		size_t nbytes_req = (*ravail+1023) & ~1023U;
+		size_t nbytes_req = ((size_t)*ravail + 1023) & ~1023U;
 		ssize_t tested;
 
 		/*


### PR DESCRIPTION
If a file close to `SSIZE_MAX` in size is mapped into memory and checked for mtree, a signed integer overflow could occur.

While this this generally harmless and the scenario very unlikely, fix the issue with a proper cast.

Proof of Concept:
1. Create a large input file without newline
```
dd if=/dev/zero bs=512 count=4194303 | tr '\0' A > input.mtree
```
2. Create POC and compile with `-ftrapv` because ASAN won't work with such an mmap
```
cat > poc.c << EOF
#include <sys/mman.h>

#include <archive.h>
#include <err.h>
#include <fcntl.h>
#include <limits.h>

int main(void)
{
        struct archive *a;
        struct archive_entry *entry;
        char *buff;
        int fd;

        fd = open("input.mtree", O_RDONLY, 0);
        if (fd < 0)
                err(1, "open");

        buff = mmap(NULL, 2147483136, PROT_READ, MAP_SHARED, fd, 0);
        if (buff == MAP_FAILED)
                err(1, "mmap");
        printf("hier\n");

        a = archive_read_new();
        archive_read_support_format_all(a);
        archive_read_support_filter_all(a);
        archive_read_open_memory(a, buff, 2147483136);
        archive_read_next_header(a, &entry);

        return 0;
}
EOF
cc -ftrapv -larchive -o poc poc.c
```
3. Run POC
```
./poc
```
```
Aborted                    (core dumped) ./poc
```