### PR TITLE
warc: require file size before writing header

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -233,10 +233,22 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			/*len*/0,
 		};
 		ssize_t r;
+		int64_t size;
 		rh.tgturi = archive_entry_pathname(entry);
 		rh.rtime = w->now;
 		rh.mtime = archive_entry_mtime(entry);
-		rh.cntlen = (size_t)archive_entry_size(entry);
+		if (!archive_entry_size_is_set(entry)) {
+			archive_set_error(&a->archive, -1,
+			    "Size required");
+			return (ARCHIVE_FAILED);
+		}
+		size = archive_entry_size(entry);
+		if (size < 0) {
+			archive_set_error(&a->archive, -1,
+			    "Size required");
+			return (ARCHIVE_FAILED);
+		}
+		rh.cntlen = (uint64_t)size;
 
 		archive_string_init(&hdr);
 		r = _popul_ehdr(&hdr, MAX_HDR_SIZE, rh);

--- a/libarchive/test/test_write_format_warc.c
+++ b/libarchive/test/test_write_format_warc.c
@@ -143,3 +143,28 @@ DEFINE_TEST(test_write_format_warc)
 
 	free(buff);
 }
+
+DEFINE_TEST(test_write_format_warc_size)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[2048];
+	size_t used;
+
+	memset(buff, 0, sizeof(buff));
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_warc(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "test");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	assertEqualIntA(a, ARCHIVE_FAILED, archive_write_header(a, ae));
+	assertEqualString("Size required", archive_error_string(a));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}


### PR DESCRIPTION
WARC records require a known `Content-Length` before writing the record body. The writer previously read `archive_entry_size()` without checking whether the size was set, and cast it through `size_t` before storing it in the `uint64_t` record header field.

Reject entries without a valid size and store the checked size directly as `uint64_t`.

Fixes two issues in the WARC writer:

- Entries without a known size were accepted even though WARC requires `Content-Length` before the record body can be written.
- `archive_entry_size()` was cast through `size_t` before being stored in the `uint64_t` WARC header field, which can truncate large sizes on 32-bit platforms.