### PR TITLE
formats: remove unused states

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -267,8 +267,6 @@ struct cffile {
 };
 
 struct cfheader {
-	/* Total bytes of all file size in a Cabinet. */
-	uint32_t		 total_bytes;
 	uint32_t		 files_offset;
 	uint16_t		 folder_count;
 	uint16_t		 file_count;
@@ -276,7 +274,6 @@ struct cfheader {
 #define PREV_CABINET	0x0001
 #define NEXT_CABINET	0x0002
 #define RESERVE_PRESENT	0x0004
-	uint16_t		 setid;
 	uint16_t		 cabinet;
 	/* Version number. */
 	unsigned char		 major;
@@ -295,8 +292,6 @@ struct cab {
 	int64_t			 entry_offset;
 	int64_t			 entry_bytes_remaining;
 	int64_t			 entry_unconsumed;
-	int64_t			 entry_compressed_bytes_read;
-	int64_t			 entry_uncompressed_bytes_read;
 	struct cffolder		*entry_cffolder;
 	struct cffile		*entry_cffile;
 	struct cfdata		*entry_cfdata;
@@ -690,7 +685,6 @@ cab_read_header(struct archive_read *a)
 		    "Couldn't find out CAB header");
 		return (ARCHIVE_FATAL);
 	}
-	hd->total_bytes = archive_le32dec(p + CFHEADER_cbCabinet);
 	hd->files_offset = archive_le32dec(p + CFHEADER_coffFiles);
 	hd->minor = p[CFHEADER_versionMinor];
 	hd->major = p[CFHEADER_versionMajor];
@@ -701,7 +695,6 @@ cab_read_header(struct archive_read *a)
 	if (hd->file_count == 0)
 		goto invalid;
 	hd->flags = archive_le16dec(p + CFHEADER_flags);
-	hd->setid = archive_le16dec(p + CFHEADER_setID);
 	hd->cabinet = archive_le16dec(p + CFHEADER_iCabinet);
 	used = CFHEADER_iCabinet + 2;
 	if (hd->flags & RESERVE_PRESENT) {
@@ -945,8 +938,6 @@ archive_read_format_cab_read_header(struct archive_read *a,
 
 	cab->end_of_entry = 0;
 	cab->end_of_entry_cleanup = 0;
-	cab->entry_compressed_bytes_read = 0;
-	cab->entry_uncompressed_bytes_read = 0;
 	cab->entry_unconsumed = 0;
 	cab->entry_cffile = file;
 

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -141,7 +141,6 @@ struct lzx_dec {
 		 */
 		int		 max_bits;
 		int		 tbl_bits;
-		int		 tree_used;
 		/* Direct access table. */
 		uint16_t	*tbl;
 	}			 at, lt, mt, pt;
@@ -3208,7 +3207,6 @@ lzx_make_huffman_table(struct huffman *hf)
 	tbl = hf->tbl;
 	bitlen = hf->bitlen;
 	len_avail = hf->len_size;
-	hf->tree_used = 0;
 	/* Initialize table to invalid values */
 	for (i = 0; i < tbl_size; i++) {
 		tbl[i] = (uint16_t)hf->len_size;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -227,8 +227,6 @@ struct rar_program_code
 {
   uint8_t *staticdata;
   uint32_t staticdatalen;
-  uint8_t *globalbackup;
-  uint32_t globalbackuplen;
   uint64_t fingerprint;
   uint32_t usagecount;
   uint32_t oldfilterlength;
@@ -3606,7 +3604,6 @@ delete_program_code(struct rar_program_code *prog)
   {
     struct rar_program_code *next = prog->next;
     free(prog->staticdata);
-    free(prog->globalbackup);
     free(prog);
     prog = next;
   }

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -167,11 +167,9 @@ enum FILTER_TYPE {
 struct filter_info {
 	int type;
 	int channels;
-	int pos_r;
 
 	int64_t block_start;
 	ssize_t block_length;
-	uint16_t width;
 };
 
 struct data_ready {

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -152,8 +152,6 @@ struct zip {
 	struct archive_string	format_name;
 	int64_t			central_directory_offset;
 	int64_t			central_directory_offset_adjusted;
-	size_t			central_directory_entries_total;
-	size_t			central_directory_entries_on_this_disk;
 	int			has_encrypted_entries;
 
 	/* List of entries (seekable Zip only) */
@@ -4203,7 +4201,6 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
 	__archive_rb_tree_init(&zip->tree, &rb_ops);
 	__archive_rb_tree_init(&zip->tree_rsrc, &rb_rsrc_ops);
 
-	zip->central_directory_entries_total = 0;
 	while (1) {
 		struct zip_entry *zip_entry;
 		size_t filename_length, extra_length, comment_length;
@@ -4232,7 +4229,6 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
 		zip_entry->next = zip->zip_entries;
 		zip_entry->flags |= LA_FROM_CENTRAL_DIRECTORY;
 		zip->zip_entries = zip_entry;
-		zip->central_directory_entries_total++;
 
 		/* version = p[4]; */
 		zip_entry->system = p[5];

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -54,7 +54,6 @@ struct warc_s {
 
 	time_t now;
 	mode_t typ;
-	unsigned int rng;
 	/* populated size */
 	uint64_t populz;
 };
@@ -140,8 +139,6 @@ archive_write_set_format_warc(struct archive *_a)
 	w->now = time(NULL);
 	/* reset file type info */
 	w->typ = 0;
-	/* also initialise our rng */
-	w->rng = (unsigned int)w->now;
 
 	a->format_data = w;
 	a->format_name = "WARC/1.0";

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -154,7 +154,6 @@ struct zip {
 	enum compression entry_compression;
 	enum encryption  entry_encryption;
 	int entry_flags;
-	int experiments;
 	struct trad_enc_ctx tctx;
 	char tctx_valid;
 	unsigned char trad_chkdat;


### PR DESCRIPTION
This PR removes unused state across several formats.

All removed fields are private format state that are assigned, reset, incremented, or freed, but never read.

* ZIP reader: Remove unused central directory entry counters from 2013 ZIP reader changes.
* CAB reader: Remove unused CAB header and per-entry accounting fields from the original 2010 CAB reader support.
* CAB LZX: Remove unused Huffman `tree_used` state from the 2011 Huffman table memory cleanup.
* RAR reader: Remove unused `globalbackup` state from the 2021 RAR filter support.
* RAR5 reader: Remove unused `filter_info` fields currently blamed to a 2019 indentation cleanup.
* ZIP writer: Remove unused `experiments` state from the 2014 experimental `LA` extra block support.
* WARC writer: Remove unused `rng` state left behind after UUID generation switched from `rand()` to `archive_random()` in 2014.

Note: The now-unused macros from CAB commit is kept as it is not within the scope of this PR, or let's say I think it's fine to keep it there as they still document the CAB layout.