### PR TITLE
zip: fix 1-byte OOB read in Mac extension check

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -4308,12 +4308,14 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
 			r = rsrc_basename(name, filename_length);
 			if (filename_length >= 9 &&
 			    strncmp("__MACOSX/", name, 9) == 0) {
+				const char *name_end;
+
+				name_end = name + filename_length;
 				/* If this file is not a resource fork nor
 				 * a directory. We should treat it as a non
 				 * resource fork file to expose it. */
 				if (name[filename_length-1] != '/' &&
-				    (r - name < 3 || r[0] != '.' ||
-				     r[1] != '_')) {
+				    (name_end - r < 2 || r[0] != '.' || r[1] != '_')) {
 					__archive_rb_tree_insert_node(
 					    &zip->tree, &zip_entry->node);
 					/* Expose its parent directories. */


### PR DESCRIPTION
The seekable ZIP reader checks whether `__MACOSX/` entries are resource fork entries by testing the basename prefix.

The existing guard used `r - name`, which is the basename offset from the start of the filename, not the basename length. For a short basename such as `__MACOSX/.`, this could read one byte past the filename.

Check the remaining basename length before reading the resource fork prefix.