### PR TITLE
bsdtar: fix 1-byte OOB read in substitution handling

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -264,6 +264,8 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result,
 
 				++i;
 				c = rule->result[i];
+				if (c == '\0')
+					break;
 				switch (c) {
 				case '~':
 				case '\\':


### PR DESCRIPTION
The replacement scanner for `-s` consumes a backslash and then reads the escaped byte. If the replacement ends in one literal backslash, the loop can advance past the terminating `NUL` and read one byte past the allocated replacement buffer.

Stop scanning when a backslash is followed by the terminating `NUL`. The final literal append then preserves the trailing backslash.

*Bonus: Run `bsdtar -s ',x,\,'` under ASan :)*