### PR TITLE
cab: Remove obsolete safety checks

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -1339,10 +1339,6 @@ cab_next_cfdata(struct archive_read *a)
 	}
 	return (ARCHIVE_OK);
 invalid:
-	cfdata->compressed_size = 0;
-	cfdata->compressed_bytes_remaining = 0;
-	cfdata->uncompressed_size = 0;
-	cfdata->uncompressed_bytes_remaining = 0;
 	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 	    "Invalid CFDATA");
 	return (ARCHIVE_FATAL);
@@ -1485,14 +1481,6 @@ cab_read_ahead_cfdata_deflate(struct archive_read *a, ssize_t *avail)
 		    cab->uncompressed_buffer + cab->stream.total_out;
 		cab->stream.avail_out =
 		    cfdata->uncompressed_size - cab->stream.total_out;
-		if ((size_t)cfdata->uncompressed_size >
-		    cab->uncompressed_buffer_size) {
-			archive_set_error(&a->archive,
-			    ARCHIVE_ERRNO_FILE_FORMAT,
-			    "Invalid CFDATA uncompressed size");
-			*avail = ARCHIVE_FATAL;
-			return (NULL);
-		}
 
 		d = __archive_read_ahead(a, 1, &bytes_avail);
 		if (bytes_avail <= 0) {
@@ -1703,13 +1691,6 @@ cab_read_ahead_cfdata_lzx(struct archive_read *a, ssize_t *avail)
 		    cab->uncompressed_buffer + cab->xstrm.total_out;
 		cab->xstrm.avail_out =
 		    cfdata->uncompressed_size - cab->xstrm.total_out;
-		
-		if ((size_t)cfdata->uncompressed_size > cab->uncompressed_buffer_size) {
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
-				"Invalid CFDATA uncompressed size");
-			*avail = ARCHIVE_FATAL;
-			return (NULL);
-		}
 
 		d = __archive_read_ahead(a, 1, &bytes_avail);
 		if (d == NULL) {


### PR DESCRIPTION
Commit e1f890dc62f7931d971e2483efd8a3d30a98b1f4 fixed the underlying root cause of these OOB checks: If a header is invalid and `ARCHIVE_FATAL` is returned, do not allow data reads anymore.

The checks while reading CFDATA already looked rather off, since the check exists in header parser and the value is never updated, but prevent worst case scenario.

Keep the tests as regression tests if `archive_read.c` is modified again.

This makes the code easier to read and audit.