### PR TITLE
tidy: prefer ARCHIVE_OK over 0 when appropriate

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -135,7 +135,7 @@ archive_write_set_bytes_per_block(struct archive *_a, int bytes_per_block)
 
 	if (bytes_per_block < 0) {
 		// Do nothing if the bytes_per_block is negative
-		return 0;
+		return ARCHIVE_OK;
 	}
 	a->bytes_per_block = bytes_per_block;
 	return (ARCHIVE_OK);

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -181,7 +181,7 @@ archive_filter_b64encode_open(struct archive_write_filter *f)
 	    (unsigned int)state->mode, state->name.s);
 
 	f->data = state;
-	return (0);
+	return (ARCHIVE_OK);
 }
 
 static void

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -200,7 +200,7 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 	state->compressed_offset = 3;
 
 	f->data = state;
-	return (0);
+	return (ARCHIVE_OK);
 }
 
 /*-

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -170,7 +170,7 @@ archive_filter_uuencode_open(struct archive_write_filter *f)
 	    (unsigned int)state->mode, state->name.s);
 
 	f->data = state;
-	return (0);
+	return (ARCHIVE_OK);
 }
 
 static void

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -363,7 +363,7 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 	ret = archive_compressor_xz_init_stream(f, data);
 	if (ret == LZMA_OK) {
 		f->data = data;
-		return (0);
+		return (ARCHIVE_OK);
 	}
 	return (ARCHIVE_FATAL);
 }

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -6014,7 +6014,7 @@ isoent_gen_iso9660_identifier(struct archive_write *a, struct isoent *isoent,
 	const int null_size = 1;
 
 	if (isoent->children.cnt == 0)
-		return (0);
+		return (ARCHIVE_OK);
 
 	iso9660 = a->format_data;
 	char_map = idr->char_map;
@@ -6271,7 +6271,7 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 	const int null_size = 2;
 
 	if (isoent->children.cnt == 0)
-		return (0);
+		return (ARCHIVE_OK);
 
 	iso9660 = a->format_data;
 	if (iso9660->opt.joliet == OPT_JOLIET_LONGNAME)

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -530,7 +530,7 @@ archive_write_shar_finish_entry(struct archive_write *a)
 
 	shar = (struct shar *)a->format_data;
 	if (shar->entry == NULL)
-		return (0);
+		return (ARCHIVE_OK);
 
 	if (shar->dump) {
 		/* Finish uuencoded data. */


### PR DESCRIPTION
I'm piloting a new lint matcher for functions that mix and match `ARCHIVE_*` and integer literals. It's a little noisy right now, but I used it to generate fixes for a bunch of cases across the code.

It mistakenly found functions which returned numbers of bytes read (0 is fine there).

The rest of the findings were real, and are included here.