### PR TITLE
xar: Fix xar_read_data() infinite loop

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1092,6 +1092,9 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_xar_doublelink.xar.uu \
 	libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu \
 	libarchive/test/test_read_format_xar_large_mode.xar.uu \
+	libarchive/test/test_read_format_xar_stream_end_eof.xar.uu \
+	libarchive/test/test_read_format_xar_stream_end_trunc.xar.uu \
+	libarchive/test/test_read_format_xar_toc_stream_end.xar.uu \
 	libarchive/test/test_read_format_zip.zip.uu \
 	libarchive/test/test_read_format_zip_7075_utf8_paths.zip.uu \
 	libarchive/test/test_read_format_zip_7z_deflate.zip.uu \

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1696,6 +1696,16 @@ decompress(struct archive_read *a, const void **buff, size_t *outbytes,
 		}
 		break;
 	}
+	/*
+	 * A finished stream keeps returning end-of-stream without consuming
+	 * or producing anything.  Callers loop until the declared length is
+	 * used up, so reject a stream that ends early instead of spinning.
+	 */
+	if (*used == 0 && *outbytes == 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "XAR decompressor made no progress");
+		return (ARCHIVE_FATAL);
+	}
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -322,6 +322,7 @@ static int	file_register_hardlink(struct archive_write *,
 static void	file_connect_hardlink_files(struct xar *);
 static void	file_init_hardlinks(struct xar *);
 static void	file_free_hardlinks(struct xar *);
+static void	file_reset_write_state(struct file *);
 
 static void	checksum_init(struct chksumwork *, enum sumalg);
 static void	checksum_update(struct chksumwork *, const void *, size_t);
@@ -636,6 +637,8 @@ xar_write_header(struct archive_write *a, struct archive_entry *entry)
 			xar->temp_offset = algsize;
 		}
 	}
+
+	file_reset_write_state(file);
 
 	if (archive_entry_hardlink(file->entry) == NULL) {
 		r = save_xattrs(a, file);
@@ -2633,6 +2636,22 @@ file_free_hardlinks(struct xar *xar)
 		__archive_rb_tree_remove_node(&(xar->hardlink_rbtree), n);
 		free(n);
 	}
+}
+
+static void
+file_reset_write_state(struct file *file)
+{
+	struct heap_data *hp, *hp_next;
+
+	for (hp = file->xattr.first; hp != NULL; hp = hp_next) {
+		hp_next = hp->next;
+		free(hp);
+	}
+	file->xattr.first = NULL;
+	file->xattr.last = &(file->xattr.first);
+	file->ea_idx = 0;
+	memset(&(file->data), 0, sizeof(file->data));
+	archive_string_empty(&(file->script));
 }
 
 static void

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -1040,3 +1040,100 @@ DEFINE_TEST(test_read_format_xar_atou64_overread)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+/*
+ * The declared length runs past the end of the compressed stream, so the
+ * decompressor stalls after the first byte.  The reader must reject the
+ * entry instead of looping forever.
+ */
+DEFINE_TEST(test_read_format_xar_stream_end_eof)
+{
+	const char *reffile = "test_read_format_xar_stream_end_eof.xar";
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+	char buf[64];
+
+	extract_reference_file(reffile);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, reffile, 10240));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString(".t1", archive_entry_pathname(ae));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
+/*
+ * The compressed stream ends before the declared size is produced, so the
+ * decompressor stalls on the first read.  The reader must reject the entry.
+ */
+DEFINE_TEST(test_read_format_xar_stream_end_trunc)
+{
+	const char *reffile = "test_read_format_xar_stream_end_trunc.xar";
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+	char buf[64];
+
+	extract_reference_file(reffile);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, reffile, 10240));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_data(a, buf, sizeof(buf)));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
+/*
+ * The table of contents is compressed, and its declared length runs past
+ * the end of the stream.  Only the expat/bsdxml backend loops on this
+ * input; the libxml2 backend stops on its own, so skip it there.
+ */
+DEFINE_TEST(test_read_format_xar_toc_stream_end)
+{
+#if defined(HAVE_LIBXML_XMLREADER_H)
+	skipping("xar TOC stall only affects the expat/bsdxml backend");
+#else
+	const char *reffile = "test_read_format_xar_toc_stream_end.xar";
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+
+	extract_reference_file(reffile);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, reffile, 10240));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
+}

