### PR TITLE
7zip: bound folder and stream counts before allocating

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -482,6 +482,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_7zip_encryption_partially.c \
 	libarchive/test/test_read_format_7zip_encryption_header.c \
 	libarchive/test/test_read_format_7zip_entries_oom.c \
+	libarchive/test/test_read_format_7zip_folders_oom.c \
 	libarchive/test/test_read_format_7zip_issue2765.c \
 	libarchive/test/test_read_format_7zip_malformed.c \
 	libarchive/test/test_read_format_7zip_packinfo_digests.c \
@@ -877,6 +878,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_encryption_header.7z.uu \
 	libarchive/test/test_read_format_7zip_encryption_partially.7z.uu \
 	libarchive/test/test_read_format_7zip_entries_oom.7z.uu \
+	libarchive/test/test_read_format_7zip_folders_oom.7z.uu \
 	libarchive/test/test_read_format_7zip_extract_second.7z.uu \
 	libarchive/test/test_read_format_7zip_issue2765.7z.uu \
 	libarchive/test/test_read_format_7zip_lzma1.7z.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -2404,6 +2404,7 @@ free_CodersInfo(struct _7z_coders_info *ci)
 static int
 read_CodersInfo(struct archive_read *a, struct _7z_coders_info *ci)
 {
+	struct _7zip *zip = (struct _7zip *)a->format->data;
 	const unsigned char *p;
 	struct _7z_digests digest;
 	size_t dataStreamIndex, i;
@@ -2420,6 +2421,14 @@ read_CodersInfo(struct archive_read *a, struct _7z_coders_info *ci)
 	 * Read NumFolders.
 	 */
 	if (parse_7zip_size(a, &(ci->numFolders)) < 0)
+		goto failed;
+	/*
+	 * Each folder is encoded by at least one byte in the coders
+	 * list that follows, so a folder count larger than the bytes
+	 * left in the header cannot be honored and is rejected here
+	 * before it is used to size the folders allocation.
+	 */
+	if (ci->numFolders > (uint64_t)zip->header_bytes_remaining)
 		goto failed;
 
 	/*

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -111,6 +111,7 @@ IF(ENABLE_TEST)
     test_read_format_7zip_encryption_header.c
     test_read_format_7zip_encryption_partially.c
     test_read_format_7zip_entries_oom.c
+    test_read_format_7zip_folders_oom.c
     test_read_format_7zip_issue2765.c
     test_read_format_7zip_malformed.c
     test_read_format_7zip_packinfo_digests.c

--- a/libarchive/test/test_read_format_7zip_folders_oom.7z.uu
+++ b/libarchive/test/test_read_format_7zip_folders_oom.7z.uu
@@ -1,0 +1,8 @@
+begin 644 test_read_format_7zip_folders_oom.7z
+M-WJ\KR<<  *^Y_3?$         !E         &/C(9T!  -A86$*  $  V)B
+M8@H  00&  ()" @* 5\J+KLX07WL  <+XR&= 0 #86%A"@ !  -B8F(*  $$
+M!@ ""0@( @ !(2$!%@$A,@$6# 0$"@&57?ASX1\F3  (   % A,9 &$ +@!T
+M '@ =     #_      !X '0    4 0 #80       &/C(9T!  -A86$*  $ 
+0 V+<MM4!@)N8]-RVU0$     
+ 
+end

--- a/libarchive/test/test_read_format_7zip_folders_oom.c
+++ b/libarchive/test/test_read_format_7zip_folders_oom.c
@@ -1,0 +1,50 @@
+/*-
+ * Copyright (c) 2026 Kaif Khan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * The NumFolders field in a 7-Zip StreamsInfo/CodersInfo header is used to
+ * size the folders allocation before any folder is read.  A crafted archive
+ * that declares a huge NumFolders must be rejected instead of attempting a
+ * multi-gigabyte allocation.
+ */
+DEFINE_TEST(test_read_format_7zip_folders_oom)
+{
+	const char *refname = "test_read_format_7zip_folders_oom.7z";
+	struct archive *a;
+	struct archive_entry *ae;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
ASan, reading a 196-byte crafted 7z:

    archive_read_support_format_7zip.c:2433:4: allocation-size-too-big: requested 0x1209aec60 (~4.8 GB) in read_CodersInfo

NumFolders is parsed from the header and sizes the folders allocation before any folder is read; parse_7zip_size only caps it at UMAX_ENTRY, so the array reaches gigabytes. NumPackStreams (read_PackInfo) and the substream total (read_SubStreamsInfo) size their arrays the same way. Each element consumes at least one header byte when it is read, so all three are rejected once they exceed header_bytes_remaining (the substream total permits one derived size per folder), matching the existing files_info_numfiles_is_sane bound for NumFiles.

test_read_format_7zip_folders_oom drives the NumFolders path; the crafted header returns ARCHIVE_FATAL instead of attempting the multi-gigabyte allocation.