### PR TITLE
warc: track remaining entry bytes when writing data

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -54,8 +54,8 @@ struct warc_s {
 
 	time_t now;
 	mode_t typ;
-	/* populated size */
-	uint64_t populz;
+	/* Remaining bytes to write for the current entry. */
+	uint64_t entry_bytes_remaining;
 };
 
 static const char warcinfo[] =
@@ -221,7 +221,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 	}
 
 	w->typ = archive_entry_filetype(entry);
-	w->populz = 0U;
+	w->entry_bytes_remaining = 0U;
 	if (w->typ == AE_IFREG) {
 		warc_essential_hdr_t rh = {
 			WT_RSRC,
@@ -252,7 +252,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 		/* otherwise append to output stream */
 		__archive_write_output(a, hdr.s, r);
 		/* and let subsequent calls to _data() know about the size */
-		w->populz = rh.cntlen;
+		w->entry_bytes_remaining = rh.cntlen;
 		archive_string_free(&hdr);
 		return (ARCHIVE_OK);
 	}
@@ -271,8 +271,8 @@ _warc_data(struct archive_write *a, const void *buf, size_t len)
 		int rc;
 
 		/* never write more bytes than announced */
-		if (len > w->populz) {
-			len = (size_t)w->populz;
+		if ((uint64_t)len > w->entry_bytes_remaining) {
+			len = (size_t)w->entry_bytes_remaining;
 		}
 
 		/* now then, out we put the whole shebang */
@@ -280,6 +280,7 @@ _warc_data(struct archive_write *a, const void *buf, size_t len)
 		if (rc != ARCHIVE_OK) {
 			return rc;
 		}
+		w->entry_bytes_remaining -= len;
 	}
 	return len;
 }

--- a/libarchive/test/test_write_format_warc.c
+++ b/libarchive/test/test_write_format_warc.c
@@ -108,6 +108,7 @@ DEFINE_TEST(test_write_format_warc)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
 	archive_entry_free(ae);
 	assertEqualIntA(a, 9, archive_write_data(a, "12345678", 9));
+	assertEqualIntA(a, 0, archive_write_data(a, "overflow", 8));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));


### PR DESCRIPTION
The WARC writer capped each data write against the full declared entry size, but never reduced that value after accepting data. This allowed repeated `archive_write_data()` calls to emit more bytes than the WARC record's declared `Content-Length`.

Track the remaining entry bytes and decrement the counter after successful writes, so later writes are clamped correctly and return zero once the entry is full.