### PR TITLE
bsdtar: fix signed overflow UB in tar_i64toa()

### DIFF
--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -196,7 +196,6 @@ int	need_report(void);
 int	pathcmp(const char *a, const char *b);
 void	safe_fprintf(FILE * ARCHIVE_RESTRICT, const char * ARCHIVE_RESTRICT fmt, ...) __LA_PRINTF(2, 3);
 void	set_chdir(struct bsdtar *, const char *newdir);
-const char *tar_i64toa(int64_t);
 void	tar_mode_c(struct bsdtar *bsdtar);
 void	tar_mode_r(struct bsdtar *bsdtar);
 void	tar_mode_t(struct bsdtar *bsdtar);

--- a/tar/read.c
+++ b/tar/read.c
@@ -121,16 +121,16 @@ progress_func(void *cookie)
 		else
 			compression = (int)((uncomp - comp) * 100 / uncomp);
 		fprintf(stderr,
-		    "In: %s bytes, compression %d%%;",
-		    tar_i64toa(comp), compression);
-		fprintf(stderr, "  Out: %d files, %s bytes\n",
-		    archive_file_count(a), tar_i64toa(uncomp));
+		    "In: %ju bytes, compression %d%%;",
+		    (uintmax_t)comp, compression);
+		fprintf(stderr, "  Out: %d files, %ju bytes\n",
+		    archive_file_count(a), (uintmax_t)uncomp);
 	}
 	if (entry != NULL) {
 		safe_fprintf(stderr, "Current: %s",
 		    archive_entry_pathname(entry));
-		fprintf(stderr, " (%s bytes)\n",
-		    tar_i64toa(archive_entry_size(entry)));
+		fprintf(stderr, " (%jd bytes)\n",
+		    (intmax_t)archive_entry_size(entry));
 	}
 }
 

--- a/tar/util.c
+++ b/tar/util.c
@@ -585,27 +585,6 @@ edit_mtime(struct bsdtar *bsdtar, struct archive_entry *entry)
 }
 
 /*
- * It would be nice to just use printf() for formatting large numbers,
- * but the compatibility problems are quite a headache.  Hence the
- * following simple utility function.
- */
-const char *
-tar_i64toa(int64_t n0)
-{
-	static char buff[24];
-	uint64_t n = n0 < 0 ? -n0 : n0;
-	char *p = buff + sizeof(buff);
-
-	*--p = '\0';
-	do {
-		*--p = '0' + (int)(n % 10);
-	} while (n /= 10);
-	if (n0 < 0)
-		*--p = '-';
-	return p;
-}
-
-/*
  * Like strcmp(), but try to be a little more aware of the fact that
  * we're comparing two paths.  Right now, it just handles leading
  * "./" and trailing '/' specially, so that "a/b/" == "./a/b"
@@ -748,7 +727,9 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 		    (unsigned long)archive_entry_rdevminor(entry));
 		p = tmp;
 	} else {
-		p = tar_i64toa(archive_entry_size(entry));
+		snprintf(tmp, sizeof(tmp), "%jd",
+		    (intmax_t)archive_entry_size(entry));
+		p = tmp;
 	}
 	if (w + strlen(p) >= bsdtar->gs_width)
 		bsdtar->gs_width = w + strlen(p) + 1;

--- a/tar/write.c
+++ b/tar/write.c
@@ -598,8 +598,8 @@ cleanup:
 	bsdtar->diskreader = NULL;
 
 	if (bsdtar->flags & OPTFLAG_TOTALS) {
-		fprintf(stderr, "Total bytes written: %s\n",
-		    tar_i64toa(archive_filter_bytes(a, -1)));
+		fprintf(stderr, "Total bytes written: %jd\n",
+		    (intmax_t)archive_filter_bytes(a, -1));
 	}
 
 	archive_write_free(a);
@@ -1043,21 +1043,20 @@ report_write(struct bsdtar *bsdtar, struct archive *a,
 		fprintf(stderr, "\n");
 	comp = archive_filter_bytes(a, -1);
 	uncomp = archive_filter_bytes(a, 0);
-	fprintf(stderr, "In: %d files, %s bytes;",
-	    archive_file_count(a), tar_i64toa(uncomp));
+	fprintf(stderr, "In: %d files, %ju bytes;",
+	    archive_file_count(a), (uintmax_t)uncomp);
 	if (comp >= uncomp)
 		compression = 0;
 	else
 		compression = (int)((uncomp - comp) * 100 / uncomp);
 	fprintf(stderr,
-	    " Out: %s bytes, compression %d%%\n",
-	    tar_i64toa(comp), compression);
-	/* Can't have two calls to tar_i64toa() pending, so split the output. */
-	safe_fprintf(stderr, "Current: %s (%s",
+	    " Out: %ju bytes, compression %d%%\n",
+	    (uintmax_t)comp, compression);
+	safe_fprintf(stderr, "Current: %s (%jd",
 	    archive_entry_pathname(entry),
-	    tar_i64toa(progress));
-	fprintf(stderr, "/%s bytes)\n",
-	    tar_i64toa(archive_entry_size(entry)));
+	    (intmax_t)progress);
+	fprintf(stderr, "/%jd bytes)\n",
+	    (intmax_t)archive_entry_size(entry));
 }
 
 static void


### PR DESCRIPTION
~~Negating `INT64_MIN` as `int64_t` overflows because its positive value cannot be represented.~~

~~Convert the value to `uint64_t` first and compute its magnitude using unsigned arithmetic so `tar_i64toa()` handles the full `int64_t` range.~~

~~Instead, I just replaced the custom integer conversion with `%jd` formatting and an `intmax_t` cast -- handles full `int64_t` range without signed overflow UB.~~

Actually, removing `tar_i64toa()` is cleaner in my opinion, and all call sites can be replaced instead.