### PR TITLE
pax: use checked size arithmetic in base64_encode

### DIFF
--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -2134,9 +2134,16 @@ base64_encode(const char *s, size_t len)
 	      '8','9','+','/' };
 	uint32_t v;
 	char *d, *out;
+	size_t out_len;
 
 	/* 3 bytes becomes 4 chars, but round up and allow for trailing NUL */
-	out = malloc((len * 4 + 2) / 3 + 1);
+	if (archive_ckd_mul_size(&out_len, len, 4) ||
+	    archive_ckd_add_size(&out_len, out_len, 2))
+		return (NULL);
+	out_len = out_len / 3;
+	if (archive_ckd_add_size(&out_len, out_len, 1))
+		return (NULL);
+	out = malloc(out_len);
 	if (out == NULL)
 		return (NULL);
 	d = out;


### PR DESCRIPTION
**Unchecked len*4 overflow in base64_encode**
The base64 buffer for a `LIBARCHIVE.xattr` value is sized `(len * 4 + 2) / 3 + 1` from the raw attribute length, so once `len` reaches `SIZE_MAX/4` the multiply wraps, the malloc comes back undersized, and the encode loop still writes about `len*4/3` bytes past it. `url_encode` right above went to checked size arithmetic in 1ff898d; this does the same for the one allocation that sweep missed.