### PR TITLE
test: enable most of the remaining disk_secure tests on Windows

### DIFF
--- a/libarchive/test/test_write_disk_secure.c
+++ b/libarchive/test/test_write_disk_secure.c
@@ -37,16 +37,17 @@
 
 DEFINE_TEST(test_write_disk_secure)
 {
-#if defined(_WIN32) && !defined(__CYGWIN__)
-	skipping("archive_write_disk security checks not supported on Windows");
-#else
 	struct archive *a;
 	struct archive_entry *ae;
-	struct stat st;
 #if defined(HAVE_LCHMOD) && defined(HAVE_SYMLINK) && \
     defined(S_IRUSR) && defined(S_IWUSR) && defined(S_IXUSR)
 	int working_lchmod;
 #endif
+
+	if (!canSymlink()) {
+		skipping("Can't test symlinks on this filesystem");
+		return;
+	}
 
 	/* Start with a known umask. */
 	assertUmask(UMASK);
@@ -67,6 +68,7 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_copy_pathname(ae, "link_to_dir");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -91,11 +93,14 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_free(ae);
 	assert(0 == archive_write_finish_entry(a));
 
+	/* These tests hardcode the location of /tmp. skip them on Windows for now. */
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	/* Write an absolute symlink to /tmp. */
 	assert((ae = archive_entry_new()) != NULL);
 	archive_entry_copy_pathname(ae, "/tmp/libarchive_test-test_write_disk_secure-absolute_symlink");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "/tmp");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -111,12 +116,14 @@ DEFINE_TEST(test_write_disk_secure)
 	assertFileNotExists("/tmp/libarchive_test-test_write_disk_secure-absolute_symlink/libarchive_test-test_write_disk_secure-absolute_symlink_path.tmp");
 	assert(0 == unlink("/tmp/libarchive_test-test_write_disk_secure-absolute_symlink"));
 	unlink("/tmp/libarchive_test-test_write_disk_secure-absolute_symlink_path.tmp");
+#endif
 
 	/* Create another link. */
 	assert((ae = archive_entry_new()) != NULL);
 	archive_entry_copy_pathname(ae, "link_to_dir2");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -138,6 +145,7 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_copy_pathname(ae, "dir/nested_link_to_dir");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "../dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -161,6 +169,7 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_copy_pathname(ae, "link_to_dir3");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -171,8 +180,7 @@ DEFINE_TEST(test_write_disk_secure)
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
 	/* Verify link was followed. */
-	assertEqualInt(0, lstat("link_to_dir3", &st));
-	assert(S_ISLNK(st.st_mode));
+	assertIsSymlink("link_to_dir3", "dir", 1);
 	archive_entry_free(ae);
 
 	/*
@@ -183,6 +191,7 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_copy_pathname(ae, "link_to_dir4");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "nonexistent_dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_DIRECTORY);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -193,8 +202,7 @@ DEFINE_TEST(test_write_disk_secure)
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
 	/* Verify link was replaced. */
-	assertEqualInt(0, lstat("link_to_dir4", &st));
-	assert(S_ISDIR(st.st_mode));
+	assertIsDir("link_to_dir4", -1);
 	archive_entry_free(ae);
 
 	/*
@@ -211,6 +219,7 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_copy_pathname(ae, "link_to_dir5");
 	archive_entry_set_mode(ae, S_IFLNK | 0777);
 	archive_entry_set_symlink(ae, "non_dir");
+	archive_entry_set_symlink_type(ae, AE_SYMLINK_TYPE_FILE);
 	archive_write_disk_set_options(a, 0);
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
@@ -221,10 +230,11 @@ DEFINE_TEST(test_write_disk_secure)
 	assert(0 == archive_write_header(a, ae));
 	assert(0 == archive_write_finish_entry(a));
 	/* Verify link was replaced. */
-	assertEqualInt(0, lstat("link_to_dir5", &st));
-	assert(S_ISDIR(st.st_mode));
+	assertIsDir("link_to_dir5", -1);
 	archive_entry_free(ae);
 
+	/* These tests hardcode the location of /tmp. skip them on Windows for now. */
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	/*
 	 * Without security checks, we should be able to
 	 * extract an absolute path.
@@ -247,17 +257,14 @@ DEFINE_TEST(test_write_disk_secure)
 	archive_entry_free(ae);
 	assert(0 == archive_write_finish_entry(a));
 	assertFileNotExists("/tmp/libarchive_test-test_write_disk_secure-absolute_path.tmp");
+#endif
 
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Test the entries on disk. */
-	assert(0 == lstat("dir", &st));
-	failure("dir: st.st_mode=%o", st.st_mode);
-	assert((st.st_mode & 0777) == 0755);
+	assertIsDir("dir", 0755);
+	assertIsSymlink("link_to_dir", "dir", 1);
 
-	assert(0 == lstat("link_to_dir", &st));
-	failure("link_to_dir: st.st_mode=%o", st.st_mode);
-	assert(S_ISLNK(st.st_mode));
 #if defined(HAVE_SYMLINK) && defined(HAVE_LCHMOD) && \
     defined(S_IRUSR) && defined(S_IWUSR) && defined(S_IXUSR)
 	/* Verify if we are able to lchmod() */
@@ -281,32 +288,18 @@ DEFINE_TEST(test_write_disk_secure)
 		working_lchmod = 0;
 
 	if (working_lchmod) {
+		struct stat st;
+		assert(0 == lstat("link_to_dir", &st));
 		failure("link_to_dir: st.st_mode=%o", st.st_mode);
 		assert((st.st_mode & 07777) == 0755);
 	}
 #endif
 
-	assert(0 == lstat("dir/filea", &st));
-	failure("dir/filea: st.st_mode=%o", st.st_mode);
-	assert((st.st_mode & 07777) == 0755);
-
-	failure("dir/fileb: This file should not have been created");
-	assert(0 != lstat("dir/fileb", &st));
-
-	assert(0 == lstat("link_to_dir2", &st));
-	failure("link_to_dir2 should have been re-created as a true dir");
-	assert(S_ISDIR(st.st_mode));
-	failure("link_to_dir2: Implicit dir creation should obey umask, but st.st_mode=%o", st.st_mode);
-	assert((st.st_mode & 0777) == 0755);
-
-	assert(0 == lstat("link_to_dir2/filec", &st));
-	assert(S_ISREG(st.st_mode));
-	failure("link_to_dir2/filec: st.st_mode=%o", st.st_mode);
-	assert((st.st_mode & 07777) == 0755);
-
-	failure("dir/filed: This file should not have been created");
-	assert(0 != lstat("dir/filed", &st));
-#endif
+	assertIsReg("dir/filea", 0755);
+	assertFileNotExists("dir/fileb");
+	assertIsDir("link_to_dir2", 0755);
+	assertIsReg("link_to_dir2/filec", 0755);
+	assertFileNotExists("dir/filed");
 }
 
 /*


### PR DESCRIPTION
This rather required porting them to assertIs{Reg,Dir,Symlink} and away from directly calling lstat.

This is possible now that 9046e753cacfa5a1ce38aa1b8a259ca0364a0825 fixed a number of other symlink issues on Windows.