### PR TITLE
tests: fix incorrect charset labels

### DIFF
--- a/libarchive/test/test_gnutar_filename_encoding.c
+++ b/libarchive/test/test_gnutar_filename_encoding.c
@@ -157,7 +157,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP1251_UTF8)
 
 	if (NULL == setlocale(LC_ALL, "Russian_Russia") &&
 	    NULL == setlocale(LC_ALL, "ru_RU.CP1251")) {
-		skipping("KOI8-R locale not available on this system.");
+		skipping("CP1251 locale not available on this system.");
 		return;
 	}
 
@@ -169,7 +169,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP1251_UTF8)
 	assertEqualInt(ARCHIVE_OK, archive_write_set_format_gnutar(a));
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
-		    " from KOI8-R to UTF-8.");
+		    " from CP1251 to UTF-8.");
 		archive_write_free(a);
 		return;
 	}
@@ -177,7 +177,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_CP1251_UTF8)
 	    archive_write_open_memory(a, buff, sizeof(buff), &used));
 
 	entry = archive_entry_new2(a);
-	/* Set a KOI8-R filename. */
+	/* Set a CP1251 filename. */
 	archive_entry_set_pathname(entry, "\xEF\xF0\xE8");
 	archive_entry_set_filetype(entry, AE_IFREG);
 	archive_entry_set_size(entry, 0);
@@ -201,7 +201,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_ru_RU_CP1251)
 	size_t used;
 
 	if (NULL == setlocale(LC_ALL, "ru_RU.CP1251")) {
-		skipping("KOI8-R locale not available on this system.");
+		skipping("CP1251 locale not available on this system.");
 		return;
 	}
 
@@ -215,7 +215,7 @@ DEFINE_TEST(test_gnutar_filename_encoding_ru_RU_CP1251)
 	    archive_write_open_memory(a, buff, sizeof(buff), &used));
 
 	entry = archive_entry_new2(a);
-	/* Set a KOI8-R filename. */
+	/* Set a CP1251 filename. */
 	archive_entry_set_pathname(entry, "\xEF\xF0\xE8");
 	archive_entry_set_filetype(entry, AE_IFREG);
 	archive_entry_set_size(entry, 0);

--- a/libarchive/test/test_pax_filename_encoding.c
+++ b/libarchive/test/test_pax_filename_encoding.c
@@ -389,7 +389,7 @@ DEFINE_TEST(test_pax_filename_encoding_CP1251)
 
 	if (NULL == setlocale(LC_ALL, "Russian_Russia") &&
 	    NULL == setlocale(LC_ALL, "ru_RU.CP1251")) {
-		skipping("KOI8-R locale not available on this system.");
+		skipping("CP1251 locale not available on this system.");
 		return;
 	}
 
@@ -398,7 +398,7 @@ DEFINE_TEST(test_pax_filename_encoding_CP1251)
 	assertEqualInt(ARCHIVE_OK, archive_write_set_format_pax(a));
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
-		    " from KOI8-R to UTF-8.");
+		    " from CP1251 to UTF-8.");
 		archive_write_free(a);
 		return;
 	}
@@ -419,7 +419,7 @@ DEFINE_TEST(test_pax_filename_encoding_CP1251)
 	archive_entry_free(entry);
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
-	/* Above three characters in KOI8-R should translate to the following
+	/* Above three characters in CP1251 should translate to the following
 	 * three characters (two bytes each) in UTF-8. */
 	assertEqualMem(buff + 512, "15 path=\xD0\xBF\xD1\x80\xD0\xB8\x0A", 15);
 }
@@ -483,7 +483,7 @@ DEFINE_TEST(test_pax_filename_encoding_CP932)
 
 	if (NULL == setlocale(LC_ALL, "Japanese_Japan") &&
 	    NULL == setlocale(LC_ALL, "ja_JP.SJIS")) {
-		skipping("eucJP locale not available on this system.");
+		skipping("CP932/SJIS locale not available on this system.");
 		return;
 	}
 

--- a/libarchive/test/test_read_format_zip_filename.c
+++ b/libarchive/test/test_read_format_zip_filename.c
@@ -176,7 +176,7 @@ DEFINE_TEST(test_read_format_zip_filename_UTF8_eucJP)
 	 * Bit 11 of its general purpose bit flag is set.
 	 */
 	if (NULL == setlocale(LC_ALL, "ja_JP.eucJP")) {
-		skipping("ja_JP.eucJP locale not availablefilename_ on "
+		skipping("ja_JP.eucJP locale not available on "
 			 "this system.");
 		return;
 	}

--- a/libarchive/test/test_ustar_filename_encoding.c
+++ b/libarchive/test/test_ustar_filename_encoding.c
@@ -158,7 +158,7 @@ DEFINE_TEST(test_ustar_filename_encoding_CP1251_UTF8)
 
 	if (NULL == setlocale(LC_ALL, "Russian_Russia") &&
 	    NULL == setlocale(LC_ALL, "ru_RU.CP1251")) {
-		skipping("KOI8-R locale not available on this system.");
+		skipping("CP1251 locale not available on this system.");
 		return;
 	}
 
@@ -170,7 +170,7 @@ DEFINE_TEST(test_ustar_filename_encoding_CP1251_UTF8)
 	assertEqualInt(ARCHIVE_OK, archive_write_set_format_ustar(a));
 	if (archive_write_set_options(a, "hdrcharset=UTF-8") != ARCHIVE_OK) {
 		skipping("This system cannot convert character-set"
-		    " from KOI8-R to UTF-8.");
+		    " from CP1251 to UTF-8.");
 		archive_write_free(a);
 		return;
 	}
@@ -178,7 +178,7 @@ DEFINE_TEST(test_ustar_filename_encoding_CP1251_UTF8)
 	    archive_write_open_memory(a, buff, sizeof(buff), &used));
 
 	entry = archive_entry_new2(a);
-	/* Set a KOI8-R filename. */
+	/* Set a CP1251 filename. */
 	archive_entry_set_pathname(entry, "\xEF\xF0\xE8");
 	archive_entry_set_filetype(entry, AE_IFREG);
 	archive_entry_set_size(entry, 0);
@@ -202,7 +202,7 @@ DEFINE_TEST(test_ustar_filename_encoding_ru_RU_CP1251)
 	size_t used;
 
 	if (NULL == setlocale(LC_ALL, "ru_RU.CP1251")) {
-		skipping("KOI8-R locale not available on this system.");
+		skipping("CP1251 locale not available on this system.");
 		return;
 	}
 
@@ -216,7 +216,7 @@ DEFINE_TEST(test_ustar_filename_encoding_ru_RU_CP1251)
 	    archive_write_open_memory(a, buff, sizeof(buff), &used));
 
 	entry = archive_entry_new2(a);
-	/* Set a KOI8-R filename. */
+	/* Set a CP1251 filename. */
 	archive_entry_set_pathname(entry, "\xEF\xF0\xE8");
 	archive_entry_set_filetype(entry, AE_IFREG);
 	archive_entry_set_size(entry, 0);


### PR DESCRIPTION
Several filename encoding tests were copied from KOI8-R or EUC-JP cases, but now use CP1251 or CP932/SJIS instead.

Update skip messages, conversion messages, and comments to match the locales and byte sequences used by the tests.

Also fix a typo in an EUC-JP ZIP filename skip message.