### PR TITLE
Handle memory allocation failure when adding writer filter

### DIFF
--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -64,6 +64,7 @@ static int archive_filter_b64encode_close(struct archive_write_filter *);
 static int archive_filter_b64encode_free(struct archive_write_filter *);
 static void la_b64_encode(struct archive_string *, const unsigned char *, size_t);
 static int64_t atol8(const char *, size_t);
+static void free_data(struct private_b64encode *);
 
 static const char base64[] = {
 	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
@@ -284,11 +285,8 @@ archive_filter_b64encode_close(struct archive_write_filter *f)
 static int
 archive_filter_b64encode_free(struct archive_write_filter *f)
 {
-	struct private_b64encode *state = (struct private_b64encode *)f->data;
-
-	archive_string_free(&state->name);
-	archive_string_free(&state->encoded_buff);
-	free(state);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -315,3 +313,12 @@ atol8(const char *p, size_t char_cnt)
 	return (l);
 }
 
+static void
+free_data(struct private_b64encode *data)
+{
+	if (data != NULL) {
+		archive_string_free(&data->name);
+		archive_string_free(&data->encoded_buff);
+		free(data);
+	}
+}

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -180,7 +180,6 @@ archive_filter_b64encode_open(struct archive_write_filter *f)
 	archive_string_sprintf(&state->encoded_buff, "begin-base64 %o %s\n",
 	    (unsigned int)state->mode, state->name.s);
 
-	f->data = state;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -98,11 +98,11 @@ archive_write_add_filter_b64encode(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = state;
 	f->name = "b64encode";
 	f->code = ARCHIVE_FILTER_UU;
-	f->open = archive_filter_b64encode_open;
+	f->data = state;
 	f->options = archive_filter_b64encode_options;
+	f->open = archive_filter_b64encode_open;
 	f->write = archive_filter_b64encode_write;
 	f->close = archive_filter_b64encode_close;
 	f->free = archive_filter_b64encode_free;

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -83,21 +83,21 @@ static const char base64[] = {
 int
 archive_write_add_filter_b64encode(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_b64encode *state;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_b64encode");
 
 	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
-		archive_set_error(a, ENOMEM,
-		    "Can't allocate data for b64encode filter");
-		return (ARCHIVE_FATAL);
-	}
+	if (state == NULL)
+		goto memerr;
 	archive_strcpy(&state->name, "-");
 	state->mode = 0644;
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = state;
 	f->name = "b64encode";
 	f->code = ARCHIVE_FILTER_UU;
@@ -108,6 +108,11 @@ archive_write_add_filter_b64encode(struct archive *a)
 	f->free = archive_filter_b64encode_free;
 
 	return (ARCHIVE_OK);
+memerr:
+	free_data(state);
+	archive_set_error(a, ENOMEM,
+	    "Can't allocate data for b64encode filter");
+	return (ARCHIVE_FATAL);
 }
 
 /*

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -81,18 +81,17 @@ static const char base64[] = {
  * Add a compress filter to this write handle.
  */
 int
-archive_write_add_filter_b64encode(struct archive *_a)
+archive_write_add_filter_b64encode(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_b64encode *state;
 
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_b64encode");
 
 	state = calloc(1, sizeof(*state));
 	if (state == NULL) {
-		archive_set_error(f->archive, ENOMEM,
+		archive_set_error(a, ENOMEM,
 		    "Can't allocate data for b64encode filter");
 		return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -91,12 +91,14 @@ archive_write_add_filter_bzip2(struct archive *a)
 		goto memerr;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	data->compression_level = 9;
+
 	r = ARCHIVE_OK;
 #else
 	data->pdata = __archive_write_program_allocate("bzip2");
 	if (data->pdata == NULL)
 		goto memerr;
 	data->compression_level = 0;
+
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external bzip2 program");
 	r = ARCHIVE_WARN;
@@ -105,14 +107,15 @@ archive_write_add_filter_bzip2(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = data;
-	f->options = &archive_compressor_bzip2_options;
-	f->close = &archive_compressor_bzip2_close;
-	f->free = &archive_compressor_bzip2_free;
-	f->open = &archive_compressor_bzip2_open;
-	f->write = archive_compressor_bzip2_write;
-	f->code = ARCHIVE_FILTER_BZIP2;
 	f->name = "bzip2";
+	f->code = ARCHIVE_FILTER_BZIP2;
+	f->data = data;
+	f->options = archive_compressor_bzip2_options;
+	f->open = archive_compressor_bzip2_open;
+	f->write = archive_compressor_bzip2_write;
+	f->close = archive_compressor_bzip2_close;
+	f->free = archive_compressor_bzip2_free;
+
 	return (r);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -196,7 +196,6 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 	ret = BZ2_bzCompressInit(&(data->stream),
 	    data->compression_level, 0, 30);
 	if (ret == BZ_OK) {
-		f->data = data;
 		return (ARCHIVE_OK);
 	}
 

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -77,18 +77,17 @@ static void free_data(struct private_data *);
  * Add a bzip2 compression filter to this write handle.
  */
 int
-archive_write_add_filter_bzip2(struct archive *_a)
+archive_write_add_filter_bzip2(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *data;
 
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_bzip2");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 9; /* default */
@@ -107,11 +106,11 @@ archive_write_add_filter_bzip2(struct archive *_a)
 	data->pdata = __archive_write_program_allocate("bzip2");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 0;
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external bzip2 program");
 	return (ARCHIVE_WARN);
 #endif

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -71,6 +71,7 @@ static int archive_compressor_bzip2_options(struct archive_write_filter *,
 		    const char *, const char *);
 static int archive_compressor_bzip2_write(struct archive_write_filter *,
 		    const void *, size_t);
+static void free_data(struct private_data *);
 
 /*
  * Add a bzip2 compression filter to this write handle.
@@ -113,6 +114,14 @@ archive_write_add_filter_bzip2(struct archive *_a)
 	    "Using external bzip2 program");
 	return (ARCHIVE_WARN);
 #endif
+}
+
+static int
+archive_compressor_bzip2_free(struct archive_write_filter *f)
+{
+	free_data(f->data);
+	f->data = NULL;
+	return (ARCHIVE_OK);
 }
 
 /*
@@ -275,20 +284,6 @@ archive_compressor_bzip2_close(struct archive_write_filter *f)
 	return ret;
 }
 
-static int
-archive_compressor_bzip2_free(struct archive_write_filter *f)
-{
-	struct private_data *data = (struct private_data *)f->data;
-
-	/* May already have been called, but not necessarily. */
-	(void)BZ2_bzCompressEnd(&(data->stream));
-
-	free(data->compressed);
-	free(data);
-	f->data = NULL;
-	return (ARCHIVE_OK);
-}
-
 /*
  * Utility function to push input data through compressor, writing
  * full output blocks as necessary.
@@ -346,6 +341,18 @@ drive_compressor(struct archive_write_filter *f,
 	}
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		/* May already have been called, but not necessarily. */
+		(void)BZ2_bzCompressEnd(&(data->stream));
+
+		free(data->compressed);
+		free(data);
+	}
+}
+
 #else /* HAVE_BZLIB_H && BZ_CONFIG_ERROR */
 
 static int
@@ -387,14 +394,13 @@ archive_compressor_bzip2_close(struct archive_write_filter *f)
 	return __archive_write_program_close(f, data->pdata);
 }
 
-static int
-archive_compressor_bzip2_free(struct archive_write_filter *f)
+static void
+free_data(struct private_data *data)
 {
-	struct private_data *data = (struct private_data *)f->data;
-
-	__archive_write_program_free(data->pdata);
-	free(data);
-	return (ARCHIVE_OK);
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }
 
 #endif /* HAVE_BZLIB_H && BZ_CONFIG_ERROR */

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -79,19 +79,32 @@ static void free_data(struct private_data *);
 int
 archive_write_add_filter_bzip2(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *data;
+	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_bzip2");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 9; /* default */
+	if (data == NULL)
+		goto memerr;
+#if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
+	data->compression_level = 9;
+	r = ARCHIVE_OK;
+#else
+	data->pdata = __archive_write_program_allocate("bzip2");
+	if (data->pdata == NULL)
+		goto memerr;
+	data->compression_level = 0;
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
+	    "Using external bzip2 program");
+	r = ARCHIVE_WARN;
+#endif
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = data;
 	f->options = &archive_compressor_bzip2_options;
 	f->close = &archive_compressor_bzip2_close;
@@ -100,20 +113,11 @@ archive_write_add_filter_bzip2(struct archive *a)
 	f->write = archive_compressor_bzip2_write;
 	f->code = ARCHIVE_FILTER_BZIP2;
 	f->name = "bzip2";
-#if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
-	return (ARCHIVE_OK);
-#else
-	data->pdata = __archive_write_program_allocate("bzip2");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 0;
-	archive_set_error(a, ARCHIVE_ERRNO_MISC,
-	    "Using external bzip2 program");
-	return (ARCHIVE_WARN);
-#endif
+	return (r);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Out of memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -98,6 +98,7 @@ archive_write_add_filter_bzip2(struct archive *_a)
 	f->close = &archive_compressor_bzip2_close;
 	f->free = &archive_compressor_bzip2_free;
 	f->open = &archive_compressor_bzip2_open;
+	f->write = archive_compressor_bzip2_write;
 	f->code = ARCHIVE_FILTER_BZIP2;
 	f->name = "bzip2";
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
@@ -199,7 +200,6 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 	memset(&data->stream, 0, sizeof(data->stream));
 	data->stream.next_out = data->compressed;
 	data->stream.avail_out = (uint32_t)data->compressed_buffer_size;
-	f->write = archive_compressor_bzip2_write;
 
 	/* Initialize compression library */
 	ret = BZ2_bzCompressInit(&(data->stream),
@@ -370,7 +370,6 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 		archive_strcat(&as, " -");
 		archive_strappend_char(&as, '0' + data->compression_level);
 	}
-	f->write = archive_compressor_bzip2_write;
 
 	r = __archive_write_program_open(f, data->pdata, as.s);
 	archive_string_free(&as);

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -141,13 +141,14 @@ archive_write_add_filter_compress(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
+	f->name = "compress";
+	f->code = ARCHIVE_FILTER_COMPRESS;
 	f->data = state;
-	f->open = &archive_compressor_compress_open;
+	f->open = archive_compressor_compress_open;
 	f->write = archive_compressor_compress_write;
 	f->close = archive_compressor_compress_close;
 	f->free = archive_compressor_compress_free;
-	f->code = ARCHIVE_FILTER_COMPRESS;
-	f->name = "compress";
+
 	return (ARCHIVE_OK);
 memerr:
 	free_data(state);

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -128,19 +128,19 @@ archive_write_set_compression_compress(struct archive *a)
 int
 archive_write_add_filter_compress(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *state;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_compress");
 
 	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
-		archive_set_error(a, ENOMEM,
-		    "Can't allocate data for compression");
-		return (ARCHIVE_FATAL);
-	}
+	if (state == NULL)
+		goto memerr;
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = state;
 	f->open = &archive_compressor_compress_open;
 	f->write = archive_compressor_compress_write;
@@ -149,6 +149,11 @@ archive_write_add_filter_compress(struct archive *a)
 	f->code = ARCHIVE_FILTER_COMPRESS;
 	f->name = "compress";
 	return (ARCHIVE_OK);
+memerr:
+	free_data(state);
+	archive_set_error(a, ENOMEM,
+	    "Can't allocate data for compression");
+	return (ARCHIVE_FATAL);
 }
 
 /*

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -147,9 +147,6 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 	struct private_data *state;
 	size_t bs = 65536, bpb;
 
-	f->code = ARCHIVE_FILTER_COMPRESS;
-	f->name = "compress";
-
 	state = calloc(1, sizeof(*state));
 	if (state == NULL) {
 		archive_set_error(f->archive, ENOMEM,

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -130,9 +130,19 @@ archive_write_add_filter_compress(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
 	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct private_data *state;
 
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_compress");
+
+	state = calloc(1, sizeof(*state));
+	if (state == NULL) {
+		archive_set_error(f->archive, ENOMEM,
+		    "Can't allocate data for compression");
+		return (ARCHIVE_FATAL);
+	}
+
+	f->data = state;
 	f->open = &archive_compressor_compress_open;
 	f->write = archive_compressor_compress_write;
 	f->close = archive_compressor_compress_close;
@@ -148,15 +158,8 @@ archive_write_add_filter_compress(struct archive *_a)
 static int
 archive_compressor_compress_open(struct archive_write_filter *f)
 {
-	struct private_data *state;
+	struct private_data *state = f->data;
 	size_t bs = 65536, bpb;
-
-	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
-		archive_set_error(f->archive, ENOMEM,
-		    "Can't allocate data for compression");
-		return (ARCHIVE_FATAL);
-	}
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 		/* Buffer size should be a multiple number of the bytes
@@ -173,7 +176,6 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 	if (state->compressed == NULL) {
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for compression buffer");
-		free(state);
 		return (ARCHIVE_FATAL);
 	}
 
@@ -196,7 +198,6 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 	state->compressed[2] = 0x90; /* Block mode, 16bit max */
 	state->compressed_offset = 3;
 
-	f->data = state;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -126,18 +126,17 @@ archive_write_set_compression_compress(struct archive *a)
  * Add a compress filter to this write handle.
  */
 int
-archive_write_add_filter_compress(struct archive *_a)
+archive_write_add_filter_compress(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *state;
 
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_compress");
 
 	state = calloc(1, sizeof(*state));
 	if (state == NULL) {
-		archive_set_error(f->archive, ENOMEM,
+		archive_set_error(a, ENOMEM,
 		    "Can't allocate data for compression");
 		return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -134,6 +134,9 @@ archive_write_add_filter_compress(struct archive *_a)
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_compress");
 	f->open = &archive_compressor_compress_open;
+	f->write = archive_compressor_compress_write;
+	f->close = archive_compressor_compress_close;
+	f->free = archive_compressor_compress_free;
 	f->code = ARCHIVE_FILTER_COMPRESS;
 	f->name = "compress";
 	return (ARCHIVE_OK);
@@ -173,10 +176,6 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 		free(state);
 		return (ARCHIVE_FATAL);
 	}
-
-	f->write = archive_compressor_compress_write;
-	f->close = archive_compressor_compress_close;
-	f->free = archive_compressor_compress_free;
 
 	state->max_maxcode = 0x10000;	/* Should NEVER generate this code. */
 	state->in_count = 0;		/* Length of input. */

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -111,6 +111,7 @@ static int archive_compressor_compress_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_compressor_compress_close(struct archive_write_filter *);
 static int archive_compressor_compress_free(struct archive_write_filter *);
+static void free_data(struct private_data *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 int
@@ -434,9 +435,16 @@ archive_compressor_compress_close(struct archive_write_filter *f)
 static int
 archive_compressor_compress_free(struct archive_write_filter *f)
 {
-	struct private_data *state = (struct private_data *)f->data;
-
-	free(state->compressed);
-	free(state);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
+}
+
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		free(data->compressed);
+		free(data);
+	}
 }

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -46,6 +46,7 @@ static int archive_write_grzip_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_grzip_close(struct archive_write_filter *);
 static int archive_write_grzip_free(struct archive_write_filter *);
+static void free_data(struct write_grzip *);
 
 int
 archive_write_add_filter_grzip(struct archive *_a)
@@ -125,9 +126,16 @@ archive_write_grzip_close(struct archive_write_filter *f)
 static int
 archive_write_grzip_free(struct archive_write_filter *f)
 {
-	struct write_grzip *data = (struct write_grzip *)f->data;
-
-	__archive_write_program_free(data->pdata);
-	free(data);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
+}
+
+static void
+free_data(struct write_grzip *data)
+{
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -51,24 +51,22 @@ static void free_data(struct write_grzip *);
 int
 archive_write_add_filter_grzip(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct write_grzip *data;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_grzip");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data == NULL)
+		goto memerr;
 	data->pdata = __archive_write_program_allocate("grzip");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data->pdata == NULL)
+		goto memerr;
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->name = "grzip";
 	f->code = ARCHIVE_FILTER_GRZIP;
 	f->data = data;
@@ -83,6 +81,10 @@ archive_write_add_filter_grzip(struct archive *a)
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external grzip program for grzip compression");
 	return (ARCHIVE_WARN);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Can't allocate memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -49,23 +49,23 @@ static int archive_write_grzip_free(struct archive_write_filter *);
 static void free_data(struct write_grzip *);
 
 int
-archive_write_add_filter_grzip(struct archive *_a)
+archive_write_add_filter_grzip(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct write_grzip *data;
 
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_grzip");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->pdata = __archive_write_program_allocate("grzip");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -80,7 +80,7 @@ archive_write_add_filter_grzip(struct archive *_a)
 
 	/* Note: This filter always uses an external program, so we
 	 * return "warn" to inform of the fact. */
-	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external grzip program for grzip compression");
 	return (ARCHIVE_WARN);
 }

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -70,8 +70,8 @@ archive_write_add_filter_grzip(struct archive *a)
 	f->name = "grzip";
 	f->code = ARCHIVE_FILTER_GRZIP;
 	f->data = data;
-	f->open = archive_write_grzip_open;
 	f->options = archive_write_grzip_options;
+	f->open = archive_write_grzip_open;
 	f->write = archive_write_grzip_write;
 	f->close = archive_write_grzip_close;
 	f->free = archive_write_grzip_free;

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -96,17 +96,16 @@ static void free_data(struct private_data *);
  * Add a gzip compression filter to this write handle.
  */
 int
-archive_write_add_filter_gzip(struct archive *_a)
+archive_write_add_filter_gzip(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *data;
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_gzip");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	f->data = data;
@@ -126,11 +125,11 @@ archive_write_add_filter_gzip(struct archive *_a)
 	data->pdata = __archive_write_program_allocate("gzip");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 0;
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external gzip program");
 	return (ARCHIVE_WARN);
 #endif

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -89,6 +89,7 @@ static int archive_compressor_gzip_free(struct archive_write_filter *);
 static int drive_compressor(struct archive_write_filter *,
 		    struct private_data *, int finishing);
 #endif
+static void free_data(struct private_data *);
 
 
 /*
@@ -137,15 +138,7 @@ archive_write_add_filter_gzip(struct archive *_a)
 static int
 archive_compressor_gzip_free(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
-
-#ifdef HAVE_ZLIB_H
-	free(data->compressed);
-#else
-	__archive_write_program_free(data->pdata);
-#endif
-	free((void*)data->original_filename);
-	free(data);
+	free_data(f->data);
 	f->data = NULL;
 	return (ARCHIVE_OK);
 }
@@ -426,6 +419,16 @@ drive_compressor(struct archive_write_filter *f,
 	}
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		free(data->compressed);
+		free(data->original_filename);
+		free(data);
+	}
+}
+
 #else /* HAVE_ZLIB_H */
 
 static int
@@ -473,4 +476,13 @@ archive_compressor_gzip_close(struct archive_write_filter *f)
 	return __archive_write_program_close(f, data->pdata);
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data->original_filename);
+		free(data);
+	}
+}
 #endif /* HAVE_ZLIB_H */

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -98,16 +98,33 @@ static void free_data(struct private_data *);
 int
 archive_write_add_filter_gzip(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *data;
+	int r;
+
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_gzip");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data == NULL)
+		goto memerr;
+	data->original_filename = NULL;
+#ifdef HAVE_ZLIB_H
+	data->compression_level = Z_DEFAULT_COMPRESSION;
+	r = ARCHIVE_OK;
+#else
+	data->pdata = __archive_write_program_allocate("gzip");
+	if (data->pdata == NULL)
+		goto memerr;
+	data->compression_level = 0;
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
+	    "Using external gzip program");
+	r = ARCHIVE_WARN;
+#endif
+
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = data;
 	f->open = &archive_compressor_gzip_open;
 	f->write = archive_compressor_gzip_write;
@@ -117,22 +134,11 @@ archive_write_add_filter_gzip(struct archive *a)
 	f->code = ARCHIVE_FILTER_GZIP;
 	f->name = "gzip";
 
-	data->original_filename = NULL;
-#ifdef HAVE_ZLIB_H
-	data->compression_level = Z_DEFAULT_COMPRESSION;
-	return (ARCHIVE_OK);
-#else
-	data->pdata = __archive_write_program_allocate("gzip");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 0;
-	archive_set_error(a, ARCHIVE_ERRNO_MISC,
-	    "Using external gzip program");
-	return (ARCHIVE_WARN);
-#endif
+	return (r);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Out of memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -284,7 +284,6 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	    Z_DEFAULT_STRATEGY);
 
 	if (init_success == Z_OK) {
-		f->data = data;
 		return (ret);
 	}
 

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -111,6 +111,7 @@ archive_write_add_filter_gzip(struct archive *_a)
 	}
 	f->data = data;
 	f->open = &archive_compressor_gzip_open;
+	f->write = archive_compressor_gzip_write;
 	f->options = &archive_compressor_gzip_options;
 	f->close = &archive_compressor_gzip_close;
 	f->free = &archive_compressor_gzip_free;
@@ -265,8 +266,6 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 			ret = ARCHIVE_WARN;
 		}
 	}
