### PR TITLE
libarchive: fix left-shift UB in several places

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -4191,7 +4191,7 @@ x86_Convert(struct _7zip *zip, uint8_t *data, size_t size)
 		if (p >= limit)
 			break;
 		prevPosT = bufferPos - prevPosT;
-		if (prevPosT > 3)
+		if (prevPosT == 0 || prevPosT > 3)
 			prevMask = 0;
 		else {
 			prevMask = (prevMask << ((int)prevPosT - 1)) & 0x7;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3858,7 +3858,7 @@ execute_filter_audio(struct rar_filter *filter, struct rar_virtual_machine *vm)
       state.delta[0] = state.lastdelta;
       predbyte = ((8 * state.lastbyte + state.weight[0] * state.delta[0] + state.weight[1] * state.delta[1] + state.weight[2] * state.delta[2]) >> 3) & 0xFF;
       byte = (predbyte - delta) & 0xFF;
-      prederror = delta << 3;
+      prederror = delta * 8;
       state.error[0] += abs(prederror);
       state.error[1] += abs(prederror - state.delta[0]); state.error[2] += abs(prederror + state.delta[0]);
       state.error[3] += abs(prederror - state.delta[1]); state.error[4] += abs(prederror + state.delta[1]);

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -2005,7 +2005,7 @@ base64_encode(const char *s, size_t len)
 	      'e','f','g','h','i','j','k','l','m','n','o','p','q','r','s',
 	      't','u','v','w','x','y','z','0','1','2','3','4','5','6','7',
 	      '8','9','+','/' };
-	int v;
+	uint32_t v;
 	char *d, *out;
 
 	/* 3 bytes becomes 4 chars, but round up and allow for trailing NUL */
@@ -2016,9 +2016,9 @@ base64_encode(const char *s, size_t len)
 
 	/* Convert each group of 3 bytes into 4 characters. */
 	while (len >= 3) {
-		v = (((int)s[0] << 16) & 0xff0000)
-		    | (((int)s[1] << 8) & 0xff00)
-		    | (((int)s[2]) & 0x00ff);
+		v = ((uint32_t)(unsigned char)s[0] << 16)
+		    | ((uint32_t)(unsigned char)s[1] << 8)
+		    | (uint32_t)(unsigned char)s[2];
 		s += 3;
 		len -= 3;
 		*d++ = digits[(v >> 18) & 0x3f];
@@ -2030,13 +2030,13 @@ base64_encode(const char *s, size_t len)
 	switch (len) {
 	case 0: break;
 	case 1:
-		v = (((int)s[0] << 16) & 0xff0000);
+		v = ((uint32_t)(unsigned char)s[0] << 16);
 		*d++ = digits[(v >> 18) & 0x3f];
 		*d++ = digits[(v >> 12) & 0x3f];
 		break;
 	case 2:
-		v = (((int)s[0] << 16) & 0xff0000)
-		    | (((int)s[1] << 8) & 0xff00);
+		v = ((uint32_t)(unsigned char)s[0] << 16)
+		    | ((uint32_t)(unsigned char)s[1] << 8);
 		*d++ = digits[(v >> 18) & 0x3f];
 		*d++ = digits[(v >> 12) & 0x3f];
 		*d++ = digits[(v >> 6) & 0x3f];

--- a/libarchive/test/test_fuzz_consumer.h
+++ b/libarchive/test/test_fuzz_consumer.h
@@ -99,14 +99,14 @@ fuzz_consume_u32(struct fuzz_consumer *c)
 FUZZ_UNUSED static int64_t
 fuzz_consume_i64(struct fuzz_consumer *c)
 {
-	int64_t val = 0;
+	uint64_t val = 0;
 	if (c->pos + 8 <= c->size) {
 		int i;
 		for (i = 0; i < 8; i++)
-			val |= (int64_t)c->data[c->pos + i] << (8 * i);
+			val |= (uint64_t)c->data[c->pos + i] << (8 * i);
 		c->pos += 8;
 	}
-	return val;
+	return (int64_t)val;
 }
 
 FUZZ_UNUSED static const char *


### PR DESCRIPTION
Fix left-shift undefined behavior in several parsing, writing, and test helper paths.

- Fix 7zip x86 BCJ previous-position shift count handling.

```
archive_read_support_format_7zip.c:4197:25:
runtime error: shift exponent -1 is negative
```

- Fix RAR audio delta scaling by using multiplication.

```
archive_read_support_format_rar.c:3861:25:
runtime error: left shift of negative value -128
```

- Fix pax base64 shifts by casting input bytes to unsigned.

```
archive_write_set_format_pax.c:2019:19:
runtime error: left shift of negative value -128
```

- Fix `fuzz_consume_i64()` construction with a `uint64_t` accumulator.

```
test_fuzz_consumer.h:106:40:
runtime error: left shift of 128 by 56 places cannot be represented
```