### PR TITLE
pathmatch: fix wide-char bracket over-read in pm_w

### DIFF
--- a/libarchive/archive_pathmatch.c
+++ b/libarchive/archive_pathmatch.c
@@ -337,7 +337,7 @@ pm_w(const wchar_t *p, const wchar_t *s, int flags, int depth)
 			}
 			if (*end == L']') {
 				/* We found [...], try to match it. */
-				if (!pm_list_w(p + 1, end, *s, flags))
+				if (*s == L'\0' || !pm_list_w(p + 1, end, *s, flags))
 					return (0);
 				p = end; /* Jump to trailing ']' char. */
 				break;

--- a/libarchive/test/test_archive_pathmatch_oob.c
+++ b/libarchive/test/test_archive_pathmatch_oob.c
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 /*
  * Regression test: malformed bracket expressions in patterns caused
@@ -37,8 +38,10 @@
  * redzones detect overreads.
  */
 
-/* Declare the internal function we want to test. */
+/* Declare the internal functions we want to test. */
 int __archive_pathmatch(const char *pattern, const char *string, int flags);
+int __archive_pathmatch_w(const wchar_t *pattern, const wchar_t *string,
+    int flags);
 
 /*
  * Replay a fuzzer repro file through __archive_pathmatch().
@@ -114,4 +117,40 @@ DEFINE_TEST(test_archive_pathmatch_oob_bracket)
 DEFINE_TEST(test_archive_pathmatch_oob_strchr)
 {
 	replay_pathmatch_repro("test_archive_pathmatch_oob_strchr.bin");
+}
+
+/*
+ * Wide-character twin of the bracket over-read.  pm_w() matched a [...]
+ * class without first checking whether the subject string was already
+ * exhausted, so a negated class ([!...]/[^...]) at end-of-string reported
+ * a match and advanced the subject pointer past its terminator.  Allocate
+ * tight wide buffers so ASan's redzones catch the over-read.
+ */
+static void
+check_pathmatch_w_oob(const wchar_t *pat, const wchar_t *str, int flags)
+{
+	size_t plen = wcslen(pat) + 1;
+	size_t slen = wcslen(str) + 1;
+	wchar_t *pattern = (wchar_t *)malloc(plen * sizeof(wchar_t));
+	wchar_t *string = (wchar_t *)malloc(slen * sizeof(wchar_t));
+
+	if (assert(pattern != NULL) && assert(string != NULL)) {
+		wmemcpy(pattern, pat, plen);
+		wmemcpy(string, str, slen);
+		/* This must not read past the allocated buffers. */
+		__archive_pathmatch_w(pattern, string, flags);
+	}
+	free(pattern);
+	free(string);
+}
+
+DEFINE_TEST(test_archive_pathmatch_oob_bracket_w)
+{
+	/* PATHMATCH_NO_ANCHOR_START | PATHMATCH_NO_ANCHOR_END, as used by
+	 * archive_match() exclusion patterns. */
+	int flags = 1 | 2;
+
+	check_pathmatch_w_oob(L"abc[!x]", L"abc", flags);
+	check_pathmatch_w_oob(L"[!a]", L"", flags);
+	check_pathmatch_w_oob(L"[^a]", L"", flags);
 }


### PR DESCRIPTION
ASan, matching `[!x]` against a shorter subject through `__archive_pathmatch_w`:

    archive_pathmatch.c:301: heap-buffer-overflow READ of size 4
      #0 pm_w archive_pathmatch.c:301
      #1 __archive_pathmatch_w archive_pathmatch.c:471

`pm_w` enters the `[` case and calls `pm_list_w(p+1, end, *s, ...)` without first checking `*s`. For a negated class the list function returns its nomatch value (a match) when the char is not listed, and `L'\\0'` never is, so with the subject already at its terminator `pm_w` falls through to `p = end; break; ++p; ++s;` and steps `s` one wchar past the end. The next iteration reads it.

`pm` (the narrow twin) already guards this at line 230 (`*s == '\\0' ||`, added in 4cbf958); the wide version was missed. Fix applies the same guard. Reached from `archive_match` inclusion/exclusion matching against entry pathnames, so a short entry name plus a bracket pattern trips it.

Test commit first: it allocates tight wide buffers and fails under ASan at pm_w before the fix, passes after.