### PR TITLE
archive_write: fix UAF when switching formats

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -683,6 +683,29 @@ __archive_write_filters_free(struct archive *_a)
 	a->filter_last = NULL;
 }
 
+int
+__archive_write_unregister_format(struct archive_write *a)
+{
+	int r = ARCHIVE_OK;
+
+	if (a->format_free != NULL)
+		r = (a->format_free)(a);
+
+	a->format_data = NULL;
+	a->format_name = NULL;
+	a->format_init = NULL;
+	a->format_options = NULL;
+	a->format_finish_entry = NULL;
+	a->format_write_header = NULL;
+	a->format_write_data = NULL;
+	a->format_close = NULL;
+	a->format_free = NULL;
+	a->archive.archive_format = 0;
+	a->archive.archive_format_name = NULL;
+
+	return (r);
+}
+
 /*
  * Destroy the archive structure.
  *
@@ -705,11 +728,9 @@ _archive_write_free(struct archive *_a)
 		r = archive_write_close(&a->archive);
 
 	/* Release format resources. */
-	if (a->format_free != NULL) {
-		r1 = (a->format_free)(a);
-		if (r1 < r)
-			r = r1;
-	}
+	r1 = __archive_write_unregister_format(a);
+	if (r1 < r)
+		r = r1;
 
 	__archive_write_filters_free(_a);
 

--- a/libarchive/archive_write_private.h
+++ b/libarchive/archive_write_private.h
@@ -132,6 +132,8 @@ struct archive_write {
 	void		*passphrase_client_data;
 };
 
