### PR TITLE
win32: fix symlink mode 'H' (hybrid) in wildcard search

### DIFF
--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -151,6 +151,8 @@ struct tree {
 	size_t			 dirname_length;
 
 	int	 depth;
+	/* Whether this tree began as a wildcard search */
+	int	 rootwild;
 
 	BY_HANDLE_FILE_INFORMATION	lst;
 	BY_HANDLE_FILE_INFORMATION	st;
@@ -926,7 +928,27 @@ next_entry(struct archive_read_disk *a, struct tree *t,
 		case 0:
 			return (ARCHIVE_EOF);
 		case TREE_POSTDESCENT:
+			if (t->depth == 1 && t->rootwild && t->symlink_mode == 'H') {
+				/*
+				 * We have descended from a directory at depth 0 specified by a
+				 * wildcard search in 'H'ybrid link mode. All items under this
+				 * directory should be 'P'hysical.
+				 */
+				t->symlink_mode = 'P';
+				a->follow_symlinks = 0;
+			}
+			break;
 		case TREE_POSTASCENT:
+			if (t->depth == 0 && t->rootwild && t->initial_symlink_mode == 'H') {
+				/*
+				 * We have returned to the root of a wildcard search, in 'H'ybrid
+				 * mode, so restore the symlink mode we overwrote in
+				 * TREE_POSTDESCENT.
+				 */
+				t->symlink_mode = t->initial_symlink_mode;
+				/* Mimics setup done in setup_symlink_mode */
+				a->follow_symlinks = 1;
+			}
 			break;
 		case TREE_REGULAR:
 			lst = tree_current_lstat(t);
@@ -966,7 +988,14 @@ next_entry(struct archive_read_disk *a, struct tree *t,
 	switch(t->symlink_mode) {
 	case 'H':
 		/* 'H': After the first item, rest like 'P'. */
-		t->symlink_mode = 'P';
+		if (!t->rootwild) {
+			/*
+			 * 'H': When we started with a wildcard, entries at the starting
+			 * depth should be kept in `H` mode; switching into 'P' mode
+			 * is handled in TREE_POSTDESCENT when we enter depth = 1.
+			 */
+			t->symlink_mode = 'P';
+		}
 		/* 'H': First item (from command line) like 'L'. */
 		/* FALLTHROUGH */
 	case 'L':
@@ -1733,6 +1762,7 @@ tree_reopen(struct tree *t, const wchar_t *path, int restore_time)
 	t->full_path_dir_length = 0;
 	t->dirname_length = 0;
 	t->depth = 0;
+	t->rootwild = 0;
 	t->descend = 0;
 	t->current = NULL;
 	t->d = INVALID_HANDLE_VALUE;
@@ -1786,6 +1816,7 @@ tree_reopen(struct tree *t, const wchar_t *path, int restore_time)
 			t->full_path.length = wcslen(t->full_path.s);
 			t->full_path_dir_length = archive_strlen(&t->full_path);
 		}
+		t->rootwild = 1;
 	}
 	tree_push(t, base, t->full_path.s, 0, 0, 0, NULL);
 	archive_wstring_free(&ws);


### PR DESCRIPTION
The Windows disk reader supports wildcards by converting a path like "foo/*" into a single tree rooted at "foo/". This does not play nicely with symlink mode `H`, which treats the first item in each tree as a dereferenced link (L) and all subsequent items as physical links (P). On Windows, we take the first _match_ in L mode and all subsequent descendants and matches in P mode.

This creates a behavioral difference between `bsdtar -c -H *` and `bsdtar -c -H one two three`.

This commit changes how we handle H->L/P transitions when doing wildcard matches. The transition from H to P is now done when we descend into our first directory, and we switch back to H mode when we ascend out of it[^1].

References #3220 
Closes #3222

[^1]: This does not matter in practice because tree is breadth-first rather than depth-first, but I've done it in the interest of completeness and not leaving ourselves caltrops to step on later.