### PR TITLE
uu: fix null pointer UB in EOF buffering

### DIFF
--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -498,8 +498,9 @@ read_more:
 		if (ensure_in_buff_size(self, uudecode,
 		    avail_in + uudecode->in_cnt) != ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
-		memcpy(uudecode->in_buff + uudecode->in_cnt,
-		    d, avail_in);
+		if (avail_in > 0)
+			memcpy(uudecode->in_buff + uudecode->in_cnt,
+			    d, avail_in);
 		d = uudecode->in_buff;
 		avail_in += uudecode->in_cnt;
 		uudecode->in_cnt = 0;


### PR DESCRIPTION
The uu filter can reach EOF while holding a partial encoded line. In that case, `d` is `NULL` and `avail_in` is zero, but the buffered-input path still passes `d` to `memcpy()` before processing the saved bytes.

UBsan log:

```
archive_read_support_filter_uu.c:502:7: runtime error:
null pointer passed as argument 2, which is declared to never be null
```

Skip the append copy when `avail_in` is zero so the saved input is handled without passing a null source pointer to `memcpy()`.

Resolves #3026