### PR TITLE
pax: fix 1-byte OOB read in sparse name building

### DIFF
--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1794,7 +1794,12 @@ build_gnu_sparse_name(char *dest, const char *src)
 	}
 
 	/* General case: build a ustar-compatible name adding
-	 * "/GNUSparseFile/". */
+	 * "/GNUSparseFile.0/". */
+
+	if (p == src) {
+		strcpy(dest, "/GNUSparseFile.0/rootdir");
+		return (dest);
+	}
 	build_ustar_entry_name(dest, src, p - src, "GNUSparseFile.0");
 
 	return (dest);


### PR DESCRIPTION
`build_gnu_sparse_name()` trims trailing slash and `/.` components before building the synthetic ustar entry name. If the sparse pathname is fully pruned, the effective source length becomes zero and `build_ustar_entry_name()` reads one byte before the pathname buffer.

Handle the all-pruned pathname case before calling the ustar name builder. The synthetic name then preserves the root-directory case.

Proof of concept:

```c
archive_write_set_format_pax(a);
archive_entry_set_pathname(e, "/");
archive_entry_set_filetype(e, AE_IFREG);
archive_entry_set_size(e, 4097);
archive_entry_sparse_add_entry(e, 4096, 1);
archive_write_header(a, e);
```