+int	__archive_write_unregister_format(struct archive_write *);
+
 /*
  * Utility function to format a USTAR header into a buffer.  If
  * "strict" is set, this tries to create the absolutely most portable

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -356,8 +356,7 @@ archive_write_set_format_7zip(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_7zip");
 
 	/* If another format was already registered, unregister it. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	zip = calloc(1, sizeof(*zip));
 	if (zip == NULL) {

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -123,8 +123,7 @@ archive_write_set_format_ar(struct archive_write *a)
 	struct ar_w *ar;
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	ar = calloc(1, sizeof(*ar));
 	if (ar == NULL) {

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -183,8 +183,7 @@ archive_write_set_format_cpio_binary(struct archive *_a, int format)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_cpio_binary");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	cpio = calloc(1, sizeof(*cpio));
 	if (cpio == NULL) {

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -113,8 +113,7 @@ archive_write_set_format_cpio_newc(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_cpio_newc");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	cpio = calloc(1, sizeof(*cpio));
 	if (cpio == NULL) {

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -108,8 +108,7 @@ archive_write_set_format_cpio_odc(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_cpio_odc");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	cpio = calloc(1, sizeof(*cpio));
 	if (cpio == NULL) {

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -174,6 +174,11 @@ archive_write_set_format_gnutar(struct archive *_a)
 	struct archive_write *a = (struct archive_write *)_a;
 	struct gnutar *gnutar;
 
+	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
+	    ARCHIVE_STATE_NEW, "archive_write_set_format_gnutar");
+
+	(void)__archive_write_unregister_format(a);
+
 	gnutar = calloc(1, sizeof(*gnutar));
 	if (gnutar == NULL) {
 		archive_set_error(&a->archive, ENOMEM,

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1059,8 +1059,7 @@ archive_write_set_format_iso9660(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_iso9660");
 
 	/* If another format was already registered, unregister it. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	iso9660 = calloc(1, sizeof(*iso9660));
 	if (iso9660 == NULL) {

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1433,8 +1433,7 @@ archive_write_set_format_mtree_default(struct archive *_a, const char *fn)
 
 	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC, ARCHIVE_STATE_NEW, fn);
 
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	if ((mtree = calloc(1, sizeof(*mtree))) == NULL) {
 		archive_set_error(&a->archive, ENOMEM,

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -145,8 +145,7 @@ archive_write_set_format_pax(struct archive *_a)
 	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_pax");
 
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	pax = calloc(1, sizeof(*pax));
 	if (pax == NULL) {

--- a/libarchive/archive_write_set_format_raw.c
+++ b/libarchive/archive_write_set_format_raw.c
@@ -55,8 +55,7 @@ archive_write_set_format_raw(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_raw");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	raw = calloc(1, sizeof(*raw));
 	if (raw == NULL) {

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -111,8 +111,7 @@ archive_write_set_format_shar(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_shar");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	shar = calloc(1, sizeof(*shar));
 	if (shar == NULL) {

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -172,8 +172,7 @@ archive_write_set_format_ustar(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_ustar");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	/* Basic internal sanity test. */
 	if (sizeof(template_header) != 512) {

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -149,8 +149,7 @@ archive_write_set_format_v7tar(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_v7tar");
 
 	/* If someone else was already registered, unregister them. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	/* Basic internal sanity test. */
 	if (sizeof(template_header) != 512) {

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -133,9 +133,7 @@ archive_write_set_format_warc(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_warc");
 
 	/* If another format was already registered, unregister it. */
-	if (a->format_free != NULL) {
-		(a->format_free)(a);
-	}
+	(void)__archive_write_unregister_format(a);
 
 	w = malloc(sizeof(*w));
 	if (w == NULL) {

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -366,8 +366,7 @@ archive_write_set_format_xar(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_xar");
 
 	/* If another format was already registered, unregister it. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	xar = calloc(1, sizeof(*xar));
 	if (xar == NULL) {

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -730,8 +730,7 @@ archive_write_set_format_zip(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_zip");
 
 	/* If another format was already registered, unregister it. */
-	if (a->format_free != NULL)
-		(a->format_free)(a);
+	(void)__archive_write_unregister_format(a);
 
 	zip = calloc(1, sizeof(*zip));
 	if (zip == NULL) {

--- a/libarchive/test/test_write_format_7zip.c
+++ b/libarchive/test/test_write_format_7zip.c
@@ -26,6 +26,9 @@
 
 #include "test.h"
 
+#define __LIBARCHIVE_TEST
+#include "archive_write_private.h"
+
 static void
 test_basic(const char *compression_type)
 {
@@ -572,4 +575,40 @@ DEFINE_TEST(test_write_format_7zip_basic_zstd)
 {
 	/* Test that making a 7-Zip archive file with zstandard compression. */
 	test_basic("zstd");
+}
+
+DEFINE_TEST(test_write_format_7zip_unregister)
+{
+	struct archive *a;
+	struct archive_write *aw;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_7zip(a));
+
+	aw = (struct archive_write *)a;
+	assert(aw->format_data != NULL);
+	assert(aw->format_free != NULL);
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    __archive_write_unregister_format(aw));
+
+	assert(aw->format_data == NULL);
+	assert(aw->format_name == NULL);
+	assert(aw->format_init == NULL);
+	assert(aw->format_options == NULL);
+	assert(aw->format_finish_entry == NULL);
+	assert(aw->format_write_header == NULL);
+	assert(aw->format_write_data == NULL);
+	assert(aw->format_close == NULL);
+	assert(aw->format_free == NULL);
+	assertEqualInt(0, aw->archive.archive_format);
+	assert(aw->archive.archive_format_name == NULL);
+
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_format_option(a, NULL, "compression",
+	        "store"));
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    __archive_write_unregister_format(aw));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }

--- a/libarchive/test/test_write_format_gnutar.c
+++ b/libarchive/test/test_write_format_gnutar.c
@@ -278,3 +278,14 @@ DEFINE_TEST(test_write_format_gnutar)
 
 	free(buff);
 }
+
+DEFINE_TEST(test_write_format_gnutar_switch)
+{
+	struct archive *a;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_7zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_gnutar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_gnutar(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}

--- a/libarchive/test/test_write_format_xar.c
+++ b/libarchive/test/test_write_format_xar.c
@@ -25,6 +25,9 @@
  */
 #include "test.h"
 
+#define __LIBARCHIVE_TEST
+#include "archive_write_private.h"
+
 #include <locale.h>
 
 static void
@@ -378,5 +381,45 @@ DEFINE_TEST(test_write_format_xar_entry_trunc)
 	assertEqualIntA(a, 3, archive_write_data(a, "foo", 3));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+}
+
+DEFINE_TEST(test_write_format_xar_unregister)
+{
+	struct archive *a;
+	struct archive_write *aw;
+
+	assert((a = archive_write_new()) != NULL);
+	if (archive_write_set_format_xar(a) != ARCHIVE_OK) {
+		skipping("xar is not supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+		return;
+	}
+
+	aw = (struct archive_write *)a;
+	assert(aw->format_data != NULL);
+	assert(aw->format_free != NULL);
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    __archive_write_unregister_format(aw));
+
+	assert(aw->format_data == NULL);
+	assert(aw->format_name == NULL);
+	assert(aw->format_init == NULL);
+	assert(aw->format_options == NULL);
+	assert(aw->format_finish_entry == NULL);
+	assert(aw->format_write_header == NULL);
+	assert(aw->format_write_data == NULL);
+	assert(aw->format_close == NULL);
+	assert(aw->format_free == NULL);
+	assertEqualInt(0, aw->archive.archive_format);
+	assert(aw->archive.archive_format_name == NULL);
+
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_write_set_format_option(a, NULL, "compression",
+	        "gzip"));
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    __archive_write_unregister_format(aw));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }


### PR DESCRIPTION
Writer format cleanup freed the old backend but left its callbacks and `format_data` set. If setting up the next format failed, later option handling or cleanup could call into freed state.

This adds one cleanup path that runs the destructor once and clears all format state before replacement. GNU tar now uses the same path and checks for `ARCHIVE_STATE_NEW`.

Tests cover 7-Zip, XAR, repeated cleanup, and switching to GNU tar.