### PR TITLE
Fix two more off-by-ones calling assertEqualMem

### DIFF
--- a/libarchive/test/test_write_format_tar_ustar.c
+++ b/libarchive/test/test_write_format_tar_ustar.c
@@ -216,7 +216,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "010034\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "0", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -237,7 +237,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "010707\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "0", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -256,7 +256,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "007747\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "5", 1); /* typeflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -275,7 +275,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "011446\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "2", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "file", 5); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -294,7 +294,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "034242\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "0", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -313,7 +313,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "026230\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "0", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */
@@ -332,7 +332,7 @@ DEFINE_TEST(test_write_format_tar_ustar)
 	myAssertEqualMem(e + 148, "055570\0 ", 8); /* checksum */
 	myAssertEqualMem(e + 156, "0", 1); /* linkflag */
 	myAssertEqualMem(e + 157, "", 1); /* linkname */
-	myAssertEqualMem(e + 257, "ustar\000000", 8); /* signature/version */
+	myAssertEqualMem(e + 257, "ustar\00000", 8); /* signature/version */
 	myAssertEqualMem(e + 265, "", 1); /* uname */
 	myAssertEqualMem(e + 297, "", 1); /* gname */
 	myAssertEqualMem(e + 329, "000000 ", 8); /* devmajor */

--- a/libarchive/test/test_write_read_format_zip.c
+++ b/libarchive/test/test_write_read_format_zip.c
@@ -436,7 +436,7 @@ verify_contents(struct archive *a, int seeking, int improved_streaming)
 	}
 	assertEqualIntA(a, 5,
 	    archive_read_data(a, filedata, sizeof(filedata)));
-	assertEqualMem(filedata, "ghijk", 4);
+	assertEqualMem(filedata, "ghijk", 5);
 
 	/* Read symlink. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
@@ -534,7 +534,7 @@ verify_contents(struct archive *a, int seeking, int improved_streaming)
 	}
 	assertEqualIntA(a, 5,
 	    archive_read_data(a, filedata, sizeof(filedata)));
-	assertEqualMem(filedata, "ijklm", 4);
+	assertEqualMem(filedata, "ijklm", 5);
 
 	/* Read symlink. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));


### PR DESCRIPTION
Similar to #3200.

Found with custom clang tooling!

```
libarchive/test/test_write_read_format_zip.c:439:36: error:
      memcmp needle has length '5', but is checked with length '4'
  439 |         assertEqualMem(filedata, "ghijk", 4);
      |                                           ^
libarchive/test/test_write_read_format_zip.c:537:36: error:
      memcmp needle has length '5', but is checked with length '4'
  537 |         assertEqualMem(filedata, "ijklm", 4);
      |                                           ^
2 errors generated.
```