### PR TITLE
acl: fix over-read on empty field in archive_acl_from_text_nl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -381,6 +381,7 @@ libarchive_test_SOURCES= \
 	$(test_utils_SOURCES) \
 	libarchive/test/read_open_memory.c \
 	libarchive/test/test_7zip_filename_encoding.c \
+	libarchive/test/test_acl_from_text_overread.c \
 	libarchive/test/test_acl_nfs4.c \
 	libarchive/test/test_acl_nfs4_null_id_overflow.c \
 	libarchive/test/test_acl_nfs4_text.c \

--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -1516,7 +1516,7 @@ archive_acl_from_text_nl(struct archive_acl *acl, const char *text,
 		const char *end;
 	} field[6], name;
 
-	const char *s, *st;
+	const char *s, *st, *text_end;
 	int numfields, fields, n, r, sol, ret;
 	int type, types, tag, permset, id;
 	size_t len;
@@ -1539,6 +1539,7 @@ archive_acl_from_text_nl(struct archive_acl *acl, const char *text,
 
 	ret = ARCHIVE_OK;
 	types = 0;
+	text_end = (text == NULL) ? text : text + length;
 
 	while (text != NULL && length > 0 && *text != '\0') {
 		/*
@@ -1563,6 +1564,18 @@ archive_acl_from_text_nl(struct archive_acl *acl, const char *text,
 		if (field[0].start == NULL || field[0].end == NULL) {
 			/* This should never happen */
 			return (ARCHIVE_FATAL);
+		}
+
+		if (field[0].start == text_end) {
+			/*
+			 * Empty entry: next_field() consumed the rest of the
+			 * buffer as separators or whitespace, leaving
+			 * field[0].start one past the end.  'text' is not
+			 * guaranteed to be NUL terminated, so the byte after it
+			 * must not be dereferenced.
+			 */
+			ret = ARCHIVE_WARN;
+			continue;
 		}
 
 		if (*(field[0].start) == '#') {

--- a/libarchive/archive_acl_private.h
+++ b/libarchive/archive_acl_private.h
@@ -27,7 +27,9 @@
 #define ARCHIVE_ACL_PRIVATE_H_INCLUDED
 
 #ifndef __LIBARCHIVE_BUILD
+#ifndef __LIBARCHIVE_TEST
 #error This header is only to be used internally to libarchive.
+#endif
 #endif
 
 #include "archive_string.h"

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -10,6 +10,7 @@ IF(ENABLE_TEST)
     read_open_memory.c
     test.h
     test_7zip_filename_encoding.c
+    test_acl_from_text_overread.c
     test_acl_nfs4.c
     test_acl_nfs4_null_id_overflow.c
     test_acl_nfs4_text.c

--- a/libarchive/test/test_acl_from_text_overread.c
+++ b/libarchive/test/test_acl_from_text_overread.c
@@ -1,0 +1,98 @@
+/*-
+ * Copyright (c) 2026 Kaif Khan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+#define __LIBARCHIVE_TEST
+#include "archive_acl_private.h"
+
+/*
+ * archive_acl_from_text_nl() takes a pointer and a length and does not
+ * require the buffer to be NUL terminated.  An entry that is only
+ * whitespace, or trailing whitespace after a valid entry, must not make
+ * the parser read past the end of the buffer.
+ *
+ * Each input is copied into a buffer sized to exactly its length so that
+ * a read past the end is out of bounds.
+ */
+static void
+parse_nl(const char *text, int type)
+{
+	size_t len = strlen(text);
+	char *buf = malloc(len);
+	struct archive_acl acl;
+
+	assert(buf != NULL);
+	memcpy(buf, text, len);
+	memset(&acl, 0, sizeof(acl));
+	/* Must not read buf[len]. */
+	archive_acl_from_text_nl(&acl, buf, len, type, NULL);
+	archive_acl_clear(&acl);
+	free(buf);
+}
+
+DEFINE_TEST(test_acl_from_text_overread)
+{
+	static const char *whitespace[] = {
+		" ", "   ", "\t", "\n\n", "user::rwx,   "
+	};
+	size_t i;
+
+	for (i = 0; i < sizeof(whitespace) / sizeof(whitespace[0]); i++) {
+		parse_nl(whitespace[i], ARCHIVE_ENTRY_ACL_TYPE_ACCESS);
+		parse_nl(whitespace[i], ARCHIVE_ENTRY_ACL_TYPE_NFS4);
+	}
+
+	/*
+	 * Trailing whitespace after a valid entry must not change the parse:
+	 * the count matches the same text without the trailing spaces.
+	 */
+	{
+		static const char clean[] = "user:100:rwx";
+		static const char padded[] = "user:100:rwx   ";
+		struct archive_acl acl1, acl2;
+		char *b1 = malloc(sizeof(clean) - 1);
+		char *b2 = malloc(sizeof(padded) - 1);
+
+		assert(b1 != NULL);
+		assert(b2 != NULL);
+		memcpy(b1, clean, sizeof(clean) - 1);
+		memcpy(b2, padded, sizeof(padded) - 1);
+		memset(&acl1, 0, sizeof(acl1));
+		memset(&acl2, 0, sizeof(acl2));
+		archive_acl_from_text_nl(&acl1, b1, sizeof(clean) - 1,
+		    ARCHIVE_ENTRY_ACL_TYPE_ACCESS, NULL);
+		archive_acl_from_text_nl(&acl2, b2, sizeof(padded) - 1,
+		    ARCHIVE_ENTRY_ACL_TYPE_ACCESS, NULL);
+		assertEqualInt(
+		    archive_acl_count(&acl1, ARCHIVE_ENTRY_ACL_TYPE_ACCESS),
+		    archive_acl_count(&acl2, ARCHIVE_ENTRY_ACL_TYPE_ACCESS));
+		assert(archive_acl_count(&acl2,
+		    ARCHIVE_ENTRY_ACL_TYPE_ACCESS) > 0);
+		archive_acl_clear(&acl1);
+		archive_acl_clear(&acl2);
+		free(b1);
+		free(b2);
+	}
+}


### PR DESCRIPTION
ASan, from a SCHILY.acl.access pax attribute whose value is whitespace only:

    ==ERROR: AddressSanitizer: heap-buffer-overflow READ of size 1
        #0 archive_acl_from_text_nl archive_acl.c:1568
    0x602000000d3 is located 0 bytes after 3-byte region

archive_acl_from_text_nl() parses ACL text from a pointer and a length and does not require a NUL terminator; the tar reader passes a __archive_read_ahead() window of exactly value_length bytes for SCHILY.acl.access/.default/.ace. When an entry is empty (a whitespace-only value, or trailing whitespace after a valid entry) next_field() consumes the rest of the buffer as whitespace and leaves field[0].start one past the end, which the '#'-comment probe then dereferences. Skip the entry when its first field starts at end-of-buffer. The wide archive_acl_from_text_w is NUL terminated and unaffected.

The regression test drives the parser with exact-length heap buffers so the read lands in an ASan redzone.