### PR TITLE
tar: fix 1-byte OOB read in number parsing

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -3517,17 +3517,17 @@ tar_atol_base_n(const char *p, size_t char_cnt, int base)
 	}
 
 	l = 0;
-	if (char_cnt != 0) {
+	while (char_cnt != 0) {
 		digit = *p - '0';
-		while (digit >= 0 && digit < base && char_cnt != 0) {
-			if (archive_ckd_mul_i64(&l, l, base) ||
-			    archive_ckd_add_i64(&l, l, sign * digit)) {
-				 /* Truncate on overflow. */
-				return sign < 0 ? INT64_MIN : INT64_MAX;
-			}
-			digit = *++p - '0';
-			char_cnt--;
+		if (digit < 0 || digit >= base)
+			break;
+		if (archive_ckd_mul_i64(&l, l, base) ||
+		    archive_ckd_add_i64(&l, l, sign * digit)) {
+			 /* Truncate on overflow. */
+			return sign < 0 ? INT64_MIN : INT64_MAX;
 		}
+		p++;
+		char_cnt--;
 	}
 	return l;
 }


### PR DESCRIPTION
`tar_atol_base_n()` read the next byte before checking whether any bytes remained. If a numeric field ended at the caller-provided boundary, this caused a 1-byte OOB read while preparing the next digit range check.

Read each digit only while bytes remain.

(Found while fixing another TAR OOB read just a few lines away... two birds in one stone.)