### PR TITLE
cpio: Prevent signed integer overflow

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -545,7 +545,8 @@ find_newc_header(struct archive_read *a)
 {
 	const void *h;
 	const char *p, *q;
-	size_t skip, skipped = 0;
+	int64_t skip;
+	uintmax_t skipped = 0;
 	ssize_t bytes;
 
 	for (;;) {
@@ -577,9 +578,9 @@ find_newc_header(struct archive_read *a)
 					if (skipped > 0) {
 						archive_set_error(&a->archive,
 						    0,
-						    "Skipped %d bytes before "
+						    "Skipped %ju bytes before "
 						    "finding valid header",
-						    (int)skipped);
+						    skipped);
 						return (ARCHIVE_WARN);
 					}
 					return (ARCHIVE_OK);


### PR DESCRIPTION
If enough bytes have to be skipped, a signed integer overflow could occur (most realistically on 32 bit systems). Use an unsigned type, which could still overflow but has only negative impact on diagnostic warning message.

Follow up of 02fa05675fdf8054ae0dd73df8c5264e61f3a068 but this time for function `find_newc_header`.