--- a/libarchive/test/test_read_format_xar_stream_end_eof.xar.uu
+++ b/libarchive/test/test_read_format_xar_stream_end_eof.xar.uu
@@ -1,0 +1,12 @@
+begin 644 test_read_format_xar_stream_end_eof.xar
+M>&%R(0`<``$````````!'P````````+G`````7C:Q5+!;H,P#+WW*Z+<:4CH
+M$*I,>ML7=!\000K1(""23K1?O\3`)J0>)^WDYQ?']GLR7.:^(U]Z<F:P)>7'
+ME!)MJZ$VMBGIQ_4]*>A%'F!6DSP0\$,5`H%JTLJ''XDWO98B%7F2YDF67GEV
+M%NF9GX#M2_!3JZM/=^^)\X].E]2UBM/X0F"XW9SV,@6V(F2=><;FP!#$%FSK
+M@=G-=)J8.JR]MK$JC#IZ#@P1<OXQ:ADK@2%$TMBAUG'<`I#KD<I/8??^A[R;
+M.I;%@'FSY,V6U\HK1`0Z;1O?2EX`6^'"KXK$7MRJCO^*"]3F_.:0&L?.5&@C
+MFY/F:4;*EKEL&PPL:MO;(?9VB'^U(WMM1U:\LN/MS^P(\N*M`L/+_09X.=@!
+ME`/8`E/OS6<FUQ&['*$.9)@;6S%XG',$``!"`$)XG',$``!"`$)XG/-P]?'Q
+:!P`$3`%U>)S%5,MNW"`4W><K+.\=7@9#Q#@`
+`
+end

--- a/libarchive/test/test_read_format_xar_stream_end_trunc.xar.uu
+++ b/libarchive/test/test_read_format_xar_stream_end_trunc.xar.uu
@@ -1,0 +1,13 @@
+begin 644 test_read_format_xar_stream_end_trunc.xar
+M>&%R(0`<``$````````!7@````````*=`````'C:=5++DH(P$+S[%11WS(.'
+M8(UXVR]P/R`D`Z26AP714K]^DPA;:[F;2WHZDYY,9^!XZ[O@BM.LQ^$0LBT-
+M`QSDJ/30',+/TT>4A\=R`S<QE9L`S"CM%H"<4!A[(S*ZQY)3GD4TBWAQ8LD^
+M3O<L`?*:XB^U*+_F2Q_,YM[A(9Q;P4)W$L!8US.:D@)9D&=G_7#B0#QP$F35
+M\%&M.PRTLL]>9`9A2VT-$`\\9>YG+%TB$`\]J8=1H:OV!)[K/647D/Z'O&CE
+MTMSFX^89-VNLA!$>!=#AT)BVY`60!3[YI2'^VMO2'*._NK/D:OUJD3B?.RV]
+MC^06-0]]#LF2*B;9ZBNJZ&];:56I'4^%K1!+E;`J+RI.BWI',65)S7C-[5G&
+M@;P)K6^YF4E(\V^%3%E=B3Q6>8X<L4BSO!)IDDE*=S*+5<%B)ED%Y%WIZ1Y9
+M[0/B?L@-&/$3!L3/VS?4I,>S3]3(&J->>R$M.(4M]M[P&T[KR[1XG',$``!"
+J`$)XG'5227*#,!"\^Q44=ZR%Q>`:XP``````````````````````````
+`
+end

--- a/libarchive/test/test_read_format_xar_toc_stream_end.xar.uu
+++ b/libarchive/test/test_read_format_xar_toc_stream_end.xar.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_xar_toc_stream_end.xar
+M>&%R(0 <  $         *                'B< P     !            
+7                                
+`
+end

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -380,3 +380,78 @@ DEFINE_TEST(test_write_format_xar_entry_trunc)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
+
+DEFINE_TEST(test_write_format_xar_duplicate_path)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	static unsigned char buf[4096];
+	static char rbuf[64];
+	size_t used;
+	const char *xname;
+	const void *xval;
+	size_t xsize;
+
+	assert((a = archive_write_new()) != NULL);
+	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
+		skipping("xar is not supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "xar:compression=none"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buf, sizeof(buf), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+
+	archive_entry_set_pathname(ae, "foo");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 4);
+	archive_entry_xattr_add_entry(ae, "user.one", "XX", 2);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, 4, archive_write_data(a, "AAAA", 4));
+
+	archive_entry_clear(ae);
+	archive_entry_set_pathname(ae, "foo");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 3);
+	archive_entry_xattr_add_entry(ae, "user.two", "Y", 1);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, 3, archive_write_data(a, "BBB", 3));
+
+	archive_entry_free(ae);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/* Read back: <length> must be 3 (second entry only), not 7 (accumulated) */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, buf, used));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("foo", archive_entry_pathname(ae));
+	assertEqualInt(3, (int)archive_entry_size(ae));
+
+	assertEqualIntA(a, 3, archive_read_data(a, rbuf, sizeof(rbuf)));
+	assertEqualMem("BBB", rbuf, 3);
+	assertEqualIntA(a, 0, archive_read_data(a, rbuf, sizeof(rbuf)));
+
+	/* Exactly one xattr */
+	assertEqualInt(1, archive_entry_xattr_reset(ae));
+	assertEqualInt(ARCHIVE_OK,
+		archive_entry_xattr_next(ae, &xname, &xval, &xsize));
+	assertEqualString("user.two", xname);
+	assertEqualInt(1, (int)xsize);
+	assertEqualMem("Y", xval, 1);
+	/* No further xattrs */
+	assertEqualInt(ARCHIVE_WARN,
+	    archive_entry_xattr_next(ae, &xname, &xval, &xsize));
+
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
It is possible that `archive_read_data` hangs forever when `decompress()` reaches the `Z_STREAM_END` branch.

Add a guard in `xar_read_data()` when `rd_contents()` makes no progress, covering the `Z_STREAM_END` case and other potential bugs. Choice made: the fix accepts junk after the end of compressed data instead of raising an error.

There is a bug on the write side that produces an archive of this case: the xar writer reuses file node without zeroing out the fields when two entries have the same path. As a result, `file->data.length` becomes the sum of the two data lengths. When `"xar:compression=none"` is set, it hits the existing `"Decompressed size error"` guard when reading back instead of hanging.

Regression test is created but there are many fields I do not know how to cover.
