### PR TITLE
formats: simplify string handling

### DIFF
--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -900,7 +900,7 @@ lha_read_file_header_1(struct archive_read *a, struct lha *lha)
 {
 	const unsigned char *p;
 	size_t extdsize;
-	int i, err, err2;
+	int err, err2;
 	int namelen, padding;
 	unsigned char headersum, sum_calculated;
 
@@ -925,10 +925,9 @@ lha_read_file_header_1(struct archive_read *a, struct lha *lha)
 	if ((p = __archive_read_ahead(a, lha->header_size, NULL)) == NULL)
 		return (truncated_error(a));
 
-	for (i = 0; i < namelen; i++) {
-		if (p[i + H1_FILE_NAME_OFFSET] == 0xff)
-			goto invalid;/* Invalid filename. */
-	}
+	if (memchr(p + H1_FILE_NAME_OFFSET, 0xff,
+	    (size_t)namelen) != NULL)
+		goto invalid; /* Invalid filename. */
 	archive_strncpy(&lha->filename, p + H1_FILE_NAME_OFFSET, namelen);
 	lha->crc = archive_le16dec(p + H1_FILE_NAME_OFFSET + namelen);
 	lha->setflag |= CRC_IS_SET;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -1666,16 +1666,18 @@ read_header(struct archive_read *a, struct archive_entry *entry,
           return (ARCHIVE_FATAL);
       }
       fn_sconv = rar->sconv_utf8;
-      while ((strp = strchr(filename, '\\')) != NULL)
-        *strp = '/';
+      strp = filename;
+      while ((strp = strchr(strp, '\\')) != NULL)
+        *strp++ = '/';
       p += filename_size;
     }
   }
   else
   {
     fn_sconv = sconv;
-    while ((strp = strchr(filename, '\\')) != NULL)
-      *strp = '/';
+    strp = filename;
+    while ((strp = strchr(strp, '\\')) != NULL)
+      *strp++ = '/';
     p += filename_size;
   }
 

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -40,6 +40,7 @@
 #include "archive.h"
 #include "archive_entry.h"
 #include "archive_private.h"
+#include "archive_string.h"
 #include "archive_write_private.h"
 #include "archive_write_set_format_private.h"
 
