### PR TITLE
cpio: fix read-ahead pointer lifetime issue

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -369,6 +369,7 @@ archive_read_format_cpio_read_header(struct archive_read *a,
 	struct archive_string_conv *sconv;
 	size_t namelength;
 	size_t name_pad;
+	int is_trailer;
 	int r;
 
 	cpio = (struct cpio *)(a->format->data);
@@ -411,6 +412,9 @@ archive_read_format_cpio_read_header(struct archive_read *a,
 		    archive_string_conversion_charset_name(sconv));
 		r = ARCHIVE_WARN;
 	}
+	/* Save this before consuming the name buffer below. */
+	is_trailer = (namelength == 11 &&
+	    memcmp((const char *)h, "TRAILER!!!", 10) == 0);
 	cpio->entry_offset = 0;
 
 	__archive_read_consume(a, namelength);
@@ -451,8 +455,7 @@ archive_read_format_cpio_read_header(struct archive_read *a,
 	 * header.  XXX */
 
 	/* Compare name to "TRAILER!!!" to test for end-of-archive. */
-	if (namelength == 11 && strncmp((const char *)h, "TRAILER!!!",
-	    10) == 0) {
+	if (is_trailer) {
 		/* TODO: Store file location of start of block. */
 		archive_clear_error(&a->archive);
 		return (ARCHIVE_EOF);


### PR DESCRIPTION
The CPIO reader checked the `TRAILER!!!` marker using the pathname buffer after the name bytes had already been consumed. Since `__archive_read_ahead()` only returns a borrowed view into the input buffer, later consumes or symlink reads may make that pointer stale. Cache the trailer decision while the pathname buffer is still valid, then use the saved result after the rest of the header handling.

This is not reliably ASan-triggerable with the normal file backend because the consumed bytes may still remain readable in buffered storage. This is still an issue because the code was depending on a read-ahead pointer after its lifetime had ended.