### PR TITLE
mtree: fix out-of-bounds read in process_global_set

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -826,7 +826,7 @@ process_global_set(struct archive_read *a,
 		line = next;
 		next = line + strcspn(line, " \t\r\n");
 		eq = strchr(line, '=');
-		if (eq > next)
+		if (eq == NULL || eq > next)
 			len = next - line;
 		else
 			len = eq - line;

--- a/libarchive/test/test_read_format_mtree.c
+++ b/libarchive/test/test_read_format_mtree.c
@@ -878,3 +878,35 @@ DEFINE_TEST(test_read_format_mtree_nano)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+/*
+ * A /set line whose value-less keyword (no '=') repeats made
+ * process_global_set() compute a bogus length and over-read the option
+ * buffer in remove_option().  Parsing must stay in bounds and succeed.
+ */
+DEFINE_TEST(test_read_format_mtree_global_set_no_value)
+{
+	static char archive[] =
+	    "#mtree\n"
+	    "/set nochange nochange\n"
+	    "a type=file\n";
+	struct archive_entry *ae;
+	struct archive *a;
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive, sizeof(archive)));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString(archive_entry_pathname(ae), "a");
+	assertEqualInt(archive_entry_filetype(ae), AE_IFREG);
+
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualInt(1, archive_file_count(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
A value-less token in a `/set` line makes `strchr(line, '=')` return NULL,
and the length calc takes the wrong branch because it omits the NULL case
that its sibling `process_add_entry()` handles:

    /set foo foo
        eq = strchr(line, '=') = NULL
        (eq > next) is false  ->  len = eq - line = (size_t)(0 - line)
        remove_option(): iter->value[len] reads ~2^64 bytes past the buffer

`remove_option()` reaches the terminator check `iter->value[len]` whenever a
value-less keyword repeats or matches an option added earlier (two bare tokens
in one `/set`, or a bare token that a prior `/set` already stored). `len` is a
wild ~2^64 value, so the read lands far outside the small option allocation.

`process_add_entry()` already guards this at the matching site with
`eq == NULL || eq > next`; both call sites were introduced together in fb859e6.
The fix mirrors that guard. Added a regression test that drives the parser with
a repeated value-less `/set` keyword.
