### PR TITLE
xar: fix one-byte over-read in parse_time date parser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1104,6 +1104,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_xar_doublelink.xar.uu \
 	libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu \
 	libarchive/test/test_read_format_xar_large_mode.xar.uu \
+	libarchive/test/test_read_format_xar_parse_time_overread.xar.uu \
 	libarchive/test/test_read_format_zip.zip.uu \
 	libarchive/test/test_read_format_zip_7075_utf8_paths.zip.uu \
 	libarchive/test/test_read_format_zip_7z_deflate.zip.uu \

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1164,31 +1164,31 @@ parse_time(const char *p, size_t n)
 	p += 4;
 	if (*p++ != '-')
 		return (t);
-	if (atou64(p, 4, 10, &data) != ARCHIVE_OK || data < 1 || data > 12)
+	if (atou64(p, 2, 10, &data) != ARCHIVE_OK || data < 1 || data > 12)
 		return (t);
 	tm.tm_mon = (int)data -1;
 	p += 2;
 	if (*p++ != '-')
 		return (t);
-	if (atou64(p, 4, 10, &data) != ARCHIVE_OK || data < 1 || data > 31)
+	if (atou64(p, 2, 10, &data) != ARCHIVE_OK || data < 1 || data > 31)
 		return (t);
 	tm.tm_mday = (int)data;
 	p += 2;
 	if (*p++ != 'T')
 		return (t);
-	if (atou64(p, 4, 10, &data) != ARCHIVE_OK || data > 23)
+	if (atou64(p, 2, 10, &data) != ARCHIVE_OK || data > 23)
 		return (t);
 	tm.tm_hour = (int)data;
 	p += 2;
 	if (*p++ != ':')
 		return (t);
-	if (atou64(p, 4, 10, &data) != ARCHIVE_OK || data > 59)
+	if (atou64(p, 2, 10, &data) != ARCHIVE_OK || data > 59)
 		return (t);
 	tm.tm_min = (int)data;
 	p += 2;
 	if (*p++ != ':')
 		return (t);
-	if (atou64(p, 4, 10, &data) != ARCHIVE_OK || data > 60)
+	if (atou64(p, 2, 10, &data) != ARCHIVE_OK || data > 60)
 		return (t);
 	tm.tm_sec = (int)data;
 #if 0

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -1040,3 +1040,38 @@ DEFINE_TEST(test_read_format_xar_atou64_overread)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+/*
+ * parse_time() reads a fixed 20-byte timestamp and handed atou64() a width
+ * of 4 for every field.  The trailing seconds field sits at offset 17, so a
+ * value whose last three bytes are all digits (here "...00:00:123") made
+ * atou64() read one byte past the 20-byte value.  This archive carries such
+ * an <mtime>; reading it must stay within the value.
+ */
+DEFINE_TEST(test_read_format_xar_parse_time_overread)
+{
+	const char *reffile = "test_read_format_xar_parse_time_overread.xar";
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+
+	extract_reference_file(reffile);
+	assert((a = archive_read_new()) != NULL);
+	assertA(0 == archive_read_support_filter_all(a));
+
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+
+	assertA(0 == archive_read_open_filename(a, reffile, 10240));
+
+	assertA(0 == archive_read_next_header(a, &ae));
+	assertEqualString("num", archive_entry_pathname(ae));
+	assertEqualInt(1234567890, archive_entry_ino64(ae));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_xar_parse_time_overread.xar.uu
+++ b/libarchive/test/test_read_format_xar_parse_time_overread.xar.uu
@@ -1,0 +1,8 @@
+begin 644 test_read_format_xar_parse_time_overread.xar
+M>&%R(0 <  $         G         #<     'C:-8Y="H,P$(3?/47(N]W5
+M_MFRQK>>P!Y 3%H")BG6%GO[K@F!@1V^W5F&NM5-XFOFMPV^E=4.I3!^#-KZ
+M9ROO_:UL9*<*6H=9%4+0$L9MLGO8R0BK.2,38>8'9Y3_.(+H,EY^+Z.V>X)H
+M,[<^:*.J>G\XGL[-!0D2R7NW6/Y2(V*)%:M'O+(X0)!VJ0ILOV,]B/T(8MT_
+$+RDZM0  
+`
+end


### PR DESCRIPTION
parse_time() reads a fixed 20-byte `YYYY-MM-DDThh:mm:ss` value but passes
atou64() a width of 4 for every field:

    <mtime> value (20 bytes):  2000-01-01T00:00:123
    seconds start at index 17; atou64(p, 4, ...) reads
    value[17], value[18], value[19], value[20]   <- value[20] is past the value

The seconds field is the last one and has no separator after it inside the 20
bytes, so its 4-byte read is the one that lands a byte past the value when
those three bytes are digits. After #3181 atou64() stops at its char_cnt, so
the over-wide width in parse_time is now what overruns. The value comes from
xml_data(), which is not NUL terminated under the expat/bsdxml backend
(libxml2 hands over a strlen'd copy that hides the read), the same path as the
atou64 (#3181) and strappend_base64 (#3175) fixes.

Give each field its real width (2 for the two-digit fields) so every read stays
inside the value. Canonical timestamps still parse identically; the added test
reads a crafted archive whose `<mtime>` ends in three digits.
