### PR TITLE
pax: add "align" write option for reflink-friendly archives

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -693,6 +693,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_mtree_quoted_filename.c\
 	libarchive/test/test_write_format_mtree_null_deref.c \
 	libarchive/test/test_write_format_pax.c \
+	libarchive/test/test_write_format_pax_align.c \
 	libarchive/test/test_write_format_raw.c \
 	libarchive/test/test_write_format_raw_b64.c \
 	libarchive/test/test_write_format_shar_empty.c \

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -45,6 +45,8 @@
 #include "archive_write_private.h"
 #include "archive_write_set_format_private.h"
 
+#define PAX_MAX_ALIGN (1U << 20)
+
 struct sparse_block {
 	struct sparse_block	*next;
 	int		is_hole;
@@ -64,6 +66,10 @@ struct pax {
 	struct archive_string_conv *sconv_utf8;
 	int			 opt_binary;
 
+	/* If non-zero, align regular file data to this many bytes in the
+	 * uncompressed stream (power of two, multiple of 512). */
+	size_t			 align;
+
 	unsigned flags;
 #define WRITE_SCHILY_XATTR       (1 << 0)
 #define WRITE_LIBARCHIVE_XATTR   (1 << 1)
@@ -79,6 +85,8 @@ static void		 add_pax_attr_int(struct archive_string *,
 static void		 add_pax_attr_time(struct archive_string *,
 			     const char *key, int64_t sec,
 			     unsigned long nanos);
+static size_t		 add_pax_padding_prefix(struct archive_string *,
+			     size_t cur_len, size_t target_len);
 static int		 add_pax_acl(struct archive_write *,
 			    struct archive_entry *, struct pax *, int);
 static ssize_t		 archive_write_pax_data(struct archive_write *,
@@ -90,6 +98,7 @@ static int		 archive_write_pax_header(struct archive_write *,
 			     struct archive_entry *);
 static int		 archive_write_pax_options(struct archive_write *,
 			     const char *, const char *);
+static int		 write_pax_padding(struct archive_write *, size_t);
 static char		*base64_encode(const char *src, size_t len);
 static char		*build_gnu_sparse_name(char *dest, const char *src);
 static char		*build_pax_attribute_name(char *dest, const char *src);
@@ -223,6 +232,25 @@ archive_write_pax_options(struct archive_write *a, const char *key,
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "pax: invalid xattr header name");
 		return (ret);
+	} else if (strcmp(key, "align") == 0) {
+		unsigned long v;
+		char *end;
+
+		if (val == NULL || val[0] == 0) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "pax: align option needs a value");
+			return (ARCHIVE_FAILED);
+		}
+		v = strtoul(val, &end, 10);
+		if (*end != '\0' || v == 0 || (v % 512) != 0 ||
+		    (v & (v - 1)) != 0 || v > PAX_MAX_ALIGN) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "pax: align must be a power of two, a multiple "
+			    "of 512, and no larger than 1 MiB");
+			return (ARCHIVE_FAILED);
+		}
+		pax->align = (size_t)v;
+		return (ARCHIVE_OK);
 	}
 
 	/* Note: The "warn" return is just to inform the options
@@ -359,6 +387,81 @@ add_pax_attr_binary(struct archive_string *as, const char *key,
 	archive_strappend_char(as, '=');
 	archive_array_append(as, value, value_len);
 	archive_strappend_char(as, '\n');
+}
+
+/*
+ * Append the length/key prefix of an ignorable "LIBARCHIVE.pad" record whose
+ * full length rounds the pax body up to 'target_len'.  Return the number of
+ * value/newline bytes that must be emitted after the in-memory header.
+ */
+static size_t
+add_pax_padding_prefix(struct archive_string *as, size_t cur_len,
+    size_t target_len)
+{
+	static const char key[] = "LIBARCHIVE.pad";
+	char tmp[1 + 3 * sizeof(int64_t)];
+	char *length;
+	size_t prefix_len, record_len;
+
+	if (target_len <= cur_len)
+		return (0);
+	record_len = target_len - cur_len;
+	tmp[sizeof(tmp) - 1] = 0;
+	length = format_int(tmp + sizeof(tmp) - 1, (int64_t)record_len);
+	prefix_len = strlen(length) + 1 + sizeof(key) - 1 + 1;
+	if (record_len <= prefix_len)
+		return (0); /* not enough room; leave unaligned */
+
+	archive_strcat(as, length);
+	archive_strappend_char(as, ' ');
+	archive_strcat(as, key);
+	archive_strappend_char(as, '=');
+	return (record_len - prefix_len);
+}
+
+/* Emit a deferred pax padding value followed by its record newline. */
+static int
+write_pax_padding(struct archive_write *a, size_t length)
+{
+	char padding[1024];
+
+	if (length == 0)
+		return (ARCHIVE_OK);
+	memset(padding, 'X', sizeof(padding));
+	while (length > 1) {
+		size_t to_write = length - 1;
+		int r;
+
+		if (to_write > sizeof(padding))
+			to_write = sizeof(padding);
+		r = __archive_write_output(a, padding, to_write);
+		if (r != ARCHIVE_OK)
+			return (r);
+		length -= to_write;
+	}
+	return (__archive_write_output(a, "\n", 1));
+}
+
+/*
+ * For the pax "align" option: given entry offset 'off' (a multiple of 512) and
+ * current extended-header body length 'l0', return the body length needed so
+ * the file data (after the x header) lands on 'align', or 'l0' if already
+ * aligned.
+ */
+static size_t
+pax_align_body_len(uint64_t off, size_t l0, size_t align)
+{
+	uint64_t amask = (uint64_t)align - 1;
+	/* Data offset with no extra padding (no x header when l0 == 0). */
+	uint64_t natural_off = (l0 == 0) ? off + 512
+	    : off + 1024 + (((uint64_t)l0 + 511) & ~(uint64_t)511);
+
+	if ((natural_off & amask) == 0)
+		return (l0);
+
+	/* Grow the body (past l0 plus pad-record room) to land data on align. */
+	uint64_t base = off + 1024;
+	return ((size_t)(((base + l0 + 64 + amask) & ~amask) - base));
 }
 
 static void