-
-	f->write = archive_compressor_gzip_write;
 
 	/* Initialize compression library. */
 	init_success = deflateInit2(&(data->stream),
@@ -453,7 +452,6 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 		/* Save timestamp. */
 		archive_strcat(&as, " -N");
 
-	f->write = archive_compressor_gzip_write;
 	r = __archive_write_program_open(f, data->pdata, as.s);
 	archive_string_free(&as);
 	return (r);

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -111,12 +111,14 @@ archive_write_add_filter_gzip(struct archive *a)
 	data->original_filename = NULL;
 #ifdef HAVE_ZLIB_H
 	data->compression_level = Z_DEFAULT_COMPRESSION;
+
 	r = ARCHIVE_OK;
 #else
 	data->pdata = __archive_write_program_allocate("gzip");
 	if (data->pdata == NULL)
 		goto memerr;
 	data->compression_level = 0;
+
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external gzip program");
 	r = ARCHIVE_WARN;
@@ -125,14 +127,14 @@ archive_write_add_filter_gzip(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = data;
-	f->open = &archive_compressor_gzip_open;
-	f->write = archive_compressor_gzip_write;
-	f->options = &archive_compressor_gzip_options;
-	f->close = &archive_compressor_gzip_close;
-	f->free = &archive_compressor_gzip_free;
-	f->code = ARCHIVE_FILTER_GZIP;
 	f->name = "gzip";
+	f->code = ARCHIVE_FILTER_GZIP;
+	f->data = data;
+	f->options = archive_compressor_gzip_options;
+	f->open = archive_compressor_gzip_open;
+	f->write = archive_compressor_gzip_write;
+	f->close = archive_compressor_gzip_close;
+	f->free = archive_compressor_gzip_free;
 
 	return (r);
 memerr:

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -76,8 +76,8 @@ archive_write_add_filter_lrzip(struct archive *a)
 	f->name = "lrzip";
 	f->code = ARCHIVE_FILTER_LRZIP;
 	f->data = data;
-	f->open = archive_write_lrzip_open;
 	f->options = archive_write_lrzip_options;
+	f->open = archive_write_lrzip_open;
 	f->write = archive_write_lrzip_write;
 	f->close = archive_write_lrzip_close;
 	f->free = archive_write_lrzip_free;

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -52,6 +52,7 @@ static int archive_write_lrzip_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_lrzip_close(struct archive_write_filter *);
 static int archive_write_lrzip_free(struct archive_write_filter *);
+static void free_data(struct write_lrzip *);
 
 int
 archive_write_add_filter_lrzip(struct archive *_a)
@@ -196,9 +197,16 @@ archive_write_lrzip_close(struct archive_write_filter *f)
 static int
 archive_write_lrzip_free(struct archive_write_filter *f)
 {
-	struct write_lrzip *data = (struct write_lrzip *)f->data;
-
-	__archive_write_program_free(data->pdata);
-	free(data);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
+}
+
+static void
+free_data(struct write_lrzip *data)
+{
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -57,24 +57,22 @@ static void free_data(struct write_lrzip *);
 int
 archive_write_add_filter_lrzip(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct write_lrzip *data;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lrzip");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data == NULL)
+		goto memerr;
 	data->pdata = __archive_write_program_allocate("lrzip");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data->pdata == NULL)
+		goto memerr;
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->name = "lrzip";
 	f->code = ARCHIVE_FILTER_LRZIP;
 	f->data = data;
@@ -89,6 +87,10 @@ archive_write_add_filter_lrzip(struct archive *a)
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lrzip program for lrzip compression");
 	return (ARCHIVE_WARN);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Can't allocate memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -55,23 +55,23 @@ static int archive_write_lrzip_free(struct archive_write_filter *);
 static void free_data(struct write_lrzip *);
 
 int
-archive_write_add_filter_lrzip(struct archive *_a)
+archive_write_add_filter_lrzip(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct write_lrzip *data;
 
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lrzip");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->pdata = __archive_write_program_allocate("lrzip");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -86,7 +86,7 @@ archive_write_add_filter_lrzip(struct archive *_a)
 
 	/* Note: This filter always uses an external program, so we
 	 * return "warn" to inform of the fact. */
-	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lrzip program for lrzip compression");
 	return (ARCHIVE_WARN);
 }

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -126,6 +126,7 @@ archive_write_add_filter_lz4(struct archive *_a)
 	f->close = &archive_filter_lz4_close;
 	f->free = &archive_filter_lz4_free;
 	f->open = &archive_filter_lz4_open;
+	f->write = archive_filter_lz4_write;
 	f->code = ARCHIVE_FILTER_LZ4;
 	f->name = "lz4";
 #if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
@@ -285,8 +286,6 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 		    "Can't allocate data for compression buffer");
 		return (ARCHIVE_FATAL);
 	}
-
-	f->write = archive_filter_lz4_write;
 
 	return (ARCHIVE_OK);
 }
@@ -671,8 +670,6 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 		archive_strcat(&as, " --no-frame-crc");
 	if (data->block_independence == 0)
 		archive_strcat(&as, " -BD");
-
-	f->write = archive_filter_lz4_write;
 
 	r = __archive_write_program_open(f, data->pdata, as.s);
 	archive_string_free(&as);

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -85,6 +85,7 @@ static int archive_filter_lz4_options(struct archive_write_filter *,
 		    const char *, const char *);
 static int archive_filter_lz4_write(struct archive_write_filter *,
 		    const void *, size_t);
+static void free_data(struct private_data *);
 
 /*
  * Add an lz4 compression filter to this write handle.
@@ -145,6 +146,14 @@ archive_write_add_filter_lz4(struct archive *_a)
 	    "Using external lz4 program");
 	return (ARCHIVE_WARN);
 #endif
+}
+
+static int
+archive_filter_lz4_free(struct archive_write_filter *f)
+{
+	free_data(f->data);
+	f->data = NULL;
+	return (ARCHIVE_OK);
 }
 
 /*
@@ -362,35 +371,6 @@ archive_filter_lz4_close(struct archive_write_filter *f)
 			    data->out_buffer, data->out - data->out_buffer);
 	}
 	return ret;
-}
-
-static int
-archive_filter_lz4_free(struct archive_write_filter *f)
-{
-	struct private_data *data = (struct private_data *)f->data;
-
-	if (data->lz4_stream != NULL) {
-#ifdef HAVE_LZ4HC_H
-		if (data->compression_level >= 3)
-#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-			LZ4_freeStreamHC(data->lz4_stream);
-#else
-			LZ4_freeHC(data->lz4_stream);
-#endif
-		else
-#endif
-#if LZ4_VERSION_MINOR >= 3
-			LZ4_freeStream(data->lz4_stream);
-#else
-			LZ4_free(data->lz4_stream);
-#endif
-	}
-	free(data->out_buffer);
-	free(data->in_buffer_allocated);
-	free(data->xxh32_state);
-	free(data);
-	f->data = NULL;
-	return (ARCHIVE_OK);
 }
 
 static int
@@ -637,6 +617,33 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 	return (ARCHIVE_OK);
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		if (data->lz4_stream != NULL) {
+#ifdef HAVE_LZ4HC_H
+			if (data->compression_level >= 3)
+#if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
+				LZ4_freeStreamHC(data->lz4_stream);
+#else
+				LZ4_freeHC(data->lz4_stream);
+#endif
+			else
+#endif
+#if LZ4_VERSION_MINOR >= 3
+				LZ4_freeStream(data->lz4_stream);
+#else
+				LZ4_free(data->lz4_stream);
+#endif
+		}
+		free(data->out_buffer);
+		free(data->in_buffer_allocated);
+		free(data->xxh32_state);
+		free(data);
+	}
+}
+
 #else /* HAVE_LIBLZ4 */
 
 static int
