### PR TITLE
Add global umask callback to avoid unsafe umask queries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -623,6 +623,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_disk_appledouble.c \
 	libarchive/test/test_write_disk_failures.c \
 	libarchive/test/test_write_disk_fixup.c \
+	libarchive/test/test_write_disk_global_umask.c \
 	libarchive/test/test_write_disk_hardlink.c \
 	libarchive/test/test_write_disk_hfs_compression.c \
 	libarchive/test/test_write_disk_lookup.c \

--- a/libarchive/archive.h
+++ b/libarchive/archive.h
@@ -989,6 +989,9 @@ __LA_DECL int		 archive_write_disk_set_options(struct archive *,
  * POSIX "tar".
  */
 __LA_DECL int	 archive_write_disk_set_standard_lookup(struct archive *);
+/* Set a global callback to query the umask.
+ * Pass NULL to restore the default behaviour. */
+__LA_DECL int	 archive_write_disk_set_global_umask_lookup(mode_t (*)(void));
 /*
  * If neither the default (naive) nor the standard (big) functions suit
  * your needs, you can write your own and register them.  Be sure to

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -168,6 +168,9 @@
 #define AT_FDCWD -100
 #endif
 
+/* Global callback to retrieve the umask */
+static mode_t (*global_umask_fn)(void) = NULL;
+
 struct fixup_entry {
 	struct fixup_entry	*next;
 	struct archive_acl	 acl;
@@ -470,6 +473,18 @@ la_opendirat(int fd, const char *path) {
 #endif
 }
 
+static mode_t
+query_umask(void)
+{
+	mode_t mask;
+
+	if (global_umask_fn != NULL)
+		return (global_umask_fn());
+	mask = umask(0);
+	umask(mask);
+	return (mask);
+}
+
 static int
 la_verify_filetype(mode_t mode, __LA_MODE_T filetype) {
 	int ret = 0;
@@ -646,7 +661,7 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	 * user edits their umask during the extraction for some
 	 * reason.
 	 */
-	umask(a->user_umask = umask(0));
+	a->user_umask = query_umask();
 
 	/* Figure out what we need to do for this entry. */
 	a->todo = TODO_MODE_BASE;
@@ -1939,6 +1954,14 @@ finish_metadata:
 }
 
 int
+archive_write_disk_set_global_umask_lookup(
+    mode_t (*get_umask)(void))
+{
+	global_umask_fn = get_umask;
+	return (ARCHIVE_OK);
+}
+
+int
 archive_write_disk_set_group_lookup(struct archive *_a,
     void *private_data,
     la_int64_t (*lookup_gid)(void *private, const char *gname, la_int64_t gid),
@@ -2014,8 +2037,8 @@ archive_write_disk_new(void)
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	a->archive.vtable = &archive_write_disk_vtable;
 	a->start_time = time(NULL);
-	/* Query and restore the umask. */
-	umask(a->user_umask = umask(0));
+	/* Query the umask. */
+	a->user_umask = query_umask();
 #ifdef HAVE_GETEUID
 	a->user_uid = geteuid();
 #endif /* HAVE_GETEUID */

--- a/libarchive/test/test_write_disk_global_umask.c
+++ b/libarchive/test/test_write_disk_global_umask.c
@@ -1,0 +1,89 @@
+/*-
+ * Copyright (c) 2026 Omar Sawalha
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#define UMASK 022
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+static mode_t
+custom_umask(void)
+{
+	return (0077);
+}
+#endif
+
+DEFINE_TEST(test_write_disk_global_umask)
+{
+#if !defined(_WIN32) || defined(__CYGWIN__)
+	struct archive *a;
+	struct archive_entry *ae;
+	struct stat st;
+
+	/* Force the umask to be different from the callback
+	 * so we can verify the callback is actually being used. */
+	assertUmask(UMASK);
+
+	/* Set the global umask callback. */
+	assertEqualInt(ARCHIVE_OK,
+	    archive_write_disk_set_global_umask_lookup(&custom_umask));
+
+	assert((a = archive_write_disk_new()) != NULL);
+
+	/* Create a file with mode 0777; the callback umask 0077
+	 * should reduce it to 0700. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "file");
+	archive_entry_set_mode(ae, S_IFREG | 0777);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_finish_entry(a));
+	archive_entry_free(ae);
+
+	/* Create a directory with mode 0777; should become 0700. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "dir");
+	archive_entry_set_mode(ae, S_IFDIR | 0777);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_finish_entry(a));
+	archive_entry_free(ae);
+
+	assertEqualInt(0, archive_write_free(a));
+
+	/* Verify the file was created with the expected permissions. */
+	assertEqualInt(0, stat("file", &st));
+	failure("File should be 0700 (0777 & ~0077)");
+	assertEqualInt(0700, st.st_mode & 0777);
+
+	/* Verify the directory was created with the expected permissions. */
+	assertEqualInt(0, stat("dir", &st));
+	failure("Dir should be 0700 (0777 & ~0077)");
+	assertEqualInt(0700, st.st_mode & 0777);
+
+	/* Reset the callback */
+	archive_write_disk_set_global_umask_lookup(NULL);
+#else
+	skipping("umask test is not supported on Windows");
+#endif
+}


### PR DESCRIPTION
We would like to extend MATLAB's current usage of libarchive to safely support execution on MATLAB threads (i.e. in a multi-threaded context). While doing so, we encountered the same umask issue discussed in this [issue](https://github.com/libarchive/libarchive/issues/1876), and would like to propose a change that helps users who may encounter this issue (in a way that is open to all versions of Unix).
 
Happy to discuss alternative approaches or adjustments if there are better ways to integrate this. Open to feedback on the design and whether a different direction would be preferred.
 
The `archive_write_disk` code queries the process umask via `umask(umask(0))`. This is not thread-safe; another thread can observe the zeroed umask between the two calls. Mutexing the pair alone doesn't help unless we also lock all code that could possibly use umask values (like `mkdir`, etc.), which is impractical.

While it is possible to read the umask via /proc/self/status, this is not a backwards-compatible solution, as it is only available on newer versions of Linux (>= Linux 4.7).

This pull request adds an optional global callback so that callers can provide their own umask retrieval (for example, by caching the value at startup). When no callback is set, the existing behaviour is preserved.

Includes a test case (`test_write_disk_global_umask`).

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY.