### PR TITLE
cab: Check `__archive_read_consume` result

### DIFF
--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -896,7 +896,8 @@ cab_read_header(struct archive_read *a)
 		return (ARCHIVE_FATAL);
 	}
 	if (skip) {
-		__archive_read_consume(a, skip);
+		if (__archive_read_consume(a, skip) < 0)
+			return (truncated_error(a));
 		cab->cab_offset += skip;
 	}
 	/* Allocate memory for CFDATA */


### PR DESCRIPTION
The bytes were not previously read, so check result of `__archive_read_consume`.