### PR TITLE
7zip: skip ArchiveProperties payload data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -863,6 +863,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_delta4_lzma2.7z.uu \
 	libarchive/test/test_read_format_7zip_empty_archive.7z.uu \
 	libarchive/test/test_read_format_7zip_empty_file.7z.uu \
+	libarchive/test/test_read_format_7zip_archive_properties.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption_header.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption_partially.7z.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2809,10 +2809,23 @@ read_Header(struct archive_read *a, struct _7z_header_info *h,
 			int64_t size;
 			if ((p = header_bytes(a, 1)) == NULL)
 				return (-1);
-			if (*p == 0)
+			if (*p == kEnd)
 				break;
 			if (parse_7zip_int64(a, &size) < 0)
 				return (-1);
+			if (size < 0 || zip->header_bytes_remaining < size)
+				return (-1);
+
+			/* Skip the property data to keep header parsing aligned. */
+			while (size > 0) {
+				int64_t skip = size;
+
+				if (skip > UBUFF_SIZE)
+					skip = UBUFF_SIZE;
+				if (header_bytes(a, (size_t)skip) == NULL)
+					return (-1);
+				size -= skip;
+			}
 		}
 		if ((p = header_bytes(a, 1)) == NULL)
 			return (-1);

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -160,6 +160,32 @@ test_empty_file(void)
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
+DEFINE_TEST(test_read_format_7zip_archive_properties)
+{
+	const char *refname = "test_read_format_7zip_archive_properties.7z";
+	struct archive_entry *ae;
+	struct archive *a;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("empty", archive_entry_pathname(ae));
+	assertEqualInt(0, archive_entry_size(ae));
+	assertEqualInt(1, archive_file_count(a));
+
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_FORMAT_7ZIP, archive_format(a));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 /*
  * Extract an encoded file.
  * The header of the 7z archive files is not encoded.

--- a/libarchive/test/test_read_format_7zip_archive_properties.7z.uu
+++ b/libarchive/test/test_read_format_7zip_archive_properties.7z.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_7zip_archive_properties.7z
+M-WJ\KR<<  ,=YJHC           S         '@@J#,! @$!J@ % 0X!@ \!
+F@!$- &4 ;0!P '0 >0   !0* 0" UD  J+*= 14& 0 @@*2!    
+`
+end


### PR DESCRIPTION
This PR fixes a 7z header parsing compatibility issue around `ArchiveProperties`.

`ArchiveProperties` entries contain a property ID, a size, and payload bytes. The reader parsed the property ID and size, but did not consume the payload. That could make the next loop iteration read payload bytes as the next property ID, misaligning the rest of header parsing and rejecting the archive as malformed.

This adds a test archive accepted by 7-Zip/7zz and skips the `ArchiveProperties` payload in bounded chunks so header parsing stays aligned.

The behavior matches how 7-Zip/7zz handles archive-level properties. In 7-Zip's C++ parser, `ReadArchiveProperties()` reads each property ID and skips the associated data until `kEnd`:

```cpp
void CInArchive::ReadArchiveProperties(CInArchiveInfo & /* archiveInfo */)
{
  for (;;)
  {
    if (ReadID() == NID::kEnd)
      break;
    SkipData();
  }
}
```