@@ -593,6 +696,7 @@ archive_write_pax_header(struct archive_write *a,
 	size_t mac_metadata_size;
 	struct archive_string_conv *sconv;
 	size_t hardlink_length, path_length, linkpath_length;
+	size_t pax_header_padding = 0;
 	size_t uname_length, gname_length;
 
 	char paxbuff[512];
@@ -1403,6 +1507,21 @@ archive_write_pax_header(struct archive_write *a,
 		return (ARCHIVE_FATAL);
 	}
 
+	/* Pad the extended header so contiguous file data starts on a pax->align
+	 * boundary (for reflinking); short and sparse files are left alone. */
+	if (pax->align > 0
+	    && archive_entry_filetype(entry_main) == AE_IFREG
+	    && hardlink == NULL
+	    && sparse_count == 0
+	    && real_size >= (uint64_t)pax->align) {
+		size_t l0 = archive_strlen(&(pax->pax_header));
+		size_t needed = pax_align_body_len(
+		    (uint64_t)a->filter_first->bytes_written, l0, pax->align);
+		if (needed != l0)
+			pax_header_padding = add_pax_padding_prefix(
+			    &(pax->pax_header), l0, needed);
+	}
+
 	/* If we built any extended attributes, write that entry first. */
 	if (archive_strlen(&(pax->pax_header)) > 0) {
 		struct archive_entry *pax_attr_entry;
@@ -1423,7 +1542,8 @@ archive_write_pax_header(struct archive_write *a,
 		archive_entry_set_pathname(pax_attr_entry,
 		    build_pax_attribute_name(pax_entry_name, p));
 		archive_entry_set_size(pax_attr_entry,
-		    archive_strlen(&(pax->pax_header)));
+		    archive_strlen(&(pax->pax_header)) +
+		    pax_header_padding);
 		/* Copy uid/gid (but clip to ustar limits). */
 		uid = archive_entry_uid(entry_main);
 		if (uid >= 1 << 18)
@@ -1489,7 +1609,8 @@ archive_write_pax_header(struct archive_write *a,
 			return (ARCHIVE_FATAL);
 		}
 
-		pax->entry_bytes_remaining = archive_strlen(&(pax->pax_header));
+		pax->entry_bytes_remaining = archive_strlen(&(pax->pax_header)) +
+		    pax_header_padding;
 		pax->entry_padding =
 		    0x1ff & (-(int64_t)pax->entry_bytes_remaining);
 
@@ -1497,6 +1618,12 @@ archive_write_pax_header(struct archive_write *a,
 		    archive_strlen(&(pax->pax_header)));
 		if (r != ARCHIVE_OK) {
 			/* If a write fails, we're pretty much toast. */
+			archive_entry_free(entry_main);
+			archive_string_free(&entry_name);
+			return (ARCHIVE_FATAL);
+		}
+		r = write_pax_padding(a, pax_header_padding);
+		if (r != ARCHIVE_OK) {
 			archive_entry_free(entry_main);
 			archive_string_free(&entry_name);
 			return (ARCHIVE_FATAL);

--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -555,6 +555,20 @@ used when translating file names.
 .El
 .It Format pax
 .Bl -tag -compact -width indent
+.It Cm align
+Pad the extended header of each regular file so that the file data that
+follows begins on a multiple of the given number of bytes within the
+uncompressed archive stream.
+The value must be a power of two and a multiple of 512.
+Because the alignment is applied to the uncompressed stream, it is
+independent of any compression filter: the decompressed archive is
+aligned regardless of whether the archive is compressed.
+This allows tools to share file contents out of an
+uncompressed archive (or an uncompressed copy of one) using
+reflinks or
+.Xr copy_file_range 2 ,
+at the cost of some extra padding.
+Files shorter than the alignment are not padded.
 .It Cm hdrcharset
 The value is used as a character set name that will be
 used when translating file, group and user names.

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -322,6 +322,7 @@ IF(ENABLE_TEST)
     test_write_format_mtree_quoted_filename.c
     test_write_format_mtree_null_deref.c
     test_write_format_pax.c
+    test_write_format_pax_align.c
     test_write_format_raw.c
     test_write_format_raw_b64.c
     test_write_format_shar_empty.c

--- a/libarchive/test/test_write_format_pax_align.c
+++ b/libarchive/test/test_write_format_pax_align.c
@@ -1,0 +1,246 @@
+/*-
+ * Copyright (c) 2024 libarchive contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * The pax "align" option must start each big-enough regular file's data on
+ * an alignment boundary in the archive stream, so it can be reflinked out.
+ */
+
+#define ALIGN 4096
+
+struct file {
+	const char *name;
+	size_t size;
+	char fill;
+	int add_xattr;		/* force a "natural" pax extended header */
+};
+
+/*
+ * A mix of entries: small/large regular files, a directory, long-name and
+ * xattr entries (which force a natural pax header), and an exactly-align file.
+ */
+static const struct file files[] = {
+	{ "small",		100,		'a', 0 },
+	{ "big1",		5000,		'b', 0 },
+	{ "adir/",		0,		0,   0 },
+	{ "big2",		ALIGN,		'c', 0 },
+	{ "tiny",		1,		'd', 0 },
+	{ "big3",		100000,		'e', 0 },
+	{ "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/longname", 8192, 'f', 0 },
+	{ "withxattr",		9000,		'g', 1 },
+	{ NULL, 0, 0, 0 }
+};
+
+static void
+verify_align_limit(void)
+{
+	struct archive *a;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_pax_restricted(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "align=1048576"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_options(a, "align=2097152"));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}
+
+static int
+memory_contains(const char *memory, size_t memory_size, const char *needle)
+{
+	size_t needle_size = strlen(needle);
+	size_t i;
+
+	for (i = 0; i + needle_size <= memory_size; i++) {
+		if (memcmp(memory + i, needle, needle_size) == 0)
+			return (1);
+	}
+	return (0);
+}
+
+static void
+verify_sparse_not_padded(void)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char *buff, *data;
+	size_t buffsize = 65536, used;
+
+	buff = malloc(buffsize);
+	data = calloc(1, 8192);
+	assert(buff != NULL);
+	assert(data != NULL);
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_pax_restricted(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "align=4096"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "sparse");
+	archive_entry_set_mode(ae, S_IFREG | 0644);
+	archive_entry_set_size(ae, 8192);
+	archive_entry_sparse_add_entry(ae, 4096, 4096);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, 8192, archive_write_data(a, data, 8192));
+	archive_entry_free(ae);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	failure("Sparse entries must not get misleading alignment padding");
+	assert(!memory_contains(buff, used, "LIBARCHIVE.pad"));
+	free(data);
+	free(buff);
+}
+
+static void
+write_archive(char *buff, size_t buffsize, size_t *used, int gzip)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	const struct file *f;
+	char *data;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_pax_restricted(a));
+	if (gzip)
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_gzip(a));
+	else
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	/* Small blocks so the writer doesn't tail-pad past our offsets. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 512));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "align=4096"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	for (f = files; f->name != NULL; f++) {
+		archive_entry_clear(ae);
+		archive_entry_set_pathname(ae, f->name);
+		archive_entry_set_mtime(ae, 5, 0);
+		if (f->name[strlen(f->name) - 1] == '/') {
+			archive_entry_set_mode(ae, S_IFDIR | 0755);
+		} else {
+			archive_entry_set_mode(ae, S_IFREG | 0644);
+			archive_entry_set_size(ae, f->size);
+		}
+		if (f->add_xattr)
+			archive_entry_xattr_add_entry(ae, "user.test",
+			    "value", 5);
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+		if (f->size > 0) {
+			data = malloc(f->size);
+			assert(data != NULL);
+			memset(data, f->fill, f->size);
+			assertEqualIntA(a, f->size,
+			    archive_write_data(a, data, f->size));
+			free(data);
+		}
+	}
+	archive_entry_free(ae);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}
+
+static void
+verify_archive(const char *buff, size_t used, int gzip)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	const struct file *f;
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
+	if (gzip)
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_gzip(a));
+	else
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, buff, used));
+
+	for (f = files; f->name != NULL; f++) {
+		int64_t off, size;
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+		assertEqualStringA(a, f->name, archive_entry_pathname(ae));
+		size = archive_entry_size(ae);
+		assertEqualIntA(a, f->size, size);
+		/*
+		 * archive_filter_bytes(a, 0) is the offset of the data in
+		 * the *decompressed* archive stream, i.e. exactly where a
+		 * reflink would read from an uncompressed archive.
+		 */
+		off = archive_filter_bytes(a, 0);
+		if (archive_entry_filetype(ae) == AE_IFREG && size >= ALIGN) {
+			failure("data for '%s' (size %jd) must start on a "
+			    "%d-byte boundary but starts at %jd",
+			    f->name, (intmax_t)size, ALIGN, (intmax_t)off);
+			assertEqualInt(0, (int)(off % ALIGN));
+		}
+		/* Data must still round-trip intact through the padding. */
+		if (size > 0) {
+			char *data = malloc((size_t)size);
+			assert(data != NULL);
+			assertEqualIntA(a, size,
+			    archive_read_data(a, data, (size_t)size));
+			assertMemoryFilledWith(data, (size_t)size, f->fill);
+			free(data);
+		}
+	}
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
+DEFINE_TEST(test_write_format_pax_align)
+{
+	size_t buffsize = 2000000;
+	char *buff;
+	size_t used;
+
+	verify_align_limit();
+	verify_sparse_not_padded();
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+
+	/* Uncompressed: the archive itself is aligned on disk. */
+	write_archive(buff, buffsize, &used, 0);
+	verify_archive(buff, used, 0);
+
+	/* Compressed: the *decompressed* stream is still aligned, which is
+	 * what a reflink-from-decompressed-copy relies on. */
+	if (canGzip()) {
+		write_archive(buff, buffsize, &used, 1);
+		verify_archive(buff, used, 1);
+	} else {
+		skipping("gzip unavailable; skipped compressed alignment check");
+	}
+
+	free(buff);
+}


### PR DESCRIPTION
Add a per-format "align" option to the pax writer that pads each
regular file's pax extended header (creating one if necessary) so the
file data that follows begins on a multiple of the requested number of
bytes within the uncompressed archive stream.  The value must be a
power of two and a multiple of the 512-byte tar block.

The alignment is applied to the stream feeding into any compression
filter, so the decompressed archive is aligned regardless of whether
the archive is compressed.  This lets tools share file contents out of
an (uncompressed copy of an) archive using reflinks / copy_file_range(2)
instead of doing a full data copy on extraction.

The padding is carried in an ignorable "LIBARCHIVE.pad" pax record, so
existing readers extract the archive unchanged.  Files shorter than the
alignment are left unpadded since they cannot share a whole block.

Add a test covering uncompressed and gzip-compressed archives and
document the option.
