### PR TITLE
tar: fix 1-byte OOB read in SUN.holesdata parsing

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -3448,13 +3448,10 @@ pax_attribute_SUN_holesdata(struct archive_read *a, struct tar *tar,
 				return (ARCHIVE_FATAL);
 			tar->sparse_last->hole = hole;
 		}
-		if (length == 0 || *e == '\n') {
-			if (length == 0 && *e == '\n') {
-				return (ARCHIVE_OK);
-			} else {
-				return (ARCHIVE_WARN);
-			}
-		}
+		if (length == 0)
+			return (ARCHIVE_OK);
+		if (*e == '\n')
+			return (ARCHIVE_WARN);
 		p = e + 1;
 		length--;
 		hole = hole == 0;


### PR DESCRIPTION
`header_pax_extension()` passes PAX attribute values without the trailing newline to `pax_attribute()`. The SUN.holesdata parser read one byte past the supplied value when the last numeric field ended at the value boundary.

Handle `length == 0` before checking `*e.`

Resolves #3251