### PR TITLE
tar: prefer multibyte pathname for AppleDouble checks

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1646,24 +1646,9 @@ is_mac_metadata_entry(struct archive_entry *entry) {
 	const char *p, *name;
 	const wchar_t *wp, *wname;
 
-	wname = wp = archive_entry_pathname_w(entry);
-	if (wp != NULL) {
+	name = p = archive_entry_pathname(entry);
+	if (p != NULL) {
 		/* Find the last path element. */
-		for (; *wp != L'\0'; ++wp) {
-			if (wp[0] == '/' && wp[1] != L'\0')
-				wname = wp + 1;
-		}
-		/*
-		 * If last path element starts with "._", then
-		 * this is a Mac extension.
-		 */
-		if (wname[0] == L'.' && wname[1] == L'_' && wname[2] != L'\0')
-			return 1;
-	} else {
-		/* Find the last path element. */
-		name = p = archive_entry_pathname(entry);
-		if (p == NULL)
-			return (ARCHIVE_FAILED);
 		for (; *p != '\0'; ++p) {
 			if (p[0] == '/' && p[1] != '\0')
 				name = p + 1;
@@ -1673,6 +1658,21 @@ is_mac_metadata_entry(struct archive_entry *entry) {
 		 * this is a Mac extension.
 		 */
 		if (name[0] == '.' && name[1] == '_' && name[2] != '\0')
+			return 1;
+	} else {
+		/* Find the last path element. */
+		wname = wp = archive_entry_pathname_w(entry);
+		if (wp == NULL)
+			return 0;
+		for (; *wp != L'\0'; ++wp) {
+			if (wp[0] == L'/' && wp[1] != L'\0')
+				wname = wp + 1;
+		}
+		/*
+		 * If last path element starts with "._", then
+		 * this is a Mac extension.
+		 */
+		if (wname[0] == L'.' && wname[1] == L'_' && wname[2] != L'\0')
 			return 1;
 	}
 	/* Not a mac extension */


### PR DESCRIPTION
This performance PR aims to avoid unnecessary wide-character pathname conversion when checking for AppleDouble metadata entries in tar archives.

AppleDouble detection only needs to check whether the final path component starts with `._`.

Previously, tar tried the wide-character pathname first on all platforms. On POSIX-like systems, this can force WCS conversion even though the multibyte pathname is the native path form.

~~This keeps WCS-first behavior on native Windows. On POSIX-like systems, it checks the multibyte pathname first and only falls back to WCS when needed.~~ (Better to be MBS-first any platform due to the nature of tar archives.)

~~While here, this also fixes the fallback case for entries without an available pathname. Those now return no match instead of letting `ARCHIVE_FAILED` behave as a truthy boolean result.~~

Benchmarks were run with hyperfine with as much stability as I could:
- 25 warmup runs, 25 measured runs
- `bsdtar -tf`, built with Release mode

| Case | Result |
| --- | ---: |
| 59 MiB, 120000 ordinary nested non-AppleDouble entries, mac-ext enabled | 1.30x faster |
| 88 MiB, 120000 entries with regular files paired with `._name` AppleDouble metadata entries, mac-ext enabled | 1.18x faster |
| 59 MiB, 120000 ordinary flat non-AppleDouble entries, mac-ext enabled | 1.13x faster |
| 59 MiB, 120000 ordinary nested non-AppleDouble entries, `--options tar:!mac-ext` | no meaningful change |