### PR TITLE
warc: propagate generated header errors

### DIFF
--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -279,7 +279,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			archive_set_error(
 				&a->archive,
 				ARCHIVE_ERRNO_FILE_FORMAT,
-				"cannot archive file");
+				"WARC resource header is too large");
 			return (ARCHIVE_FATAL);
 		}
 		/* Append the header to the output stream. */

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -193,6 +193,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 	/* Emit the warcinfo record if needed. */
 	if (!w->omit_warcinfo) {
 		ssize_t r;
+		int rc;
 		warc_essential_hdr_t wi = {
 			WT_INFO,
 			/* URI */NULL,
@@ -207,17 +208,27 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 
 		archive_string_init(&hdr);
 		r = _popul_ehdr(&hdr, MAX_HDR_SIZE, wi);
-		if (r >= 0) {
-			/* Header was populated successfully. */
-			/* Reuse the header buffer for the warcinfo payload. */
-			archive_strncat(&hdr, warcinfo, sizeof(warcinfo) -1);
-
-			/* Append the end-of-record indicator. */
-			archive_strncat(&hdr, "\r\n\r\n", 4);
-
-			/* Write the warcinfo record to the output stream. */
-			__archive_write_output(a, hdr.s, archive_strlen(&hdr));
+		if (r < 0) {
+			archive_string_free(&hdr);
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Cannot archive warcinfo record");
+			return (ARCHIVE_FAILED);
 		}
+
+		/* Reuse the header buffer for the warcinfo payload. */
+		archive_strncat(&hdr, warcinfo, sizeof(warcinfo) -1);
+
+		/* Append the end-of-record indicator. */
+		archive_strncat(&hdr, "\r\n\r\n", 4);
+
+		/* Write the warcinfo record to the output stream. */
+		rc = __archive_write_output(a, hdr.s, archive_strlen(&hdr));
+		if (rc != ARCHIVE_OK) {
+			archive_string_free(&hdr);
+			return (rc);
+		}
+
 		/* Mark the file header as written. */
 		w->omit_warcinfo = 1U;
 		archive_string_free(&hdr);
@@ -242,6 +253,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			/* Content length */0,
 		};
 		ssize_t r;
+		int rc;
 		int64_t size;
 		rh.tgturi = archive_entry_pathname(entry);
 		rh.rtime = w->now;
@@ -268,10 +280,14 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 				&a->archive,
 				ARCHIVE_ERRNO_FILE_FORMAT,
 				"cannot archive file");
-			return (ARCHIVE_WARN);
+			return (ARCHIVE_FATAL);
 		}
 		/* Append the header to the output stream. */
-		__archive_write_output(a, hdr.s, r);
+		rc = __archive_write_output(a, hdr.s, r);
+		if (rc != ARCHIVE_OK) {
+			archive_string_free(&hdr);
+			return (rc);
+		}
 		/* Save the remaining size for subsequent _data() calls. */
 		w->entry_bytes_remaining = rh.cntlen;
 		archive_string_free(&hdr);

--- a/libarchive/test/test_write_format_warc.c
+++ b/libarchive/test/test_write_format_warc.c
@@ -197,3 +197,55 @@ DEFINE_TEST(test_write_format_warc_incomplete)
 	    archive_error_string(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
+
+DEFINE_TEST(test_write_format_warc_warcinfo_output_error)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[1];
+	size_t used;
+
+	memset(buff, 0, sizeof(buff));
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_warc(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "test");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 1);
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}
+
+DEFINE_TEST(test_write_format_warc_resource_output_error)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[1];
+	size_t used;
+
+	memset(buff, 0, sizeof(buff));
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_warc(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_format_option(a, NULL, "omit-warcinfo", NULL));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "test");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 1);
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}


### PR DESCRIPTION
This fixes WARC writer error handling for generated headers.

The writer previously ignored `__archive_write_output()` failures when writing generated `warcinfo` and `resource` headers. It could also return `ARCHIVE_WARN` after `_popul_ehdr()` failed for a resource header, even though no valid WARC resource header was emitted.

This PR makes generated header failures stop the entry with `ARCHIVE_FAILED` or the real output error. It also adds tests for write failures in both generated header paths.

An extra commit changes `cannot archive file` to `WARC resource header is too large`. This should be low-risk for userspace because the old message was vague and lowercase.