### PR TITLE
iso9660: fix 1-byte OOB read in iso-level option

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1427,8 +1427,8 @@ iso9660_options(struct archive_write *a, const char *key, const char *value)
 		break;
 	case 'i':
 		if (strcmp(key, "iso-level") == 0) {
-			if (value != NULL && value[1] == '\0' &&
-			    (value[0] >= '1' && value[0] <= '4')) {
+			if (value != NULL && value[0] >= '1' &&
+			    value[0] <= '4' && value[1] == '\0') {
 				iso9660->opt.iso_level = value[0]-'0';
 				return (ARCHIVE_OK);
 			}


### PR DESCRIPTION
`iso9660_options()` checks the second byte of the `iso-level` option value before checking that the first byte contains a valid ISO level.

For an empty option value such as `iso9660:iso-level=`, `archive_write_set_options()` passes a value pointer to the terminating `NUL` byte of the duplicated options string. Reading `value[1]` then reads one byte past that heap allocation.

Check `value[0]` before reading `value[1]`. This keeps the same accepted values while rejecting the empty value without reading past the option buffer.

Proof of concept:

```c
a = archive_write_new();
archive_write_set_format_iso9660(a);
archive_write_set_options(a, "iso9660:iso-level=");
```

It is also reproducible with bsdtar:

```sh
bsdtar --format iso9660 --options 'iso9660:iso-level=' -cf out.iso -C input file
```