@@ -689,14 +696,13 @@ archive_filter_lz4_close(struct archive_write_filter *f)
 	return __archive_write_program_close(f, data->pdata);
 }
 
-static int
-archive_filter_lz4_free(struct archive_write_filter *f)
+static void
+free_data(struct private_data *data)
 {
-	struct private_data *data = (struct private_data *)f->data;
-
-	__archive_write_program_free(data->pdata);
-	free(data);
-	return (ARCHIVE_OK);
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }
 
 #endif /* HAVE_LIBLZ4 */

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -91,18 +91,17 @@ static void free_data(struct private_data *);
  * Add an lz4 compression filter to this write handle.
  */
 int
-archive_write_add_filter_lz4(struct archive *_a)
+archive_write_add_filter_lz4(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *data;
 
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lz4");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -139,11 +138,11 @@ archive_write_add_filter_lz4(struct archive *_a)
 	data->pdata = __archive_write_program_allocate("lz4");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 0;
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lz4 program");
 	return (ARCHIVE_WARN);
 #endif

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -115,6 +115,7 @@ archive_write_add_filter_lz4(struct archive *a)
 	data->block_maximum_size = 7;
 #if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
 	data->compression_level = 1;
+
 	r = ARCHIVE_OK;
 #else
 	/*
@@ -125,6 +126,7 @@ archive_write_add_filter_lz4(struct archive *a)
 	if (data->pdata == NULL)
 		goto memerr;
 	data->compression_level = 0;
+
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lz4 program");
 	r = ARCHIVE_WARN;
@@ -136,14 +138,15 @@ archive_write_add_filter_lz4(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = data;
-	f->options = &archive_filter_lz4_options;
-	f->close = &archive_filter_lz4_close;
-	f->free = &archive_filter_lz4_free;
-	f->open = &archive_filter_lz4_open;
-	f->write = archive_filter_lz4_write;
-	f->code = ARCHIVE_FILTER_LZ4;
 	f->name = "lz4";
+	f->code = ARCHIVE_FILTER_LZ4;
+	f->data = data;
+	f->options = archive_filter_lz4_options;
+	f->open = archive_filter_lz4_open;
+	f->write = archive_filter_lz4_write;
+	f->close = archive_filter_lz4_close;
+	f->free = archive_filter_lz4_free;
+
 	return (r);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -93,22 +93,19 @@ static void free_data(struct private_data *);
 int
 archive_write_add_filter_lz4(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *data;
+	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lz4");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-
+	if (data == NULL)
+		goto memerr;
 	/*
 	 * Setup default settings.
 	 */
-	data->compression_level = 1;
 	data->version_number = 0x01;
 	data->block_independence = 1;
 	data->block_checksum = 0;
@@ -116,10 +113,29 @@ archive_write_add_filter_lz4(struct archive *a)
 	data->stream_checksum = 1;
 	data->preset_dictionary = 0;
 	data->block_maximum_size = 7;
+#if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
+	data->compression_level = 1;
+	r = ARCHIVE_OK;
+#else
+	/*
+	 * We don't have lz4 library, and execute external lz4 program
+	 * instead.
+	 */
+	data->pdata = __archive_write_program_allocate("lz4");
+	if (data->pdata == NULL)
+		goto memerr;
+	data->compression_level = 0;
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
+	    "Using external lz4 program");
+	r = ARCHIVE_WARN;
+#endif
 
 	/*
 	 * Setup a filter setting.
 	 */
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = data;
 	f->options = &archive_filter_lz4_options;
 	f->close = &archive_filter_lz4_close;
