### PR TITLE
7zip: drop redundant BCJ2 assignments

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3953,15 +3953,11 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 				}
 			}
 			coder2 = &(fc[3]);
-			zip->main_stream_bytes_remaining =
-				folder->unPackSize[2];
 			remaining = folder->unPackSize[2];
 		} else if (coder2 != NULL && coder2->codec == _7Z_X86_BCJ2 &&
 		    zip->pack_stream_remaining == 4 &&
 		    folder->numInStreams == 5 && folder->numOutStreams == 2) {
 			/* Source type 0 made by 7z */
-			zip->main_stream_bytes_remaining =
-				folder->unPackSize[0];
 			remaining = folder->unPackSize[0];
 		} else {
 			/* We got an unexpected form. */


### PR DESCRIPTION
Both supported BCJ2 layout branches store the chosen unpack size in remaining.

`main_stream_bytes_remaining` is set from remaining immediately after the branch, so the earlier assignments are redundant.