### PR TITLE
 tar: avoid redundant mode parsing

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1347,6 +1347,7 @@ header_common(struct archive_read *a, struct tar *tar,
 	const struct archive_entry_header_ustar	*header;
 	const char *existing_linkpath;
 	const wchar_t *existing_wcs_linkpath;
+	mode_t header_mode;
 	int     err = ARCHIVE_OK;
 
 	header = (const struct archive_entry_header_ustar *)h;
@@ -1354,12 +1355,10 @@ header_common(struct archive_read *a, struct tar *tar,
 	/* Parse out the numeric fields (all are octal) */
 
 	/* Split mode handling: Set filetype always, perm only if not already set */
-	archive_entry_set_filetype(entry,
-	    (mode_t)tar_atol(header->mode, sizeof(header->mode)));
-	if (!archive_entry_perm_is_set(entry)) {
-		archive_entry_set_perm(entry,
-			(mode_t)tar_atol(header->mode, sizeof(header->mode)));
-	}
+	header_mode = (mode_t)tar_atol(header->mode, sizeof(header->mode));
+	archive_entry_set_filetype(entry, header_mode);
+	if (!archive_entry_perm_is_set(entry))
+		archive_entry_set_perm(entry, header_mode);
 
 	/* Set uid, gid, mtime if not already set */
 	if (!archive_entry_uid_is_set(entry)) {

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1338,14 +1338,6 @@ archive_write_pax_header(struct archive_write *a,
 		archive_entry_set_size(entry_main, 0);
 
 	/*
-	 * Pax-restricted does not store data for hardlinks, in order
-	 * to improve compatibility with ustar.
-	 */
-	if (a->archive.archive_format != ARCHIVE_FORMAT_TAR_PAX_INTERCHANGE &&
-	    hardlink != NULL)
-		archive_entry_set_size(entry_main, 0);
-
-	/*
 	 * XXX Full pax interchange format does permit a hardlink
 	 * entry to have data associated with it.  I'm not supporting
 	 * that here because the client expects me to tell them whether


### PR DESCRIPTION
This PR aims to avoid parsing the tar mode field twice in `header_common()` by caching the parsed value and reusing it for both file type and permission handling.

`archive_entry_set_filetype()` and `archive_entry_set_perm()` already mask the relevant bits, so passing the full header mode to both setters preserves the existing behavior. The permission-set guard is unchanged.

While at it, remove a redundant pax hardlink size assignment. The narrower restricted-pax hardlink check is immediately covered by the following hardlink check, which sets all hardlink entries to size zero.

The resulting binary compiled under Release mode was inspected: 1st commit avoided reparsing the same mode header, while 2nd commit had identical codegen (still a nice source cleanup).