@@ -128,24 +144,11 @@ archive_write_add_filter_lz4(struct archive *a)
 	f->write = archive_filter_lz4_write;
 	f->code = ARCHIVE_FILTER_LZ4;
 	f->name = "lz4";
-#if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
-	return (ARCHIVE_OK);
-#else
-	/*
-	 * We don't have lz4 library, and execute external lz4 program
-	 * instead.
-	 */
-	data->pdata = __archive_write_program_allocate("lz4");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 0;
-	archive_set_error(a, ARCHIVE_ERRNO_MISC,
-	    "Using external lz4 program");
-	return (ARCHIVE_WARN);
-#endif
+	return (r);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Out of memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -136,18 +136,47 @@ static const unsigned char header[] = {
 int
 archive_write_add_filter_lzop(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct write_lzop *data;
+	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lzop");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
+	if (data == NULL)
+		goto memerr;
+#if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
+	if (lzo_init() != LZO_E_OK) {
+		free_data(data);
+		archive_set_error(a, ARCHIVE_ERRNO_MISC,
+		    "lzo_init(type check) failed");
 		return (ARCHIVE_FATAL);
 	}
+	if (lzo_version() < 0x940) {
+		free_data(data);
+		archive_set_error(a, ARCHIVE_ERRNO_MISC,
+		    "liblzo library is too old(%s < 0.940)",
+		    lzo_version_string());
+		return (ARCHIVE_FATAL);
+	}
+	data->compression_level = 5;
+	r = ARCHIVE_OK;
+#else
+	data->pdata = __archive_write_program_allocate("lzop");
+	if (data->pdata == NULL)
+		goto memerr;
+	data->compression_level = 0;
+	/* Note: We return "warn" to inform of using an external lzop
+	 * program. */
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
+	    "Using external lzop program for lzop compression");
+	r = ARCHIVE_WARN;
+#endif
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->name = "lzop";
 	f->code = ARCHIVE_FILTER_LZOP;
 	f->data = data;
@@ -156,36 +185,11 @@ archive_write_add_filter_lzop(struct archive *a)
 	f->write = archive_write_lzop_write;
 	f->close = archive_write_lzop_close;
 	f->free = archive_write_lzop_free;
-#if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
-	if (lzo_init() != LZO_E_OK) {
-		free(data);
-		archive_set_error(a, ARCHIVE_ERRNO_MISC,
-		    "lzo_init(type check) failed");
-		return (ARCHIVE_FATAL);
-	}
-	if (lzo_version() < 0x940) {
-		free(data);
-		archive_set_error(a, ARCHIVE_ERRNO_MISC,
-		    "liblzo library is too old(%s < 0.940)",
-		    lzo_version_string());
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 5;
-	return (ARCHIVE_OK);
-#else
-	data->pdata = __archive_write_program_allocate("lzop");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Can't allocate memory");
-		return (ARCHIVE_FATAL);
-	}
-	data->compression_level = 0;
-	/* Note: We return "warn" to inform of using an external lzop
-	 * program. */
-	archive_set_error(a, ARCHIVE_ERRNO_MISC,
-	    "Using external lzop program for lzop compression");
-	return (ARCHIVE_WARN);
-#endif
+	return (r);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Can't allocate memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -161,12 +161,14 @@ archive_write_add_filter_lzop(struct archive *a)
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 5;
+
 	r = ARCHIVE_OK;
 #else
 	data->pdata = __archive_write_program_allocate("lzop");
 	if (data->pdata == NULL)
 		goto memerr;
 	data->compression_level = 0;
+
 	/* Note: We return "warn" to inform of using an external lzop
 	 * program. */
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
@@ -180,11 +182,12 @@ archive_write_add_filter_lzop(struct archive *a)
 	f->name = "lzop";
 	f->code = ARCHIVE_FILTER_LZOP;
 	f->data = data;
-	f->open = archive_write_lzop_open;
 	f->options = archive_write_lzop_options;
+	f->open = archive_write_lzop_open;
 	f->write = archive_write_lzop_write;
 	f->close = archive_write_lzop_close;
 	f->free = archive_write_lzop_free;
+
 	return (r);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -80,6 +80,7 @@ static int archive_write_lzop_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_lzop_close(struct archive_write_filter *);
 static int archive_write_lzop_free(struct archive_write_filter *);
+static void free_data(struct write_lzop *);
 
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 /* Maximum block size. */
@@ -190,16 +191,8 @@ archive_write_add_filter_lzop(struct archive *_a)
 static int
 archive_write_lzop_free(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
-
-#if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
-	free(data->uncompressed);
-	free(data->compressed);
-	free(data->work_buffer);
-#else
-	__archive_write_program_free(data->pdata);
-#endif
-	free(data);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -439,6 +432,17 @@ archive_write_lzop_close(struct archive_write_filter *f)
 	return __archive_write_filter(f->next_filter, &endmark, sizeof(endmark));
 }
 
+static void
+free_data(struct write_lzop *data)
+{
+	if (data != NULL) {
+		free(data->uncompressed);
+		free(data->compressed);
+		free(data->work_buffer);
+		free(data);
+	}
+}
+
 #else
 static int
 archive_write_lzop_open(struct archive_write_filter *f)
@@ -476,5 +480,14 @@ archive_write_lzop_close(struct archive_write_filter *f)
 	struct write_lzop *data = (struct write_lzop *)f->data;
 
 	return __archive_write_program_close(f, data->pdata);
+}
+
+static void
+free_data(struct write_lzop *data)
+{
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }
 #endif

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -134,17 +134,17 @@ static const unsigned char header[] = {
 #endif
 
 int
-archive_write_add_filter_lzop(struct archive *_a)
+archive_write_add_filter_lzop(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct write_lzop *data;
 
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lzop");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -159,13 +159,13 @@ archive_write_add_filter_lzop(struct archive *_a)
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	if (lzo_init() != LZO_E_OK) {
 		free(data);
-		archive_set_error(_a, ARCHIVE_ERRNO_MISC,
+		archive_set_error(a, ARCHIVE_ERRNO_MISC,
 		    "lzo_init(type check) failed");
 		return (ARCHIVE_FATAL);
 	}
 	if (lzo_version() < 0x940) {
 		free(data);
-		archive_set_error(_a, ARCHIVE_ERRNO_MISC,
+		archive_set_error(a, ARCHIVE_ERRNO_MISC,
 		    "liblzo library is too old(%s < 0.940)",
 		    lzo_version_string());
 		return (ARCHIVE_FATAL);
@@ -176,13 +176,13 @@ archive_write_add_filter_lzop(struct archive *_a)
 	data->pdata = __archive_write_program_allocate("lzop");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(_a, ENOMEM, "Can't allocate memory");
+		archive_set_error(a, ENOMEM, "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
 	data->compression_level = 0;
 	/* Note: We return "warn" to inform of using an external lzop
 	 * program. */
-	archive_set_error(_a, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lzop program for lzop compression");
 	return (ARCHIVE_WARN);
 #endif

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -90,26 +90,22 @@ static void free_data(struct private_data *);
 int
 archive_write_add_filter_program(struct archive *a, const char *cmd)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *data;
 	static const char prefix[] = "Program: ";
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_program");
 
-	f->data = calloc(1, sizeof(*data));
-	if (f->data == NULL)
+	data = calloc(1, sizeof(*data));
+	if (data == NULL)
 		goto memerr;
-	data = (struct private_data *)f->data;
-
 	data->cmd = strdup(cmd);
 	if (data->cmd == NULL)
 		goto memerr;
-
 	data->pdata = __archive_write_program_allocate(cmd);
 	if (data->pdata == NULL)
 		goto memerr;
-
 	/* Make up a description string. */
 	if (archive_string_ensure(&data->description,
 	    strlen(prefix) + strlen(cmd) + 1) == NULL)
@@ -117,15 +113,19 @@ archive_write_add_filter_program(struct archive *a, const char *cmd)
 	archive_strcpy(&data->description, prefix);
 	archive_strcat(&data->description, cmd);
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->name = data->description.s;
 	f->code = ARCHIVE_FILTER_PROGRAM;
+	f->data = data;
 	f->open = archive_compressor_program_open;
 	f->write = archive_compressor_program_write;
 	f->close = archive_compressor_program_close;
 	f->free = archive_compressor_program_free;
 	return (ARCHIVE_OK);
 memerr:
-	archive_compressor_program_free(f);
+	free_data(data);
 	archive_set_error(a, ENOMEM,
 	    "Can't allocate memory for filter program");
 	return (ARCHIVE_FATAL);

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -88,13 +88,13 @@ static void free_data(struct private_data *);
  * external program.
  */
 int
-archive_write_add_filter_program(struct archive *_a, const char *cmd)
+archive_write_add_filter_program(struct archive *a, const char *cmd)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *data;
 	static const char prefix[] = "Program: ";
 
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_program");
 
 	f->data = calloc(1, sizeof(*data));
@@ -126,7 +126,7 @@ archive_write_add_filter_program(struct archive *_a, const char *cmd)
 	return (ARCHIVE_OK);
 memerr:
 	archive_compressor_program_free(f);
-	archive_set_error(_a, ENOMEM,
+	archive_set_error(a, ENOMEM,
 	    "Can't allocate memory for filter program");
 	return (ARCHIVE_FATAL);
 }

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -81,6 +81,7 @@ static int archive_compressor_program_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_compressor_program_close(struct archive_write_filter *);
 static int archive_compressor_program_free(struct archive_write_filter *);
+static void free_data(struct private_data *);
 
 /*
  * Add a filter to this write handle that passes all data through an
@@ -158,15 +159,8 @@ archive_compressor_program_close(struct archive_write_filter *f)
 static int
 archive_compressor_program_free(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
-
-	if (data) {
-		free(data->cmd);
-		archive_string_free(&data->description);
-		__archive_write_program_free(data->pdata);
-		free(data);
-		f->data = NULL;
-	}
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -391,3 +385,13 @@ cleanup:
 	return ret;
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data) {
+		free(data->cmd);
+		archive_string_free(&data->description);
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
+}

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -123,6 +123,7 @@ archive_write_add_filter_program(struct archive *a, const char *cmd)
 	f->write = archive_compressor_program_write;
 	f->close = archive_compressor_program_close;
 	f->free = archive_compressor_program_free;
+
 	return (ARCHIVE_OK);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -70,18 +70,17 @@ static void free_data(struct private_uuencode *);
  * Add a compress filter to this write handle.
  */
 int
-archive_write_add_filter_uuencode(struct archive *_a)
+archive_write_add_filter_uuencode(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_uuencode *state;
 
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uu");
 
 	state = calloc(1, sizeof(*state));
 	if (state == NULL) {
-		archive_set_error(f->archive, ENOMEM,
+		archive_set_error(a, ENOMEM,
 		    "Can't allocate data for uuencode filter");
 		return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -76,7 +76,7 @@ archive_write_add_filter_uuencode(struct archive *a)
 	struct private_uuencode *state;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
-	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uu");
+	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uuencode");
 
 	state = calloc(1, sizeof(*state));
 	if (state == NULL)

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -169,7 +169,6 @@ archive_filter_uuencode_open(struct archive_write_filter *f)
 	archive_string_sprintf(&state->encoded_buff, "begin %o %s\n",
 	    (unsigned int)state->mode, state->name.s);
 
-	f->data = state;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -64,6 +64,7 @@ static int archive_filter_uuencode_close(struct archive_write_filter *);
 static int archive_filter_uuencode_free(struct archive_write_filter *);
 static void uu_encode(struct archive_string *, const unsigned char *, size_t);
 static int64_t atol8(const char *, size_t);
+static void free_data(struct private_uuencode *);
 
 /*
  * Add a compress filter to this write handle.
@@ -275,11 +276,8 @@ archive_filter_uuencode_close(struct archive_write_filter *f)
 static int
 archive_filter_uuencode_free(struct archive_write_filter *f)
 {
-	struct private_uuencode *state = (struct private_uuencode *)f->data;
-
-	archive_string_free(&state->name);
-	archive_string_free(&state->encoded_buff);
-	free(state);
+	free_data(f->data);
+	f->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -306,3 +304,12 @@ atol8(const char *p, size_t char_cnt)
 	return (l);
 }
 
+static void
+free_data(struct private_uuencode *data)
+{
+	if (data != NULL) {
+		archive_string_free(&data->name);
+		archive_string_free(&data->encoded_buff);
+		free(data);
+	}
+}

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -72,21 +72,21 @@ static void free_data(struct private_uuencode *);
 int
 archive_write_add_filter_uuencode(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_uuencode *state;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uu");
 
 	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
-		archive_set_error(a, ENOMEM,
-		    "Can't allocate data for uuencode filter");
-		return (ARCHIVE_FATAL);
-	}
+	if (state == NULL)
+		goto memerr;
 	archive_strcpy(&state->name, "-");
 	state->mode = 0644;
 
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->data = state;
 	f->name = "uuencode";
 	f->code = ARCHIVE_FILTER_UU;
@@ -97,6 +97,11 @@ archive_write_add_filter_uuencode(struct archive *a)
 	f->free = archive_filter_uuencode_free;
 
 	return (ARCHIVE_OK);
+memerr:
+	free_data(state);
+	archive_set_error(a, ENOMEM,
+	    "Can't allocate data for uuencode filter");
+	return (ARCHIVE_FATAL);
 }
 
 /*

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -87,11 +87,11 @@ archive_write_add_filter_uuencode(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = state;
 	f->name = "uuencode";
 	f->code = ARCHIVE_FILTER_UU;
-	f->open = archive_filter_uuencode_open;
+	f->data = state;
 	f->options = archive_filter_uuencode_options;
+	f->open = archive_filter_uuencode_open;
 	f->write = archive_filter_uuencode_write;
 	f->close = archive_filter_uuencode_close;
 	f->free = archive_filter_uuencode_free;

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -160,11 +160,12 @@ common_setup(struct archive *a, const char *name, int code)
 	f->name = name;
 	f->code = code;
 	f->data = data;
-	f->open = &archive_compressor_xz_open;
+	f->options = archive_compressor_xz_options;
+	f->open = archive_compressor_xz_open;
 	f->write = archive_compressor_xz_write;
 	f->close = archive_compressor_xz_close;
 	f->free = archive_compressor_xz_free;
-	f->options = &archive_compressor_xz_options;
+
 	return (ARCHIVE_OK);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -362,7 +362,6 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 	}
 	ret = archive_compressor_xz_init_stream(f, data);
 	if (ret == LZMA_OK) {
-		f->data = data;
 		return (ARCHIVE_OK);
 	}
 	return (ARCHIVE_FATAL);

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -146,24 +146,30 @@ static int
 common_setup(struct archive *a, const char *name, int code)
 {
 	struct private_data *data;
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data == NULL)
+		goto memerr;
+	data->compression_level = LZMA_PRESET_DEFAULT;
+	data->threads = 1;
+
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
 	f->name = name;
 	f->code = code;
 	f->data = data;
-	data->compression_level = LZMA_PRESET_DEFAULT;
-	data->threads = 1;
 	f->open = &archive_compressor_xz_open;
 	f->write = archive_compressor_xz_write;
 	f->close = archive_compressor_xz_close;
 	f->free = archive_compressor_xz_free;
 	f->options = &archive_compressor_xz_options;
 	return (ARCHIVE_OK);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Out of memory");
+	return (ARCHIVE_FATAL);
 }
 
 /*

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -143,15 +143,18 @@ static const struct option_value option_values[] = {
 };
 
 static int
-common_setup(struct archive_write_filter *f)
+common_setup(struct archive *a, const char *name, int code)
 {
 	struct private_data *data;
-	struct archive_write *a = (struct archive_write *)f->archive;
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
+	f->name = name;
+	f->code = code;
 	f->data = data;
 	data->compression_level = LZMA_PRESET_DEFAULT;
 	data->threads = 1;
@@ -167,57 +170,33 @@ common_setup(struct archive_write_filter *f)
  * Add an xz compression filter to this write handle.
  */
 int
-archive_write_add_filter_xz(struct archive *_a)
+archive_write_add_filter_xz(struct archive *a)
 {
-	struct archive_write_filter *f;
-	int r;
-
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_xz");
-	f = __archive_write_allocate_filter(_a);
-	r = common_setup(f);
-	if (r == ARCHIVE_OK) {
-		f->code = ARCHIVE_FILTER_XZ;
-		f->name = "xz";
-	}
-	return (r);
+
+	return common_setup(a, "xz", ARCHIVE_FILTER_XZ);
 }
 
 /* LZMA is handled identically, we just need a different compression
  * code set.  (The liblzma setup looks at the code to determine
  * the one place that XZ and LZMA require different handling.) */
 int
-archive_write_add_filter_lzma(struct archive *_a)
+archive_write_add_filter_lzma(struct archive *a)
 {
-	struct archive_write_filter *f;
-	int r;
-
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lzma");
-	f = __archive_write_allocate_filter(_a);
-	r = common_setup(f);
-	if (r == ARCHIVE_OK) {
-		f->code = ARCHIVE_FILTER_LZMA;
-		f->name = "lzma";
-	}
-	return (r);
+
+	return common_setup(a, "lzma", ARCHIVE_FILTER_LZMA);
 }
 
 int
-archive_write_add_filter_lzip(struct archive *_a)
+archive_write_add_filter_lzip(struct archive *a)
 {
-	struct archive_write_filter *f;
-	int r;
-
-	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lzip");
-	f = __archive_write_allocate_filter(_a);
-	r = common_setup(f);
-	if (r == ARCHIVE_OK) {
-		f->code = ARCHIVE_FILTER_LZIP;
-		f->name = "lzip";
-	}
-	return (r);
+
+	return common_setup(a, "lzip", ARCHIVE_FILTER_LZIP);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -156,6 +156,7 @@ common_setup(struct archive_write_filter *f)
 	data->compression_level = LZMA_PRESET_DEFAULT;
 	data->threads = 1;
 	f->open = &archive_compressor_xz_open;
+	f->write = archive_compressor_xz_write;
 	f->close = archive_compressor_xz_close;
 	f->free = archive_compressor_xz_free;
 	f->options = &archive_compressor_xz_options;
@@ -330,8 +331,6 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 			return (ARCHIVE_FATAL);
 		}
 	}
-
-	f->write = archive_compressor_xz_write;
 
 	/* Initialize compression library. */
 	if (f->code == ARCHIVE_FILTER_LZIP) {

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -122,6 +122,7 @@ static int	archive_compressor_xz_close(struct archive_write_filter *);
 static int	archive_compressor_xz_free(struct archive_write_filter *);
 static int	drive_compressor(struct archive_write_filter *,
 		    struct private_data *, int finishing);
+static void	free_data(struct private_data *);
 
 struct option_value {
 	uint32_t dict_size;
@@ -477,9 +478,7 @@ archive_compressor_xz_close(struct archive_write_filter *f)
 static int
 archive_compressor_xz_free(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
-	free(data->compressed);
-	free(data);
+	free_data(f->data);
 	f->data = NULL;
 	return (ARCHIVE_OK);
 }
@@ -548,6 +547,15 @@ drive_compressor(struct archive_write_filter *f,
 			    ret);
 			return (ARCHIVE_FATAL);
 		}
+	}
+}
+
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		free(data->compressed);
+		free(data);
 	}
 }
 

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -114,26 +114,16 @@ static void free_data(struct private_data *);
 int
 archive_write_add_filter_zstd(struct archive *a)
 {
-	struct archive_write_filter *f = __archive_write_allocate_filter(a);
+	struct archive_write_filter *f;
 	struct private_data *data;
+	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_zstd");
 
 	data = calloc(1, sizeof(*data));
-	if (data == NULL) {
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
-	f->data = data;
-	f->open = &archive_compressor_zstd_open;
-	f->write = archive_compressor_zstd_write;
-	f->options = &archive_compressor_zstd_options;
-	f->flush = &archive_compressor_zstd_flush;
-	f->close = &archive_compressor_zstd_close;
-	f->free = &archive_compressor_zstd_free;
-	f->code = ARCHIVE_FILTER_ZSTD;
-	f->name = "zstd";
+	if (data == NULL)
+		goto memerr;
 	data->compression_level = CLEVEL_DEFAULT;
 	data->threads = 0;
 	data->long_distance = 0;
@@ -146,25 +136,36 @@ archive_write_add_filter_zstd(struct archive *a)
 	data->cur_frame_in = 0;
 	data->cur_frame_out = 0;
 	data->cstream = ZSTD_createCStream();
-	if (data->cstream == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM,
-		    "Failed to allocate zstd compressor object");
-		return (ARCHIVE_FATAL);
-	}
+	if (data->cstream == NULL)
+		goto memerr;
 
-	return (ARCHIVE_OK);
+	r = ARCHIVE_OK;
 #else
 	data->pdata = __archive_write_program_allocate("zstd");
-	if (data->pdata == NULL) {
-		free(data);
-		archive_set_error(a, ENOMEM, "Out of memory");
-		return (ARCHIVE_FATAL);
-	}
+	if (data->pdata == NULL)
+		goto memerr;
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external zstd program");
-	return (ARCHIVE_WARN);
+	r = ARCHIVE_WARN;
 #endif
+
+	f = __archive_write_allocate_filter(a);
+	if (f == NULL)
+		goto memerr;
+	f->data = data;
+	f->open = &archive_compressor_zstd_open;
+	f->write = archive_compressor_zstd_write;
+	f->options = &archive_compressor_zstd_options;
+	f->flush = &archive_compressor_zstd_flush;
+	f->close = &archive_compressor_zstd_close;
+	f->free = &archive_compressor_zstd_free;
+	f->code = ARCHIVE_FILTER_ZSTD;
+	f->name = "zstd";
+	return (r);
+memerr:
+	free_data(data);
+	archive_set_error(a, ENOMEM, "Out of memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -127,6 +127,7 @@ archive_write_add_filter_zstd(struct archive *_a)
 	}
 	f->data = data;
 	f->open = &archive_compressor_zstd_open;
+	f->write = archive_compressor_zstd_write;
 	f->options = &archive_compressor_zstd_options;
 	f->flush = &archive_compressor_zstd_flush;
 	f->close = &archive_compressor_zstd_close;
@@ -397,8 +398,6 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 		}
 	}
 
-	f->write = archive_compressor_zstd_write;
-
 	if (ZSTD_isError(ZSTD_initCStream(data->cstream,
 	    data->compression_level))) {
 		archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
@@ -564,7 +563,6 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 		archive_string_sprintf(&as, " --long=%d", data->long_distance);
 	}
 
-	f->write = archive_compressor_zstd_write;
 	r = __archive_write_program_open(f, data->pdata, as.s);
 	archive_string_free(&as);
 	return (r);

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -144,6 +144,7 @@ archive_write_add_filter_zstd(struct archive *a)
 	data->pdata = __archive_write_program_allocate("zstd");
 	if (data->pdata == NULL)
 		goto memerr;
+
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external zstd program");
 	r = ARCHIVE_WARN;
@@ -152,15 +153,16 @@ archive_write_add_filter_zstd(struct archive *a)
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->data = data;
-	f->open = &archive_compressor_zstd_open;
-	f->write = archive_compressor_zstd_write;
-	f->options = &archive_compressor_zstd_options;
-	f->flush = &archive_compressor_zstd_flush;
-	f->close = &archive_compressor_zstd_close;
-	f->free = &archive_compressor_zstd_free;
-	f->code = ARCHIVE_FILTER_ZSTD;
 	f->name = "zstd";
+	f->code = ARCHIVE_FILTER_ZSTD;
+	f->data = data;
+	f->options = archive_compressor_zstd_options;
+	f->open = archive_compressor_zstd_open;
+	f->write = archive_compressor_zstd_write;
+	f->flush = archive_compressor_zstd_flush;
+	f->close = archive_compressor_zstd_close;
+	f->free = archive_compressor_zstd_free;
+
 	return (r);
 memerr:
 	free_data(data);

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -112,17 +112,17 @@ static void free_data(struct private_data *);
  * Add a zstd compression filter to this write handle.
  */
 int
-archive_write_add_filter_zstd(struct archive *_a)
+archive_write_add_filter_zstd(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct archive_write_filter *f = __archive_write_allocate_filter(_a);
+	struct archive_write_filter *f = __archive_write_allocate_filter(a);
 	struct private_data *data;
-	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
+
+	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_zstd");
 
 	data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
 	f->data = data;
@@ -148,7 +148,7 @@ archive_write_add_filter_zstd(struct archive *_a)
 	data->cstream = ZSTD_createCStream();
 	if (data->cstream == NULL) {
 		free(data);
-		archive_set_error(&a->archive, ENOMEM,
+		archive_set_error(a, ENOMEM,
 		    "Failed to allocate zstd compressor object");
 		return (ARCHIVE_FATAL);
 	}
@@ -158,10 +158,10 @@ archive_write_add_filter_zstd(struct archive *_a)
 	data->pdata = __archive_write_program_allocate("zstd");
 	if (data->pdata == NULL) {
 		free(data);
-		archive_set_error(&a->archive, ENOMEM, "Out of memory");
+		archive_set_error(a, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
-	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external zstd program");
 	return (ARCHIVE_WARN);
 #endif

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -105,6 +105,7 @@ static int archive_compressor_zstd_free(struct archive_write_filter *);
 static int drive_compressor(struct archive_write_filter *,
 		    struct private_data *, int, const void *, size_t);
 #endif
+static void free_data(struct private_data *);
 
 
 /*
@@ -168,14 +169,7 @@ archive_write_add_filter_zstd(struct archive *_a)
 static int
 archive_compressor_zstd_free(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
-#if HAVE_ZSTD_H && HAVE_ZSTD_compressStream
-	ZSTD_freeCStream(data->cstream);
-	free(data->out.dst);
-#else
-	__archive_write_program_free(data->pdata);
-#endif
-	free(data);
+	free_data(f->data);
 	f->data = NULL;
 	return (ARCHIVE_OK);
 }
@@ -529,6 +523,16 @@ fatal:
 	return (ARCHIVE_FATAL);
 }
 
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		ZSTD_freeCStream(data->cstream);
+		free(data->out.dst);
+		free(data);
+	}
+}
+
 #else /* HAVE_ZSTD_H && HAVE_ZSTD_compressStream */
 
 static int
@@ -589,6 +593,15 @@ archive_compressor_zstd_close(struct archive_write_filter *f)
 	struct private_data *data = (struct private_data *)f->data;
 
 	return __archive_write_program_close(f, data->pdata);
+}
+
+static void
+free_data(struct private_data *data)
+{
+	if (data != NULL) {
+		__archive_write_program_free(data->pdata);
+		free(data);
+	}
 }
 
 #endif /* HAVE_ZSTD_H && HAVE_ZSTD_compressStream */


### PR DESCRIPTION
The function `__archive_write_allocate_filter` can fail, so a `NULL` return value must be gracefully handled.

And that's where all this started...

In order to do this:
- Extract the data free logic into its own re-usable function
- Allocate filter last, because reverting is rather difficult
- Unify memory allocation failure handling between data and filter allocation for easier review

While not technically necessary, a review is much easier if the rest is in sync as well:
- Set filter function pointers only once
- Set filter data only once
- Access archive directly instead of through filter (which is a big help because filter allocation can fail)
- Unify style of filter addition (mostly based on program filter)

I strongly recommend to look at the commits instead of the final diff, which is rather difficult to verify in a single step.