### PR TITLE
iso9660: fix 1-byte OOB read in directory scanning

### DIFF
--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -1086,7 +1086,7 @@ read_children(struct archive_read *a, struct file_info *parent)
 		p = b;
 		b += iso9660->logical_block_size;
 		step -= iso9660->logical_block_size;
-		for (; *p != 0 && p + DR_name_offset < b && p + *p <= b;
+		for (; p < b && b - p > DR_name_offset && *p != 0 && *p <= b - p;
 			p += *p) {
 			struct file_info *child;
 


### PR DESCRIPTION
`read_children()` checked the directory record length byte before ensuring that the record pointer was still inside the current logical block.

If directory records exactly filled the final block, the next loop condition could read one byte past the image buffer.

Check the remaining block length before reading the record length byte.