### PR TITLE
iso9660: always recalculate remaining extra space writing multi-part NM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -680,6 +680,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_iso9660_filename.c \
 	libarchive/test/test_write_format_iso9660_joliet_id.c \
 	libarchive/test/test_write_format_iso9660_rockridge.c \
+	libarchive/test/test_write_format_iso9660_rockridge_overflow.c \
 	libarchive/test/test_write_format_iso9660_zisofs.c \
 	libarchive/test/test_write_format_iso9660_zisofs_overflow.c \
 	libarchive/test/test_write_format_mtree.c \

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -2921,10 +2921,10 @@ set_directory_record_rr(unsigned char *bp, int dr_len,
 			extra_tell_used_size(&ctl, length);
 			if (extra_space(&ctl) < 6) {
 				bp = extra_next_record(&ctl, 6);
-				nmmax = extra_space(&ctl);
-				if (nmmax > 0xff)
-					nmmax = 0xff;
 			}
+			nmmax = extra_space(&ctl);
+			if (nmmax > 0xff)
+				nmmax = 0xff;
 			if (bp != NULL) {
 				bp[1] = 'N';
 				bp[2] = 'M';

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -308,6 +308,7 @@ IF(ENABLE_TEST)
     test_write_format_iso9660_filename.c
     test_write_format_iso9660_joliet_id.c
     test_write_format_iso9660_rockridge.c
+    test_write_format_iso9660_rockridge_overflow.c
     test_write_format_iso9660_zisofs.c
     test_write_format_iso9660_zisofs_overflow.c
     test_write_format_iso9660_bugs.c

--- a/libarchive/test/test_write_format_iso9660_rockridge_overflow.c
+++ b/libarchive/test/test_write_format_iso9660_rockridge_overflow.c
@@ -1,0 +1,74 @@
+/*-
+ * Copyright (c) 2026 Microsoft Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+DEFINE_TEST(test_write_format_iso9660_rockridge_overflow)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	unsigned char *buff;
+	char name[706];
+	size_t buffsize = 256 * 2048;
+	size_t used;
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+	if (buff == NULL)
+		return;
+
+	assert((a = archive_write_new()) != NULL);
+	assertA(0 == archive_write_set_format_iso9660(a));
+	assertA(0 == archive_write_add_filter_none(a));
+	assertA(0 == archive_write_set_bytes_per_block(a, 1));
+	assertA(0 == archive_write_set_bytes_in_last_block(a, 1));
+	assertA(0 == archive_write_open_memory(a, buff, buffsize, &used));
+
+	
+	name[0] = '.';
+	name[1] = '/';
+	/* Empirically, it seems it requires at least 7 iterations to line up the RR blocks and trigger the ASAN failure */
+	for (int i = 0; i < 10; ++i) {
+		/* AAAA... BBBB... CCCC... */
+		memset(&name[2], 0x41 + i, 703);
+		name[705] = '\0';
+
+		assert((ae = archive_entry_new()) != NULL);
+		archive_entry_set_atime(ae, 2, 0);
+		archive_entry_set_ctime(ae, 4, 0);
+		archive_entry_set_mtime(ae, 5, 0);
+		archive_entry_copy_pathname(ae, name);
+		archive_entry_set_mode(ae, S_IFREG | 0755);
+
+		assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+		archive_entry_free(ae);
+	}
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+
+	/* Close out the archive. */
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	free(buff);
+}


### PR DESCRIPTION
Writing an iso archive with a series of long names in it would eventually
cause an out-of-bounds write off the end of the rockridge extra data.

This happened when we allocated a net-new block for a file with a name
longer than would fit in two records spanning multiple blocks. We would:

- Fill up the extra_space in the last block
- Allocate a new block
- Write 250 + 5 (header) bytes of the name into it
- Try to copy 250 _more_ bytes out of the name, even if we did not have
  space left.