### PR TITLE
Check `archive_entry_new2` return value

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -103,6 +103,10 @@ archive_read_new(void)
 
 	a->archive.state = ARCHIVE_STATE_NEW;
 	a->entry = archive_entry_new2(&a->archive);
+	if (a->entry == NULL) {
+		free(a);
+		return (NULL);
+	}
 	a->archive.vtable = &archive_read_vtable;
 
 	a->passphrases.last = &a->passphrases.first;

--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -453,6 +453,10 @@ archive_read_disk_new(void)
 	a->archive.state = ARCHIVE_STATE_NEW;
 	a->archive.vtable = &archive_read_disk_vtable;
 	a->entry = archive_entry_new2(&a->archive);
+	if (a->entry == NULL) {
+		free(a);
+		return (NULL);
+	}
 	a->lookup_uname = trivial_lookup_uname;
 	a->lookup_gname = trivial_lookup_gname;
 	a->flags = ARCHIVE_READDISK_MAC_COPYFILE;

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -555,6 +555,10 @@ archive_read_disk_new(void)
 	a->archive.state = ARCHIVE_STATE_NEW;
 	a->archive.vtable = &archive_read_disk_vtable;
 	a->entry = archive_entry_new2(&a->archive);
+	if (a->entry == NULL) {
+		free(a);
+		return (NULL);
+	}
 	a->lookup_uname = trivial_lookup_uname;
 	a->lookup_gname = trivial_lookup_gname;
 	a->flags = ARCHIVE_READDISK_MAC_COPYFILE;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2481,6 +2481,9 @@ static int skip_base_block(struct archive_read* a) {
 	 * by header reader; operations on this archive_entry will be discarded.
 	 */
 	struct archive_entry* entry = archive_entry_new();
+	if (entry == NULL)
+		return ARCHIVE_FATAL;
+
 	ret = process_base_block(a, entry);
 
 	/* Discard operations on this archive_entry structure. */

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -430,6 +430,8 @@ archive_write_newc_close(struct archive_write *a)
 	struct archive_entry *trailer;
 
 	trailer = archive_entry_new();
+	if (trailer == NULL)
+		return ARCHIVE_FATAL;
 	archive_entry_set_nlink(trailer, 1);
 	archive_entry_set_size(trailer, 0);
 	archive_entry_set_pathname(trailer, "TRAILER!!!");

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -494,6 +494,13 @@ archive_write_gnutar_header(struct archive_write *a,
 		size_t length = gnutar->linkname_length + 1;
 		struct archive_entry *temp = archive_entry_new2(&a->archive);
 
+		if (temp == NULL) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "Can't allocate memory for Linkname");
+			ret = ARCHIVE_FATAL;
+			goto exit_write_header;
+		}
+
 		/* Uname/gname here don't really matter since no one reads them;
 		 * these are the values that GNU tar happens to use on FreeBSD. */
 		archive_entry_set_uname(temp, "root");
@@ -523,6 +530,13 @@ archive_write_gnutar_header(struct archive_write *a,
 		const char *pathname = gnutar->pathname;
 		size_t length = gnutar->pathname_length + 1;
 		struct archive_entry *temp = archive_entry_new2(&a->archive);
+
+		if (temp == NULL) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "Can't allocate memory for Linkname");
+			ret = ARCHIVE_FATAL;
+			goto exit_write_header;
+		}
 
 		/* Uname/gname here don't really matter since no one reads them;
 		 * these are the values that GNU tar happens to use on FreeBSD. */

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1419,6 +1419,14 @@ archive_write_pax_header(struct archive_write *a,
 		__LA_MODE_T mode;
 
 		pax_attr_entry = archive_entry_new2(&a->archive);
+		if (pax_attr_entry == NULL) {
+			archive_set_error(&a->archive, ENOMEM,
+			    "Out of memory");
+			archive_entry_free(entry_main);
+			archive_string_free(&entry_name);
+			return (ARCHIVE_FATAL);
+		}
+
 		p = entry_name.s;
 		archive_entry_set_pathname(pax_attr_entry,
 		    build_pax_attribute_name(pax_entry_name, p));

--- a/tar/write.c
+++ b/tar/write.c
@@ -560,6 +560,8 @@ write_archive(struct archive *a, struct bsdtar *bsdtar)
 		 * without failure.
 		 */
 		entry2 = archive_entry_new();
+		if (entry2 == NULL)
+			lafe_errc(1, errno, "Out of memory");
 		r = archive_read_next_header2(disk, entry2);
 		archive_entry_free(entry2);
 		if (r != ARCHIVE_OK) {


### PR DESCRIPTION
The memory allocation might fail. Check return value and properly handle error cases.