@@ -78,7 +79,6 @@ static ssize_t		 archive_write_ar_data(struct archive_write *,
 static int		 archive_write_ar_free(struct archive_write *);
 static int		 archive_write_ar_close(struct archive_write *);
 static int		 archive_write_ar_finish_entry(struct archive_write *);
-static const char	*ar_basename(const char *path);
 static int		 format_octal(int64_t v, char *p, int s);
 static int		 format_decimal(int64_t v, char *p, int s);
 
@@ -147,16 +147,19 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 {
 	int ret, append_fn;
 	char buff[60];
-	char *ss, *se;
+	char *ss;
 	struct ar_w *ar;
+	struct archive_string se;
 	const char *pathname;
 	const char *filename;
+	size_t filename_length;
 	int64_t size;
 
 	append_fn = 0;
 	ar = (struct ar_w *)a->format_data;
 	ar->is_strtab = 0;
 	filename = NULL;
+	filename_length = 0;
 	size = archive_entry_size(entry);
 
 
@@ -215,12 +218,17 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	 * Otherwise, entry is a normal archive member.
 	 * Strip leading paths from filenames, if any.
 	 */
-	if ((filename = ar_basename(pathname)) == NULL) {
+	filename = strrchr(pathname, '/');
+	if (filename == NULL)
+		filename = pathname;
+	else if (filename[1] == '\0') {
 		/* Reject filenames with trailing "/" */
 		archive_set_error(&a->archive, EINVAL,
 		    "Invalid filename");
 		return (ARCHIVE_WARN);
-	}
+	} else
+		filename++;
+	filename_length = strlen(filename);
 
 	if (a->archive.archive_format == ARCHIVE_FORMAT_AR_GNU) {
 		/*
@@ -229,10 +237,10 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 		 * So, the longest filename here (without extension) is
 		 * actually 15 bytes.
 		 */
-		if (strlen(filename) <= 15) {
+		if (filename_length <= 15) {
 			memcpy(&buff[AR_name_offset],
-			    filename, strlen(filename));
-			buff[AR_name_offset + strlen(filename)] = '/';
+			    filename, filename_length);
+			buff[AR_name_offset + filename_length] = '/';
 		} else {
 			/*
 			 * For filename longer than 15 bytes, GNU variant
@@ -246,18 +254,10 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 				return (ARCHIVE_WARN);
 			}
 
-			se = malloc(strlen(filename) + 3);
-			if (se == NULL) {
-				archive_set_error(&a->archive, ENOMEM,
-				    "Can't allocate filename buffer");
-				return (ARCHIVE_FATAL);
-			}
-
-			memcpy(se, filename, strlen(filename));
-			strcpy(se + strlen(filename), "/\n");
-
-			ss = strstr(ar->strtab, se);
-			free(se);
+			archive_string_init(&se);
+			archive_string_sprintf(&se, "%s/\n", filename);
+			ss = strstr(ar->strtab, se.s);
+			archive_string_free(&se);
 
 			if (ss == NULL) {
 				archive_set_error(&a->archive, EINVAL,
@@ -289,13 +289,13 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 		 * The name is then written immediately following the
 		 * archive header.
 		 */
-		if (strlen(filename) <= 16 && strchr(filename, ' ') == NULL) {
-			memcpy(&buff[AR_name_offset], filename, strlen(filename));
-			buff[AR_name_offset + strlen(filename)] = ' ';
+		if (filename_length <= 16 && strchr(filename, ' ') == NULL) {
+			memcpy(&buff[AR_name_offset], filename, filename_length);
+			buff[AR_name_offset + filename_length] = ' ';
 		}
 		else {
 			memcpy(buff + AR_name_offset, "#1/", 3);
-			if (format_decimal(strlen(filename),
+			if (format_decimal(filename_length,
 			    buff + AR_name_offset + 3,
 			    AR_name_size - 3)) {
 				archive_set_error(&a->archive, ERANGE,
@@ -303,7 +303,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 				return (ARCHIVE_WARN);
 			}
 			append_fn = 1;
-			size += strlen(filename);
+			size += filename_length;
 		}
 	}
 
@@ -353,10 +353,10 @@ size:
 	ar->entry_padding = ar->entry_bytes_remaining % 2;
 
 	if (append_fn > 0) {
-		ret = __archive_write_output(a, filename, strlen(filename));
+		ret = __archive_write_output(a, filename, filename_length);
 		if (ret != ARCHIVE_OK)
 			return (ret);
-		ar->entry_bytes_remaining -= strlen(filename);
+		ar->entry_bytes_remaining -= filename_length;
 	}
 
 	return (ARCHIVE_OK);
@@ -545,25 +545,4 @@ format_decimal(int64_t v, char *p, int s)
 		*p++ = '9';
 
 	return (-1);
-}
-
-static const char *
-ar_basename(const char *path)
-{
-	const char *endp, *startp;
-
-	endp = path + strlen(path) - 1;
-	/*
-	 * For filename with trailing slash(es), we return
-	 * NULL indicating an error.
-	 */
-	if (*endp == '/')
-		return (NULL);
-
-	/* Find the start of the base */
-	startp = endp;
-	while (startp > path && *(startp - 1) != '/')
-		startp--;
-	
-	return (startp);
 }

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1574,18 +1574,21 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
 	char *p;
 	int need_slash = 0; /* Was there a trailing slash? */
 	size_t suffix_length = 98; /* 99 - 1 for trailing slash */
-	size_t insert_length;
+	size_t insert_length, insert_name_length;
 
 	/* Length of additional dir element to be added. */
-	if (insert == NULL)
+	if (insert == NULL) {
+		insert_name_length = 0;
 		insert_length = 0;
-	else
+	} else {
+		insert_name_length = strlen(insert);
 		/* +2 here allows for '/' before and after the insert. */
-		insert_length = strlen(insert) + 2;
+		insert_length = insert_name_length + 2;
+	}
 
 	/* Step 0: Quick bailout in a common case. */
 	if (src_length < 100 && insert == NULL) {
-		strncpy(dest, src, src_length);
+		memcpy(dest, src, src_length);
 		dest[src_length] = '\0';
 		return (dest);
 	}
@@ -1647,24 +1650,22 @@ build_ustar_entry_name(char *dest, const char *src, size_t src_length,
 		suffix_end++;
 
 	/* Step 4: Build the new name. */
-	/* The OpenBSD strlcpy function is safer, but less portable. */
-	/* Rather than maintain two versions, just use the strncpy version. */
 	p = dest;
 	if (prefix_end > prefix) {
-		strncpy(p, prefix, prefix_end - prefix);
+		memcpy(p, prefix, (size_t)(prefix_end - prefix));
 		p += prefix_end - prefix;
 	}
 	if (suffix_end > suffix) {
-		strncpy(p, suffix, suffix_end - suffix);
+		memcpy(p, suffix, (size_t)(suffix_end - suffix));
 		p += suffix_end - suffix;
 	}
 	if (insert != NULL) {
 		/* Note: assume insert does not have leading or trailing '/' */
-		strcpy(p, insert);
-		p += strlen(insert);
+		memcpy(p, insert, insert_name_length);
+		p += insert_name_length;
 		*p++ = '/';
 	}
-	strncpy(p, filename, filename_end - filename);
+	memcpy(p, filename, (size_t)(filename_end - filename));
 	p += filename_end - filename;
 	if (need_slash)
 		*p++ = '/';


### PR DESCRIPTION
Simplify several format-specific string operations:

* LHA: use `memchr()` for bounded filename scanning
* RAR: avoid repeatedly rescanning filenames while replacing separators
* AR: remove the single-use basename helper and reuse the filename length
* PAX: use known lengths with `memcpy()` in the writer

These changes reduce redundant work and make the affected code more direct. No behavior change is intended.