### PR TITLE
program: fix dangling pointer after close

### DIFF
--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -87,7 +87,7 @@ archive_read_support_filter_program(struct archive *a, const char *cmd)
  * bid twice in the same pipeline.
  */
 struct program_bidder {
-	char *description;
+	struct archive_string description;
 	char *cmd;
 	void *signature;
 	size_t signature_len;
@@ -145,6 +145,8 @@ archive_read_support_filter_program_signature(struct archive *_a,
 	state->cmd = strdup(cmd);
 	if (state->cmd == NULL)
 		goto memerr;
+	archive_strcpy(&state->description, "Program: ");
+	archive_strcat(&state->description, cmd);
 
 	if (signature != NULL && signature_len > 0) {
 		state->signature_len = signature_len;
@@ -180,6 +182,7 @@ free_state(struct program_bidder *state)
 {
 
 	if (state) {
+		archive_string_free(&state->description);
 		free(state->cmd);
 		free(state->signature);
 		free(state);
@@ -442,9 +445,12 @@ static int
 program_bidder_init(struct archive_read_filter *f)
 {
 	struct program_bidder   *bidder_state;
+	int r;
 
 	bidder_state = (struct program_bidder *)f->bidder->data;
-	return (__archive_read_program(f, bidder_state->cmd));
+	r = __archive_read_program(f, bidder_state->cmd);
+	f->name = bidder_state->description.s;
+	return (r);
 }
 
 static ssize_t

--- a/libarchive/test/test_read_filter_program.c
+++ b/libarchive/test/test_read_filter_program.c
@@ -77,6 +77,8 @@ DEFINE_TEST(test_read_filter_program)
 	    archive_read_next_header(a, &ae));
 	assertEqualInt(archive_filter_code(a, 0), ARCHIVE_FILTER_PROGRAM);
 	assertEqualInt(archive_format(a), ARCHIVE_FORMAT_TAR_USTAR);
+	assertEqualString("Program: gzip -d", archive_filter_name(a, 0));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualString("Program: gzip -d", archive_filter_name(a, 0));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }


### PR DESCRIPTION
Fix a dangling pointer (that can eventually lead to a UAF) when querying the name of an external program filter after `archive_read_close()`.

The program filter stores its name in the active filter state. That state is released during `archive_read_close()`, but the filter object remains available until `archive_read_free()`.

As a result, `archive_filter_name()` can return a dangling pointer after the archive has been closed.

Store the program filter description in the bidder state instead. The bidder state remains valid until `archive_read_free()`, keeping the filter name available for the full lifetime of the object.

Proof of concept:

```c
struct archive *a;
struct archive_entry *entry;

a = archive_read_new();
archive_read_support_filter_program(a, "gzip -d");
archive_read_support_format_tar(a);
archive_read_open_memory(a, gzip_tar, gzip_tar_size);
archive_read_next_header(a, &entry);

archive_read_close(a);

/* UAF under ASan. */
printf("%s\n", archive_filter_name(a, 0));

archive_read_free(a);
```