### PR TITLE
warc: reject incomplete resource records

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -313,8 +313,15 @@ _warc_finish_entry(struct archive_write *a)
 	struct warc_s *w = a->format_data;
 
 	if (w->typ == AE_IFREG) {
-		int rc = __archive_write_output(a, _eor, sizeof(_eor) - 1U);
+		int rc;
 
+		if (w->entry_bytes_remaining != 0U) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "WARC entry is shorter than Content-Length");
+			return (ARCHIVE_FATAL);
+		}
+
+		rc = __archive_write_output(a, _eor, sizeof(_eor) - 1U);
 		if (rc != ARCHIVE_OK) {
 			return rc;
 		}

--- a/libarchive/test/test_write_format_warc.c
+++ b/libarchive/test/test_write_format_warc.c
@@ -169,3 +169,31 @@ DEFINE_TEST(test_write_format_warc_size)
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
+
+DEFINE_TEST(test_write_format_warc_incomplete)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[2048];
+	size_t used;
+
+	memset(buff, 0, sizeof(buff));
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_warc(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "test");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 9);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, 8, archive_write_data(a, "12345678", 8));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
+	assertEqualString("WARC entry is shorter than Content-Length",
+	    archive_error_string(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}


### PR DESCRIPTION
Reject resource records when less data was written than `Content-Length`.

Do not append the WARC end marker after a short entry. Return fatal because the record body has already been started.

This avoids writing a record whose length does not match its body.