### PR TITLE
test_sparse_basic: avoid out-of-bounds pointer arithmetic in verify

### DIFF
--- a/libarchive/test/test_sparse_basic.c
+++ b/libarchive/test/test_sparse_basic.c
@@ -370,7 +370,9 @@ verify_sparse_file(struct archive *a, const char *path,
 		/* Block that overlaps beginning of data */
 		if (expected_offset < offset
 		    && expected_offset + (int64_t)sparse->size <= offset + (int64_t)bytes_read) {
-			const char *end = (const char *)buff + (expected_offset - offset) + (size_t)sparse->size;
+			/* Avoid forming an intermediate pointer before buff. */
+			const char *end = (const char *)buff
+			    + ((expected_offset - offset) + (int64_t)sparse->size);
 #if DEBUG
 			fprintf(stderr, "    overlapping hole expected_offset=%d, size=%d\n", (int)expected_offset, (int)sparse->size);
 #endif
@@ -385,7 +387,8 @@ verify_sparse_file(struct archive *a, const char *path,
 		}
 		/* Blocks completely contained in data we just read. */
 		while (expected_offset + (int64_t)sparse->size <= offset + (int64_t)bytes_read) {
-			const char *end = (const char *)buff + (expected_offset - offset) + (size_t)sparse->size;
+			const char *end = (const char *)buff
+			    + ((expected_offset - offset) + (int64_t)sparse->size);
 			if (sparse->type == HOLE) {
 #if DEBUG
 				fprintf(stderr, "    contained hole expected_offset=%d, size=%d\n", (int)expected_offset, (int)sparse->size);


### PR DESCRIPTION
When a sparse map entry began before the current data block
(expected_offset < offset), verify_sparse_file() formed the intermediate
pointer "buff + (expected_offset - offset)" before adding the entry
size.  That intermediate points before buff, which is undefined behavior;
with file4's large hole it trapped the test under UBSan
(-fsanitize=pointer-overflow).  Fold the size into the displacement so the
whole byte offset is computed as one integer and added to buff in a
single, in-bounds step.
