### PR TITLE
Unify filter and format data handling

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -176,28 +176,28 @@ archive_read_open2(struct archive *a, void *client_data,
 }
 
 static ssize_t
-client_read_proxy(struct archive_read_filter *self, const void **buff)
+client_read_proxy(struct archive_read_filter *f, const void **buff)
 {
 	ssize_t r;
-	r = (self->archive->client.reader)(&self->archive->archive,
-	    self->data, buff);
+	r = (f->archive->client.reader)(&f->archive->archive,
+	    f->data, buff);
 	return (r);
 }
 
 static int64_t
-client_skip_proxy(struct archive_read_filter *self, int64_t request)
+client_skip_proxy(struct archive_read_filter *f, int64_t request)
 {
 	if (request < 0)
 		__archive_errx(1, "Negative skip requested");
 	if (request == 0)
 		return 0;
 
-	if (self->archive->client.skipper != NULL) {
+	if (f->archive->client.skipper != NULL) {
 		int64_t total = 0;
 		for (;;) {
 			int64_t get, ask = request;
-			get = (self->archive->client.skipper)
-				(&self->archive->archive, self->data, ask);
+			get = (f->archive->client.skipper)
+				(&f->archive->archive, f->data, ask);
 			total += get;
 			if (get == 0 || get == request)
 				return (total);
@@ -205,7 +205,7 @@ client_skip_proxy(struct archive_read_filter *self, int64_t request)
 				return ARCHIVE_FATAL;
 			request -= get;
 		}
-	} else if (self->archive->client.seeker != NULL
+	} else if (f->archive->client.seeker != NULL
 		&& request > 64 * 1024) {
 		/* If the client provided a seeker but not a skipper,
 		 * we can use the seeker to skip forward.
@@ -218,9 +218,9 @@ client_skip_proxy(struct archive_read_filter *self, int64_t request)
 		 * to just reading and discarding.  That's why we
 		 * only do this for skips of over 64k.
 		 */
-		int64_t before = self->position;
-		int64_t after = (self->archive->client.seeker)
-		    (&self->archive->archive, self->data, request, SEEK_CUR);
+		int64_t before = f->position;
+		int64_t after = (f->archive->client.seeker)
+		    (&f->archive->archive, f->data, request, SEEK_CUR);
 		if (after != before + request)
 			return ARCHIVE_FATAL;
 		return after - before;
@@ -229,20 +229,20 @@ client_skip_proxy(struct archive_read_filter *self, int64_t request)
 }
 
 static int64_t
-client_seek_proxy(struct archive_read_filter *self, int64_t offset, int whence)
+client_seek_proxy(struct archive_read_filter *f, int64_t offset, int whence)
 {
 	/* DO NOT use the skipper here!  If we transparently handled
 	 * forward seek here by using the skipper, that will break
 	 * other libarchive code that assumes a successful forward
 	 * seek means it can also seek backwards.
 	 */
-	if (self->archive->client.seeker == NULL) {
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	if (f->archive->client.seeker == NULL) {
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Current client reader does not support seeking a device");
 		return (ARCHIVE_FAILED);
 	}
-	return (self->archive->client.seeker)(&self->archive->archive,
-	    self->data, offset, whence);
+	return (f->archive->client.seeker)(&f->archive->archive,
+	    f->data, offset, whence);
 }
 
 static int
@@ -264,21 +264,21 @@ read_client_close_proxy(struct archive_read *a)
 }
 
 static int
-client_close_proxy(struct archive_read_filter *self)
+client_close_proxy(struct archive_read_filter *f)
 {
-	return read_client_close_proxy(self->archive);
+	return read_client_close_proxy(f->archive);
 }
 
 static int
-client_switch_proxy(struct archive_read_filter *self, unsigned int iindex)
+client_switch_proxy(struct archive_read_filter *f, unsigned int iindex)
 {
 	struct archive_read *a;
 	int r1 = ARCHIVE_OK, r2 = ARCHIVE_OK;
 	void *data2;
 
-	while (self->upstream != NULL)
-		self = self->upstream;
-	a = self->archive;
+	while (f->upstream != NULL)
+		f = f->upstream;
+	a = f->archive;
 
 	/* Don't do anything if already in the specified data node */
 	if (a->client.cursor == iindex)
@@ -289,19 +289,19 @@ client_switch_proxy(struct archive_read_filter *self, unsigned int iindex)
 	if (a->client.switcher != NULL)
 	{
 		r1 = r2 = (a->client.switcher)
-			((struct archive *)a, self->data, data2);
-		self->data = data2;
+			((struct archive *)a, f->data, data2);
+		f->data = data2;
 	}
 	else
 	{
 		/* Attempt to call close and open instead */
 		if (a->client.closer != NULL)
 			r1 = (a->client.closer)
-				((struct archive *)a, self->data);
-		self->data = data2;
+				((struct archive *)a, f->data);
+		f->data = data2;
 		if (a->client.opener != NULL)
 			r2 = (a->client.opener)
-				((struct archive *)a, self->data);
+				((struct archive *)a, f->data);
 	}
 	return (r1 < r2) ? r1 : r2;
 }
@@ -1384,13 +1384,13 @@ __archive_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
 }
 
 const void *
-__archive_read_filter_ahead(struct archive_read_filter *filter,
+__archive_read_filter_ahead(struct archive_read_filter *f,
     size_t min, ssize_t *avail)
 {
 	ssize_t bytes_read;
 	size_t tocopy;
 
-	if (filter->fatal) {
+	if (f->fatal) {
 		if (avail)
 			*avail = ARCHIVE_FATAL;
 		return (NULL);
@@ -1407,79 +1407,79 @@ __archive_read_filter_ahead(struct archive_read_filter *filter,
 		 * note that min == 0 is a perfectly well-defined
 		 * request.
 		 */
-		if (filter->avail >= min && filter->avail > 0) {
+		if (f->avail >= min && f->avail > 0) {
 			if (avail != NULL)
-				*avail = filter->avail;
-			return (filter->next);
+				*avail = f->avail;
+			return (f->next);
 		}
 
 		/*
 		 * We can satisfy directly from client buffer if everything
 		 * currently in the copy buffer is still in the client buffer.
 		 */
-		if (filter->client_total >= filter->client_avail + filter->avail
-		    && filter->client_avail + filter->avail >= min) {
+		if (f->client_total >= f->client_avail + f->avail
+		    && f->client_avail + f->avail >= min) {
 			/* "Roll back" to client buffer. */
-			filter->client_avail += filter->avail;
-			filter->client_next -= filter->avail;
+			f->client_avail += f->avail;
+			f->client_next -= f->avail;
 			/* Copy buffer is now empty. */
-			filter->avail = 0;
-			filter->next = filter->buffer;
+			f->avail = 0;
+			f->next = f->buffer;
 			/* Return data from client buffer. */
 			if (avail != NULL)
-				*avail = filter->client_avail;
-			return (filter->client_next);
+				*avail = f->client_avail;
+			return (f->client_next);
 		}
 
 		/* Move data forward in copy buffer if necessary. */
-		if (filter->next > filter->buffer &&
-		    min > filter->buffer_size - (filter->next - filter->buffer)) {
-			if (filter->avail > 0)
-				memmove(filter->buffer, filter->next,
-				    filter->avail);
-			filter->next = filter->buffer;
+		if (f->next > f->buffer &&
+		    min > f->buffer_size - (f->next - f->buffer)) {
+			if (f->avail > 0)
+				memmove(f->buffer, f->next,
+				    f->avail);
+			f->next = f->buffer;
 		}
 
 		/* If we've used up the client data, get more. */
-		if (filter->client_avail <= 0) {
-			if (filter->end_of_file) {
+		if (f->client_avail <= 0) {
+			if (f->end_of_file) {
 				if (avail != NULL)
-					*avail = filter->avail;
+					*avail = f->avail;
 				return (NULL);
 			}
-			bytes_read = (filter->vtable->read)(filter,
-			    &filter->client_buff);
+			bytes_read = (f->vtable->read)(f,
+			    &f->client_buff);
 			if (bytes_read < 0) {		/* Read error. */
-				filter->client_total = filter->client_avail = 0;
-				filter->client_next =
-				    filter->client_buff = NULL;
-				filter->fatal = 1;
+				f->client_total = f->client_avail = 0;
+				f->client_next =
+				    f->client_buff = NULL;
+				f->fatal = 1;
 				if (avail != NULL)
 					*avail = ARCHIVE_FATAL;
 				return (NULL);
 			}
 			if (bytes_read == 0) {
 				/* Check for another client object first */
-				if (filter->archive->client.cursor !=
-				      filter->archive->client.nodes - 1) {
-					if (client_switch_proxy(filter,
-					    filter->archive->client.cursor + 1)
+				if (f->archive->client.cursor !=
+				      f->archive->client.nodes - 1) {
+					if (client_switch_proxy(f,
+					    f->archive->client.cursor + 1)
 					    == ARCHIVE_OK)
 						continue;
 				}
 				/* Premature end-of-file. */
-				filter->client_total = filter->client_avail = 0;
-				filter->client_next =
-				    filter->client_buff = NULL;
-				filter->end_of_file = 1;
+				f->client_total = f->client_avail = 0;
+				f->client_next =
+				    f->client_buff = NULL;
+				f->end_of_file = 1;
 				/* Return whatever we do have. */
 				if (avail != NULL)
-					*avail = filter->avail;
+					*avail = f->avail;
 				return (NULL);
 			}
-			filter->client_total = bytes_read;
-			filter->client_avail = filter->client_total;
-			filter->client_next = filter->client_buff;
+			f->client_total = bytes_read;
+			f->client_avail = f->client_total;
+			f->client_next = f->client_buff;
 		} else {
 			/*
 			 * We can't satisfy the request from the copy
@@ -1489,23 +1489,23 @@ __archive_read_filter_ahead(struct archive_read_filter *filter,
 			 */
 
 			/* Ensure the buffer is big enough. */
-			if (min > filter->buffer_size) {
+			if (min > f->buffer_size) {
 				size_t s;
 				char *p;
 
 				/* Double the buffer; watch for overflow. */
-				s = filter->buffer_size;
+				s = f->buffer_size;
 				if (s == 0)
 					s = min;
 				while (s < min) {
 					if (archive_ckd_mul_size(&s, s, 2)) {
 						/* Integer overflow! */
 						archive_set_error(
-						    &filter->archive->archive,
+						    &f->archive->archive,
 						    ENOMEM,
 						    "Unable to allocate copy"
 						    " buffer");
-						filter->fatal = 1;
+						f->fatal = 1;
 						if (avail != NULL)
 							*avail = ARCHIVE_FATAL;
 						return (NULL);
@@ -1515,40 +1515,40 @@ __archive_read_filter_ahead(struct archive_read_filter *filter,
 				p = malloc(s);
 				if (p == NULL) {
 					archive_set_error(
-						&filter->archive->archive,
+						&f->archive->archive,
 						ENOMEM,
 					    "Unable to allocate copy buffer");
-					filter->fatal = 1;
+					f->fatal = 1;
 					if (avail != NULL)
 						*avail = ARCHIVE_FATAL;
 					return (NULL);
 				}
 				/* Move data into newly-enlarged buffer. */
-				if (filter->avail > 0)
-					memmove(p, filter->next, filter->avail);
-				free(filter->buffer);
-				filter->next = filter->buffer = p;
-				filter->buffer_size = s;
+				if (f->avail > 0)
+					memmove(p, f->next, f->avail);
+				free(f->buffer);
+				f->next = f->buffer = p;
+				f->buffer_size = s;
 			}
 
 			/* We can add client data to copy buffer. */
 			/* First estimate: copy to fill rest of buffer. */
-			tocopy = (filter->buffer + filter->buffer_size)
-			    - (filter->next + filter->avail);
+			tocopy = (f->buffer + f->buffer_size)
+			    - (f->next + f->avail);
 			/* Don't waste time buffering more than we need to. */
-			if (tocopy + filter->avail > min)
-				tocopy = min - filter->avail;
+			if (tocopy + f->avail > min)
+				tocopy = min - f->avail;
 			/* Don't copy more than is available. */
-			if (tocopy > filter->client_avail)
-				tocopy = filter->client_avail;
+			if (tocopy > f->client_avail)
+				tocopy = f->client_avail;
 
-			memcpy(filter->next + filter->avail,
-			    filter->client_next, tocopy);
+			memcpy(f->next + f->avail,
+			    f->client_next, tocopy);
 			/* Remove this data from client buffer. */
-			filter->client_next += tocopy;
-			filter->client_avail -= tocopy;
+			f->client_next += tocopy;
+			f->client_avail -= tocopy;
 			/* add it to copy buffer. */
-			filter->avail += tocopy;
+			f->avail += tocopy;
 		}
 	}
 }
@@ -1593,45 +1593,45 @@ __archive_read_filter_consume(struct archive_read_filter * filter,
  * Returns a negative value if there's an I/O error.
  */
 static int64_t
-advance_file_pointer(struct archive_read_filter *filter, int64_t request)
+advance_file_pointer(struct archive_read_filter *f, int64_t request)
 {
 	int64_t bytes_skipped, total_bytes_skipped = 0;
 	ssize_t bytes_read;
 	size_t min;
 
-	if (filter->fatal)
+	if (f->fatal)
 		return (-1);
 
 	/* Use up the copy buffer first. */
-	if (filter->avail > 0) {
-		min = (size_t)minimum(request, (int64_t)filter->avail);
-		filter->next += min;
-		filter->avail -= min;
+	if (f->avail > 0) {
+		min = (size_t)minimum(request, (int64_t)f->avail);
+		f->next += min;
+		f->avail -= min;
 		request -= min;
-		filter->position += min;
+		f->position += min;
 		total_bytes_skipped += min;
 	}
 
 	/* Then use up the client buffer. */
-	if (filter->client_avail > 0) {
-		min = (size_t)minimum(request, (int64_t)filter->client_avail);
-		filter->client_next += min;
-		filter->client_avail -= min;
+	if (f->client_avail > 0) {
+		min = (size_t)minimum(request, (int64_t)f->client_avail);
+		f->client_next += min;
+		f->client_avail -= min;
 		request -= min;
-		filter->position += min;
+		f->position += min;
 		total_bytes_skipped += min;
 	}
 	if (request == 0)
 		return (total_bytes_skipped);
 
 	/* If there's an optimized skip function, use it. */
-	if (filter->can_skip != 0) {
-		bytes_skipped = client_skip_proxy(filter, request);
+	if (f->can_skip != 0) {
+		bytes_skipped = client_skip_proxy(f, request);
 		if (bytes_skipped < 0) {	/* error */
-			filter->fatal = 1;
+			f->fatal = 1;
 			return (bytes_skipped);
 		}
-		filter->position += bytes_skipped;
+		f->position += bytes_skipped;
 		total_bytes_skipped += bytes_skipped;
 		request -= bytes_skipped;
 		if (request == 0)
@@ -1640,37 +1640,37 @@ advance_file_pointer(struct archive_read_filter *filter, int64_t request)
 
 	/* Use ordinary reads as necessary to complete the request. */
 	for (;;) {
-		bytes_read = (filter->vtable->read)(filter, &filter->client_buff);
+		bytes_read = (f->vtable->read)(f, &f->client_buff);
 		if (bytes_read < 0) {
-			filter->client_buff = NULL;
-			filter->fatal = 1;
+			f->client_buff = NULL;
+			f->fatal = 1;
 			return (bytes_read);
 		}
 
 		if (bytes_read == 0) {
-			if (filter->archive->client.cursor !=
-			      filter->archive->client.nodes - 1) {
-				if (client_switch_proxy(filter,
-				    filter->archive->client.cursor + 1)
+			if (f->archive->client.cursor !=
+			      f->archive->client.nodes - 1) {
+				if (client_switch_proxy(f,
+				    f->archive->client.cursor + 1)
 				    == ARCHIVE_OK)
 					continue;
 			}
-			filter->client_buff = NULL;
-			filter->end_of_file = 1;
+			f->client_buff = NULL;
+			f->end_of_file = 1;
 			return (total_bytes_skipped);
 		}
 
 		if (bytes_read >= request) {
-			filter->client_next =
-			    ((const char *)filter->client_buff) + request;
-			filter->client_avail = (size_t)(bytes_read - request);
-			filter->client_total = bytes_read;
+			f->client_next =
+			    ((const char *)f->client_buff) + request;
+			f->client_avail = (size_t)(bytes_read - request);
+			f->client_total = bytes_read;
 			total_bytes_skipped += request;
-			filter->position += request;
+			f->position += request;
 			return (total_bytes_skipped);
 		}
 
-		filter->position += bytes_read;
+		f->position += bytes_read;
 		total_bytes_skipped += bytes_read;
 		request -= bytes_read;
 	}
@@ -1686,23 +1686,23 @@ __archive_read_seek(struct archive_read *a, int64_t offset, int whence)
 }
 
 int64_t
-__archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
+__archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
     int whence)
 {
 	struct archive_read_client *client;
 	int64_t r;
 	unsigned int cursor;
 
-	if (filter->closed || filter->fatal)
+	if (f->closed || f->fatal)
 		return (ARCHIVE_FATAL);
-	if (filter->can_seek == 0)
+	if (f->can_seek == 0)
 		return (ARCHIVE_FAILED);
 
-	client = &(filter->archive->client);
+	client = &(f->archive->client);
 	switch (whence) {
 	case SEEK_CUR:
 		/* Adjust the offset and use SEEK_SET instead */
-		offset += filter->position;
+		offset += f->position;
 		__LA_FALLTHROUGH;
 	case SEEK_SET:
 		cursor = 0;
@@ -1719,10 +1719,10 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 			client->dataset[++cursor].begin_position = r;
 		}
 		while (1) {
-			r = client_switch_proxy(filter, cursor);
+			r = client_switch_proxy(f, cursor);
 			if (r != ARCHIVE_OK)
 				return r;
-			if ((r = client_seek_proxy(filter, 0, SEEK_END)) < 0)
+			if ((r = client_seek_proxy(f, 0, SEEK_END)) < 0)
 				return r;
 			client->dataset[cursor].total_size = r;
 			if (client->dataset[cursor].begin_position +
@@ -1737,7 +1737,7 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 		if (offset < 0
 		    || offset > client->dataset[cursor].total_size)
 			return ARCHIVE_FATAL;
-		if ((r = client_seek_proxy(filter, offset, SEEK_SET)) < 0)
+		if ((r = client_seek_proxy(f, offset, SEEK_SET)) < 0)
 			return r;
 		break;
 
@@ -1753,10 +1753,10 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 			client->dataset[++cursor].begin_position = r;
 		}
 		while (1) {
-			r = client_switch_proxy(filter, cursor);
+			r = client_switch_proxy(f, cursor);
 			if (r != ARCHIVE_OK)
 				return r;
-			if ((r = client_seek_proxy(filter, 0, SEEK_END)) < 0)
+			if ((r = client_seek_proxy(f, 0, SEEK_END)) < 0)
 				return r;
 			client->dataset[cursor].total_size = r;
 			r = client->dataset[cursor].begin_position +
@@ -1777,9 +1777,9 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 				client->dataset[cursor].total_size;
 		}
 		offset = (r + offset) - client->dataset[cursor].begin_position;
-		if ((r = client_switch_proxy(filter, cursor)) != ARCHIVE_OK)
+		if ((r = client_switch_proxy(f, cursor)) != ARCHIVE_OK)
 			return r;
-		r = client_seek_proxy(filter, offset, SEEK_SET);
+		r = client_seek_proxy(f, offset, SEEK_SET);
 		if (r < ARCHIVE_OK)
 			return r;
 		break;
@@ -1807,10 +1807,10 @@ __archive_read_filter_seek(struct archive_read_filter *filter, int64_t offset,
 		 * size is (r - offset).  Can we use that to simplify
 		 * the TODO items above?
 		 */
-		filter->avail = filter->client_avail = 0;
-		filter->next = filter->buffer;
-		filter->position = r;
-		filter->end_of_file = 0;
+		f->avail = f->client_avail = 0;
+		f->next = f->buffer;
+		f->position = r;
+		f->end_of_file = 0;
 	}
 	return r;
 }

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -482,7 +482,7 @@ int
 archive_read_open1(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct archive_read_filter *filter, *tmp;
+	struct archive_read_filter *f, *tmp;
 	int slot, e = ARCHIVE_OK;
 
 	archive_check_magic(_a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_NEW,
@@ -506,23 +506,23 @@ archive_read_open1(struct archive *_a)
 		}
 	}
 
-	filter = calloc(1, sizeof(*filter));
-	if (filter == NULL)
+	f = calloc(1, sizeof(*f));
+	if (f == NULL)
 		return (ARCHIVE_FATAL);
-	filter->bidder = NULL;
-	filter->upstream = NULL;
-	filter->archive = a;
-	filter->data = a->client.dataset[0].data;
-	filter->vtable = &none_reader_vtable;
-	filter->name = "none";
-	filter->code = ARCHIVE_FILTER_NONE;
-	filter->can_skip = 1;
-	filter->can_seek = 1;
+	f->bidder = NULL;
+	f->upstream = NULL;
+	f->archive = a;
+	f->data = a->client.dataset[0].data;
+	f->vtable = &none_reader_vtable;
+	f->name = "none";
+	f->code = ARCHIVE_FILTER_NONE;
+	f->can_skip = 1;
+	f->can_seek = 1;
 
 	a->client.dataset[0].begin_position = 0;
 	if (!a->filter || !a->bypass_filter_bidding)
 	{
-		a->filter = filter;
+		a->filter = f;
 		/* Build out the input pipeline. */
 		e = choose_filters(a);
 		if (e < ARCHIVE_WARN) {
@@ -536,7 +536,7 @@ archive_read_open1(struct archive *_a)
 		tmp = a->filter;
 		while (tmp->upstream)
 			tmp = tmp->upstream;
-		tmp->upstream = filter;
+		tmp->upstream = f;
 	}
 
 	if (!a->format)
@@ -571,7 +571,7 @@ choose_filters(struct archive_read *a)
 {
 	int number_bidders, i, bid, best_bid, number_filters;
 	struct archive_read_filter_bidder *bidder, *best_bidder;
-	struct archive_read_filter *filter;
+	struct archive_read_filter *f;
 	ssize_t avail;
 	int r;
 
@@ -603,13 +603,13 @@ choose_filters(struct archive_read *a)
 			return (ARCHIVE_OK);
 		}
 
-		filter = calloc(1, sizeof(*filter));
-		if (filter == NULL)
+		f = calloc(1, sizeof(*f));
+		if (f == NULL)
 			return (ARCHIVE_FATAL);
-		filter->bidder = best_bidder;
-		filter->archive = a;
-		filter->upstream = a->filter;
-		a->filter = filter;
+		f->bidder = best_bidder;
+		f->archive = a;
+		f->upstream = a->filter;
+		a->filter = f;
 		r = (best_bidder->vtable->init)(a->filter);
 		if (r != ARCHIVE_OK) {
 			__archive_read_free_filters(a);
@@ -1563,7 +1563,7 @@ __archive_read_consume(struct archive_read *a, int64_t request)
 }
 
 int64_t
-__archive_read_filter_consume(struct archive_read_filter * filter,
+__archive_read_filter_consume(struct archive_read_filter *f,
     int64_t request)
 {
 	int64_t skipped;
@@ -1573,13 +1573,13 @@ __archive_read_filter_consume(struct archive_read_filter * filter,
 	if (request == 0)
 		return 0;
 
-	skipped = advance_file_pointer(filter, request);
+	skipped = advance_file_pointer(f, request);
 	if (skipped == request)
 		return (skipped);
 	/* We hit EOF before we satisfied the skip request. */
 	if (skipped < 0)  /* Map error code to 0 for error message below. */
 		skipped = 0;
-	archive_set_error(&filter->archive->archive,
+	archive_set_error(&f->archive->archive,
 	    ARCHIVE_ERRNO_MISC,
 	    "Truncated input file (needed %jd bytes, only %jd available)",
 	    (intmax_t)request, (intmax_t)skipped);

--- a/libarchive/archive_read_append_filter.c
+++ b/libarchive/archive_read_append_filter.c
@@ -38,8 +38,8 @@ archive_read_append_filter(struct archive *_a, int code)
 {
   int r1, r2, number_bidders, i;
   const char *str;
-  struct archive_read_filter_bidder *bidder;
-  struct archive_read_filter *filter;
+  struct archive_read_filter_bidder *b;
+  struct archive_read_filter *f;
   struct archive_read *a = (struct archive_read *)_a;
 
   r2 = (ARCHIVE_OK);
@@ -118,30 +118,30 @@ archive_read_append_filter(struct archive *_a, int code)
   {
     number_bidders = sizeof(a->bidders) / sizeof(a->bidders[0]);
 
-    bidder = a->bidders;
-    for (i = 1; i < number_bidders; i++, bidder++)
+    b = a->bidders;
+    for (i = 1; i < number_bidders; i++, b++)
     {
-      if (!bidder->name || !strcmp(bidder->name, str))
+      if (!b->name || !strcmp(b->name, str))
         break;
     }
-    if (!bidder->name || strcmp(bidder->name, str))
+    if (!b->name || strcmp(b->name, str))
     {
       archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
           "Internal error: Unable to append filter");
       return (ARCHIVE_FATAL);
     }
 
-    filter = calloc(1, sizeof(*filter));
-    if (filter == NULL)
+    f = calloc(1, sizeof(*f));
+    if (f == NULL)
     {
       archive_set_error(&a->archive, ENOMEM, "Out of memory");
       return (ARCHIVE_FATAL);
     }
-    filter->bidder = bidder;
-    filter->archive = a;
-    filter->upstream = a->filter;
-    a->filter = filter;
-    r2 = (bidder->vtable->init)(a->filter);
+    f->bidder = b;
+    f->archive = a;
+    f->upstream = a->filter;
+    a->filter = f;
+    r2 = (b->vtable->init)(a->filter);
     if (r2 != ARCHIVE_OK) {
       __archive_read_free_filters(a);
       return (ARCHIVE_FATAL);
@@ -163,8 +163,8 @@ archive_read_append_filter_program_signature(struct archive *_a,
   const char *cmd, const void *signature, size_t signature_len)
 {
   int r, number_bidders, i;
-  struct archive_read_filter_bidder *bidder;
-  struct archive_read_filter *filter;
+  struct archive_read_filter_bidder *b;
+  struct archive_read_filter *f;
   struct archive_read *a = (struct archive_read *)_a;
 
   if (archive_read_support_filter_program_signature(_a, cmd, signature,
@@ -173,36 +173,36 @@ archive_read_append_filter_program_signature(struct archive *_a,
 
   number_bidders = sizeof(a->bidders) / sizeof(a->bidders[0]);
 
-  bidder = a->bidders;
-  for (i = 0; i < number_bidders; i++, bidder++)
+  b = a->bidders;
+  for (i = 0; i < number_bidders; i++, b++)
   {
     /* Program bidder name set to filter name after initialization */
-    if (bidder->data && !bidder->name)
+    if (b->data && !b->name)
       break;
   }
-  if (!bidder->data)
+  if (!b->data)
   {
     archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
         "Internal error: Unable to append program filter");
     return (ARCHIVE_FATAL);
   }
 
-  filter = calloc(1, sizeof(*filter));
-  if (filter == NULL)
+  f = calloc(1, sizeof(*f));
+  if (f == NULL)
   {
     archive_set_error(&a->archive, ENOMEM, "Out of memory");
     return (ARCHIVE_FATAL);
   }
-  filter->bidder = bidder;
-  filter->archive = a;
-  filter->upstream = a->filter;
-  a->filter = filter;
-  r = (bidder->vtable->init)(a->filter);
+  f->bidder = b;
+  f->archive = a;
+  f->upstream = a->filter;
+  a->filter = f;
+  r = (b->vtable->init)(a->filter);
   if (r != ARCHIVE_OK) {
     __archive_read_free_filters(a);
     return (ARCHIVE_FATAL);
   }
-  bidder->name = a->filter->name;
+  b->name = a->filter->name;
 
   a->bypass_filter_bidding = 1;
   return r;

--- a/libarchive/archive_read_private.h
+++ b/libarchive/archive_read_private.h
@@ -76,10 +76,10 @@ struct archive_read_filter_bidder {
 struct archive_read_filter_vtable {
 	/* Return next block. */
 	ssize_t (*read)(struct archive_read_filter *, const void **);
-	/* Close (just this filter) and free(self). */
-	int (*close)(struct archive_read_filter *self);
+	/* Close (just this filter) and free(filter). */
+	int (*close)(struct archive_read_filter *);
 	/* Read any header metadata if available. */
-	int (*read_header)(struct archive_read_filter *self, struct archive_entry *entry);
+	int (*read_header)(struct archive_read_filter *, struct archive_entry *);
 };
 
 /*

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -215,12 +215,10 @@ bzip2_reader_init(struct archive_read_filter *self)
 static ssize_t
 bzip2_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	size_t decompressed;
 	const char *read_buf;
 	ssize_t ret;
-
-	state = (struct private_data *)self->data;
 
 	if (state->eof) {
 		*p = NULL;
@@ -338,10 +336,8 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 static int
 bzip2_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	int ret = ARCHIVE_OK;
-
-	state = (struct private_data *)self->data;
 
 	if (state->valid) {
 		switch (BZ2_bzDecompressEnd(&state->stream)) {

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -50,7 +50,7 @@
 #include "archive_read_private.h"
 
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
-struct private_data {
+struct bzip2 {
 	bz_stream	 stream;
 	char		*out_block;
 	size_t		 out_block_size;
@@ -186,24 +186,24 @@ bzip2_reader_init(struct archive_read_filter *self)
 {
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
-	struct private_data *state;
+	struct bzip2 *bzip2;
 
 	self->code = ARCHIVE_FILTER_BZIP2;
 	self->name = "bzip2";
 
-	state = calloc(1, sizeof(*state));
+	bzip2 = calloc(1, sizeof(*bzip2));
 	out_block = malloc(out_block_size);
-	if (state == NULL || out_block == NULL) {
+	if (bzip2 == NULL || out_block == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for bzip2 decompression");
 		free(out_block);
-		free(state);
+		free(bzip2);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
-	state->out_block_size = out_block_size;
-	state->out_block = out_block;
+	self->data = bzip2;
+	bzip2->out_block_size = out_block_size;
+	bzip2->out_block = out_block;
 	self->vtable = &bzip2_reader_vtable;
 
 	return (ARCHIVE_OK);
@@ -215,40 +215,40 @@ bzip2_reader_init(struct archive_read_filter *self)
 static ssize_t
 bzip2_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct bzip2 *bzip2 = self->data;
 	size_t decompressed;
 	const char *read_buf;
 	ssize_t ret;
 
-	if (state->eof) {
+	if (bzip2->eof) {
 		*p = NULL;
 		return (0);
 	}
 
 	/* Empty our output buffer. */
-	state->stream.next_out = state->out_block;
-	state->stream.avail_out = (uint32_t)state->out_block_size;
+	bzip2->stream.next_out = bzip2->out_block;
+	bzip2->stream.avail_out = (uint32_t)bzip2->out_block_size;
 
 	/* Try to fill the output buffer. */
 	for (;;) {
 		ssize_t max_in;
 
-		if (!state->valid) {
+		if (!bzip2->valid) {
 			if (bzip2_reader_bid(self->bidder, self->upstream) == 0) {
-				state->eof = 1;
-				*p = state->out_block;
-				decompressed = state->stream.next_out
-				    - state->out_block;
+				bzip2->eof = 1;
+				*p = bzip2->out_block;
+				decompressed = bzip2->stream.next_out
+				    - bzip2->out_block;
 				return (decompressed);
 			}
 			/* Initialize compression library. */
-			ret = BZ2_bzDecompressInit(&(state->stream),
+			ret = BZ2_bzDecompressInit(&(bzip2->stream),
 					   0 /* library verbosity */,
 					   0 /* don't use low-mem algorithm */);
 
 			/* If init fails, try low-memory algorithm instead. */
 			if (ret == BZ_MEM_ERROR)
-				ret = BZ2_bzDecompressInit(&(state->stream),
+				ret = BZ2_bzDecompressInit(&(bzip2->stream),
 					   0 /* library verbosity */,
 					   1 /* do use low-mem algo */);
 
@@ -273,7 +273,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 				    detail);
 				return (ARCHIVE_FATAL);
 			}
-			state->valid = 1;
+			bzip2->valid = 1;
 		}
 
 		/* stream.next_in is really const, but bzlib
@@ -286,23 +286,23 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 			    "truncated bzip2 input");
 			return (ARCHIVE_FATAL);
 		}
-		state->stream.next_in = (char *)(uintptr_t)read_buf;
+		bzip2->stream.next_in = (char *)(uintptr_t)read_buf;
 		if (UINT_MAX >= SSIZE_MAX)
 			max_in = SSIZE_MAX;
 		else
 			max_in = UINT_MAX;
 		if (ret > max_in)
 			ret = max_in;
-		state->stream.avail_in = (uint32_t)ret;
+		bzip2->stream.avail_in = (uint32_t)ret;
 
 		/* Decompress as much as we can in one pass. */
-		ret = BZ2_bzDecompress(&(state->stream));
+		ret = BZ2_bzDecompress(&(bzip2->stream));
 		__archive_read_filter_consume(self->upstream,
-		    state->stream.next_in - read_buf);
+		    bzip2->stream.next_in - read_buf);
 
 		switch (ret) {
 		case BZ_STREAM_END: /* Found end of stream. */
-			switch (BZ2_bzDecompressEnd(&(state->stream))) {
+			switch (BZ2_bzDecompressEnd(&(bzip2->stream))) {
 			case BZ_OK:
 				break;
 			default:
@@ -311,14 +311,14 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 					  "Failed to clean up decompressor");
 				return (ARCHIVE_FATAL);
 			}
-			state->valid = 0;
+			bzip2->valid = 0;
 			/* FALLTHROUGH */
 		case BZ_OK: /* Decompressor made some progress. */
 			/* If we filled our buffer, update stats and return. */
-			if (state->stream.avail_out == 0) {
-				*p = state->out_block;
-				decompressed = state->stream.next_out
-				    - state->out_block;
+			if (bzip2->stream.avail_out == 0) {
+				*p = bzip2->out_block;
+				decompressed = bzip2->stream.next_out
+				    - bzip2->out_block;
 				return (decompressed);
 			}
 			break;
@@ -336,11 +336,11 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 static int
 bzip2_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct bzip2 *bzip2 = self->data;
 	int ret = ARCHIVE_OK;
 
-	if (state->valid) {
-		switch (BZ2_bzDecompressEnd(&state->stream)) {
+	if (bzip2->valid) {
+		switch (BZ2_bzDecompressEnd(&bzip2->stream)) {
 		case BZ_OK:
 			break;
 		default:
@@ -349,11 +349,11 @@ bzip2_filter_close(struct archive_read_filter *self)
 					  "Failed to clean up decompressor");
 			ret = ARCHIVE_FATAL;
 		}
-		state->valid = 0;
+		bzip2->valid = 0;
 	}
 
-	free(state->out_block);
-	free(state);
+	free(bzip2->out_block);
+	free(bzip2);
 	return (ret);
 }
 

--- a/libarchive/archive_read_support_filter_bzip2.c
+++ b/libarchive/archive_read_support_filter_bzip2.c
@@ -112,15 +112,15 @@ archive_read_support_filter_bzip2(struct archive *_a)
  * from verifying as much as we would like.
  */
 static int
-bzip2_reader_bid(struct archive_read_filter_bidder *self, struct archive_read_filter *filter)
+bzip2_reader_bid(struct archive_read_filter_bidder *b, struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	int bits_checked;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
 	/* Minimal bzip2 archive is 14 bytes. */
-	buffer = __archive_read_filter_ahead(filter, 14, NULL);
+	buffer = __archive_read_filter_ahead(f, 14, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -156,16 +156,16 @@ bzip2_reader_bid(struct archive_read_filter_bidder *self, struct archive_read_fi
  * in case that's available.
  */
 static int
-bzip2_reader_init(struct archive_read_filter *self)
+bzip2_reader_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "bzip2 -d");
+	r = __archive_read_program(f, "bzip2 -d");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_BZIP2;
-	self->name = "bzip2";
+	f->code = ARCHIVE_FILTER_BZIP2;
+	f->name = "bzip2";
 	return (r);
 }
 
@@ -182,29 +182,29 @@ bzip2_reader_vtable = {
  * Setup the callbacks.
  */
 static int
-bzip2_reader_init(struct archive_read_filter *self)
+bzip2_reader_init(struct archive_read_filter *f)
 {
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
 	struct bzip2 *bzip2;
 
-	self->code = ARCHIVE_FILTER_BZIP2;
-	self->name = "bzip2";
+	f->code = ARCHIVE_FILTER_BZIP2;
+	f->name = "bzip2";
 
 	bzip2 = calloc(1, sizeof(*bzip2));
 	out_block = malloc(out_block_size);
 	if (bzip2 == NULL || out_block == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for bzip2 decompression");
 		free(out_block);
 		free(bzip2);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = bzip2;
+	f->data = bzip2;
 	bzip2->out_block_size = out_block_size;
 	bzip2->out_block = out_block;
-	self->vtable = &bzip2_reader_vtable;
+	f->vtable = &bzip2_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
@@ -213,9 +213,9 @@ bzip2_reader_init(struct archive_read_filter *self)
  * Return the next block of decompressed data.
  */
 static ssize_t
-bzip2_filter_read(struct archive_read_filter *self, const void **p)
+bzip2_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct bzip2 *bzip2 = self->data;
+	struct bzip2 *bzip2 = f->data;
 	size_t decompressed;
 	const char *read_buf;
 	ssize_t ret;
@@ -234,7 +234,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 		ssize_t max_in;
 
 		if (!bzip2->valid) {
-			if (bzip2_reader_bid(self->bidder, self->upstream) == 0) {
+			if (bzip2_reader_bid(f->bidder, f->upstream) == 0) {
 				bzip2->eof = 1;
 				*p = bzip2->out_block;
 				decompressed = bzip2->stream.next_out
@@ -267,7 +267,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 					detail = "mis-compiled library";
 					break;
 				}
-				archive_set_error(&self->archive->archive, err,
+				archive_set_error(&f->archive->archive, err,
 				    "Internal error initializing decompressor%s%s",
 				    detail == NULL ? "" : ": ",
 				    detail);
@@ -279,9 +279,9 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 		/* stream.next_in is really const, but bzlib
 		 * doesn't declare it so. <sigh> */
 		read_buf =
-		    __archive_read_filter_ahead(self->upstream, 1, &ret);
+		    __archive_read_filter_ahead(f->upstream, 1, &ret);
 		if (read_buf == NULL) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated bzip2 input");
 			return (ARCHIVE_FATAL);
@@ -297,7 +297,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 
 		/* Decompress as much as we can in one pass. */
 		ret = BZ2_bzDecompress(&(bzip2->stream));
-		__archive_read_filter_consume(self->upstream,
+		__archive_read_filter_consume(f->upstream,
 		    bzip2->stream.next_in - read_buf);
 
 		switch (ret) {
@@ -306,7 +306,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 			case BZ_OK:
 				break;
 			default:
-				archive_set_error(&(self->archive->archive),
+				archive_set_error(&(f->archive->archive),
 					  ARCHIVE_ERRNO_MISC,
 					  "Failed to clean up decompressor");
 				return (ARCHIVE_FATAL);
@@ -323,7 +323,7 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
 			}
 			break;
 		default: /* Return an error. */
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC, "bzip decompression failed");
 			return (ARCHIVE_FATAL);
 		}
@@ -334,9 +334,9 @@ bzip2_filter_read(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-bzip2_filter_close(struct archive_read_filter *self)
+bzip2_filter_close(struct archive_read_filter *f)
 {
-	struct bzip2 *bzip2 = self->data;
+	struct bzip2 *bzip2 = f->data;
 	int ret = ARCHIVE_OK;
 
 	if (bzip2->valid) {
@@ -344,7 +344,7 @@ bzip2_filter_close(struct archive_read_filter *self)
 		case BZ_OK:
 			break;
 		default:
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 					  ARCHIVE_ERRNO_MISC,
 					  "Failed to clean up decompressor");
 			ret = ARCHIVE_FATAL;

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -90,7 +90,7 @@
  * names and structure here don't exactly match those used by compress.
  */
 
-struct private_data {
+struct compress {
 	/* Input variables. */
 	const unsigned char	*next_in;
 	size_t			 avail_in;
@@ -209,27 +209,27 @@ compress_reader_vtable = {
 static int
 compress_bidder_init(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct compress *compress;
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
 
 	self->code = ARCHIVE_FILTER_COMPRESS;
 	self->name = "compress (.Z)";
 
-	state = calloc(1, sizeof(*state));
+	compress = calloc(1, sizeof(*compress));
 	out_block = malloc(out_block_size);
-	if (state == NULL || out_block == NULL) {
+	if (compress == NULL || out_block == NULL) {
 		free(out_block);
-		free(state);
+		free(compress);
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for %s decompression",
 		    self->name);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
-	state->out_block_size = out_block_size;
-	state->out_block = out_block;
+	self->data = compress;
+	compress->out_block_size = out_block_size;
+	compress->out_block = out_block;
 	self->vtable = &compress_reader_vtable;
 
 	return (ARCHIVE_OK);
@@ -238,10 +238,10 @@ compress_bidder_init(struct archive_read_filter *self)
 static int
 compress_filter_init(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct compress *compress = self->data;
 	int code;
 
-	state->initialized = 1;
+	compress->initialized = 1;
 
 	(void)getbits(self, 8); /* Skip first signature byte. */
 	(void)getbits(self, 8); /* Skip second signature byte. */
@@ -253,21 +253,21 @@ compress_filter_init(struct archive_read_filter *self)
 		    "Invalid compressed data");
 		return (ARCHIVE_FATAL);
 	}
-	state->maxcode_bits = code & 0x1f;
-	state->maxcode = (1 << state->maxcode_bits);
-	state->use_reset_code = code & 0x80;
+	compress->maxcode_bits = code & 0x1f;
+	compress->maxcode = (1 << compress->maxcode_bits);
+	compress->use_reset_code = code & 0x80;
 
 	/* Initialize decompressor. */
-	state->free_ent = 256;
-	state->stackp = state->stack;
-	if (state->use_reset_code)
-		state->free_ent++;
-	state->bits = 9;
-	state->section_end_code = (1<<state->bits) - 1;
-	state->oldcode = -1;
+	compress->free_ent = 256;
+	compress->stackp = compress->stack;
+	if (compress->use_reset_code)
+		compress->free_ent++;
+	compress->bits = 9;
+	compress->section_end_code = (1<<compress->bits) - 1;
+	compress->oldcode = -1;
 	for (code = 255; code >= 0; code--) {
-		state->prefix[code] = 0;
-		state->suffix[code] = code;
+		compress->prefix[code] = 0;
+		compress->suffix[code] = code;
 	}
 	next_code(self);
 
@@ -281,29 +281,29 @@ compress_filter_init(struct archive_read_filter *self)
 static ssize_t
 compress_filter_read(struct archive_read_filter *self, const void **pblock)
 {
-	struct private_data *state = self->data;
+	struct compress *compress = self->data;
 	unsigned char *p, *start, *end;
 	int ret;
 
-	if (!state->initialized) {
+	if (!compress->initialized) {
 		ret = compress_filter_init(self);
 		if (ret != ARCHIVE_OK)
 			return (ret);
 	}
-	if (state->end_of_stream) {
+	if (compress->end_of_stream) {
 		*pblock = NULL;
 		return (0);
 	}
-	p = start = (unsigned char *)state->out_block;
-	end = start + state->out_block_size;
+	p = start = (unsigned char *)compress->out_block;
+	end = start + compress->out_block_size;
 
-	while (p < end && !state->end_of_stream) {
-		if (state->stackp > state->stack) {
-			*p++ = *--state->stackp;
+	while (p < end && !compress->end_of_stream) {
+		if (compress->stackp > compress->stack) {
+			*p++ = *--compress->stackp;
 		} else {
 			ret = next_code(self);
 			if (ret == -1)
-				state->end_of_stream = ret;
+				compress->end_of_stream = ret;
 			else if (ret != ARCHIVE_OK)
 				return (ret);
 		}
@@ -319,10 +319,10 @@ compress_filter_read(struct archive_read_filter *self, const void **pblock)
 static int
 compress_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct compress *compress = self->data;
 
-	free(state->out_block);
-	free(state);
+	free(compress->out_block);
+	free(compress);
 	return (ARCHIVE_OK);
 }
 
@@ -334,16 +334,16 @@ compress_filter_close(struct archive_read_filter *self)
 static int
 next_code(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct compress *compress = self->data;
 	int code, newcode;
 
 again:
-	code = newcode = getbits(self, state->bits);
+	code = newcode = getbits(self, compress->bits);
 	if (code < 0)
 		return (code);
 
 	/* If it's a reset code, reset the dictionary. */
-	if ((code == 256) && state->use_reset_code) {
+	if ((code == 256) && compress->use_reset_code) {
 		/*
 		 * The original 'compress' implementation blocked its
 		 * I/O in a manner that resulted in junk bytes being
@@ -351,26 +351,26 @@ again:
 		 * this junk.  (Yes, the number of *bytes* to skip is
 		 * a function of the current *bit* length.)
 		 */
-		int skip_bytes =  state->bits -
-		    (state->bytes_in_section % state->bits);
-		skip_bytes %= state->bits;
-		state->bits_avail = 0; /* Discard rest of this byte. */
+		int skip_bytes =  compress->bits -
+		    (compress->bytes_in_section % compress->bits);
+		skip_bytes %= compress->bits;
+		compress->bits_avail = 0; /* Discard rest of this byte. */
 		while (skip_bytes-- > 0) {
 			code = getbits(self, 8);
 			if (code < 0)
 				return (code);
 		}
 		/* Now, actually do the reset. */
-		state->bytes_in_section = 0;
-		state->bits = 9;
-		state->section_end_code = (1 << state->bits) - 1;
-		state->free_ent = 257;
-		state->oldcode = -1;
+		compress->bytes_in_section = 0;
+		compress->bits = 9;
+		compress->section_end_code = (1 << compress->bits) - 1;
+		compress->free_ent = 257;
+		compress->oldcode = -1;
 		goto again;
 	}
 
-	if (code > state->free_ent
-	    || (code == state->free_ent && state->oldcode < 0)) {
+	if (code > compress->free_ent
+	    || (code == compress->free_ent && compress->oldcode < 0)) {
 		/* An invalid code is a fatal error. */
 		archive_set_error(&(self->archive->archive), -1,
 		    "Invalid compressed data");
@@ -378,36 +378,36 @@ again:
 	}
 
 	/* Special case for KwKwK string. */
-	if (code >= state->free_ent) {
-		*state->stackp++ = state->finbyte;
-		code = state->oldcode;
+	if (code >= compress->free_ent) {
+		*compress->stackp++ = compress->finbyte;
+		code = compress->oldcode;
 	}
 
 	/* Generate output characters in reverse order. */
 	while (code >= 256) {
-		*state->stackp++ = state->suffix[code];
-		code = state->prefix[code];
+		*compress->stackp++ = compress->suffix[code];
+		code = compress->prefix[code];
 	}
-	*state->stackp++ = state->finbyte = code;
+	*compress->stackp++ = compress->finbyte = code;
 
 	/* Generate the new entry. */
-	code = state->free_ent;
-	if (code < state->maxcode && state->oldcode >= 0) {
-		state->prefix[code] = state->oldcode;
-		state->suffix[code] = state->finbyte;
-		++state->free_ent;
+	code = compress->free_ent;
+	if (code < compress->maxcode && compress->oldcode >= 0) {
+		compress->prefix[code] = compress->oldcode;
+		compress->suffix[code] = compress->finbyte;
+		++compress->free_ent;
 	}
-	if (state->free_ent > state->section_end_code) {
-		state->bits++;
-		state->bytes_in_section = 0;
-		if (state->bits == state->maxcode_bits)
-			state->section_end_code = state->maxcode;
+	if (compress->free_ent > compress->section_end_code) {
+		compress->bits++;
+		compress->bytes_in_section = 0;
+		if (compress->bits == compress->maxcode_bits)
+			compress->section_end_code = compress->maxcode;
 		else
-			state->section_end_code = (1 << state->bits) - 1;
+			compress->section_end_code = (1 << compress->bits) - 1;
 	}
 
 	/* Remember previous code. */
-	state->oldcode = newcode;
+	compress->oldcode = newcode;
 	return (ARCHIVE_OK);
 }
 
@@ -419,7 +419,7 @@ again:
 static int
 getbits(struct archive_read_filter *self, int n)
 {
-	struct private_data *state = self->data;
+	struct compress *compress = self->data;
 	int code;
 	ssize_t ret;
 	static const int mask[] = {
@@ -427,31 +427,31 @@ getbits(struct archive_read_filter *self, int n)
 		0x1ff, 0x3ff, 0x7ff, 0xfff, 0x1fff, 0x3fff, 0x7fff, 0xffff
 	};
 
-	while (state->bits_avail < n) {
-		if (state->avail_in <= 0) {
-			if (state->consume_unnotified) {
+	while (compress->bits_avail < n) {
+		if (compress->avail_in <= 0) {
+			if (compress->consume_unnotified) {
 				__archive_read_filter_consume(self->upstream,
-					state->consume_unnotified);
-				state->consume_unnotified = 0;
+					compress->consume_unnotified);
+				compress->consume_unnotified = 0;
 			}
-			state->next_in
+			compress->next_in
 			    = __archive_read_filter_ahead(self->upstream,
 				1, &ret);
 			if (ret == 0)
 				return (-1);
-			if (state->next_in == NULL)
+			if (compress->next_in == NULL)
 				return (ARCHIVE_FATAL);
-			state->consume_unnotified = state->avail_in = ret;
+			compress->consume_unnotified = compress->avail_in = ret;
 		}
-		state->bit_buffer |= *state->next_in++ << state->bits_avail;
-		state->avail_in--;
-		state->bits_avail += 8;
-		state->bytes_in_section++;
+		compress->bit_buffer |= *compress->next_in++ << compress->bits_avail;
+		compress->avail_in--;
+		compress->bits_avail += 8;
+		compress->bytes_in_section++;
 	}
 
-	code = state->bit_buffer;
-	state->bit_buffer >>= n;
-	state->bits_avail -= n;
+	code = compress->bit_buffer;
+	compress->bit_buffer >>= n;
+	compress->bits_avail -= n;
 
 	return (code & mask[n]);
 }

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -238,7 +238,7 @@ compress_bidder_init(struct archive_read_filter *self)
 static int
 compress_filter_init(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	int code;
 
 	state->initialized = 1;
@@ -281,11 +281,10 @@ compress_filter_init(struct archive_read_filter *self)
 static ssize_t
 compress_filter_read(struct archive_read_filter *self, const void **pblock)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	unsigned char *p, *start, *end;
 	int ret;
 
-	state = (struct private_data *)self->data;
 	if (!state->initialized) {
 		ret = compress_filter_init(self);
 		if (ret != ARCHIVE_OK)
@@ -320,7 +319,7 @@ compress_filter_read(struct archive_read_filter *self, const void **pblock)
 static int
 compress_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 
 	free(state->out_block);
 	free(state);
@@ -335,7 +334,7 @@ compress_filter_close(struct archive_read_filter *self)
 static int
 next_code(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	int code, newcode;
 
 again:
@@ -420,7 +419,7 @@ again:
 static int
 getbits(struct archive_read_filter *self, int n)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	int code;
 	ssize_t ret;
 	static const int mask[] = {

--- a/libarchive/archive_read_support_filter_compress.c
+++ b/libarchive/archive_read_support_filter_compress.c
@@ -169,16 +169,16 @@ archive_read_support_filter_compress(struct archive *_a)
  * This logic returns zero if any part of the signature fails.
  */
 static int
-compress_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+compress_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	int bits_checked;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
 	/* Shortest valid compress file is 3 bytes. */
-	buffer = __archive_read_filter_ahead(filter, 3, NULL);
+	buffer = __archive_read_filter_ahead(f, 3, NULL);
 
 	if (buffer == NULL)
 		return (0);
@@ -207,49 +207,49 @@ compress_reader_vtable = {
  * Setup the callbacks.
  */
 static int
-compress_bidder_init(struct archive_read_filter *self)
+compress_bidder_init(struct archive_read_filter *f)
 {
 	struct compress *compress;
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
 
-	self->code = ARCHIVE_FILTER_COMPRESS;
-	self->name = "compress (.Z)";
+	f->code = ARCHIVE_FILTER_COMPRESS;
+	f->name = "compress (.Z)";
 
 	compress = calloc(1, sizeof(*compress));
 	out_block = malloc(out_block_size);
 	if (compress == NULL || out_block == NULL) {
 		free(out_block);
 		free(compress);
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for %s decompression",
-		    self->name);
+		    f->name);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = compress;
+	f->data = compress;
 	compress->out_block_size = out_block_size;
 	compress->out_block = out_block;
-	self->vtable = &compress_reader_vtable;
+	f->vtable = &compress_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
 static int
-compress_filter_init(struct archive_read_filter *self)
+compress_filter_init(struct archive_read_filter *f)
 {
-	struct compress *compress = self->data;
+	struct compress *compress = f->data;
 	int code;
 
 	compress->initialized = 1;
 
-	(void)getbits(self, 8); /* Skip first signature byte. */
-	(void)getbits(self, 8); /* Skip second signature byte. */
+	(void)getbits(f, 8); /* Skip first signature byte. */
+	(void)getbits(f, 8); /* Skip second signature byte. */
 
 	/* Get compression parameters. */
-	code = getbits(self, 8);
+	code = getbits(f, 8);
 	if (code < 0 || (code & 0x1f) > 16) {
-		archive_set_error(&self->archive->archive, -1,
+		archive_set_error(&f->archive->archive, -1,
 		    "Invalid compressed data");
 		return (ARCHIVE_FATAL);
 	}
@@ -269,7 +269,7 @@ compress_filter_init(struct archive_read_filter *self)
 		compress->prefix[code] = 0;
 		compress->suffix[code] = code;
 	}
-	next_code(self);
+	next_code(f);
 
 	return (ARCHIVE_OK);
 }
@@ -279,14 +279,14 @@ compress_filter_init(struct archive_read_filter *self)
  * as necessary.
  */
 static ssize_t
-compress_filter_read(struct archive_read_filter *self, const void **pblock)
+compress_filter_read(struct archive_read_filter *f, const void **pblock)
 {
-	struct compress *compress = self->data;
+	struct compress *compress = f->data;
 	unsigned char *p, *start, *end;
 	int ret;
 
 	if (!compress->initialized) {
-		ret = compress_filter_init(self);
+		ret = compress_filter_init(f);
 		if (ret != ARCHIVE_OK)
 			return (ret);
 	}
@@ -301,7 +301,7 @@ compress_filter_read(struct archive_read_filter *self, const void **pblock)
 		if (compress->stackp > compress->stack) {
 			*p++ = *--compress->stackp;
 		} else {
-			ret = next_code(self);
+			ret = next_code(f);
 			if (ret == -1)
 				compress->end_of_stream = ret;
 			else if (ret != ARCHIVE_OK)
@@ -317,9 +317,9 @@ compress_filter_read(struct archive_read_filter *self, const void **pblock)
  * Close and release the filter.
  */
 static int
-compress_filter_close(struct archive_read_filter *self)
+compress_filter_close(struct archive_read_filter *f)
 {
-	struct compress *compress = self->data;
+	struct compress *compress = f->data;
 
 	free(compress->out_block);
 	free(compress);
@@ -332,13 +332,13 @@ compress_filter_close(struct archive_read_filter *self)
  * format error, ARCHIVE_EOF if we hit end of data, ARCHIVE_OK otherwise.
  */
 static int
-next_code(struct archive_read_filter *self)
+next_code(struct archive_read_filter *f)
 {
-	struct compress *compress = self->data;
+	struct compress *compress = f->data;
 	int code, newcode;
 
 again:
-	code = newcode = getbits(self, compress->bits);
+	code = newcode = getbits(f, compress->bits);
 	if (code < 0)
 		return (code);
 
@@ -356,7 +356,7 @@ again:
 		skip_bytes %= compress->bits;
 		compress->bits_avail = 0; /* Discard rest of this byte. */
 		while (skip_bytes-- > 0) {
-			code = getbits(self, 8);
+			code = getbits(f, 8);
 			if (code < 0)
 				return (code);
 		}
@@ -372,7 +372,7 @@ again:
 	if (code > compress->free_ent
 	    || (code == compress->free_ent && compress->oldcode < 0)) {
 		/* An invalid code is a fatal error. */
-		archive_set_error(&(self->archive->archive), -1,
+		archive_set_error(&(f->archive->archive), -1,
 		    "Invalid compressed data");
 		return (ARCHIVE_FATAL);
 	}
@@ -417,9 +417,9 @@ again:
  * -1 indicates end of available data.
  */
 static int
-getbits(struct archive_read_filter *self, int n)
+getbits(struct archive_read_filter *f, int n)
 {
-	struct compress *compress = self->data;
+	struct compress *compress = f->data;
 	int code;
 	ssize_t ret;
 	static const int mask[] = {
@@ -430,12 +430,12 @@ getbits(struct archive_read_filter *self, int n)
 	while (compress->bits_avail < n) {
 		if (compress->avail_in <= 0) {
 			if (compress->consume_unnotified) {
-				__archive_read_filter_consume(self->upstream,
+				__archive_read_filter_consume(f->upstream,
 					compress->consume_unnotified);
 				compress->consume_unnotified = 0;
 			}
 			compress->next_in
-			    = __archive_read_filter_ahead(self->upstream,
+			    = __archive_read_filter_ahead(f->upstream,
 				1, &ret);
 			if (ret == 0)
 				return (-1);

--- a/libarchive/archive_read_support_filter_grzip.c
+++ b/libarchive/archive_read_support_filter_grzip.c
@@ -76,14 +76,14 @@ archive_read_support_filter_grzip(struct archive *_a)
  * Bidder just verifies the header and returns the number of verified bits.
  */
 static int
-grzip_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+grzip_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *p;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	p = __archive_read_filter_ahead(filter, sizeof(grzip_magic), NULL);
+	p = __archive_read_filter_ahead(f, sizeof(grzip_magic), NULL);
 	if (p == NULL)
 		return (0);
 
@@ -94,15 +94,15 @@ grzip_bidder_bid(struct archive_read_filter_bidder *self,
 }
 
 static int
-grzip_bidder_init(struct archive_read_filter *self)
+grzip_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "grzip -d");
+	r = __archive_read_program(f, "grzip -d");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_GRZIP;
-	self->name = "grzip";
+	f->code = ARCHIVE_FILTER_GRZIP;
+	f->name = "grzip";
 	return (r);
 }

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -274,9 +274,7 @@ gzip_bidder_init(struct archive_read_filter *self)
 static int
 gzip_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 {
-	struct private_data *state;
-
-	state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 
 	/* An mtime of 0 is considered invalid/missing. */
 	if (state->mtime != 0)
@@ -334,12 +332,10 @@ gzip_bidder_init(struct archive_read_filter *self)
 static int
 consume_header(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	ssize_t avail, max_in;
 	size_t len;
 	int ret;
-
-	state = (struct private_data *)self->data;
 
 	/* If this is a real header, consume it. */
 	len = peek_at_header(self->upstream, NULL, state);
@@ -404,10 +400,8 @@ consume_header(struct archive_read_filter *self)
 static int
 consume_trailer(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	const unsigned char *p;
-
-	state = (struct private_data *)self->data;
 
 	state->in_stream = 0;
 	switch (inflateEnd(&(state->stream))) {
@@ -436,12 +430,10 @@ consume_trailer(struct archive_read_filter *self)
 static ssize_t
 gzip_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	size_t decompressed;
 	ssize_t avail_in, max_in;
 	int ret;
-
-	state = (struct private_data *)self->data;
 
 	/* Empty our output buffer. */
 	state->stream.next_out = state->out_block;
@@ -520,10 +512,9 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 static int
 gzip_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	int ret;
 
-	state = (struct private_data *)self->data;
 	ret = ARCHIVE_OK;
 
 	if (state->in_stream) {

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -51,7 +51,7 @@
 #include "archive_read_private.h"
 
 #ifdef HAVE_ZLIB_H
-struct private_data {
+struct gzip {
 	z_stream	 stream;
 	char		 in_stream;
 	unsigned char	*out_block;
@@ -122,7 +122,7 @@ archive_read_support_filter_gzip(struct archive *_a)
 static ssize_t
 peek_at_header(struct archive_read_filter *filter, int *pbits,
 #ifdef HAVE_ZLIB_H
-	       struct private_data *state
+	       struct gzip *gzip
 #else
 	       void *state
 #endif
@@ -152,8 +152,8 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 	header_flags = p[3];
 	/* Bytes 4-7 are mod time in little endian. */
 #ifdef HAVE_ZLIB_H
-	if (state)
-		state->mtime = archive_le32dec(p + 4);
+	if (gzip)
+		gzip->mtime = archive_le32dec(p + 4);
 #endif
 	/* Byte 8 is deflate flags. */
 	/* XXXX TODO: return deflate flags back to consume_header for use
@@ -188,10 +188,10 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 		} while (p[len - 1] != 0);
 
 #ifdef HAVE_ZLIB_H
-		if (state) {
+		if (gzip) {
 			/* Reset the name in case of repeat header reads. */
-			free(state->name);
-			state->name = strdup((const char *)&p[file_start]);
+			free(gzip->name);
+			gzip->name = strdup((const char *)&p[file_start]);
 		}
 #endif
 	}
@@ -274,15 +274,15 @@ gzip_bidder_init(struct archive_read_filter *self)
 static int
 gzip_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 {
-	struct private_data *state = self->data;
+	struct gzip *gzip = self->data;
 
 	/* An mtime of 0 is considered invalid/missing. */
-	if (state->mtime != 0)
-		archive_entry_set_mtime(entry, state->mtime, 0);
+	if (gzip->mtime != 0)
+		archive_entry_set_mtime(entry, gzip->mtime, 0);
 
 	/* If the name is available, extract it. */
-	if (state->name)
-		archive_entry_set_pathname(entry, state->name);
+	if (gzip->name)
+		archive_entry_set_pathname(entry, gzip->name);
 
 	return (ARCHIVE_OK);
 }
@@ -302,29 +302,29 @@ gzip_reader_vtable = {
 static int
 gzip_bidder_init(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct gzip *gzip;
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
 
 	self->code = ARCHIVE_FILTER_GZIP;
 	self->name = "gzip";
 
-	state = calloc(1, sizeof(*state));
+	gzip = calloc(1, sizeof(*gzip));
 	out_block = malloc(out_block_size);
-	if (state == NULL || out_block == NULL) {
+	if (gzip == NULL || out_block == NULL) {
 		free(out_block);
-		free(state);
+		free(gzip);
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for gzip decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
-	state->out_block_size = out_block_size;
-	state->out_block = out_block;
+	self->data = gzip;
+	gzip->out_block_size = out_block_size;
+	gzip->out_block = out_block;
 	self->vtable = &gzip_reader_vtable;
 
-	state->in_stream = 0; /* We're not actually within a stream yet. */
+	gzip->in_stream = 0; /* We're not actually within a stream yet. */
 
 	return (ARCHIVE_OK);
 }
@@ -332,22 +332,22 @@ gzip_bidder_init(struct archive_read_filter *self)
 static int
 consume_header(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct gzip *gzip = self->data;
 	ssize_t avail, max_in;
 	size_t len;
 	int ret;
 
 	/* If this is a real header, consume it. */
-	len = peek_at_header(self->upstream, NULL, state);
+	len = peek_at_header(self->upstream, NULL, gzip);
 	if (len == 0)
 		return (ARCHIVE_EOF);
 	__archive_read_filter_consume(self->upstream, len);
 
 	/* Initialize CRC accumulator. */
-	state->crc = crc32(0L, NULL, 0);
+	gzip->crc = crc32(0L, NULL, 0);
 
 	/* Initialize compression library. */
-	state->stream.next_in = (unsigned char *)(uintptr_t)
+	gzip->stream.next_in = (unsigned char *)(uintptr_t)
 	    __archive_read_filter_ahead(self->upstream, 1, &avail);
 	if (avail < 0) {
 		archive_set_error(&self->archive->archive,
@@ -361,14 +361,14 @@ consume_header(struct archive_read_filter *self)
 		max_in = UINT_MAX;
 	if (avail > max_in)
 		avail = max_in;
-	state->stream.avail_in = (uInt)avail;
-	ret = inflateInit2(&(state->stream),
+	gzip->stream.avail_in = (uInt)avail;
+	ret = inflateInit2(&(gzip->stream),
 	    -15 /* Don't check for zlib header */);
 
 	/* Decipher the error code. */
 	switch (ret) {
 	case Z_OK:
-		state->in_stream = 1;
+		gzip->in_stream = 1;
 		return (ARCHIVE_OK);
 	case Z_STREAM_ERROR:
 		archive_set_error(&self->archive->archive,
@@ -400,11 +400,11 @@ consume_header(struct archive_read_filter *self)
 static int
 consume_trailer(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct gzip *gzip = self->data;
 	const unsigned char *p;
 
-	state->in_stream = 0;
-	switch (inflateEnd(&(state->stream))) {
+	gzip->in_stream = 0;
+	switch (inflateEnd(&(gzip->stream))) {
 	case Z_OK:
 		break;
 	default:
@@ -430,23 +430,23 @@ consume_trailer(struct archive_read_filter *self)
 static ssize_t
 gzip_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct gzip *gzip = self->data;
 	size_t decompressed;
 	ssize_t avail_in, max_in;
 	int ret;
 
 	/* Empty our output buffer. */
-	state->stream.next_out = state->out_block;
-	state->stream.avail_out = (uInt)state->out_block_size;
+	gzip->stream.next_out = gzip->out_block;
+	gzip->stream.avail_out = (uInt)gzip->out_block_size;
 
 	/* Try to fill the output buffer. */
-	while (state->stream.avail_out > 0 && !state->eof) {
+	while (gzip->stream.avail_out > 0 && !gzip->eof) {
 		/* If we're not in a stream, read a header
 		 * and initialize the decompression library. */
-		if (!state->in_stream) {
+		if (!gzip->in_stream) {
 			ret = consume_header(self);
 			if (ret == ARCHIVE_EOF) {
-				state->eof = 1;
+				gzip->eof = 1;
 				break;
 			}
 			if (ret < ARCHIVE_OK)
@@ -456,9 +456,9 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 		/* Peek at the next available data. */
 		/* ZLib treats stream.next_in as const but doesn't declare
 		 * it so, hence this ugly cast. */
-		state->stream.next_in = (unsigned char *)(uintptr_t)
+		gzip->stream.next_in = (unsigned char *)(uintptr_t)
 		    __archive_read_filter_ahead(self->upstream, 1, &avail_in);
-		if (state->stream.next_in == NULL) {
+		if (gzip->stream.next_in == NULL) {
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated gzip input");
@@ -470,18 +470,18 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 			max_in = UINT_MAX;
 		if (avail_in > max_in)
 			avail_in = max_in;
-		state->stream.avail_in = (uInt)avail_in;
+		gzip->stream.avail_in = (uInt)avail_in;
 
 		/* Decompress and consume some of that data. */
-		ret = inflate(&(state->stream), 0);
+		ret = inflate(&(gzip->stream), 0);
 		switch (ret) {
 		case Z_OK: /* Decompressor made some progress. */
 			__archive_read_filter_consume(self->upstream,
-			    avail_in - state->stream.avail_in);
+			    avail_in - gzip->stream.avail_in);
 			break;
 		case Z_STREAM_END: /* Found end of stream. */
 			__archive_read_filter_consume(self->upstream,
-			    avail_in - state->stream.avail_in);
+			    avail_in - gzip->stream.avail_in);
 			/* Consume the stream trailer; release the
 			 * decompression library. */
 			ret = consume_trailer(self);
@@ -498,11 +498,11 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 	}
 
 	/* We've read as much as we can. */
-	decompressed = state->stream.next_out - state->out_block;
+	decompressed = gzip->stream.next_out - gzip->out_block;
 	if (decompressed == 0)
 		*p = NULL;
 	else
-		*p = state->out_block;
+		*p = gzip->out_block;
 	return (decompressed);
 }
 
@@ -512,13 +512,13 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 static int
 gzip_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct gzip *gzip = self->data;
 	int ret;
 
 	ret = ARCHIVE_OK;
 
-	if (state->in_stream) {
-		switch (inflateEnd(&(state->stream))) {
+	if (gzip->in_stream) {
+		switch (inflateEnd(&(gzip->stream))) {
 		case Z_OK:
 			break;
 		default:
@@ -529,9 +529,9 @@ gzip_filter_close(struct archive_read_filter *self)
 		}
 	}
 
-	free(state->name);
-	free(state->out_block);
-	free(state);
+	free(gzip->name);
+	free(gzip->out_block);
+	free(gzip);
 	return (ret);
 }
 

--- a/libarchive/archive_read_support_filter_gzip.c
+++ b/libarchive/archive_read_support_filter_gzip.c
@@ -120,7 +120,7 @@ archive_read_support_filter_gzip(struct archive *_a)
 #define MAX_FILENAME_LENGTH (1024 * 1024L)
 #define MAX_COMMENT_LENGTH (1024 * 1024L)
 static ssize_t
-peek_at_header(struct archive_read_filter *filter, int *pbits,
+peek_at_header(struct archive_read_filter *f, int *pbits,
 #ifdef HAVE_ZLIB_H
 	       struct gzip *gzip
 #else
@@ -139,7 +139,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 	/* Start by looking at the first ten bytes of the header, which
 	 * is all fixed layout. */
 	len = 10;
-	p = __archive_read_filter_ahead(filter, len, &avail);
+	p = __archive_read_filter_ahead(f, len, &avail);
 	if (p == NULL)
 		return (0);
 	/* We only support deflation- third byte must be 0x08. */
@@ -162,7 +162,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 
 	/* Optional extra data:  2 byte length plus variable body. */
 	if (header_flags & 4) {
-		p = __archive_read_filter_ahead(filter, len + 2, &avail);
+		p = __archive_read_filter_ahead(f, len + 2, &avail);
 		if (p == NULL)
 			return (0);
 		len += archive_le16dec(p + len);
@@ -180,7 +180,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 				if (avail > MAX_FILENAME_LENGTH) {
 					return (0);
 				}
-				p = __archive_read_filter_ahead(filter,
+				p = __archive_read_filter_ahead(f,
 				    len, &avail);
 			}
 			if (p == NULL)
@@ -204,7 +204,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 				if (avail > MAX_COMMENT_LENGTH) {
 					return (0);
 				}
-				p = __archive_read_filter_ahead(filter,
+				p = __archive_read_filter_ahead(f,
 				    len, &avail);
 			}
 			if (p == NULL)
@@ -214,7 +214,7 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
 
 	/* Optional header CRC */
 	if ((header_flags & 2)) {
-		p = __archive_read_filter_ahead(filter, len + 2, &avail);
+		p = __archive_read_filter_ahead(f, len + 2, &avail);
 		if (p == NULL)
 			return (0);
 #if 0
@@ -236,14 +236,14 @@ peek_at_header(struct archive_read_filter *filter, int *pbits,
  * Bidder just verifies the header and returns the number of verified bits.
  */
 static int
-gzip_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+gzip_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	int bits_checked;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	if (peek_at_header(filter, &bits_checked, NULL))
+	if (peek_at_header(f, &bits_checked, NULL))
 		return (bits_checked);
 	return (0);
 }
@@ -256,25 +256,25 @@ gzip_bidder_bid(struct archive_read_filter_bidder *self,
  * in case that's available.
  */
 static int
-gzip_bidder_init(struct archive_read_filter *self)
+gzip_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "gzip -d");
+	r = __archive_read_program(f, "gzip -d");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_GZIP;
-	self->name = "gzip";
+	f->code = ARCHIVE_FILTER_GZIP;
+	f->name = "gzip";
 	return (r);
 }
 
 #else
 
 static int
-gzip_read_header(struct archive_read_filter *self, struct archive_entry *entry)
+gzip_read_header(struct archive_read_filter *f, struct archive_entry *entry)
 {
-	struct gzip *gzip = self->data;
+	struct gzip *gzip = f->data;
 
 	/* An mtime of 0 is considered invalid/missing. */
 	if (gzip->mtime != 0)
@@ -300,29 +300,29 @@ gzip_reader_vtable = {
  * Initialize the filter object.
  */
 static int
-gzip_bidder_init(struct archive_read_filter *self)
+gzip_bidder_init(struct archive_read_filter *f)
 {
 	struct gzip *gzip;
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
 
-	self->code = ARCHIVE_FILTER_GZIP;
-	self->name = "gzip";
+	f->code = ARCHIVE_FILTER_GZIP;
+	f->name = "gzip";
 
 	gzip = calloc(1, sizeof(*gzip));
 	out_block = malloc(out_block_size);
 	if (gzip == NULL || out_block == NULL) {
 		free(out_block);
 		free(gzip);
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for gzip decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = gzip;
+	f->data = gzip;
 	gzip->out_block_size = out_block_size;
 	gzip->out_block = out_block;
-	self->vtable = &gzip_reader_vtable;
+	f->vtable = &gzip_reader_vtable;
 
 	gzip->in_stream = 0; /* We're not actually within a stream yet. */
 
@@ -330,27 +330,27 @@ gzip_bidder_init(struct archive_read_filter *self)
 }
 
 static int
-consume_header(struct archive_read_filter *self)
+consume_header(struct archive_read_filter *f)
 {
-	struct gzip *gzip = self->data;
+	struct gzip *gzip = f->data;
 	ssize_t avail, max_in;
 	size_t len;
 	int ret;
 
 	/* If this is a real header, consume it. */
-	len = peek_at_header(self->upstream, NULL, gzip);
+	len = peek_at_header(f->upstream, NULL, gzip);
 	if (len == 0)
 		return (ARCHIVE_EOF);
-	__archive_read_filter_consume(self->upstream, len);
+	__archive_read_filter_consume(f->upstream, len);
 
 	/* Initialize CRC accumulator. */
 	gzip->crc = crc32(0L, NULL, 0);
 
 	/* Initialize compression library. */
 	gzip->stream.next_in = (unsigned char *)(uintptr_t)
-	    __archive_read_filter_ahead(self->upstream, 1, &avail);
+	    __archive_read_filter_ahead(f->upstream, 1, &avail);
 	if (avail < 0) {
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Failed to read gzip input");
 		return (ARCHIVE_FATAL);
@@ -371,24 +371,24 @@ consume_header(struct archive_read_filter *self)
 		gzip->in_stream = 1;
 		return (ARCHIVE_OK);
 	case Z_STREAM_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Internal error initializing compression library: "
 		    "invalid setup parameter");
 		break;
 	case Z_MEM_ERROR:
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Internal error initializing compression library: "
 		    "out of memory");
 		break;
 	case Z_VERSION_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Internal error initializing compression library: "
 		    "invalid library version");
 		break;
 	default:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Internal error initializing compression library: "
 		    " Zlib error %d", ret);
@@ -398,9 +398,9 @@ consume_header(struct archive_read_filter *self)
 }
 
 static int
-consume_trailer(struct archive_read_filter *self)
+consume_trailer(struct archive_read_filter *f)
 {
-	struct gzip *gzip = self->data;
+	struct gzip *gzip = f->data;
 	const unsigned char *p;
 
 	gzip->in_stream = 0;
@@ -408,29 +408,29 @@ consume_trailer(struct archive_read_filter *self)
 	case Z_OK:
 		break;
 	default:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Failed to clean up gzip decompressor");
 		return (ARCHIVE_FATAL);
 	}
 
 	/* GZip trailer is a fixed 8 byte structure. */
-	p = __archive_read_filter_ahead(self->upstream, 8, NULL);
+	p = __archive_read_filter_ahead(f->upstream, 8, NULL);
 	if (p == NULL)
 		return (ARCHIVE_FATAL);
 
 	/* XXX TODO: Verify the length and CRC. */
 
 	/* We've verified the trailer, so consume it now. */
-	__archive_read_filter_consume(self->upstream, 8);
+	__archive_read_filter_consume(f->upstream, 8);
 
 	return (ARCHIVE_OK);
 }
 
 static ssize_t
-gzip_filter_read(struct archive_read_filter *self, const void **p)
+gzip_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct gzip *gzip = self->data;
+	struct gzip *gzip = f->data;
 	size_t decompressed;
 	ssize_t avail_in, max_in;
 	int ret;
@@ -444,7 +444,7 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 		/* If we're not in a stream, read a header
 		 * and initialize the decompression library. */
 		if (!gzip->in_stream) {
-			ret = consume_header(self);
+			ret = consume_header(f);
 			if (ret == ARCHIVE_EOF) {
 				gzip->eof = 1;
 				break;
@@ -457,9 +457,9 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 		/* ZLib treats stream.next_in as const but doesn't declare
 		 * it so, hence this ugly cast. */
 		gzip->stream.next_in = (unsigned char *)(uintptr_t)
-		    __archive_read_filter_ahead(self->upstream, 1, &avail_in);
+		    __archive_read_filter_ahead(f->upstream, 1, &avail_in);
 		if (gzip->stream.next_in == NULL) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated gzip input");
 			return (ARCHIVE_FATAL);
@@ -476,21 +476,21 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
 		ret = inflate(&(gzip->stream), 0);
 		switch (ret) {
 		case Z_OK: /* Decompressor made some progress. */
-			__archive_read_filter_consume(self->upstream,
+			__archive_read_filter_consume(f->upstream,
 			    avail_in - gzip->stream.avail_in);
 			break;
 		case Z_STREAM_END: /* Found end of stream. */
-			__archive_read_filter_consume(self->upstream,
+			__archive_read_filter_consume(f->upstream,
 			    avail_in - gzip->stream.avail_in);
 			/* Consume the stream trailer; release the
 			 * decompression library. */
-			ret = consume_trailer(self);
+			ret = consume_trailer(f);
 			if (ret < ARCHIVE_OK)
 				return (ret);
 			break;
 		default:
 			/* Return an error. */
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "gzip decompression failed");
 			return (ARCHIVE_FATAL);
@@ -510,9 +510,9 @@ gzip_filter_read(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-gzip_filter_close(struct archive_read_filter *self)
+gzip_filter_close(struct archive_read_filter *f)
 {
-	struct gzip *gzip = self->data;
+	struct gzip *gzip = f->data;
 	int ret;
 
 	ret = ARCHIVE_OK;
@@ -522,7 +522,7 @@ gzip_filter_close(struct archive_read_filter *self)
 		case Z_OK:
 			break;
 		default:
-			archive_set_error(&(self->archive->archive),
+			archive_set_error(&(f->archive->archive),
 			    ARCHIVE_ERRNO_MISC,
 			    "Failed to clean up gzip compressor");
 			ret = ARCHIVE_FATAL;

--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -75,18 +75,18 @@ archive_read_support_filter_lrzip(struct archive *_a)
  * Bidder just verifies the header and returns the number of verified bits.
  */
 static int
-lrzip_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+lrzip_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *p;
 	ssize_t len;
 	int i;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 	/* Start by looking at the first six bytes of the header, which
 	 * is all fixed layout. */
 	len = 6;
-	p = __archive_read_filter_ahead(filter, len, NULL);
+	p = __archive_read_filter_ahead(f, len, NULL);
 	if (p == NULL)
 		return (0);
 
@@ -105,15 +105,15 @@ lrzip_bidder_bid(struct archive_read_filter_bidder *self,
 }
 
 static int
-lrzip_bidder_init(struct archive_read_filter *self)
+lrzip_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "lrzip -d -q");
+	r = __archive_read_program(f, "lrzip -d -q");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_LRZIP;
-	self->name = "lrzip";
+	f->code = ARCHIVE_FILTER_LRZIP;
+	f->name = "lrzip";
 	return (r);
 }

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -139,8 +139,8 @@ archive_read_support_filter_lz4(struct archive *_a)
  * from verifying as much as we would like.
  */
 static int
-lz4_reader_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+lz4_reader_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	ssize_t avail;
@@ -159,7 +159,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 	const size_t max_lookahead = 64 * 1024;
 	uint32_t magic_number;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
 	/*
 	 * Zstd and LZ4 skippable frame magic numbers are identical. To
@@ -168,7 +168,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 	 */
 
 	/* Minimal lz4 archive is 11 bytes. */
-	buffer = __archive_read_filter_ahead(filter, min_lz4_archive_size,
+	buffer = __archive_read_filter_ahead(f, min_lz4_archive_size,
 	    &avail);
 	if (buffer == NULL)
 		return (0);
@@ -184,7 +184,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 
 		/* Ensure that we can read another 4 bytes. */
 		if (offset_in_buffer + 4 > (size_t)avail) {
-			buffer = __archive_read_filter_ahead(filter,
+			buffer = __archive_read_filter_ahead(f,
 			    offset_in_buffer + 4, &avail);
 			if (buffer == NULL)
 				return (0);
@@ -212,7 +212,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
 			if (min > max_lookahead)
 				return (0); 
 
-			buffer = __archive_read_filter_ahead(filter,
+			buffer = __archive_read_filter_ahead(f,
 			    min, &avail);
 			if (buffer == NULL)
 				return (0); 
@@ -271,16 +271,16 @@ lz4_reader_bid(struct archive_read_filter_bidder *self,
  * in case that's available.
  */
 static int
-lz4_reader_init(struct archive_read_filter *self)
+lz4_reader_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "lz4 -d -q");
+	r = __archive_read_program(f, "lz4 -d -q");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_LZ4;
-	self->name = "lz4";
+	f->code = ARCHIVE_FILTER_LZ4;
+	f->name = "lz4";
 	return (r);
 }
 
@@ -297,31 +297,31 @@ lz4_reader_vtable = {
  * Setup the callbacks.
  */
 static int
-lz4_reader_init(struct archive_read_filter *self)
+lz4_reader_init(struct archive_read_filter *f)
 {
 	struct lz4 *lz4;
 
-	self->code = ARCHIVE_FILTER_LZ4;
-	self->name = "lz4";
+	f->code = ARCHIVE_FILTER_LZ4;
+	f->name = "lz4";
 
 	lz4 = calloc(1, sizeof(*lz4));
 	if (lz4 == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for lz4 decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = lz4;
+	f->data = lz4;
 	lz4->stage = SELECT_STREAM;
-	self->vtable = &lz4_reader_vtable;
+	f->vtable = &lz4_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
 static int
-lz4_allocate_out_block(struct archive_read_filter *self)
+lz4_allocate_out_block(struct archive_read_filter *f)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	size_t out_block_size = lz4->flags.block_maximum_size;
 	void *out_block;
 
@@ -333,7 +333,7 @@ lz4_allocate_out_block(struct archive_read_filter *self)
 		out_block = malloc(out_block_size);
 		if (out_block == NULL) {
 			lz4->out_block_size = 0;
-			archive_set_error(&self->archive->archive, ENOMEM,
+			archive_set_error(&f->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
@@ -346,9 +346,9 @@ lz4_allocate_out_block(struct archive_read_filter *self)
 }
 
 static int
-lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
+lz4_allocate_out_block_for_legacy(struct archive_read_filter *f)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	size_t out_block_size = LEGACY_BLOCK_SIZE;
 	void *out_block;
 
@@ -358,7 +358,7 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 		out_block = malloc(out_block_size);
 		if (out_block == NULL) {
 			lz4->out_block_size = 0;
-			archive_set_error(&self->archive->archive, ENOMEM,
+			archive_set_error(&f->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
@@ -372,9 +372,9 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
  * Return the next block of decompressed data.
  */
 static ssize_t
-lz4_filter_read(struct archive_read_filter *self, const void **p)
+lz4_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	ssize_t ret;
 
 	if (lz4->eof) {
@@ -382,7 +382,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 		return (0);
 	}
 
-	__archive_read_filter_consume(self->upstream, lz4->unconsumed);
+	__archive_read_filter_consume(f->upstream, lz4->unconsumed);
 	lz4->unconsumed = 0;
 
 	switch (lz4->stage) {
@@ -391,21 +391,21 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 	case READ_DEFAULT_STREAM:
 	case READ_LEGACY_STREAM:
 		/* Reading an lz4 stream already failed. */
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Invalid sequence");
 		return (ARCHIVE_FATAL);
 	case READ_DEFAULT_BLOCK:
-		ret = lz4_filter_read_default_stream(self, p);
+		ret = lz4_filter_read_default_stream(f, p);
 		if (ret != 0 || lz4->stage != SELECT_STREAM)
 			return ret;
 		break;
 	case READ_LEGACY_BLOCK:
-		ret = lz4_filter_read_legacy_stream(self, p);
+		ret = lz4_filter_read_legacy_stream(f, p);
 		if (ret != 0 || lz4->stage != SELECT_STREAM)
 			return ret;
 		break;
 	default:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Program error");
 		return (ARCHIVE_FATAL);
 	}
@@ -414,7 +414,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 		const char *read_buf;
 
 		/* Read a magic number. */
-		read_buf = __archive_read_filter_ahead(self->upstream, 4,
+		read_buf = __archive_read_filter_ahead(f->upstream, 4,
 				NULL);
 		if (read_buf == NULL) {
 			lz4->eof = 1;
@@ -422,26 +422,26 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 			return (0);
 		}
 		uint32_t number = archive_le32dec(read_buf);
-		__archive_read_filter_consume(self->upstream, 4);
+		__archive_read_filter_consume(f->upstream, 4);
 		if (number == LZ4_MAGICNUMBER)
-			return lz4_filter_read_default_stream(self, p);
+			return lz4_filter_read_default_stream(f, p);
 		else if (number == LZ4_LEGACY)
-			return lz4_filter_read_legacy_stream(self, p);
+			return lz4_filter_read_legacy_stream(f, p);
 		else if ((number & LZ4_SKIPPABLE_MASK) == LZ4_SKIPPABLE_START) {
 			read_buf = __archive_read_filter_ahead(
-				self->upstream, 4, NULL);
+				f->upstream, 4, NULL);
 			if (read_buf == NULL) {
 				archive_set_error(
-				    &self->archive->archive,
+				    &f->archive->archive,
 		    		    ARCHIVE_ERRNO_MISC,
 				    "Malformed lz4 data");
 				return (ARCHIVE_FATAL);
 			}
 			int64_t skip_bytes = archive_le32dec(read_buf);
-			if (__archive_read_filter_consume(self->upstream,
+			if (__archive_read_filter_consume(f->upstream,
 			    4 + skip_bytes) < 0) {
 				archive_set_error(
-				    &self->archive->archive,
+				    &f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Malformed lz4 data");
 				return (ARCHIVE_FATAL);
@@ -459,9 +459,9 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 }
 
 static int
-lz4_filter_read_descriptor(struct archive_read_filter *self)
+lz4_filter_read_descriptor(struct archive_read_filter *f)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	const char *read_buf;
 	ssize_t bytes_remaining;
 	ssize_t descriptor_bytes;
@@ -469,10 +469,10 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	unsigned int chsum, chsum_verifier;
 
 	/* Make sure we have 2 bytes for flags. */
-	read_buf = __archive_read_filter_ahead(self->upstream, 2,
+	read_buf = __archive_read_filter_ahead(f->upstream, 2,
 	    &bytes_remaining);
 	if (read_buf == NULL) {
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "truncated lz4 input");
 		return (ARCHIVE_FATAL);
@@ -524,10 +524,10 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	if (lz4->flags.preset_dictionary)
 		descriptor_bytes += 4;
 	if (bytes_remaining < descriptor_bytes) {
-		read_buf = __archive_read_filter_ahead(self->upstream,
+		read_buf = __archive_read_filter_ahead(f->upstream,
 		    descriptor_bytes, &bytes_remaining);
 		if (read_buf == NULL) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated lz4 input");
 			return (ARCHIVE_FATAL);
@@ -542,10 +542,10 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 		goto malformed_error;
 #endif
 
-	__archive_read_filter_consume(self->upstream, descriptor_bytes);
+	__archive_read_filter_consume(f->upstream, descriptor_bytes);
 
 	/* Make sure we have a large enough buffer for uncompressed data. */
-	if (lz4_allocate_out_block(self) != ARCHIVE_OK)
+	if (lz4_allocate_out_block(f) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
 	if (lz4->flags.stream_checksum) {
 		lz4->xxh32_state = __archive_xxhash.XXH32_init(0);
@@ -557,15 +557,15 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	/* Success */
 	return (ARCHIVE_OK);
 malformed_error:
-	archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 	    "malformed lz4 data");
 	return (ARCHIVE_FATAL);
 }
 
 static ssize_t
-lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
+lz4_filter_read_data_block(struct archive_read_filter *f, const void **p)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	ssize_t compressed_size;
 	const char *read_buf;
 	int checksum_size;
@@ -575,7 +575,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	*p = NULL;
 
 	/* Make sure we have 4 bytes for a block size. */
-	read_buf = __archive_read_filter_ahead(self->upstream, 4, NULL);
+	read_buf = __archive_read_filter_ahead(f->upstream, 4, NULL);
 	if (read_buf == NULL)
 		goto truncated_error;
 	compressed_size = archive_le32dec(read_buf);
@@ -583,7 +583,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 		goto malformed_error;
 	/* A compressed size == 0 means the end of stream blocks. */
 	if (compressed_size == 0) {
-		__archive_read_filter_consume(self->upstream, 4);
+		__archive_read_filter_consume(f->upstream, 4);
 		return 0;
 	}
 
@@ -600,7 +600,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	  for its decompression speed, so we read a whole block and allocate
 	  a huge buffer used for decoded data.
 	*/
-	read_buf = __archive_read_filter_ahead(self->upstream,
+	read_buf = __archive_read_filter_ahead(f->upstream,
 	    4 + compressed_size + checksum_size, NULL);
 	if (read_buf == NULL)
 		goto truncated_error;
@@ -684,7 +684,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 
 	/* Check if an error occurred in the decompression process. */
 	if (uncompressed_size < 0) {
-		archive_set_error(&(self->archive->archive),
+		archive_set_error(&(f->archive->archive),
 		    ARCHIVE_ERRNO_MISC, "lz4 decompression failed");
 		return (ARCHIVE_FATAL);
 	}
@@ -695,31 +695,31 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	return uncompressed_size;
 
 malformed_error:
-	archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 	    "malformed lz4 data");
 	return (ARCHIVE_FATAL);
 truncated_error:
-	archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 	    "truncated lz4 input");
 	return (ARCHIVE_FATAL);
 }
 
 static ssize_t
-lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
+lz4_filter_read_default_stream(struct archive_read_filter *f, const void **p)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	const char *read_buf;
 	ssize_t ret;
 
 	if (lz4->stage == SELECT_STREAM) {
 		lz4->stage = READ_DEFAULT_STREAM;
 		/* First, read a descriptor. */
-		if((ret = lz4_filter_read_descriptor(self)) != ARCHIVE_OK)
+		if((ret = lz4_filter_read_descriptor(f)) != ARCHIVE_OK)
 			return (ret);
 		lz4->stage = READ_DEFAULT_BLOCK;
 	}
 	/* Decompress a block. */
-	ret = lz4_filter_read_data_block(self, p);
+	ret = lz4_filter_read_data_block(f, p);
 
 	/* If the end of block is detected, change the filter status
 	   to read next stream. */
@@ -731,21 +731,21 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 		if (lz4->stage == SELECT_STREAM) {
 			unsigned int checksum;
 			unsigned int checksum_stream;
-			read_buf = __archive_read_filter_ahead(self->upstream,
+			read_buf = __archive_read_filter_ahead(f->upstream,
 			    4, NULL);
 			if (read_buf == NULL) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC, "truncated lz4 input");
 				return (ARCHIVE_FATAL);
 			}
 			checksum = archive_le32dec(read_buf);
-			__archive_read_filter_consume(self->upstream, 4);
+			__archive_read_filter_consume(f->upstream, 4);
 			checksum_stream = __archive_xxhash.XXH32_digest(
 			    lz4->xxh32_state);
 			lz4->xxh32_state = NULL;
 			if (checksum != checksum_stream) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "lz4 stream checksum error");
 				return (ARCHIVE_FATAL);
@@ -759,24 +759,24 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 }
 
 static ssize_t
-lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
+lz4_filter_read_legacy_stream(struct archive_read_filter *f, const void **p)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	uint32_t compressed;
 	const char *read_buf;
 	ssize_t ret;
 
 	*p = NULL;
-	ret = lz4_allocate_out_block_for_legacy(self);
+	ret = lz4_allocate_out_block_for_legacy(f);
 	if (ret != ARCHIVE_OK)
 		return ret;
 
 	/* Make sure we have 4 bytes for a block size. */
-	read_buf = __archive_read_filter_ahead(self->upstream, 4, NULL);
+	read_buf = __archive_read_filter_ahead(f->upstream, 4, NULL);
 	if (read_buf == NULL) {
 		if (lz4->stage == SELECT_STREAM) {
 			lz4->stage = READ_LEGACY_STREAM;
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated lz4 input");
 			return (ARCHIVE_FATAL);
@@ -792,17 +792,17 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 	}
 
 	/* Make sure we have a whole block. */
-	read_buf = __archive_read_filter_ahead(self->upstream,
+	read_buf = __archive_read_filter_ahead(f->upstream,
 	    4 + compressed, NULL);
 	if (read_buf == NULL) {
-		archive_set_error(&(self->archive->archive),
+		archive_set_error(&(f->archive->archive),
 		    ARCHIVE_ERRNO_MISC, "truncated lz4 input");
 		return (ARCHIVE_FATAL);
 	}
 	ret = LZ4_decompress_safe(read_buf + 4, lz4->out_block,
 	    compressed, (int)lz4->out_block_size);
 	if (ret < 0) {
-		archive_set_error(&(self->archive->archive),
+		archive_set_error(&(f->archive->archive),
 		    ARCHIVE_ERRNO_MISC, "lz4 decompression failed");
 		return (ARCHIVE_FATAL);
 	}
@@ -815,9 +815,9 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-lz4_filter_close(struct archive_read_filter *self)
+lz4_filter_close(struct archive_read_filter *f)
 {
-	struct lz4 *lz4 = self->data;
+	struct lz4 *lz4 = f->data;
 	int ret = ARCHIVE_OK;
 
 	free(lz4->xxh32_state);

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -321,7 +321,7 @@ lz4_reader_init(struct archive_read_filter *self)
 static int
 lz4_allocate_out_block(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	size_t out_block_size = state->flags.block_maximum_size;
 	void *out_block;
 
@@ -348,7 +348,7 @@ lz4_allocate_out_block(struct archive_read_filter *self)
 static int
 lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	size_t out_block_size = LEGACY_BLOCK_SIZE;
 	void *out_block;
 
@@ -374,7 +374,7 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 static ssize_t
 lz4_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	ssize_t ret;
 
 	if (state->eof) {
@@ -461,7 +461,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 static int
 lz4_filter_read_descriptor(struct archive_read_filter *self)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	const char *read_buf;
 	ssize_t bytes_remaining;
 	ssize_t descriptor_bytes;
@@ -565,7 +565,7 @@ malformed_error:
 static ssize_t
 lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	ssize_t compressed_size;
 	const char *read_buf;
 	int checksum_size;
@@ -707,7 +707,7 @@ truncated_error:
 static ssize_t
 lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	const char *read_buf;
 	ssize_t ret;
 
@@ -761,7 +761,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 static ssize_t
 lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 	uint32_t compressed;
 	const char *read_buf;
 	ssize_t ret;
@@ -817,10 +817,9 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 static int
 lz4_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	int ret = ARCHIVE_OK;
 
-	state = (struct private_data *)self->data;
 	free(state->xxh32_state);
 	free(state->out_block);
 	free(state);

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -57,7 +57,7 @@
 #define LZ4_SKIPPABLE_MASK 0xFFFFFFF0
 
 #if defined(HAVE_LIBLZ4)
-struct private_data {
+struct lz4 {
 	enum {  SELECT_STREAM,
 		READ_DEFAULT_STREAM,
 		READ_DEFAULT_BLOCK,
@@ -299,20 +299,20 @@ lz4_reader_vtable = {
 static int
 lz4_reader_init(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct lz4 *lz4;
 
 	self->code = ARCHIVE_FILTER_LZ4;
 	self->name = "lz4";
 
-	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
+	lz4 = calloc(1, sizeof(*lz4));
+	if (lz4 == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for lz4 decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
-	state->stage = SELECT_STREAM;
+	self->data = lz4;
+	lz4->stage = SELECT_STREAM;
 	self->vtable = &lz4_reader_vtable;
 
 	return (ARCHIVE_OK);
@@ -321,49 +321,49 @@ lz4_reader_init(struct archive_read_filter *self)
 static int
 lz4_allocate_out_block(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
-	size_t out_block_size = state->flags.block_maximum_size;
+	struct lz4 *lz4 = self->data;
+	size_t out_block_size = lz4->flags.block_maximum_size;
 	void *out_block;
 
-	if (!state->flags.block_independence)
+	if (!lz4->flags.block_independence)
 		out_block_size += 64 * 1024;
-	if (state->out_block_size < out_block_size) {
-		free(state->out_block);
-		state->out_block = NULL;
+	if (lz4->out_block_size < out_block_size) {
+		free(lz4->out_block);
+		lz4->out_block = NULL;
 		out_block = malloc(out_block_size);
 		if (out_block == NULL) {
-			state->out_block_size = 0;
+			lz4->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
-		state->out_block_size = out_block_size;
-		state->out_block = out_block;
+		lz4->out_block_size = out_block_size;
+		lz4->out_block = out_block;
 	}
-	if (!state->flags.block_independence)
-		memset(state->out_block, 0, 64 * 1024);
+	if (!lz4->flags.block_independence)
+		memset(lz4->out_block, 0, 64 * 1024);
 	return (ARCHIVE_OK);
 }
 
 static int
 lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	size_t out_block_size = LEGACY_BLOCK_SIZE;
 	void *out_block;
 
-	if (state->out_block_size < out_block_size) {
-		free(state->out_block);
-		state->out_block = NULL;
+	if (lz4->out_block_size < out_block_size) {
+		free(lz4->out_block);
+		lz4->out_block = NULL;
 		out_block = malloc(out_block_size);
 		if (out_block == NULL) {
-			state->out_block_size = 0;
+			lz4->out_block_size = 0;
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lz4 decompression");
 			return (ARCHIVE_FATAL);
 		}
-		state->out_block_size = out_block_size;
-		state->out_block = out_block;
+		lz4->out_block_size = out_block_size;
+		lz4->out_block = out_block;
 	}
 	return (ARCHIVE_OK);
 }
@@ -374,18 +374,18 @@ lz4_allocate_out_block_for_legacy(struct archive_read_filter *self)
 static ssize_t
 lz4_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	ssize_t ret;
 
-	if (state->eof) {
+	if (lz4->eof) {
 		*p = NULL;
 		return (0);
 	}
 
-	__archive_read_filter_consume(self->upstream, state->unconsumed);
-	state->unconsumed = 0;
+	__archive_read_filter_consume(self->upstream, lz4->unconsumed);
+	lz4->unconsumed = 0;
 
-	switch (state->stage) {
+	switch (lz4->stage) {
 	case SELECT_STREAM:
 		break;
 	case READ_DEFAULT_STREAM:
@@ -396,12 +396,12 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 		return (ARCHIVE_FATAL);
 	case READ_DEFAULT_BLOCK:
 		ret = lz4_filter_read_default_stream(self, p);
-		if (ret != 0 || state->stage != SELECT_STREAM)
+		if (ret != 0 || lz4->stage != SELECT_STREAM)
 			return ret;
 		break;
 	case READ_LEGACY_BLOCK:
 		ret = lz4_filter_read_legacy_stream(self, p);
-		if (ret != 0 || state->stage != SELECT_STREAM)
+		if (ret != 0 || lz4->stage != SELECT_STREAM)
 			return ret;
 		break;
 	default:
@@ -410,14 +410,14 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 		return (ARCHIVE_FATAL);
 	}
 
-	while (state->stage == SELECT_STREAM) {
+	while (lz4->stage == SELECT_STREAM) {
 		const char *read_buf;
 
 		/* Read a magic number. */
 		read_buf = __archive_read_filter_ahead(self->upstream, 4,
 				NULL);
 		if (read_buf == NULL) {
-			state->eof = 1;
+			lz4->eof = 1;
 			*p = NULL;
 			return (0);
 		}
@@ -448,12 +448,12 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 			}
 		} else {
 			/* Ignore following unrecognized data. */
-			state->eof = 1;
+			lz4->eof = 1;
 			*p = NULL;
 			return (0);
 		}
 	}
-	state->eof = 1;
+	lz4->eof = 1;
 	*p = NULL;
 	return (0);
 }
@@ -461,7 +461,7 @@ lz4_filter_read(struct archive_read_filter *self, const void **p)
 static int
 lz4_filter_read_descriptor(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	const char *read_buf;
 	ssize_t bytes_remaining;
 	ssize_t descriptor_bytes;
@@ -488,11 +488,11 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	/* A reserved bit must be zero. */
 	if (flag & 0x02)
 		goto malformed_error;
-	state->flags.block_independence = (flag & 0x20) != 0;
-	state->flags.block_checksum = (flag & 0x10)?4:0;
-	state->flags.stream_size = (flag & 0x08) != 0;
-	state->flags.stream_checksum = (flag & 0x04) != 0;
-	state->flags.preset_dictionary = (flag & 0x01) != 0;
+	lz4->flags.block_independence = (flag & 0x20) != 0;
+	lz4->flags.block_checksum = (flag & 0x10)?4:0;
+	lz4->flags.stream_size = (flag & 0x08) != 0;
+	lz4->flags.stream_checksum = (flag & 0x04) != 0;
+	lz4->flags.preset_dictionary = (flag & 0x01) != 0;
 
 	/* BD */
 	bd = (unsigned char)read_buf[1];
@@ -502,16 +502,16 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	/* Get a maximum block size. */
 	switch (read_buf[1] >> 4) {
 	case 4: /* 64 KB */
-		state->flags.block_maximum_size = 64 * 1024;
+		lz4->flags.block_maximum_size = 64 * 1024;
 		break;
 	case 5: /* 256 KB */
-		state->flags.block_maximum_size = 256 * 1024;
+		lz4->flags.block_maximum_size = 256 * 1024;
 		break;
 	case 6: /* 1 MB */
-		state->flags.block_maximum_size = 1024 * 1024;
+		lz4->flags.block_maximum_size = 1024 * 1024;
 		break;
 	case 7: /* 4 MB */
-		state->flags.block_maximum_size = 4 * 1024 * 1024;
+		lz4->flags.block_maximum_size = 4 * 1024 * 1024;
 		break;
 	default:
 		goto malformed_error;
@@ -519,9 +519,9 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 
 	/* Read the whole descriptor in a stream block. */
 	descriptor_bytes = 3;
-	if (state->flags.stream_size)
+	if (lz4->flags.stream_size)
 		descriptor_bytes += 8;
-	if (state->flags.preset_dictionary)
+	if (lz4->flags.preset_dictionary)
 		descriptor_bytes += 4;
 	if (bytes_remaining < descriptor_bytes) {
 		read_buf = __archive_read_filter_ahead(self->upstream,
@@ -547,13 +547,13 @@ lz4_filter_read_descriptor(struct archive_read_filter *self)
 	/* Make sure we have a large enough buffer for uncompressed data. */
 	if (lz4_allocate_out_block(self) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
-	if (state->flags.stream_checksum) {
-		state->xxh32_state = __archive_xxhash.XXH32_init(0);
-		if (state->xxh32_state == NULL)
+	if (lz4->flags.stream_checksum) {
+		lz4->xxh32_state = __archive_xxhash.XXH32_init(0);
+		if (lz4->xxh32_state == NULL)
 			return (ARCHIVE_FATAL);
 	}
 
-	state->decoded_size = 0;
+	lz4->decoded_size = 0;
 	/* Success */
 	return (ARCHIVE_OK);
 malformed_error:
@@ -565,7 +565,7 @@ malformed_error:
 static ssize_t
 lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	ssize_t compressed_size;
 	const char *read_buf;
 	int checksum_size;
@@ -579,7 +579,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	if (read_buf == NULL)
 		goto truncated_error;
 	compressed_size = archive_le32dec(read_buf);
-	if ((compressed_size & 0x7fffffff) > state->flags.block_maximum_size)
+	if ((compressed_size & 0x7fffffff) > lz4->flags.block_maximum_size)
 		goto malformed_error;
 	/* A compressed size == 0 means the end of stream blocks. */
 	if (compressed_size == 0) {
@@ -587,7 +587,7 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 		return 0;
 	}
 
-	checksum_size = state->flags.block_checksum;
+	checksum_size = lz4->flags.block_checksum;
 	/* Check if the block is uncompressed. */
 	if (compressed_size & 0x80000000U) {
 		compressed_size &= 0x7fffffff;
@@ -621,24 +621,24 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	/* If the block is uncompressed, there is nothing to do. */
 	if (uncompressed_size) {
 		/* Prepare a prefix 64k block for next block. */
-		if (!state->flags.block_independence) {
+		if (!lz4->flags.block_independence) {
 			prefix64k = 64 * 1024;
 			if (uncompressed_size < (ssize_t)prefix64k) {
-				memcpy(state->out_block
+				memcpy(lz4->out_block
 					+ prefix64k - uncompressed_size,
 				    read_buf + 4,
 				    uncompressed_size);
-				memset(state->out_block, 0,
+				memset(lz4->out_block, 0,
 				    prefix64k - uncompressed_size);
 			} else {
-				memcpy(state->out_block,
+				memcpy(lz4->out_block,
 				    read_buf + 4
 					+ uncompressed_size - prefix64k,
 				    prefix64k);
 			}
-			state->decoded_size = 0;
+			lz4->decoded_size = 0;
 		}
-		state->unconsumed = 4 + uncompressed_size + checksum_size;
+		lz4->unconsumed = 4 + uncompressed_size + checksum_size;
 		*p = read_buf + 4;
 		return uncompressed_size;
 	}
@@ -646,39 +646,39 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 	/*
 	   Decompress a block data.
 	 */
-	if (state->flags.block_independence) {
+	if (lz4->flags.block_independence) {
 		prefix64k = 0;
 		uncompressed_size = LZ4_decompress_safe(read_buf + 4,
-		    state->out_block, (int)compressed_size,
-		    state->flags.block_maximum_size);
+		    lz4->out_block, (int)compressed_size,
+		    lz4->flags.block_maximum_size);
 	} else {
 		prefix64k = 64 * 1024;
-		if (state->decoded_size) {
-			if (state->decoded_size < prefix64k) {
-				memmove(state->out_block
-					+ prefix64k - state->decoded_size,
-				    state->out_block + prefix64k,
-				    state->decoded_size);
-				memset(state->out_block, 0,
-				    prefix64k - state->decoded_size);
+		if (lz4->decoded_size) {
+			if (lz4->decoded_size < prefix64k) {
+				memmove(lz4->out_block
+					+ prefix64k - lz4->decoded_size,
+				    lz4->out_block + prefix64k,
+				    lz4->decoded_size);
+				memset(lz4->out_block, 0,
+				    prefix64k - lz4->decoded_size);
 			} else {
-				memmove(state->out_block,
-				    state->out_block + state->decoded_size,
+				memmove(lz4->out_block,
+				    lz4->out_block + lz4->decoded_size,
 				    prefix64k);
 			}
 		}
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		uncompressed_size = LZ4_decompress_safe_usingDict(
 		    read_buf + 4,
-		    state->out_block + prefix64k, (int)compressed_size,
-		    state->flags.block_maximum_size,
-		    state->out_block,
+		    lz4->out_block + prefix64k, (int)compressed_size,
+		    lz4->flags.block_maximum_size,
+		    lz4->out_block,
 		    (int)prefix64k);
 #else
 		uncompressed_size = LZ4_decompress_safe_withPrefix64k(
 		    read_buf + 4,
-		    state->out_block + prefix64k, (int)compressed_size,
-		    state->flags.block_maximum_size);
+		    lz4->out_block + prefix64k, (int)compressed_size,
+		    lz4->flags.block_maximum_size);
 #endif
 	}
 
@@ -689,9 +689,9 @@ lz4_filter_read_data_block(struct archive_read_filter *self, const void **p)
 		return (ARCHIVE_FATAL);
 	}
 
-	state->unconsumed = 4 + compressed_size + checksum_size;
-	*p = state->out_block + prefix64k;
-	state->decoded_size = uncompressed_size;
+	lz4->unconsumed = 4 + compressed_size + checksum_size;
+	*p = lz4->out_block + prefix64k;
+	lz4->decoded_size = uncompressed_size;
 	return uncompressed_size;
 
 malformed_error:
@@ -707,16 +707,16 @@ truncated_error:
 static ssize_t
 lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	const char *read_buf;
 	ssize_t ret;
 
-	if (state->stage == SELECT_STREAM) {
-		state->stage = READ_DEFAULT_STREAM;
+	if (lz4->stage == SELECT_STREAM) {
+		lz4->stage = READ_DEFAULT_STREAM;
 		/* First, read a descriptor. */
 		if((ret = lz4_filter_read_descriptor(self)) != ARCHIVE_OK)
 			return (ret);
-		state->stage = READ_DEFAULT_BLOCK;
+		lz4->stage = READ_DEFAULT_BLOCK;
 	}
 	/* Decompress a block. */
 	ret = lz4_filter_read_data_block(self, p);
@@ -724,11 +724,11 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 	/* If the end of block is detected, change the filter status
 	   to read next stream. */
 	if (ret == 0 && *p == NULL)
-		state->stage = SELECT_STREAM;
+		lz4->stage = SELECT_STREAM;
 
 	/* Optional processing, checking a stream sum. */
-	if (state->flags.stream_checksum) {
-		if (state->stage == SELECT_STREAM) {
+	if (lz4->flags.stream_checksum) {
+		if (lz4->stage == SELECT_STREAM) {
 			unsigned int checksum;
 			unsigned int checksum_stream;
 			read_buf = __archive_read_filter_ahead(self->upstream,
@@ -741,8 +741,8 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 			checksum = archive_le32dec(read_buf);
 			__archive_read_filter_consume(self->upstream, 4);
 			checksum_stream = __archive_xxhash.XXH32_digest(
-			    state->xxh32_state);
-			state->xxh32_state = NULL;
+			    lz4->xxh32_state);
+			lz4->xxh32_state = NULL;
 			if (checksum != checksum_stream) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
 				archive_set_error(&self->archive->archive,
@@ -752,7 +752,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 #endif
 			}
 		} else if (ret > 0)
-			__archive_xxhash.XXH32_update(state->xxh32_state,
+			__archive_xxhash.XXH32_update(lz4->xxh32_state,
 			    *p, (int)ret);
 	}
 	return (ret);
@@ -761,7 +761,7 @@ lz4_filter_read_default_stream(struct archive_read_filter *self, const void **p)
 static ssize_t
 lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	uint32_t compressed;
 	const char *read_buf;
 	ssize_t ret;
@@ -774,20 +774,20 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 	/* Make sure we have 4 bytes for a block size. */
 	read_buf = __archive_read_filter_ahead(self->upstream, 4, NULL);
 	if (read_buf == NULL) {
-		if (state->stage == SELECT_STREAM) {
-			state->stage = READ_LEGACY_STREAM;
+		if (lz4->stage == SELECT_STREAM) {
+			lz4->stage = READ_LEGACY_STREAM;
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated lz4 input");
 			return (ARCHIVE_FATAL);
 		}
-		state->stage = SELECT_STREAM;
+		lz4->stage = SELECT_STREAM;
 		return 0;
 	}
-	state->stage = READ_LEGACY_BLOCK;
+	lz4->stage = READ_LEGACY_BLOCK;
 	compressed = archive_le32dec(read_buf);
 	if (compressed > LZ4_COMPRESSBOUND(LEGACY_BLOCK_SIZE)) {
-		state->stage = SELECT_STREAM;
+		lz4->stage = SELECT_STREAM;
 		return 0;
 	}
 
@@ -799,15 +799,15 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 		    ARCHIVE_ERRNO_MISC, "truncated lz4 input");
 		return (ARCHIVE_FATAL);
 	}
-	ret = LZ4_decompress_safe(read_buf + 4, state->out_block,
-	    compressed, (int)state->out_block_size);
+	ret = LZ4_decompress_safe(read_buf + 4, lz4->out_block,
+	    compressed, (int)lz4->out_block_size);
 	if (ret < 0) {
 		archive_set_error(&(self->archive->archive),
 		    ARCHIVE_ERRNO_MISC, "lz4 decompression failed");
 		return (ARCHIVE_FATAL);
 	}
-	*p = state->out_block;
-	state->unconsumed = 4 + compressed;
+	*p = lz4->out_block;
+	lz4->unconsumed = 4 + compressed;
 	return ret;
 }
 
@@ -817,12 +817,12 @@ lz4_filter_read_legacy_stream(struct archive_read_filter *self, const void **p)
 static int
 lz4_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct lz4 *lz4 = self->data;
 	int ret = ARCHIVE_OK;
 
-	free(state->xxh32_state);
-	free(state->out_block);
-	free(state);
+	free(lz4->xxh32_state);
+	free(lz4->out_block);
+	free(lz4);
 	return (ret);
 }
 

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -68,7 +68,7 @@
 #define LZOP_HEADER_MAGIC_LEN 9
 
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
-struct read_lzop {
+struct lzop {
 	unsigned char	*out_block;
 	size_t		 out_block_size;
 	int		 flags;
@@ -177,19 +177,19 @@ lzop_reader_vtable = {
 static int
 lzop_bidder_init(struct archive_read_filter *self)
 {
-	struct read_lzop *state;
+	struct lzop *lzop;
 
 	self->code = ARCHIVE_FILTER_LZOP;
 	self->name = "lzop";
 
-	state = calloc(1, sizeof(*state));
-	if (state == NULL) {
+	lzop = calloc(1, sizeof(*lzop));
+	if (lzop == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for lzop decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
+	self->data = lzop;
 	self->vtable = &lzop_reader_vtable;
 
 	return (ARCHIVE_OK);
@@ -198,7 +198,7 @@ lzop_bidder_init(struct archive_read_filter *self)
 static int
 consume_header(struct archive_read_filter *self)
 {
-	struct read_lzop *state = self->data;
+	struct lzop *lzop = self->data;
 	const unsigned char *p, *_p;
 	unsigned checksum, flags, len, method, version;
 
@@ -291,8 +291,8 @@ consume_header(struct archive_read_filter *self)
 		__archive_read_filter_consume(self->upstream,
 		    (int64_t)len + 4 + 4);
 	}
-	state->flags = flags;
-	state->in_stream = 1;
+	lzop->flags = flags;
+	lzop->in_stream = 1;
 	return (ARCHIVE_OK);
 truncated:
 	archive_set_error(&self->archive->archive,
@@ -307,42 +307,42 @@ corrupted:
 static int
 consume_block_info(struct archive_read_filter *self)
 {
-	struct read_lzop *state = self->data;
+	struct lzop *lzop = self->data;
 	const unsigned char *p;
-	unsigned flags = state->flags;
+	unsigned flags = lzop->flags;
 
 	p = __archive_read_filter_ahead(self->upstream, 4, NULL);
 	if (p == NULL)
 		goto truncated;
-	state->uncompressed_size = archive_be32dec(p);
+	lzop->uncompressed_size = archive_be32dec(p);
 	__archive_read_filter_consume(self->upstream, 4);
-	if (state->uncompressed_size == 0)
+	if (lzop->uncompressed_size == 0)
 		return (ARCHIVE_EOF);
-	if (state->uncompressed_size > MAX_BLOCK_SIZE)
+	if (lzop->uncompressed_size > MAX_BLOCK_SIZE)
 		goto corrupted;
 
 	p = __archive_read_filter_ahead(self->upstream, 4, NULL);
 	if (p == NULL)
 		goto truncated;
-	state->compressed_size = archive_be32dec(p);
+	lzop->compressed_size = archive_be32dec(p);
 	__archive_read_filter_consume(self->upstream, 4);
-	if (state->compressed_size > state->uncompressed_size)
+	if (lzop->compressed_size > lzop->uncompressed_size)
 		goto corrupted;
 
 	if (flags & (CRC32_UNCOMPRESSED | ADLER32_UNCOMPRESSED)) {
 		p = __archive_read_filter_ahead(self->upstream, 4, NULL);
 		if (p == NULL)
 			goto truncated;
-		state->compressed_cksum = state->uncompressed_cksum =
+		lzop->compressed_cksum = lzop->uncompressed_cksum =
 		    archive_be32dec(p);
 		__archive_read_filter_consume(self->upstream, 4);
 	}
 	if ((flags & (CRC32_COMPRESSED | ADLER32_COMPRESSED)) &&
-	    state->compressed_size < state->uncompressed_size) {
+	    lzop->compressed_size < lzop->uncompressed_size) {
 		p = __archive_read_filter_ahead(self->upstream, 4, NULL);
 		if (p == NULL)
 			goto truncated;
-		state->compressed_cksum = archive_be32dec(p);
+		lzop->compressed_cksum = archive_be32dec(p);
 		__archive_read_filter_consume(self->upstream, 4);
 	}
 	return (ARCHIVE_OK);
@@ -359,27 +359,27 @@ corrupted:
 static ssize_t
 lzop_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct read_lzop *state = self->data;
+	struct lzop *lzop = self->data;
 	const void *b;
 	lzo_uint out_size;
 	uint32_t cksum;
 	int ret, r;
 
-	if (state->unconsumed_bytes) {
+	if (lzop->unconsumed_bytes) {
 		__archive_read_filter_consume(self->upstream,
-		    state->unconsumed_bytes);
-		state->unconsumed_bytes = 0;
+		    lzop->unconsumed_bytes);
+		lzop->unconsumed_bytes = 0;
 	}
-	if (state->eof)
+	if (lzop->eof)
 		return (0);
 
 	for (;;) {
-		if (!state->in_stream) {
+		if (!lzop->in_stream) {
 			ret = consume_header(self);
 			if (ret < ARCHIVE_OK)
 				return (ret);
 			if (ret == ARCHIVE_EOF) {
-				state->eof = 1;
+				lzop->eof = 1;
 				return (0);
 			}
 		}
@@ -387,39 +387,39 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 		if (ret < ARCHIVE_OK)
 			return (ret);
 		if (ret == ARCHIVE_EOF)
-			state->in_stream = 0;
+			lzop->in_stream = 0;
 		else
 			break;
 	}
 
-	if (state->out_block == NULL ||
-	    state->out_block_size < state->uncompressed_size) {
+	if (lzop->out_block == NULL ||
+	    lzop->out_block_size < lzop->uncompressed_size) {
 		void *new_block;
 
-		new_block = realloc(state->out_block, state->uncompressed_size);
+		new_block = realloc(lzop->out_block, lzop->uncompressed_size);
 		if (new_block == NULL) {
 			archive_set_error(&self->archive->archive, ENOMEM,
 			    "Can't allocate data for lzop decompression");
 			return (ARCHIVE_FATAL);
 		}
-		state->out_block = new_block;
-		state->out_block_size = state->uncompressed_size;
+		lzop->out_block = new_block;
+		lzop->out_block_size = lzop->uncompressed_size;
 	}
 
 	b = __archive_read_filter_ahead(self->upstream,
-		state->compressed_size, NULL);
+		lzop->compressed_size, NULL);
 	if (b == NULL) {
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_FILE_FORMAT, "Truncated lzop data");
 		return (ARCHIVE_FATAL);
 	}
-	if (state->flags & CRC32_COMPRESSED)
-		cksum = crc32(crc32(0, NULL, 0), b, state->compressed_size);
-	else if (state->flags & ADLER32_COMPRESSED)
-		cksum = adler32(adler32(0, NULL, 0), b, state->compressed_size);
+	if (lzop->flags & CRC32_COMPRESSED)
+		cksum = crc32(crc32(0, NULL, 0), b, lzop->compressed_size);
+	else if (lzop->flags & ADLER32_COMPRESSED)
+		cksum = adler32(adler32(0, NULL, 0), b, lzop->compressed_size);
 	else
-		cksum = state->compressed_cksum;
-	if (cksum != state->compressed_cksum) {
+		cksum = lzop->compressed_cksum;
+	if (cksum != lzop->compressed_cksum) {
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
 		return (ARCHIVE_FATAL);
@@ -429,21 +429,21 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	 * If both uncompressed size and compressed size are the same,
 	 * we do not decompress this block.
 	 */
-	if (state->uncompressed_size == state->compressed_size) {
+	if (lzop->uncompressed_size == lzop->compressed_size) {
 		*p = b;
-		state->unconsumed_bytes = state->compressed_size;
-		return ((ssize_t)state->uncompressed_size);
+		lzop->unconsumed_bytes = lzop->compressed_size;
+		return ((ssize_t)lzop->uncompressed_size);
 	}
 
 	/*
 	 * Drive lzo uncompression.
 	 */
-	out_size = (lzo_uint)state->uncompressed_size;
-	r = lzo1x_decompress_safe(b, (lzo_uint)state->compressed_size,
-		state->out_block, &out_size, NULL);
+	out_size = (lzo_uint)lzop->uncompressed_size;
+	r = lzo1x_decompress_safe(b, (lzo_uint)lzop->compressed_size,
+		lzop->out_block, &out_size, NULL);
 	switch (r) {
 	case LZO_E_OK:
-		if (out_size == state->uncompressed_size)
+		if (out_size == lzop->uncompressed_size)
 			break;
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
@@ -458,22 +458,22 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 		return (ARCHIVE_FATAL);
 	}
 
-	if (state->flags & CRC32_UNCOMPRESSED)
-		cksum = crc32(crc32(0, NULL, 0), state->out_block,
-		    state->uncompressed_size);
-	else if (state->flags & ADLER32_UNCOMPRESSED)
-		cksum = adler32(adler32(0, NULL, 0), state->out_block,
-		    state->uncompressed_size);
+	if (lzop->flags & CRC32_UNCOMPRESSED)
+		cksum = crc32(crc32(0, NULL, 0), lzop->out_block,
+		    lzop->uncompressed_size);
+	else if (lzop->flags & ADLER32_UNCOMPRESSED)
+		cksum = adler32(adler32(0, NULL, 0), lzop->out_block,
+		    lzop->uncompressed_size);
 	else
-		cksum = state->uncompressed_cksum;
-	if (cksum != state->uncompressed_cksum) {
+		cksum = lzop->uncompressed_cksum;
+	if (cksum != lzop->uncompressed_cksum) {
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
 		return (ARCHIVE_FATAL);
 	}
 
-	__archive_read_filter_consume(self->upstream, state->compressed_size);
-	*p = state->out_block;
+	__archive_read_filter_consume(self->upstream, lzop->compressed_size);
+	*p = lzop->out_block;
 	return ((ssize_t)out_size);
 }
 
@@ -483,10 +483,10 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 static int
 lzop_filter_close(struct archive_read_filter *self)
 {
-	struct read_lzop *state = self->data;
+	struct lzop *lzop = self->data;
 
-	free(state->out_block);
-	free(state);
+	free(lzop->out_block);
+	free(lzop);
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -198,7 +198,7 @@ lzop_bidder_init(struct archive_read_filter *self)
 static int
 consume_header(struct archive_read_filter *self)
 {
-	struct read_lzop *state = (struct read_lzop *)self->data;
+	struct read_lzop *state = self->data;
 	const unsigned char *p, *_p;
 	unsigned checksum, flags, len, method, version;
 
@@ -307,7 +307,7 @@ corrupted:
 static int
 consume_block_info(struct archive_read_filter *self)
 {
-	struct read_lzop *state = (struct read_lzop *)self->data;
+	struct read_lzop *state = self->data;
 	const unsigned char *p;
 	unsigned flags = state->flags;
 
@@ -359,7 +359,7 @@ corrupted:
 static ssize_t
 lzop_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct read_lzop *state = (struct read_lzop *)self->data;
+	struct read_lzop *state = self->data;
 	const void *b;
 	lzo_uint out_size;
 	uint32_t cksum;
@@ -483,7 +483,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 static int
 lzop_filter_close(struct archive_read_filter *self)
 {
-	struct read_lzop *state = (struct read_lzop *)self->data;
+	struct read_lzop *state = self->data;
 
 	free(state->out_block);
 	free(state);

--- a/libarchive/archive_read_support_filter_lzop.c
+++ b/libarchive/archive_read_support_filter_lzop.c
@@ -127,14 +127,14 @@ archive_read_support_filter_lzop(struct archive *_a)
  * Bidder just verifies the header and returns the number of verified bits.
  */
 static int
-lzop_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+lzop_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *p;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	p = __archive_read_filter_ahead(filter, LZOP_HEADER_MAGIC_LEN, NULL);
+	p = __archive_read_filter_ahead(f, LZOP_HEADER_MAGIC_LEN, NULL);
 	if (p == NULL)
 		return (0);
 
@@ -151,16 +151,16 @@ lzop_bidder_bid(struct archive_read_filter_bidder *self,
  * in case that's available.
  */
 static int
-lzop_bidder_init(struct archive_read_filter *self)
+lzop_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "lzop -d");
+	r = __archive_read_program(f, "lzop -d");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_LZOP;
-	self->name = "lzop";
+	f->code = ARCHIVE_FILTER_LZOP;
+	f->name = "lzop";
 	return (r);
 }
 #else
@@ -175,47 +175,47 @@ lzop_reader_vtable = {
  * Initialize the filter object.
  */
 static int
-lzop_bidder_init(struct archive_read_filter *self)
+lzop_bidder_init(struct archive_read_filter *f)
 {
 	struct lzop *lzop;
 
-	self->code = ARCHIVE_FILTER_LZOP;
-	self->name = "lzop";
+	f->code = ARCHIVE_FILTER_LZOP;
+	f->name = "lzop";
 
 	lzop = calloc(1, sizeof(*lzop));
 	if (lzop == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for lzop decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = lzop;
-	self->vtable = &lzop_reader_vtable;
+	f->data = lzop;
+	f->vtable = &lzop_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
 static int
-consume_header(struct archive_read_filter *self)
+consume_header(struct archive_read_filter *f)
 {
-	struct lzop *lzop = self->data;
+	struct lzop *lzop = f->data;
 	const unsigned char *p, *_p;
 	unsigned checksum, flags, len, method, version;
 
 	/*
 	 * Check LZOP magic code.
 	 */
-	p = __archive_read_filter_ahead(self->upstream,
+	p = __archive_read_filter_ahead(f->upstream,
 		LZOP_HEADER_MAGIC_LEN, NULL);
 	if (p == NULL)
 		return (ARCHIVE_EOF);
 
 	if (memcmp(p, LZOP_HEADER_MAGIC, LZOP_HEADER_MAGIC_LEN))
 		return (ARCHIVE_EOF);
-	__archive_read_filter_consume(self->upstream,
+	__archive_read_filter_consume(f->upstream,
 	    LZOP_HEADER_MAGIC_LEN);
 
-	p = __archive_read_filter_ahead(self->upstream, 29, NULL);
+	p = __archive_read_filter_ahead(f->upstream, 29, NULL);
 	if (p == NULL)
 		goto truncated;
 	_p = p;
@@ -225,7 +225,7 @@ consume_header(struct archive_read_filter *self)
 	if (version >= 0x940) {
 		unsigned reqversion = archive_be16dec(p); p += 2;
 		if (reqversion < 0x900) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC, "Invalid required version");
 			return (ARCHIVE_FAILED);
 		}
@@ -233,7 +233,7 @@ consume_header(struct archive_read_filter *self)
 
 	method = *p++;
 	if (method < 1 || method > 3) {
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Unsupported method");
 		return (ARCHIVE_FAILED);
 	}
@@ -252,7 +252,7 @@ consume_header(struct archive_read_filter *self)
 			;/* NOP */
 #endif
 		else if (level > 9) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC, "Invalid level");
 			return (ARCHIVE_FAILED);
 		}
@@ -270,7 +270,7 @@ consume_header(struct archive_read_filter *self)
 	len = *p++; /* Read filename length */
 	len += p - _p;
 	/* Make sure we have all bytes we need to calculate checksum. */
-	p = __archive_read_filter_ahead(self->upstream, len + 4, NULL);
+	p = __archive_read_filter_ahead(f->upstream, len + 4, NULL);
 	if (p == NULL)
 		goto truncated;
 	if (flags & CRC32_HEADER)
@@ -281,92 +281,92 @@ consume_header(struct archive_read_filter *self)
 	if (archive_be32dec(p + len) != checksum)
 		goto corrupted;
 #endif
-	__archive_read_filter_consume(self->upstream, len + 4);
+	__archive_read_filter_consume(f->upstream, len + 4);
 	if (flags & EXTRA_FIELD) {
 		/* Skip extra field */
-		p = __archive_read_filter_ahead(self->upstream, 4, NULL);
+		p = __archive_read_filter_ahead(f->upstream, 4, NULL);
 		if (p == NULL)
 			goto truncated;
 		len = archive_be32dec(p);
-		__archive_read_filter_consume(self->upstream,
+		__archive_read_filter_consume(f->upstream,
 		    (int64_t)len + 4 + 4);
 	}
 	lzop->flags = flags;
 	lzop->in_stream = 1;
 	return (ARCHIVE_OK);
 truncated:
-	archive_set_error(&self->archive->archive,
+	archive_set_error(&f->archive->archive,
 	    ARCHIVE_ERRNO_FILE_FORMAT, "Truncated lzop data");
 	return (ARCHIVE_FAILED);
 corrupted:
-	archive_set_error(&self->archive->archive,
+	archive_set_error(&f->archive->archive,
 	    ARCHIVE_ERRNO_FILE_FORMAT, "Corrupted lzop header");
 	return (ARCHIVE_FAILED);
 }
 
 static int
-consume_block_info(struct archive_read_filter *self)
+consume_block_info(struct archive_read_filter *f)
 {
-	struct lzop *lzop = self->data;
+	struct lzop *lzop = f->data;
 	const unsigned char *p;
 	unsigned flags = lzop->flags;
 
-	p = __archive_read_filter_ahead(self->upstream, 4, NULL);
+	p = __archive_read_filter_ahead(f->upstream, 4, NULL);
 	if (p == NULL)
 		goto truncated;
 	lzop->uncompressed_size = archive_be32dec(p);
-	__archive_read_filter_consume(self->upstream, 4);
+	__archive_read_filter_consume(f->upstream, 4);
 	if (lzop->uncompressed_size == 0)
 		return (ARCHIVE_EOF);
 	if (lzop->uncompressed_size > MAX_BLOCK_SIZE)
 		goto corrupted;
 
-	p = __archive_read_filter_ahead(self->upstream, 4, NULL);
+	p = __archive_read_filter_ahead(f->upstream, 4, NULL);
 	if (p == NULL)
 		goto truncated;
 	lzop->compressed_size = archive_be32dec(p);
-	__archive_read_filter_consume(self->upstream, 4);
+	__archive_read_filter_consume(f->upstream, 4);
 	if (lzop->compressed_size > lzop->uncompressed_size)
 		goto corrupted;
 
 	if (flags & (CRC32_UNCOMPRESSED | ADLER32_UNCOMPRESSED)) {
-		p = __archive_read_filter_ahead(self->upstream, 4, NULL);
+		p = __archive_read_filter_ahead(f->upstream, 4, NULL);
 		if (p == NULL)
 			goto truncated;
 		lzop->compressed_cksum = lzop->uncompressed_cksum =
 		    archive_be32dec(p);
-		__archive_read_filter_consume(self->upstream, 4);
+		__archive_read_filter_consume(f->upstream, 4);
 	}
 	if ((flags & (CRC32_COMPRESSED | ADLER32_COMPRESSED)) &&
 	    lzop->compressed_size < lzop->uncompressed_size) {
-		p = __archive_read_filter_ahead(self->upstream, 4, NULL);
+		p = __archive_read_filter_ahead(f->upstream, 4, NULL);
 		if (p == NULL)
 			goto truncated;
 		lzop->compressed_cksum = archive_be32dec(p);
-		__archive_read_filter_consume(self->upstream, 4);
+		__archive_read_filter_consume(f->upstream, 4);
 	}
 	return (ARCHIVE_OK);
 truncated:
-	archive_set_error(&self->archive->archive,
+	archive_set_error(&f->archive->archive,
 	    ARCHIVE_ERRNO_FILE_FORMAT, "Truncated lzop data");
 	return (ARCHIVE_FAILED);
 corrupted:
-	archive_set_error(&self->archive->archive,
+	archive_set_error(&f->archive->archive,
 	    ARCHIVE_ERRNO_FILE_FORMAT, "Corrupted lzop header");
 	return (ARCHIVE_FAILED);
 }
 
 static ssize_t
-lzop_filter_read(struct archive_read_filter *self, const void **p)
+lzop_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct lzop *lzop = self->data;
+	struct lzop *lzop = f->data;
 	const void *b;
 	lzo_uint out_size;
 	uint32_t cksum;
 	int ret, r;
 
 	if (lzop->unconsumed_bytes) {
-		__archive_read_filter_consume(self->upstream,
+		__archive_read_filter_consume(f->upstream,
 		    lzop->unconsumed_bytes);
 		lzop->unconsumed_bytes = 0;
 	}
@@ -375,7 +375,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 
 	for (;;) {
 		if (!lzop->in_stream) {
-			ret = consume_header(self);
+			ret = consume_header(f);
 			if (ret < ARCHIVE_OK)
 				return (ret);
 			if (ret == ARCHIVE_EOF) {
@@ -383,7 +383,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 				return (0);
 			}
 		}
-		ret = consume_block_info(self);
+		ret = consume_block_info(f);
 		if (ret < ARCHIVE_OK)
 			return (ret);
 		if (ret == ARCHIVE_EOF)
@@ -398,7 +398,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 
 		new_block = realloc(lzop->out_block, lzop->uncompressed_size);
 		if (new_block == NULL) {
-			archive_set_error(&self->archive->archive, ENOMEM,
+			archive_set_error(&f->archive->archive, ENOMEM,
 			    "Can't allocate data for lzop decompression");
 			return (ARCHIVE_FATAL);
 		}
@@ -406,10 +406,10 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 		lzop->out_block_size = lzop->uncompressed_size;
 	}
 
-	b = __archive_read_filter_ahead(self->upstream,
+	b = __archive_read_filter_ahead(f->upstream,
 		lzop->compressed_size, NULL);
 	if (b == NULL) {
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_FILE_FORMAT, "Truncated lzop data");
 		return (ARCHIVE_FATAL);
 	}
@@ -420,7 +420,7 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	else
 		cksum = lzop->compressed_cksum;
 	if (cksum != lzop->compressed_cksum) {
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
 		return (ARCHIVE_FATAL);
 	}
@@ -445,15 +445,15 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	case LZO_E_OK:
 		if (out_size == lzop->uncompressed_size)
 			break;
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
 		return (ARCHIVE_FATAL);
 	case LZO_E_OUT_OF_MEMORY:
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "lzop decompression failed: out of memory");
 		return (ARCHIVE_FATAL);
 	default:
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "lzop decompression failed: %d", r);
 		return (ARCHIVE_FATAL);
 	}
@@ -467,12 +467,12 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
 	else
 		cksum = lzop->uncompressed_cksum;
 	if (cksum != lzop->uncompressed_cksum) {
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC, "Corrupted data");
 		return (ARCHIVE_FATAL);
 	}
 
-	__archive_read_filter_consume(self->upstream, lzop->compressed_size);
+	__archive_read_filter_consume(f->upstream, lzop->compressed_size);
 	*p = lzop->out_block;
 	return ((ssize_t)out_size);
 }
@@ -481,9 +481,9 @@ lzop_filter_read(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-lzop_filter_close(struct archive_read_filter *self)
+lzop_filter_close(struct archive_read_filter *f)
 {
-	struct lzop *lzop = self->data;
+	struct lzop *lzop = f->data;
 
 	free(lzop->out_block);
 	free(lzop);

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -168,9 +168,9 @@ memerr:
 }
 
 static void
-program_bidder_free(struct archive_read_filter_bidder *self)
+program_bidder_free(struct archive_read_filter_bidder *b)
 {
-	struct program_bidder *state = (struct program_bidder *)self->data;
+	struct program_bidder *state = (struct program_bidder *)b->data;
 
 	free_state(state);
 }
@@ -193,15 +193,15 @@ free_state(struct program_bidder *state)
  * we're called, then never bid again.
  */
 static int
-program_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *upstream)
+program_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
-	struct program_bidder *state = self->data;
+	struct program_bidder *state = b->data;
 	const char *p;
 
 	/* If we have a signature, use that to match. */
 	if (state->signature_len > 0) {
-		p = __archive_read_filter_ahead(upstream,
+		p = __archive_read_filter_ahead(f,
 		    state->signature_len, NULL);
 		if (p == NULL)
 			return (0);
@@ -226,7 +226,7 @@ program_bidder_bid(struct archive_read_filter_bidder *self,
  * (including error message if the child came to a bad end).
  */
 static int
-child_stop(struct archive_read_filter *self, struct program *program)
+child_stop(struct archive_read_filter *f, struct program *program)
 {
 	/* Close our side of the I/O with the child. */
 	if (program->child_stdin != -1) {
@@ -249,7 +249,7 @@ child_stop(struct archive_read_filter *self, struct program *program)
 
 	if (program->waitpid_return < 0) {
 		/* waitpid() failed?  This is ugly. */
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Error closing child process");
 		return (ARCHIVE_WARN);
 	}
@@ -266,7 +266,7 @@ child_stop(struct archive_read_filter *self, struct program *program)
 		if (WTERMSIG(program->exit_status) == SIGPIPE)
 			return (ARCHIVE_OK);
 #endif
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Child process exited with signal %d",
 		    WTERMSIG(program->exit_status));
 		return (ARCHIVE_WARN);
@@ -277,7 +277,7 @@ child_stop(struct archive_read_filter *self, struct program *program)
 		if (WEXITSTATUS(program->exit_status) == 0)
 			return (ARCHIVE_OK);
 
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Child process exited with status %d",
 		    WEXITSTATUS(program->exit_status));
@@ -291,9 +291,9 @@ child_stop(struct archive_read_filter *self, struct program *program)
  * Use select() to decide whether the child is ready for read or write.
  */
 static ssize_t
-child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
+child_read(struct archive_read_filter *f, char *buf, size_t buf_len)
 {
-	struct program *program = self->data;
+	struct program *program = f->data;
 	ssize_t ret, requested, avail;
 	const char *p;
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -333,7 +333,7 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 		if (ret == 0 || (ret == -1 && errno == EPIPE))
 			/* Child has closed its output; reap the child
 			 * and return the status. */
-			return (child_stop(self, program));
+			return (child_stop(f, program));
 		if (ret == -1 && errno != EAGAIN)
 			return (-1);
 
@@ -345,7 +345,7 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 		}
 
 		/* Get some more data from upstream. */
-		p = __archive_read_filter_ahead(self->upstream, 1, &avail);
+		p = __archive_read_filter_ahead(f->upstream, 1, &avail);
 		if (p == NULL) {
 			close(program->child_stdin);
 			program->child_stdin = -1;
@@ -361,7 +361,7 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 
 		if (ret > 0) {
 			/* Consume whatever we managed to write. */
-			__archive_read_filter_consume(self->upstream, ret);
+			__archive_read_filter_consume(f->upstream, ret);
 		} else if (ret == -1 && errno == EAGAIN) {
 			/* Block until child has some I/O ready. */
 			__archive_check_child(program->child_stdin,
@@ -387,7 +387,7 @@ program_reader_vtable = {
 };
 
 int
-__archive_read_program(struct archive_read_filter *self, const char *cmd)
+__archive_read_program(struct archive_read_filter *f, const char *cmd)
 {
 	struct program *program;
 	static const size_t out_buf_len = 65536;
@@ -401,7 +401,7 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	out_buf = malloc(out_buf_len);
 	if (program == NULL || out_buf == NULL ||
 	    archive_string_ensure(&program->description, l) == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate input data");
 		if (program != NULL) {
 			archive_string_free(&program->description);
@@ -413,8 +413,8 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	archive_strcpy(&program->description, prefix);
 	archive_strcat(&program->description, cmd);
 
-	self->code = ARCHIVE_FILTER_PROGRAM;
-	self->name = program->description.s;
+	f->code = ARCHIVE_FILTER_PROGRAM;
+	f->name = program->description.s;
 
 	program->out_buf = out_buf;
 	program->out_buf_len = out_buf_len;
@@ -425,32 +425,32 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 		free(program->out_buf);
 		archive_string_free(&program->description);
 		free(program);
-		archive_set_error(&self->archive->archive, EINVAL,
+		archive_set_error(&f->archive->archive, EINVAL,
 		    "Can't initialize filter; unable to run program \"%s\"",
 		    cmd);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = program;
-	self->vtable = &program_reader_vtable;
+	f->data = program;
+	f->vtable = &program_reader_vtable;
 
 	/* XXX Check that we can read at least one byte? */
 	return (ARCHIVE_OK);
 }
 
 static int
-program_bidder_init(struct archive_read_filter *self)
+program_bidder_init(struct archive_read_filter *f)
 {
 	struct program_bidder   *bidder_state;
 
-	bidder_state = (struct program_bidder *)self->bidder->data;
-	return (__archive_read_program(self, bidder_state->cmd));
+	bidder_state = (struct program_bidder *)f->bidder->data;
+	return (__archive_read_program(f, bidder_state->cmd));
 }
 
 static ssize_t
-program_filter_read(struct archive_read_filter *self, const void **buff)
+program_filter_read(struct archive_read_filter *f, const void **buff)
 {
-	struct program *program = self->data;
+	struct program *program = f->data;
 	ssize_t bytes;
 	size_t total;
 	char *p;
@@ -458,7 +458,7 @@ program_filter_read(struct archive_read_filter *self, const void **buff)
 	total = 0;
 	p = program->out_buf;
 	while (program->child_stdout != -1 && total < program->out_buf_len) {
-		bytes = child_read(self, p, program->out_buf_len - total);
+		bytes = child_read(f, p, program->out_buf_len - total);
 		if (bytes < 0)
 			/* No recovery is possible if we can no longer
 			 * read from the child. */
@@ -475,12 +475,12 @@ program_filter_read(struct archive_read_filter *self, const void **buff)
 }
 
 static int
-program_filter_close(struct archive_read_filter *self)
+program_filter_close(struct archive_read_filter *f)
 {
-	struct program *program = self->data;
+	struct program *program = f->data;
 	int e;
 
-	e = child_stop(self, program);
+	e = child_stop(f, program);
 
 	/* Release our private data. */
 	free(program->out_buf);

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -102,7 +102,7 @@ static void	program_bidder_free(struct archive_read_filter_bidder *);
 /*
  * The actual filter needs to track input and output data.
  */
-struct program_filter {
+struct program {
 	struct archive_string description;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	HANDLE		 child;
@@ -226,28 +226,28 @@ program_bidder_bid(struct archive_read_filter_bidder *self,
  * (including error message if the child came to a bad end).
  */
 static int
-child_stop(struct archive_read_filter *self, struct program_filter *state)
+child_stop(struct archive_read_filter *self, struct program *program)
 {
 	/* Close our side of the I/O with the child. */
-	if (state->child_stdin != -1) {
-		close(state->child_stdin);
-		state->child_stdin = -1;
+	if (program->child_stdin != -1) {
+		close(program->child_stdin);
+		program->child_stdin = -1;
 	}
-	if (state->child_stdout != -1) {
-		close(state->child_stdout);
-		state->child_stdout = -1;
+	if (program->child_stdout != -1) {
+		close(program->child_stdout);
+		program->child_stdout = -1;
 	}
 
-	if (state->child != 0) {
+	if (program->child != 0) {
 		/* Reap the child. */
 		do {
-			state->waitpid_return
-			    = waitpid(state->child, &state->exit_status, 0);
-		} while (state->waitpid_return == -1 && errno == EINTR);
-		state->child = 0;
+			program->waitpid_return
+			    = waitpid(program->child, &program->exit_status, 0);
+		} while (program->waitpid_return == -1 && errno == EINTR);
+		program->child = 0;
 	}
 
-	if (state->waitpid_return < 0) {
+	if (program->waitpid_return < 0) {
 		/* waitpid() failed?  This is ugly. */
 		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Error closing child process");
@@ -255,7 +255,7 @@ child_stop(struct archive_read_filter *self, struct program_filter *state)
 	}
 
 #if !defined(_WIN32) || defined(__CYGWIN__)
-	if (WIFSIGNALED(state->exit_status)) {
+	if (WIFSIGNALED(program->exit_status)) {
 #ifdef SIGPIPE
 		/* If the child died because we stopped reading before
 		 * it was done, that's okay.  Some archive formats
@@ -263,24 +263,24 @@ child_stop(struct archive_read_filter *self, struct program_filter *state)
 		/* The alternative to this would be to add a step
 		 * before close(child_stdout) above to read from the
 		 * child until the child has no more to write. */
-		if (WTERMSIG(state->exit_status) == SIGPIPE)
+		if (WTERMSIG(program->exit_status) == SIGPIPE)
 			return (ARCHIVE_OK);
 #endif
 		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Child process exited with signal %d",
-		    WTERMSIG(state->exit_status));
+		    WTERMSIG(program->exit_status));
 		return (ARCHIVE_WARN);
 	}
 #endif /* !_WIN32 || __CYGWIN__ */
 
-	if (WIFEXITED(state->exit_status)) {
-		if (WEXITSTATUS(state->exit_status) == 0)
+	if (WIFEXITED(program->exit_status)) {
+		if (WEXITSTATUS(program->exit_status) == 0)
 			return (ARCHIVE_OK);
 
 		archive_set_error(&self->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Child process exited with status %d",
-		    WEXITSTATUS(state->exit_status));
+		    WEXITSTATUS(program->exit_status));
 		return (ARCHIVE_WARN);
 	}
 
@@ -293,11 +293,11 @@ child_stop(struct archive_read_filter *self, struct program_filter *state)
 static ssize_t
 child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 {
-	struct program_filter *state = self->data;
+	struct program *program = self->data;
 	ssize_t ret, requested, avail;
 	const char *p;
 #if defined(_WIN32) && !defined(__CYGWIN__)
-	HANDLE handle = (HANDLE)_get_osfhandle(state->child_stdout);
+	HANDLE handle = (HANDLE)_get_osfhandle(program->child_stdout);
 #endif
 
 	requested = buf_len > SSIZE_MAX ? SSIZE_MAX : buf_len;
@@ -325,7 +325,7 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 				break;
 			}
 #endif
-			ret = read(state->child_stdout, buf, requested);
+			ret = read(program->child_stdout, buf, requested);
 		} while (ret == -1 && errno == EINTR);
 
 		if (ret > 0)
@@ -333,30 +333,30 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 		if (ret == 0 || (ret == -1 && errno == EPIPE))
 			/* Child has closed its output; reap the child
 			 * and return the status. */
-			return (child_stop(self, state));
+			return (child_stop(self, program));
 		if (ret == -1 && errno != EAGAIN)
 			return (-1);
 
-		if (state->child_stdin == -1) {
+		if (program->child_stdin == -1) {
 			/* Block until child has some I/O ready. */
-			__archive_check_child(state->child_stdin,
-			    state->child_stdout);
+			__archive_check_child(program->child_stdin,
+			    program->child_stdout);
 			continue;
 		}
 
 		/* Get some more data from upstream. */
 		p = __archive_read_filter_ahead(self->upstream, 1, &avail);
 		if (p == NULL) {
-			close(state->child_stdin);
-			state->child_stdin = -1;
-			fcntl(state->child_stdout, F_SETFL, 0);
+			close(program->child_stdin);
+			program->child_stdin = -1;
+			fcntl(program->child_stdout, F_SETFL, 0);
 			if (avail < 0)
 				return (avail);
 			continue;
 		}
 
 		do {
-			ret = write(state->child_stdin, p, avail);
+			ret = write(program->child_stdin, p, avail);
 		} while (ret == -1 && errno == EINTR);
 
 		if (ret > 0) {
@@ -364,13 +364,13 @@ child_read(struct archive_read_filter *self, char *buf, size_t buf_len)
 			__archive_read_filter_consume(self->upstream, ret);
 		} else if (ret == -1 && errno == EAGAIN) {
 			/* Block until child has some I/O ready. */
-			__archive_check_child(state->child_stdin,
-			    state->child_stdout);
+			__archive_check_child(program->child_stdin,
+			    program->child_stdout);
 		} else {
 			/* Write failed. */
-			close(state->child_stdin);
-			state->child_stdin = -1;
-			fcntl(state->child_stdout, F_SETFL, 0);
+			close(program->child_stdin);
+			program->child_stdin = -1;
+			fcntl(program->child_stdout, F_SETFL, 0);
 			/* If it was a bad error, we're done; otherwise
 			 * it was EPIPE or EOF, and we can still read
 			 * from the child. */
@@ -389,7 +389,7 @@ program_reader_vtable = {
 int
 __archive_read_program(struct archive_read_filter *self, const char *cmd)
 {
-	struct program_filter	*state;
+	struct program *program;
 	static const size_t out_buf_len = 65536;
 	char *out_buf;
 	const char *prefix = "Program: ";
@@ -397,41 +397,41 @@ __archive_read_program(struct archive_read_filter *self, const char *cmd)
 	size_t l;
 
 	l = strlen(prefix) + strlen(cmd) + 1;
-	state = calloc(1, sizeof(*state));
+	program = calloc(1, sizeof(*program));
 	out_buf = malloc(out_buf_len);
-	if (state == NULL || out_buf == NULL ||
-	    archive_string_ensure(&state->description, l) == NULL) {
+	if (program == NULL || out_buf == NULL ||
+	    archive_string_ensure(&program->description, l) == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate input data");
-		if (state != NULL) {
-			archive_string_free(&state->description);
-			free(state);
+		if (program != NULL) {
+			archive_string_free(&program->description);
+			free(program);
 		}
 		free(out_buf);
 		return (ARCHIVE_FATAL);
 	}
-	archive_strcpy(&state->description, prefix);
-	archive_strcat(&state->description, cmd);
+	archive_strcpy(&program->description, prefix);
+	archive_strcat(&program->description, cmd);
 
 	self->code = ARCHIVE_FILTER_PROGRAM;
-	self->name = state->description.s;
+	self->name = program->description.s;
 
-	state->out_buf = out_buf;
-	state->out_buf_len = out_buf_len;
+	program->out_buf = out_buf;
+	program->out_buf_len = out_buf_len;
 
-	ret = __archive_create_child(cmd, &state->child_stdin,
-	    &state->child_stdout, &state->child);
+	ret = __archive_create_child(cmd, &program->child_stdin,
+	    &program->child_stdout, &program->child);
 	if (ret != ARCHIVE_OK) {
-		free(state->out_buf);
-		archive_string_free(&state->description);
-		free(state);
+		free(program->out_buf);
+		archive_string_free(&program->description);
+		free(program);
 		archive_set_error(&self->archive->archive, EINVAL,
 		    "Can't initialize filter; unable to run program \"%s\"",
 		    cmd);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
+	self->data = program;
 	self->vtable = &program_reader_vtable;
 
 	/* XXX Check that we can read at least one byte? */
@@ -450,15 +450,15 @@ program_bidder_init(struct archive_read_filter *self)
 static ssize_t
 program_filter_read(struct archive_read_filter *self, const void **buff)
 {
-	struct program_filter *state = self->data;
+	struct program *program = self->data;
 	ssize_t bytes;
 	size_t total;
 	char *p;
 
 	total = 0;
-	p = state->out_buf;
-	while (state->child_stdout != -1 && total < state->out_buf_len) {
-		bytes = child_read(self, p, state->out_buf_len - total);
+	p = program->out_buf;
+	while (program->child_stdout != -1 && total < program->out_buf_len) {
+		bytes = child_read(self, p, program->out_buf_len - total);
 		if (bytes < 0)
 			/* No recovery is possible if we can no longer
 			 * read from the child. */
@@ -470,22 +470,22 @@ program_filter_read(struct archive_read_filter *self, const void **buff)
 		p += bytes;
 	}
 
-	*buff = state->out_buf;
+	*buff = program->out_buf;
 	return (total);
 }
 
 static int
 program_filter_close(struct archive_read_filter *self)
 {
-	struct program_filter *state = self->data;
+	struct program *program = self->data;
 	int e;
 
-	e = child_stop(self, state);
+	e = child_stop(self, program);
 
 	/* Release our private data. */
-	free(state->out_buf);
-	archive_string_free(&state->description);
-	free(state);
+	free(program->out_buf);
+	archive_string_free(&program->description);
+	free(program);
 
 	return (e);
 }

--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -450,12 +450,10 @@ program_bidder_init(struct archive_read_filter *self)
 static ssize_t
 program_filter_read(struct archive_read_filter *self, const void **buff)
 {
-	struct program_filter *state;
+	struct program_filter *state = self->data;
 	ssize_t bytes;
 	size_t total;
 	char *p;
-
-	state = (struct program_filter *)self->data;
 
 	total = 0;
 	p = state->out_buf;
@@ -479,10 +477,9 @@ program_filter_read(struct archive_read_filter *self, const void **buff)
 static int
 program_filter_close(struct archive_read_filter *self)
 {
-	struct program_filter	*state;
+	struct program_filter *state = self->data;
 	int e;
 
-	state = (struct program_filter *)self->data;
 	e = child_stop(self, state);
 
 	/* Release our private data. */

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -220,10 +220,8 @@ skip_prologue(struct archive_read_filter *self)
 static ssize_t
 rpm_filter_read(struct archive_read_filter *self, const void **buff)
 {
-	struct rpm *rpm;
+	struct rpm *rpm = self->data;
 	ssize_t r;
-
-	rpm = (struct rpm *)self->data;
 
 	if (!rpm->data_reached) {
 		r = skip_prologue(self);
@@ -242,9 +240,8 @@ rpm_filter_read(struct archive_read_filter *self, const void **buff)
 static int
 rpm_filter_close(struct archive_read_filter *self)
 {
-	struct rpm *rpm;
+	struct rpm *rpm = self->data;
 
-	rpm = (struct rpm *)self->data;
 	free(rpm);
 
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_filter_rpm.c
+++ b/libarchive/archive_read_support_filter_rpm.c
@@ -76,38 +76,38 @@ archive_read_support_filter_rpm(struct archive *_a)
 }
 
 static int
-rpm_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+rpm_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
-	const unsigned char *b;
+	const unsigned char *p;
 	int bits_checked;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	b = __archive_read_filter_ahead(filter, 8, NULL);
-	if (b == NULL)
+	p = __archive_read_filter_ahead(f, 8, NULL);
+	if (p == NULL)
 		return (0);
 
 	bits_checked = 0;
 	/*
 	 * Verify Header Magic Bytes : 0XED 0XAB 0XEE 0XDB
 	 */
-	if (memcmp(b, "\xED\xAB\xEE\xDB", 4) != 0)
+	if (memcmp(p, "\xED\xAB\xEE\xDB", 4) != 0)
 		return (0);
 	bits_checked += 32;
 	/*
 	 * Check major version.
 	 */
-	if (b[4] != 3 && b[4] != 4)
+	if (p[4] != 3 && p[4] != 4)
 		return (0);
 	bits_checked += 8;
 	/*
 	 * Check package type; binary or source.
 	 */
-	if (b[6] != 0)
+	if (p[6] != 0)
 		return (0);
 	bits_checked += 8;
-	if (b[7] != 0 && b[7] != 1)
+	if (p[7] != 0 && p[7] != 1)
 		return (0);
 	bits_checked += 8;
 
@@ -121,40 +121,40 @@ rpm_reader_vtable = {
 };
 
 static int
-rpm_bidder_init(struct archive_read_filter *self)
+rpm_bidder_init(struct archive_read_filter *f)
 {
 	struct rpm   *rpm;
 
-	self->code = ARCHIVE_FILTER_RPM;
-	self->name = "rpm";
+	f->code = ARCHIVE_FILTER_RPM;
+	f->name = "rpm";
 
 	rpm = calloc(1, sizeof(*rpm));
 	if (rpm == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for rpm");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = rpm;
+	f->data = rpm;
 	rpm->data_reached = 0;
-	self->vtable = &rpm_reader_vtable;
+	f->vtable = &rpm_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
 static ssize_t
-skip_padding(struct archive_read_filter *self)
+skip_padding(struct archive_read_filter *f)
 {
 	const unsigned char *h;
 	ssize_t avail, count, r;
 
 	do {
-		h = __archive_read_filter_ahead(self->upstream, 1, &avail);
+		h = __archive_read_filter_ahead(f->upstream, 1, &avail);
 		if (h == NULL)
 			return (ARCHIVE_FATAL);
 		for (count = 0; count < avail && *h++ == '\0'; count++)
 			;
-		r = __archive_read_filter_consume(self->upstream, count);
+		r = __archive_read_filter_consume(f->upstream, count);
 		if (r < 0)
 			return (r);
 	} while (count == avail);
@@ -163,20 +163,20 @@ skip_padding(struct archive_read_filter *self)
 }
 
 static ssize_t
-skip_prologue(struct archive_read_filter *self)
+skip_prologue(struct archive_read_filter *f)
 {
 	const unsigned char *h;
 	ssize_t r;
 	int header, seen_header = 0;
 
 	/* Skip lead size. */
-	r = __archive_read_filter_consume(self->upstream, RPM_LEAD_SIZE);
+	r = __archive_read_filter_consume(f->upstream, RPM_LEAD_SIZE);
 	if (r < 0)
 		return (r);
 
 	do {
 		/* Read header intro. */
-		h = __archive_read_filter_ahead(self->upstream,
+		h = __archive_read_filter_ahead(f->upstream,
 		    RPM_MIN_HEAD_SIZE, NULL);
 		if (h == NULL)
 			return (ARCHIVE_FATAL);
@@ -193,13 +193,13 @@ skip_prologue(struct archive_read_filter *self)
 			length = RPM_MIN_HEAD_SIZE + section * 16 + bytes;
 
 			/* Skip header. */
-			r = __archive_read_filter_consume(self->upstream,
+			r = __archive_read_filter_consume(f->upstream,
 			     length);
 			if (r < 0)
 				return (r);
 
 			/* Skip padding. */
-			r = skip_padding(self);
+			r = skip_padding(f);
 			if (r != ARCHIVE_OK)
 				return (r);
 		}
@@ -208,7 +208,7 @@ skip_prologue(struct archive_read_filter *self)
 	/* At least one header must have been encountered. */
 	if (!seen_header) {
 		archive_set_error(
-		    &self->archive->archive,
+		    &f->archive->archive,
 		    ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Unrecognized rpm header");
 		return (ARCHIVE_FATAL);
@@ -218,29 +218,29 @@ skip_prologue(struct archive_read_filter *self)
 }
 
 static ssize_t
-rpm_filter_read(struct archive_read_filter *self, const void **buff)
+rpm_filter_read(struct archive_read_filter *f, const void **buff)
 {
-	struct rpm *rpm = self->data;
+	struct rpm *rpm = f->data;
 	ssize_t r;
 
 	if (!rpm->data_reached) {
-		r = skip_prologue(self);
+		r = skip_prologue(f);
 		if (r != ARCHIVE_OK)
 			return (r);
 		rpm->data_reached = 1;
 	}
 
-	*buff = __archive_read_filter_ahead(self->upstream, 1, &r);
+	*buff = __archive_read_filter_ahead(f->upstream, 1, &r);
 	if (r > 0)
-		__archive_read_filter_consume(self->upstream, r);
+		__archive_read_filter_consume(f->upstream, r);
 
 	return r;
 }
 
 static int
-rpm_filter_close(struct archive_read_filter *self)
+rpm_filter_close(struct archive_read_filter *f)
 {
-	struct rpm *rpm = self->data;
+	struct rpm *rpm = f->data;
 
 	free(rpm);
 

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -207,7 +207,7 @@ get_line(const unsigned char *b, ssize_t avail, ssize_t *nlsize)
 }
 
 static ssize_t
-bid_get_line(struct archive_read_filter *filter,
+bid_get_line(struct archive_read_filter *f,
     const unsigned char **b, ssize_t *avail, ssize_t *ravail,
     ssize_t *nl, size_t* nbytes_read)
 {
@@ -235,12 +235,12 @@ bid_get_line(struct archive_read_filter *filter,
 		if (nbytes_req < (size_t)*ravail + 160)
 			nbytes_req <<= 1;
 
-		*b = __archive_read_filter_ahead(filter, nbytes_req, avail);
+		*b = __archive_read_filter_ahead(f, nbytes_req, avail);
 		if (*b == NULL) {
 			if (*ravail >= *avail)
 				return (0);
 			/* Reading bytes reaches the end of a stream. */
-			*b = __archive_read_filter_ahead(filter, *avail, avail);
+			*b = __archive_read_filter_ahead(f, *avail, avail);
 			quit = 1;
 		}
 		*nbytes_read = *avail;
@@ -258,42 +258,42 @@ bid_get_line(struct archive_read_filter *filter,
 #define UUDECODE(c) (((c) - 0x20) & 0x3f)
 
 static int
-uudecode_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+uudecode_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
-	const unsigned char *b;
+	const unsigned char *p;
 	ssize_t avail, ravail;
 	ssize_t len, nl;
 	int l;
 	int firstline;
 	size_t nbytes_read;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	b = __archive_read_filter_ahead(filter, 1, &avail);
-	if (b == NULL)
+	p = __archive_read_filter_ahead(f, 1, &avail);
+	if (p == NULL)
 		return (0);
 
 	firstline = 20;
 	ravail = avail;
 	nbytes_read = avail;
 	for (;;) {
-		len = bid_get_line(filter, &b, &avail, &ravail, &nl, &nbytes_read);
+		len = bid_get_line(f, &p, &avail, &ravail, &nl, &nbytes_read);
 		if (len < 0 || nl == 0)
 			return (0); /* No match found. */
-		if (len - nl >= 11 && memcmp(b, "begin ", 6) == 0)
+		if (len - nl >= 11 && memcmp(p, "begin ", 6) == 0)
 			l = 6;
-		else if (len -nl >= 18 && memcmp(b, "begin-base64 ", 13) == 0)
+		else if (len -nl >= 18 && memcmp(p, "begin-base64 ", 13) == 0)
 			l = 13;
 		else
 			l = 0;
 
-		if (l > 0 && (b[l] < '0' || b[l] > '7' ||
-		    b[l+1] < '0' || b[l+1] > '7' ||
-		    b[l+2] < '0' || b[l+2] > '7' || b[l+3] != ' '))
+		if (l > 0 && (p[l] < '0' || p[l] > '7' ||
+		    p[l+1] < '0' || p[l+1] > '7' ||
+		    p[l+2] < '0' || p[l+2] > '7' || p[l+3] != ' '))
 			l = 0;
 
-		b += len;
+		p += len;
 		avail -= len;
 		if (l)
 			break;
@@ -305,51 +305,51 @@ uudecode_bidder_bid(struct archive_read_filter_bidder *self,
 	}
 	if (!avail)
 		return (0);
-	len = bid_get_line(filter, &b, &avail, &ravail, &nl, &nbytes_read);
+	len = bid_get_line(f, &p, &avail, &ravail, &nl, &nbytes_read);
 	if (len < 0 || nl == 0)
 		return (0);/* There are non-ascii characters. */
 	avail -= len;
 
 	if (l == 6) {
 		/* "begin " */
-		if (!uuchar[*b])
+		if (!uuchar[*p])
 			return (0);
 		/* Get a length of decoded bytes. */
-		l = UUDECODE(*b++); len--;
+		l = UUDECODE(*p++); len--;
 		if (l > 45)
 			/* Normally, maximum length is 45(character 'M'). */
 			return (0);
 		if (l > len - nl)
 			return (0); /* Line too short. */
 		while (l) {
-			if (!uuchar[*b++])
+			if (!uuchar[*p++])
 				return (0);
 			--len;
 			--l;
 		}
 		if (len-nl == 1 &&
-		    (uuchar[*b] ||		 /* Check sum. */
-		     (*b >= 'a' && *b <= 'z'))) {/* Padding data(MINIX). */
-			++b;
+		    (uuchar[*p] ||		 /* Check sum. */
+		     (*p >= 'a' && *p <= 'z'))) {/* Padding data(MINIX). */
+			++p;
 			--len;
 		}
-		b += nl;
-		if (avail && uuchar[*b])
+		p += nl;
+		if (avail && uuchar[*p])
 			return (firstline+30);
 	} else if (l == 13) {
 		/* "begin-base64 " */
 		while (len-nl > 0) {
-			if (!base64[*b++])
+			if (!base64[*p++])
 				return (0);
 			--len;
 		}
-		b += nl;
+		p += nl;
 
-		if (avail >= 5 && memcmp(b, "====\n", 5) == 0)
+		if (avail >= 5 && memcmp(p, "====\n", 5) == 0)
 			return (firstline+40);
-		if (avail >= 6 && memcmp(b, "====\r\n", 6) == 0)
+		if (avail >= 6 && memcmp(p, "====\r\n", 6) == 0)
 			return (firstline+40);
-		if (avail > 0 && base64[*b])
+		if (avail > 0 && base64[*p])
 			return (firstline+30);
 	}
 
@@ -364,20 +364,20 @@ uudecode_reader_vtable = {
 };
 
 static int
-uudecode_bidder_init(struct archive_read_filter *self)
+uudecode_bidder_init(struct archive_read_filter *f)
 {
 	struct uu   *uu;
 	void *out_buff;
 	void *in_buff;
 
-	self->code = ARCHIVE_FILTER_UU;
-	self->name = "uu";
+	f->code = ARCHIVE_FILTER_UU;
+	f->name = "uu";
 
 	uu = calloc(1, sizeof(*uu));
 	out_buff = malloc(OUT_BUFF_SIZE);
 	in_buff = malloc(IN_BUFF_SIZE);
 	if (uu == NULL || out_buff == NULL || in_buff == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for uudecode");
 		free(uu);
 		free(out_buff);
@@ -385,7 +385,7 @@ uudecode_bidder_init(struct archive_read_filter *self)
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = uu;
+	f->data = uu;
 	uu->in_buff = in_buff;
 	uu->in_cnt = 0;
 	uu->in_allocated = IN_BUFF_SIZE;
@@ -393,13 +393,13 @@ uudecode_bidder_init(struct archive_read_filter *self)
 	uu->state = ST_FIND_HEAD;
 	uu->mode_set = 0;
 	uu->name = NULL;
-	self->vtable = &uudecode_reader_vtable;
+	f->vtable = &uudecode_reader_vtable;
 
 	return (ARCHIVE_OK);
 }
 
 static int
-ensure_in_buff_size(struct archive_read_filter *self,
+ensure_in_buff_size(struct archive_read_filter *f,
     struct uu *uu, size_t size)
 {
 
@@ -421,7 +421,7 @@ ensure_in_buff_size(struct archive_read_filter *self,
 		/* Allocate the new buffer. */
 		ptr = malloc(newsize);
 		if (ptr == NULL) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ENOMEM,
     			    "Can't allocate data for uudecode");
 			return (ARCHIVE_FATAL);
@@ -438,10 +438,9 @@ ensure_in_buff_size(struct archive_read_filter *self,
 }
 
 static int
-uudecode_read_header(struct archive_read_filter *self, struct archive_entry *entry)
+uudecode_read_header(struct archive_read_filter *f, struct archive_entry *entry)
 {
-
-	struct uu *uu = self->data;
+	struct uu *uu = f->data;
 
 	if (uu->mode_set != 0)
 		archive_entry_set_mode(entry, S_IFREG | uu->mode);
@@ -453,9 +452,9 @@ uudecode_read_header(struct archive_read_filter *self, struct archive_entry *ent
 }
 
 static ssize_t
-uudecode_filter_read(struct archive_read_filter *self, const void **buff)
+uudecode_filter_read(struct archive_read_filter *f, const void **buff)
 {
-	struct uu *uu = self->data;
+	struct uu *uu = f->data;
 	const unsigned char *b, *d;
 	unsigned char *out;
 	ssize_t avail_in, ravail;
@@ -464,7 +463,7 @@ uudecode_filter_read(struct archive_read_filter *self, const void **buff)
 	ssize_t len, llen, nl, namelen;
 
 read_more:
-	d = __archive_read_filter_ahead(self->upstream, 1, &avail_in);
+	d = __archive_read_filter_ahead(f->upstream, 1, &avail_in);
 	if (d == NULL && avail_in < 0)
 		return (ARCHIVE_FATAL);
 	/* Quiet a code analyzer; make sure avail_in must be zero
@@ -483,7 +482,7 @@ read_more:
 	}
 	if (uu->in_cnt) {
 		if (uu->in_cnt > UUENCODE_BID_MAX_READ) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Invalid format data");
 			return (ARCHIVE_FATAL);
@@ -492,7 +491,7 @@ read_more:
 		 * If there is remaining data which is saved by
 		 * a previous call, use it first.
 		 */
-		if (ensure_in_buff_size(self, uu,
+		if (ensure_in_buff_size(f, uu,
 		    avail_in + uu->in_cnt) != ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
 		if (avail_in > 0)
@@ -515,13 +514,13 @@ read_more:
 				used = avail_in;
 				goto finish;
 			}
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "Insufficient compressed data");
 			return (ARCHIVE_FATAL);
 		}
 		if (len > UUENCODE_BID_MAX_READ) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Invalid format data");
 			return (ARCHIVE_FATAL);
@@ -530,7 +529,7 @@ read_more:
 		if ((nl == 0) && (uu->state != ST_UUEND)) {
 			if (total == 0 && ravail <= 0) {
 				/* There is nothing more to read, fail */
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
 				    "Missing format data");
 				return (ARCHIVE_FATAL);
@@ -539,7 +538,7 @@ read_more:
 			 * Save remaining data which does not contain
 			 * NL('\n','\r').
 			 */
-			if (ensure_in_buff_size(self, uu, len)
+			if (ensure_in_buff_size(f, uu, len)
 			    != ARCHIVE_OK)
 				return (ARCHIVE_FATAL);
 			if (uu->in_buff != b)
@@ -549,7 +548,7 @@ read_more:
 				/* Do not return 0; it means end-of-file.
 				 * We should try to read more bytes. */
 				__archive_read_filter_consume(
-				    self->upstream, ravail);
+				    f->upstream, ravail);
 				goto read_more;
 			}
 			used += len;
@@ -560,7 +559,7 @@ read_more:
 		case ST_FIND_HEAD:
 			/* Do not read more than UUENCODE_BID_MAX_READ bytes */
 			if (total + len >= UUENCODE_BID_MAX_READ) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
 				    "Invalid format data");
 				return (ARCHIVE_FATAL);
@@ -591,7 +590,7 @@ read_more:
 					uu->name = malloc(namelen + 1);
 					if (uu->name == NULL) {
 						archive_set_error(
-						    &self->archive->archive,
+						    &f->archive->archive,
 						    ENOMEM,
 						    "Can't allocate data for uudecode");
 						return (ARCHIVE_FATAL);
@@ -608,7 +607,7 @@ read_more:
 				goto finish;
 			body = len - nl;
 			if (!uuchar[*b] || body <= 0) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Insufficient compressed data");
 				return (ARCHIVE_FATAL);
@@ -617,7 +616,7 @@ read_more:
 			l = UUDECODE(*b++);
 			body--;
 			if (l > body) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Insufficient compressed data");
 				return (ARCHIVE_FATAL);
@@ -652,7 +651,7 @@ read_more:
 				}
 			}
 			if (l) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Insufficient compressed data");
 				return (ARCHIVE_FATAL);
@@ -662,7 +661,7 @@ read_more:
 			if (len - nl == 3 && memcmp(b, "end ", 3) == 0)
 				uu->state = ST_FIND_HEAD;
 			else {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Insufficient compressed data");
 				return (ARCHIVE_FATAL);
@@ -707,7 +706,7 @@ read_more:
 				}
 			}
 			if (l && *b != '=') {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Insufficient compressed data");
 				return (ARCHIVE_FATAL);
@@ -718,7 +717,7 @@ read_more:
 finish:
 	if (ravail < avail_in)
 		used -= avail_in - ravail;
-	__archive_read_filter_consume(self->upstream, used);
+	__archive_read_filter_consume(f->upstream, used);
 
 	*buff = uu->out_buff;
 	uu->total += total;
@@ -726,9 +725,9 @@ finish:
 }
 
 static int
-uudecode_filter_close(struct archive_read_filter *self)
+uudecode_filter_close(struct archive_read_filter *f)
 {
-	struct uu *uu = self->data;
+	struct uu *uu = f->data;
 
 	free(uu->in_buff);
 	free(uu->out_buff);

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -63,7 +63,7 @@ struct uu {
 };
 
 static int	uudecode_bidder_bid(struct archive_read_filter_bidder *,
-		    struct archive_read_filter *filter);
+		    struct archive_read_filter *f);
 static int	uudecode_bidder_init(struct archive_read_filter *);
 
 static int	uudecode_read_header(struct archive_read_filter *,

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -441,8 +441,7 @@ static int
 uudecode_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 {
 
-	struct uudecode *uudecode;
-	uudecode = (struct uudecode *)self->data;
+	struct uudecode *uudecode = self->data;
 
 	if (uudecode->mode_set != 0)
 		archive_entry_set_mode(entry, S_IFREG | uudecode->mode);
@@ -456,15 +455,13 @@ uudecode_read_header(struct archive_read_filter *self, struct archive_entry *ent
 static ssize_t
 uudecode_filter_read(struct archive_read_filter *self, const void **buff)
 {
-	struct uudecode *uudecode;
+	struct uudecode *uudecode = self->data;
 	const unsigned char *b, *d;
 	unsigned char *out;
 	ssize_t avail_in, ravail;
 	ssize_t used;
 	ssize_t total;
 	ssize_t len, llen, nl, namelen;
-
-	uudecode = (struct uudecode *)self->data;
 
 read_more:
 	d = __archive_read_filter_ahead(self->upstream, 1, &avail_in);
@@ -731,9 +728,8 @@ finish:
 static int
 uudecode_filter_close(struct archive_read_filter *self)
 {
-	struct uudecode *uudecode;
+	struct uudecode *uudecode = self->data;
 
-	uudecode = (struct uudecode *)self->data;
 	free(uudecode->in_buff);
 	free(uudecode->out_buff);
 	free(uudecode->name);

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -43,7 +43,7 @@
 /* Maximum lookahead during bid phase */
 #define UUENCODE_BID_MAX_READ 128*1024 /* in bytes */
 
-struct uudecode {
+struct uu {
 	int64_t		 total;
 	unsigned char	*in_buff;
 #define IN_BUFF_SIZE	(1024)
@@ -366,33 +366,33 @@ uudecode_reader_vtable = {
 static int
 uudecode_bidder_init(struct archive_read_filter *self)
 {
-	struct uudecode   *uudecode;
+	struct uu   *uu;
 	void *out_buff;
 	void *in_buff;
 
 	self->code = ARCHIVE_FILTER_UU;
 	self->name = "uu";
 
-	uudecode = calloc(1, sizeof(*uudecode));
+	uu = calloc(1, sizeof(*uu));
 	out_buff = malloc(OUT_BUFF_SIZE);
 	in_buff = malloc(IN_BUFF_SIZE);
-	if (uudecode == NULL || out_buff == NULL || in_buff == NULL) {
+	if (uu == NULL || out_buff == NULL || in_buff == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for uudecode");
-		free(uudecode);
+		free(uu);
 		free(out_buff);
 		free(in_buff);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = uudecode;
-	uudecode->in_buff = in_buff;
-	uudecode->in_cnt = 0;
-	uudecode->in_allocated = IN_BUFF_SIZE;
-	uudecode->out_buff = out_buff;
-	uudecode->state = ST_FIND_HEAD;
-	uudecode->mode_set = 0;
-	uudecode->name = NULL;
+	self->data = uu;
+	uu->in_buff = in_buff;
+	uu->in_cnt = 0;
+	uu->in_allocated = IN_BUFF_SIZE;
+	uu->out_buff = out_buff;
+	uu->state = ST_FIND_HEAD;
+	uu->mode_set = 0;
+	uu->name = NULL;
 	self->vtable = &uudecode_reader_vtable;
 
 	return (ARCHIVE_OK);
@@ -400,10 +400,10 @@ uudecode_bidder_init(struct archive_read_filter *self)
 
 static int
 ensure_in_buff_size(struct archive_read_filter *self,
-    struct uudecode *uudecode, size_t size)
+    struct uu *uu, size_t size)
 {
 
-	if (size > uudecode->in_allocated) {
+	if (size > uu->in_allocated) {
 		unsigned char *ptr;
 		size_t newsize;
 
@@ -411,7 +411,7 @@ ensure_in_buff_size(struct archive_read_filter *self,
 		 * Calculate a new buffer size for in_buff.
 		 * Increase its value until it is enough for our needs.
 		 */
-		newsize = uudecode->in_allocated;
+		newsize = uu->in_allocated;
 		do {
 			if (newsize < IN_BUFF_SIZE*32)
 				newsize <<= 1;
@@ -427,12 +427,12 @@ ensure_in_buff_size(struct archive_read_filter *self,
 			return (ARCHIVE_FATAL);
 		}
 		/* Move the remaining data in in_buff into the new buffer. */
-		if (uudecode->in_cnt)
-			memmove(ptr, uudecode->in_buff, uudecode->in_cnt);
+		if (uu->in_cnt)
+			memmove(ptr, uu->in_buff, uu->in_cnt);
 		/* Replace in_buff with the new buffer. */
-		free(uudecode->in_buff);
-		uudecode->in_buff = ptr;
-		uudecode->in_allocated = newsize;
+		free(uu->in_buff);
+		uu->in_buff = ptr;
+		uu->in_allocated = newsize;
 	}
 	return (ARCHIVE_OK);
 }
@@ -441,13 +441,13 @@ static int
 uudecode_read_header(struct archive_read_filter *self, struct archive_entry *entry)
 {
 
-	struct uudecode *uudecode = self->data;
+	struct uu *uu = self->data;
 
-	if (uudecode->mode_set != 0)
-		archive_entry_set_mode(entry, S_IFREG | uudecode->mode);
+	if (uu->mode_set != 0)
+		archive_entry_set_mode(entry, S_IFREG | uu->mode);
 
-	if (uudecode->name != NULL)
-		archive_entry_set_pathname(entry, uudecode->name);
+	if (uu->name != NULL)
+		archive_entry_set_pathname(entry, uu->name);
 
 	return (ARCHIVE_OK);
 }
@@ -455,7 +455,7 @@ uudecode_read_header(struct archive_read_filter *self, struct archive_entry *ent
 static ssize_t
 uudecode_filter_read(struct archive_read_filter *self, const void **buff)
 {
-	struct uudecode *uudecode = self->data;
+	struct uu *uu = self->data;
 	const unsigned char *b, *d;
 	unsigned char *out;
 	ssize_t avail_in, ravail;
@@ -473,16 +473,16 @@ read_more:
 		avail_in = 0;
 	used = 0;
 	total = 0;
-	out = uudecode->out_buff;
+	out = uu->out_buff;
 	if (avail_in > 2 * UUENCODE_BID_MAX_READ)
 		avail_in = 2 * UUENCODE_BID_MAX_READ;
 	ravail = avail_in;
-	if (uudecode->state == ST_IGNORE) {
+	if (uu->state == ST_IGNORE) {
 		used = avail_in;
 		goto finish;
 	}
-	if (uudecode->in_cnt) {
-		if (uudecode->in_cnt > UUENCODE_BID_MAX_READ) {
+	if (uu->in_cnt) {
+		if (uu->in_cnt > UUENCODE_BID_MAX_READ) {
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Invalid format data");
@@ -492,15 +492,15 @@ read_more:
 		 * If there is remaining data which is saved by
 		 * a previous call, use it first.
 		 */
-		if (ensure_in_buff_size(self, uudecode,
-		    avail_in + uudecode->in_cnt) != ARCHIVE_OK)
+		if (ensure_in_buff_size(self, uu,
+		    avail_in + uu->in_cnt) != ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
 		if (avail_in > 0)
-			memcpy(uudecode->in_buff + uudecode->in_cnt,
+			memcpy(uu->in_buff + uu->in_cnt,
 			    d, avail_in);
-		d = uudecode->in_buff;
-		avail_in += uudecode->in_cnt;
-		uudecode->in_cnt = 0;
+		d = uu->in_buff;
+		avail_in += uu->in_cnt;
+		uu->in_cnt = 0;
 	}
 	for (;used < avail_in; d += llen, used += llen) {
 		ssize_t l, body;
@@ -509,9 +509,9 @@ read_more:
 		len = get_line(b, avail_in - used, &nl);
 		if (len < 0) {
 			/* Non-ascii character is found. */
-			if (uudecode->state == ST_FIND_HEAD &&
-			    (uudecode->total > 0 || total > 0)) {
-				uudecode->state = ST_IGNORE;
+			if (uu->state == ST_FIND_HEAD &&
+			    (uu->total > 0 || total > 0)) {
+				uu->state = ST_IGNORE;
 				used = avail_in;
 				goto finish;
 			}
@@ -527,7 +527,7 @@ read_more:
 			return (ARCHIVE_FATAL);
 		}
 		llen = len;
-		if ((nl == 0) && (uudecode->state != ST_UUEND)) {
+		if ((nl == 0) && (uu->state != ST_UUEND)) {
 			if (total == 0 && ravail <= 0) {
 				/* There is nothing more to read, fail */
 				archive_set_error(&self->archive->archive,
@@ -539,12 +539,12 @@ read_more:
 			 * Save remaining data which does not contain
 			 * NL('\n','\r').
 			 */
-			if (ensure_in_buff_size(self, uudecode, len)
+			if (ensure_in_buff_size(self, uu, len)
 			    != ARCHIVE_OK)
 				return (ARCHIVE_FATAL);
-			if (uudecode->in_buff != b)
-				memmove(uudecode->in_buff, b, len);
-			uudecode->in_cnt = len;
+			if (uu->in_buff != b)
+				memmove(uu->in_buff, b, len);
+			uu->in_cnt = len;
 			if (total == 0) {
 				/* Do not return 0; it means end-of-file.
 				 * We should try to read more bytes. */
@@ -555,7 +555,7 @@ read_more:
 			used += len;
 			break;
 		}
-		switch (uudecode->state) {
+		switch (uu->state) {
 		default:
 		case ST_FIND_HEAD:
 			/* Do not read more than UUENCODE_BID_MAX_READ bytes */
@@ -576,30 +576,30 @@ read_more:
 			    b[l+1] >= '0' && b[l+1] <= '7' &&
 			    b[l+2] >= '0' && b[l+2] <= '7' && b[l+3] == ' ') {
 				if (l == 6)
-					uudecode->state = ST_READ_UU;
+					uu->state = ST_READ_UU;
 				else
-					uudecode->state = ST_READ_BASE64;
-				uudecode->mode = (mode_t)(
+					uu->state = ST_READ_BASE64;
+				uu->mode = (mode_t)(
 				    ((int)(b[l] - '0') * 64) +
 				    ((int)(b[l+1] - '0') * 8) +
 				     (int)(b[l+2] - '0'));
-				uudecode->mode_set = 1;
+				uu->mode_set = 1;
 				namelen = len - nl - 4 - l;
 				if (namelen > 1) {
-					if (uudecode->name != NULL)
-						free(uudecode->name);
-					uudecode->name = malloc(namelen + 1);
-					if (uudecode->name == NULL) {
+					if (uu->name != NULL)
+						free(uu->name);
+					uu->name = malloc(namelen + 1);
+					if (uu->name == NULL) {
 						archive_set_error(
 						    &self->archive->archive,
 						    ENOMEM,
 						    "Can't allocate data for uudecode");
 						return (ARCHIVE_FATAL);
 					}
-					strncpy(uudecode->name,
+					strncpy(uu->name,
 					    (const char *)(b + l + 4),
 					    namelen);
-					uudecode->name[namelen] = '\0';
+					uu->name[namelen] = '\0';
 				}
 			}
 			break;
@@ -623,7 +623,7 @@ read_more:
 				return (ARCHIVE_FATAL);
 			}
 			if (l == 0) {
-				uudecode->state = ST_UUEND;
+				uu->state = ST_UUEND;
 				break;
 			}
 			while (l > 0) {
@@ -660,7 +660,7 @@ read_more:
 			break;
 		case ST_UUEND:
 			if (len - nl == 3 && memcmp(b, "end ", 3) == 0)
-				uudecode->state = ST_FIND_HEAD;
+				uu->state = ST_FIND_HEAD;
 			else {
 				archive_set_error(&self->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
@@ -674,7 +674,7 @@ read_more:
 			l = len - nl;
 			if (l >= 3 && b[0] == '=' && b[1] == '=' &&
 			    b[2] == '=') {
-				uudecode->state = ST_FIND_HEAD;
+				uu->state = ST_FIND_HEAD;
 				break;
 			}
 			while (l > 0) {
@@ -720,20 +720,20 @@ finish:
 		used -= avail_in - ravail;
 	__archive_read_filter_consume(self->upstream, used);
 
-	*buff = uudecode->out_buff;
-	uudecode->total += total;
+	*buff = uu->out_buff;
+	uu->total += total;
 	return (total);
 }
 
 static int
 uudecode_filter_close(struct archive_read_filter *self)
 {
-	struct uudecode *uudecode = self->data;
+	struct uu *uu = self->data;
 
-	free(uudecode->in_buff);
-	free(uudecode->out_buff);
-	free(uudecode->name);
-	free(uudecode);
+	free(uu->in_buff);
+	free(uu->out_buff);
+	free(uu->name);
+	free(uu);
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -528,14 +528,13 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 static int
 lzip_init(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	const unsigned char *h;
 	lzma_filter filters[2];
 	unsigned char props[5];
 	uint32_t dicsize;
 	int log2dic, ret;
 
-	state = (struct private_data *)self->data;
 	h = __archive_read_filter_ahead(self->upstream, 6, NULL);
 	if (h == NULL)
 		return (ARCHIVE_FATAL);
@@ -583,12 +582,11 @@ lzip_init(struct archive_read_filter *self)
 static int
 lzip_tail(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	const unsigned char *f;
 	ssize_t avail_in;
 	int tail;
 
-	state = (struct private_data *)self->data;
 	if (state->lzip_ver == 0)
 		tail = 12;
 	else
@@ -646,13 +644,11 @@ lzip_tail(struct archive_read_filter *self)
 static ssize_t
 xz_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	int64_t member_in;
 	int ret;
-
-	state = (struct private_data *)self->data;
 
 	redo:
 	/* Empty our output buffer. */
@@ -734,9 +730,8 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 static int
 xz_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 
-	state = (struct private_data *)self->data;
 	lzma_end(&(state->stream));
 	free(state->out_block);
 	free(state);

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -50,7 +50,7 @@
 
 #if HAVE_LZMA_H && HAVE_LIBLZMA
 
-struct private_data {
+struct xz {
 	lzma_stream	 stream;
 	unsigned char	*out_block;
 	size_t		 out_block_size;
@@ -468,48 +468,48 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 {
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
-	struct private_data *state;
+	struct xz *xz;
 	int ret;
 
-	state = calloc(1, sizeof(*state));
+	xz = calloc(1, sizeof(*xz));
 	out_block = malloc(out_block_size);
-	if (state == NULL || out_block == NULL) {
+	if (xz == NULL || out_block == NULL) {
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for xz decompression");
 		free(out_block);
-		free(state);
+		free(xz);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
-	state->out_block_size = out_block_size;
-	state->out_block = out_block;
+	self->data = xz;
+	xz->out_block_size = out_block_size;
+	xz->out_block = out_block;
 	self->vtable = &xz_lzma_reader_vtable;
 
-	state->stream.avail_in = 0;
+	xz->stream.avail_in = 0;
 
-	state->stream.next_out = state->out_block;
-	state->stream.avail_out = state->out_block_size;
+	xz->stream.next_out = xz->out_block;
+	xz->stream.avail_out = xz->out_block_size;
 
-	state->crc32 = 0;
+	xz->crc32 = 0;
 	if (self->code == ARCHIVE_FILTER_LZIP) {
 		/*
 		 * We have to read a lzip header and use it to initialize
 		 * compression library, thus we cannot initialize the
 		 * library for lzip here.
 		 */
-		state->in_stream = 0;
+		xz->in_stream = 0;
 		return (ARCHIVE_OK);
 	} else
-		state->in_stream = 1;
+		xz->in_stream = 1;
 
 	/* Initialize compression library. */
 	if (self->code == ARCHIVE_FILTER_XZ)
-		ret = lzma_stream_decoder(&(state->stream),
+		ret = lzma_stream_decoder(&(xz->stream),
 		    LZMA_MEMLIMIT,/* memlimit */
 		    LZMA_CONCATENATED);
 	else
-		ret = lzma_alone_decoder(&(state->stream),
+		ret = lzma_alone_decoder(&(xz->stream),
 		    LZMA_MEMLIMIT);/* memlimit */
 
 	if (ret == LZMA_OK)
@@ -518,8 +518,8 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	/* Library setup failed: Choose an error message and clean up. */
 	set_error(self, ret);
 
-	free(state->out_block);
-	free(state);
+	free(xz->out_block);
+	free(xz);
 	self->data = NULL;
 	self->vtable = NULL;
 	return (ARCHIVE_FATAL);
@@ -528,7 +528,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 static int
 lzip_init(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct xz *xz = self->data;
 	const unsigned char *h;
 	lzma_filter filters[2];
 	unsigned char props[5];
@@ -540,7 +540,7 @@ lzip_init(struct archive_read_filter *self)
 		return (ARCHIVE_FATAL);
 
 	/* Get a version number. */
-	state->lzip_ver = h[4];
+	xz->lzip_ver = h[4];
 
 	/*
 	 * Setup lzma property.
@@ -558,7 +558,7 @@ lzip_init(struct archive_read_filter *self)
 
 	/* Consume lzip header. */
 	__archive_read_filter_consume(self->upstream, 6);
-	state->member_in = 6;
+	xz->member_in = 6;
 
 	filters[0].id = LZMA_FILTER_LZMA1;
 	filters[0].options = NULL;
@@ -570,7 +570,7 @@ lzip_init(struct archive_read_filter *self)
 		set_error(self, ret);
 		return (ARCHIVE_FATAL);
 	}
-	ret = lzma_raw_decoder(&(state->stream), filters);
+	ret = lzma_raw_decoder(&(xz->stream), filters);
 	free(filters[0].options);
 	if (ret != LZMA_OK) {
 		set_error(self, ret);
@@ -582,12 +582,12 @@ lzip_init(struct archive_read_filter *self)
 static int
 lzip_tail(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct xz *xz = self->data;
 	const unsigned char *f;
 	ssize_t avail_in;
 	int tail;
 
-	if (state->lzip_ver == 0)
+	if (xz->lzip_ver == 0)
 		tail = 12;
 	else
 		tail = 20;
@@ -602,7 +602,7 @@ lzip_tail(struct archive_read_filter *self)
 
 	/* Check the crc32 value of the uncompressed data of the current
 	 * member */
-	if (state->crc32 != archive_le32dec(f)) {
+	if (xz->crc32 != archive_le32dec(f)) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
 		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: CRC32 error");
@@ -611,15 +611,15 @@ lzip_tail(struct archive_read_filter *self)
 	}
 
 	/* Check the uncompressed size of the current member */
-	if ((uint64_t)state->member_out != archive_le64dec(f + 4)) {
+	if ((uint64_t)xz->member_out != archive_le64dec(f + 4)) {
 		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: Uncompressed size error");
 		return (ARCHIVE_FAILED);
 	}
 
 	/* Check the total size of the current member */
-	if (state->lzip_ver == 1 &&
-	    (uint64_t)state->member_in + tail != archive_le64dec(f + 12)) {
+	if (xz->lzip_ver == 1 &&
+	    (uint64_t)xz->member_in + tail != archive_le64dec(f + 12)) {
 		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: Member size error");
 		return (ARCHIVE_FAILED);
@@ -629,11 +629,11 @@ lzip_tail(struct archive_read_filter *self)
 	/* If current lzip data consists of multi member, try decompressing
 	 * a next member. */
 	if (lzip_has_member(self->upstream) != 0) {
-		state->in_stream = 0;
-		state->crc32 = 0;
-		state->member_out = 0;
-		state->member_in = 0;
-		state->eof = 0;
+		xz->in_stream = 0;
+		xz->crc32 = 0;
+		xz->member_out = 0;
+		xz->member_in = 0;
+		xz->eof = 0;
 	}
 	return (ARCHIVE_OK);
 }
@@ -644,7 +644,7 @@ lzip_tail(struct archive_read_filter *self)
 static ssize_t
 xz_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct xz *xz = self->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	int64_t member_in;
@@ -652,43 +652,43 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 
 	redo:
 	/* Empty our output buffer. */
-	state->stream.next_out = state->out_block;
-	state->stream.avail_out = state->out_block_size;
-	member_in = state->member_in;
+	xz->stream.next_out = xz->out_block;
+	xz->stream.avail_out = xz->out_block_size;
+	member_in = xz->member_in;
 
 	/* Try to fill the output buffer. */
-	while (state->stream.avail_out > 0 && !state->eof) {
-		if (!state->in_stream) {
+	while (xz->stream.avail_out > 0 && !xz->eof) {
+		if (!xz->in_stream) {
 			/*
 			 * Initialize liblzma for lzip
 			 */
 			ret = lzip_init(self);
 			if (ret != ARCHIVE_OK)
 				return (ret);
-			state->in_stream = 1;
+			xz->in_stream = 1;
 		}
-		state->stream.next_in =
+		xz->stream.next_in =
 		    __archive_read_filter_ahead(self->upstream, 1, &avail_in);
-		if (state->stream.next_in == NULL && avail_in < 0) {
+		if (xz->stream.next_in == NULL && avail_in < 0) {
 			archive_set_error(&self->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated input");
 			return (ARCHIVE_FATAL);
 		}
-		state->stream.avail_in = avail_in;
+		xz->stream.avail_in = avail_in;
 
 		/* Decompress as much as we can in one pass. */
-		ret = lzma_code(&(state->stream),
-		    (state->stream.avail_in == 0)? LZMA_FINISH: LZMA_RUN);
+		ret = lzma_code(&(xz->stream),
+		    (xz->stream.avail_in == 0)? LZMA_FINISH: LZMA_RUN);
 		switch (ret) {
 		case LZMA_STREAM_END: /* Found end of stream. */
-			state->eof = 1;
+			xz->eof = 1;
 			/* FALL THROUGH */
 		case LZMA_OK: /* Decompressor made some progress. */
 			__archive_read_filter_consume(self->upstream,
-			    avail_in - state->stream.avail_in);
-			state->member_in +=
-			    avail_in - state->stream.avail_in;
+			    avail_in - xz->stream.avail_in);
+			xz->member_in +=
+			    avail_in - xz->stream.avail_in;
 			break;
 		default:
 			set_error(self, ret);
@@ -696,25 +696,25 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 		}
 	}
 
-	decompressed = state->stream.next_out - state->out_block;
-	state->member_out += decompressed;
+	decompressed = xz->stream.next_out - xz->out_block;
+	xz->member_out += decompressed;
 	if (decompressed == 0) {
-		if (member_in != state->member_in &&
+		if (member_in != xz->member_in &&
 		    self->code == ARCHIVE_FILTER_LZIP &&
-		    state->eof) {
+		    xz->eof) {
 			ret = lzip_tail(self);
 			if (ret != ARCHIVE_OK)
 				return (ret);
-			if (!state->eof)
+			if (!xz->eof)
 				goto redo;
 		}
 		*p = NULL;
 	} else {
-		*p = state->out_block;
+		*p = xz->out_block;
 		if (self->code == ARCHIVE_FILTER_LZIP) {
-			state->crc32 = lzma_crc32(state->out_block,
-			    decompressed, state->crc32);
-			if (state->eof) {
+			xz->crc32 = lzma_crc32(xz->out_block,
+			    decompressed, xz->crc32);
+			if (xz->eof) {
 				ret = lzip_tail(self);
 				if (ret != ARCHIVE_OK)
 					return (ret);
@@ -730,11 +730,11 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 static int
 xz_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct xz *xz = self->data;
 
-	lzma_end(&(state->stream));
-	free(state->out_block);
-	free(state);
+	lzma_end(&(xz->stream));
+	free(xz->out_block);
+	free(xz);
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_filter_xz.c
+++ b/libarchive/archive_read_support_filter_xz.c
@@ -197,14 +197,14 @@ archive_read_support_filter_lzip(struct archive *_a)
  * Test whether we can handle this data.
  */
 static int
-xz_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+xz_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, 6, NULL);
+	buffer = __archive_read_filter_ahead(f, 6, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -230,17 +230,17 @@ xz_bidder_bid(struct archive_read_filter_bidder *self,
  * they have other evidence (file name, command-line option) to go on.
  */
 static int
-lzma_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+lzma_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	uint32_t dicsize;
 	uint64_t uncompressed_size;
 	int bits_checked;
 
-	(void)self; /* UNUSED */
+	(void)b; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, 14, NULL);
+	buffer = __archive_read_filter_ahead(f, 14, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -336,13 +336,13 @@ lzma_bidder_bid(struct archive_read_filter_bidder *self,
 }
 
 static int
-lzip_has_member(struct archive_read_filter *filter)
+lzip_has_member(struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	int bits_checked;
 	int log2dic;
 
-	buffer = __archive_read_filter_ahead(filter, 6, NULL);
+	buffer = __archive_read_filter_ahead(f, 6, NULL);
 	if (buffer == NULL)
 		return (0);
 
@@ -369,12 +369,12 @@ lzip_has_member(struct archive_read_filter *filter)
 }
 
 static int
-lzip_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+lzip_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 
-	(void)self; /* UNUSED */
-	return (lzip_has_member(filter));
+	(void)b; /* UNUSED */
+	return (lzip_has_member(f));
 }
 
 #if HAVE_LZMA_H && HAVE_LIBLZMA
@@ -383,34 +383,34 @@ lzip_bidder_bid(struct archive_read_filter_bidder *self,
  * liblzma 4.999.7 and later support both lzma and xz streams.
  */
 static int
-xz_bidder_init(struct archive_read_filter *self)
+xz_bidder_init(struct archive_read_filter *f)
 {
-	self->code = ARCHIVE_FILTER_XZ;
-	self->name = "xz";
-	return (xz_lzma_bidder_init(self));
+	f->code = ARCHIVE_FILTER_XZ;
+	f->name = "xz";
+	return (xz_lzma_bidder_init(f));
 }
 
 static int
-lzma_bidder_init(struct archive_read_filter *self)
+lzma_bidder_init(struct archive_read_filter *f)
 {
-	self->code = ARCHIVE_FILTER_LZMA;
-	self->name = "lzma";
-	return (xz_lzma_bidder_init(self));
+	f->code = ARCHIVE_FILTER_LZMA;
+	f->name = "lzma";
+	return (xz_lzma_bidder_init(f));
 }
 
 static int
-lzip_bidder_init(struct archive_read_filter *self)
+lzip_bidder_init(struct archive_read_filter *f)
 {
-	self->code = ARCHIVE_FILTER_LZIP;
-	self->name = "lzip";
-	return (xz_lzma_bidder_init(self));
+	f->code = ARCHIVE_FILTER_LZIP;
+	f->name = "lzip";
+	return (xz_lzma_bidder_init(f));
 }
 
 /*
  * Set an error code and choose an error message
  */
 static void
-set_error(struct archive_read_filter *self, int ret)
+set_error(struct archive_read_filter *f, int ret)
 {
 
 	switch (ret) {
@@ -418,36 +418,36 @@ set_error(struct archive_read_filter *self, int ret)
 	case LZMA_OK: /* Decompressor made some progress. */
 		break;
 	case LZMA_MEM_ERROR:
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Lzma library error: Cannot allocate memory");
 		break;
 	case LZMA_MEMLIMIT_ERROR:
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Lzma library error: Out of memory");
 		break;
 	case LZMA_FORMAT_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Lzma library error: format not recognized");
 		break;
 	case LZMA_OPTIONS_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Lzma library error: Invalid options");
 		break;
 	case LZMA_DATA_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Lzma library error: Corrupted input data");
 		break;
 	case LZMA_BUF_ERROR:
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Lzma library error:  No progress is possible");
 		break;
 	default:
 		/* Return an error. */
-		archive_set_error(&self->archive->archive,
+		archive_set_error(&f->archive->archive,
 		    ARCHIVE_ERRNO_MISC,
 		    "Lzma decompression failed:  Unknown error");
 		break;
@@ -464,7 +464,7 @@ xz_lzma_reader_vtable = {
  * Setup the callbacks.
  */
 static int
-xz_lzma_bidder_init(struct archive_read_filter *self)
+xz_lzma_bidder_init(struct archive_read_filter *f)
 {
 	static const size_t out_block_size = 64 * 1024;
 	void *out_block;
@@ -474,17 +474,17 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	xz = calloc(1, sizeof(*xz));
 	out_block = malloc(out_block_size);
 	if (xz == NULL || out_block == NULL) {
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for xz decompression");
 		free(out_block);
 		free(xz);
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = xz;
+	f->data = xz;
 	xz->out_block_size = out_block_size;
 	xz->out_block = out_block;
-	self->vtable = &xz_lzma_reader_vtable;
+	f->vtable = &xz_lzma_reader_vtable;
 
 	xz->stream.avail_in = 0;
 
@@ -492,7 +492,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 	xz->stream.avail_out = xz->out_block_size;
 
 	xz->crc32 = 0;
-	if (self->code == ARCHIVE_FILTER_LZIP) {
+	if (f->code == ARCHIVE_FILTER_LZIP) {
 		/*
 		 * We have to read a lzip header and use it to initialize
 		 * compression library, thus we cannot initialize the
@@ -504,7 +504,7 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 		xz->in_stream = 1;
 
 	/* Initialize compression library. */
-	if (self->code == ARCHIVE_FILTER_XZ)
+	if (f->code == ARCHIVE_FILTER_XZ)
 		ret = lzma_stream_decoder(&(xz->stream),
 		    LZMA_MEMLIMIT,/* memlimit */
 		    LZMA_CONCATENATED);
@@ -516,26 +516,26 @@ xz_lzma_bidder_init(struct archive_read_filter *self)
 		return (ARCHIVE_OK);
 
 	/* Library setup failed: Choose an error message and clean up. */
-	set_error(self, ret);
+	set_error(f, ret);
 
 	free(xz->out_block);
 	free(xz);
-	self->data = NULL;
-	self->vtable = NULL;
+	f->data = NULL;
+	f->vtable = NULL;
 	return (ARCHIVE_FATAL);
 }
 
 static int
-lzip_init(struct archive_read_filter *self)
+lzip_init(struct archive_read_filter *f)
 {
-	struct xz *xz = self->data;
+	struct xz *xz = f->data;
 	const unsigned char *h;
 	lzma_filter filters[2];
 	unsigned char props[5];
 	uint32_t dicsize;
 	int log2dic, ret;
 
-	h = __archive_read_filter_ahead(self->upstream, 6, NULL);
+	h = __archive_read_filter_ahead(f->upstream, 6, NULL);
 	if (h == NULL)
 		return (ARCHIVE_FATAL);
 
@@ -557,7 +557,7 @@ lzip_init(struct archive_read_filter *self)
 	archive_le32enc(props+1, dicsize);
 
 	/* Consume lzip header. */
-	__archive_read_filter_consume(self->upstream, 6);
+	__archive_read_filter_consume(f->upstream, 6);
 	xz->member_in = 6;
 
 	filters[0].id = LZMA_FILTER_LZMA1;
@@ -567,23 +567,23 @@ lzip_init(struct archive_read_filter *self)
 
 	ret = lzma_properties_decode(&filters[0], NULL, props, sizeof(props));
 	if (ret != LZMA_OK) {
-		set_error(self, ret);
+		set_error(f, ret);
 		return (ARCHIVE_FATAL);
 	}
 	ret = lzma_raw_decoder(&(xz->stream), filters);
 	free(filters[0].options);
 	if (ret != LZMA_OK) {
-		set_error(self, ret);
+		set_error(f, ret);
 		return (ARCHIVE_FATAL);
 	}
 	return (ARCHIVE_OK);
 }
 
 static int
-lzip_tail(struct archive_read_filter *self)
+lzip_tail(struct archive_read_filter *f)
 {
-	struct xz *xz = self->data;
-	const unsigned char *f;
+	struct xz *xz = f->data;
+	const unsigned char *p;
 	ssize_t avail_in;
 	int tail;
 
@@ -591,44 +591,44 @@ lzip_tail(struct archive_read_filter *self)
 		tail = 12;
 	else
 		tail = 20;
-	f = __archive_read_filter_ahead(self->upstream, tail, &avail_in);
-	if (f == NULL && avail_in < 0)
+	p = __archive_read_filter_ahead(f->upstream, tail, &avail_in);
+	if (p == NULL && avail_in < 0)
 		return (ARCHIVE_FATAL);
-	if (f == NULL || avail_in < tail) {
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	if (p == NULL || avail_in < tail) {
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: Remaining data is less bytes");
 		return (ARCHIVE_FAILED);
 	}
 
 	/* Check the crc32 value of the uncompressed data of the current
 	 * member */
-	if (xz->crc32 != archive_le32dec(f)) {
+	if (xz->crc32 != archive_le32dec(p)) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: CRC32 error");
 		return (ARCHIVE_FAILED);
 #endif
 	}
 
 	/* Check the uncompressed size of the current member */
-	if ((uint64_t)xz->member_out != archive_le64dec(f + 4)) {
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	if ((uint64_t)xz->member_out != archive_le64dec(p + 4)) {
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: Uncompressed size error");
 		return (ARCHIVE_FAILED);
 	}
 
 	/* Check the total size of the current member */
 	if (xz->lzip_ver == 1 &&
-	    (uint64_t)xz->member_in + tail != archive_le64dec(f + 12)) {
-		archive_set_error(&self->archive->archive, ARCHIVE_ERRNO_MISC,
+	    (uint64_t)xz->member_in + tail != archive_le64dec(p + 12)) {
+		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
 		    "Lzip: Member size error");
 		return (ARCHIVE_FAILED);
 	}
-	__archive_read_filter_consume(self->upstream, tail);
+	__archive_read_filter_consume(f->upstream, tail);
 
 	/* If current lzip data consists of multi member, try decompressing
 	 * a next member. */
-	if (lzip_has_member(self->upstream) != 0) {
+	if (lzip_has_member(f->upstream) != 0) {
 		xz->in_stream = 0;
 		xz->crc32 = 0;
 		xz->member_out = 0;
@@ -642,9 +642,9 @@ lzip_tail(struct archive_read_filter *self)
  * Return the next block of decompressed data.
  */
 static ssize_t
-xz_filter_read(struct archive_read_filter *self, const void **p)
+xz_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct xz *xz = self->data;
+	struct xz *xz = f->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	int64_t member_in;
@@ -662,15 +662,15 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 			/*
 			 * Initialize liblzma for lzip
 			 */
-			ret = lzip_init(self);
+			ret = lzip_init(f);
 			if (ret != ARCHIVE_OK)
 				return (ret);
 			xz->in_stream = 1;
 		}
 		xz->stream.next_in =
-		    __archive_read_filter_ahead(self->upstream, 1, &avail_in);
+		    __archive_read_filter_ahead(f->upstream, 1, &avail_in);
 		if (xz->stream.next_in == NULL && avail_in < 0) {
-			archive_set_error(&self->archive->archive,
+			archive_set_error(&f->archive->archive,
 			    ARCHIVE_ERRNO_MISC,
 			    "truncated input");
 			return (ARCHIVE_FATAL);
@@ -685,13 +685,13 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 			xz->eof = 1;
 			/* FALL THROUGH */
 		case LZMA_OK: /* Decompressor made some progress. */
-			__archive_read_filter_consume(self->upstream,
+			__archive_read_filter_consume(f->upstream,
 			    avail_in - xz->stream.avail_in);
 			xz->member_in +=
 			    avail_in - xz->stream.avail_in;
 			break;
 		default:
-			set_error(self, ret);
+			set_error(f, ret);
 			return (ARCHIVE_FATAL);
 		}
 	}
@@ -700,9 +700,9 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 	xz->member_out += decompressed;
 	if (decompressed == 0) {
 		if (member_in != xz->member_in &&
-		    self->code == ARCHIVE_FILTER_LZIP &&
+		    f->code == ARCHIVE_FILTER_LZIP &&
 		    xz->eof) {
-			ret = lzip_tail(self);
+			ret = lzip_tail(f);
 			if (ret != ARCHIVE_OK)
 				return (ret);
 			if (!xz->eof)
@@ -711,11 +711,11 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
 		*p = NULL;
 	} else {
 		*p = xz->out_block;
-		if (self->code == ARCHIVE_FILTER_LZIP) {
+		if (f->code == ARCHIVE_FILTER_LZIP) {
 			xz->crc32 = lzma_crc32(xz->out_block,
 			    decompressed, xz->crc32);
 			if (xz->eof) {
-				ret = lzip_tail(self);
+				ret = lzip_tail(f);
 				if (ret != ARCHIVE_OK)
 					return (ret);
 			}
@@ -728,9 +728,9 @@ xz_filter_read(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-xz_filter_close(struct archive_read_filter *self)
+xz_filter_close(struct archive_read_filter *f)
 {
-	struct xz *xz = self->data;
+	struct xz *xz = f->data;
 
 	lzma_end(&(xz->stream));
 	free(xz->out_block);
@@ -748,44 +748,44 @@ xz_filter_close(struct archive_read_filter *self)
  *
  */
 static int
-lzma_bidder_init(struct archive_read_filter *self)
+lzma_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "lzma -d -qq");
+	r = __archive_read_program(f, "lzma -d -qq");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_LZMA;
-	self->name = "lzma";
+	f->code = ARCHIVE_FILTER_LZMA;
+	f->name = "lzma";
 	return (r);
 }
 
 static int
-xz_bidder_init(struct archive_read_filter *self)
+xz_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "xz -d -qq");
+	r = __archive_read_program(f, "xz -d -qq");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_XZ;
-	self->name = "xz";
+	f->code = ARCHIVE_FILTER_XZ;
+	f->name = "xz";
 	return (r);
 }
 
 static int
-lzip_bidder_init(struct archive_read_filter *self)
+lzip_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "lzip -d -q");
+	r = __archive_read_program(f, "lzip -d -q");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_LZIP;
-	self->name = "lzip";
+	f->code = ARCHIVE_FILTER_LZIP;
+	f->name = "lzip";
 	return (r);
 }
 

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -270,14 +270,12 @@ zstd_bidder_init(struct archive_read_filter *self)
 static ssize_t
 zstd_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state;
+	struct private_data *state = self->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	ZSTD_outBuffer out;
 	ZSTD_inBuffer in;
 	size_t ret;
-
-	state = (struct private_data *)self->data;
 
 	out = (ZSTD_outBuffer) { state->out_block, state->out_block_size, 0 };
 
@@ -346,9 +344,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 static int
 zstd_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state;
-
-	state = (struct private_data *)self->data;
+	struct private_data *state = self->data;
 
 	ZSTD_freeDStream(state->dstream);
 	free(state->out_block);

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -104,8 +104,8 @@ archive_read_support_filter_zstd(struct archive *_a)
  * Test whether we can handle this data.
  */
 static int
-zstd_bidder_bid(struct archive_read_filter_bidder *self,
-    struct archive_read_filter *filter)
+zstd_bidder_bid(struct archive_read_filter_bidder *b,
+    struct archive_read_filter *f)
 {
 	const unsigned char *buffer;
 	ssize_t avail;
@@ -132,9 +132,9 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 	const uint32_t zstd_magic_skippable_start = 0x184D2A50;
 	const uint32_t zstd_magic_skippable_mask  = 0xFFFFFFF0;
 
-	(void) self; /* UNUSED */
+	(void) b; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, min_zstd_frame_size,
+	buffer = __archive_read_filter_ahead(f, min_zstd_frame_size,
 	    &avail);
 	if (buffer == NULL)
 		return (0);
@@ -151,7 +151,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 
 		/* Ensure that we can read another 4 bytes. */
 		if (offset_in_buffer + 4 > (size_t)avail) {
-			buffer = __archive_read_filter_ahead(filter,
+			buffer = __archive_read_filter_ahead(f,
 			    offset_in_buffer + 4, &avail);
 			if (buffer == NULL)
 				return (0);
@@ -178,7 +178,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
 			if (min > max_lookahead)
 				return (0);
 
-			buffer = __archive_read_filter_ahead(filter,
+			buffer = __archive_read_filter_ahead(f,
 			    min, &avail);
 			if (buffer == NULL)
 				return (0);
@@ -206,16 +206,16 @@ zstd_bidder_bid(struct archive_read_filter_bidder *self,
  * in case that's available.
  */
 static int
-zstd_bidder_init(struct archive_read_filter *self)
+zstd_bidder_init(struct archive_read_filter *f)
 {
 	int r;
 
-	r = __archive_read_program(self, "zstd -d -qq");
+	r = __archive_read_program(f, "zstd -d -qq");
 	/* Note: We set the format here even if __archive_read_program()
 	 * above fails.  We do, after all, know what the format is
 	 * even if we weren't able to read it. */
-	self->code = ARCHIVE_FILTER_ZSTD;
-	self->name = "zstd";
+	f->code = ARCHIVE_FILTER_ZSTD;
+	f->name = "zstd";
 	return (r);
 }
 
@@ -231,15 +231,15 @@ zstd_reader_vtable = {
  * Initialize the filter object
  */
 static int
-zstd_bidder_init(struct archive_read_filter *self)
+zstd_bidder_init(struct archive_read_filter *f)
 {
 	struct zstd *zstd;
 	size_t out_block_size = ZSTD_DStreamOutSize();
 	void *out_block;
 	ZSTD_DStream *dstream;
 
-	self->code = ARCHIVE_FILTER_ZSTD;
-	self->name = "zstd";
+	f->code = ARCHIVE_FILTER_ZSTD;
+	f->name = "zstd";
 
 	zstd = calloc(1, sizeof(*zstd));
 	out_block = malloc(out_block_size);
@@ -249,17 +249,17 @@ zstd_bidder_init(struct archive_read_filter *self)
 		free(out_block);
 		free(zstd);
 		ZSTD_freeDStream(dstream); /* supports free on NULL */
-		archive_set_error(&self->archive->archive, ENOMEM,
+		archive_set_error(&f->archive->archive, ENOMEM,
 		    "Can't allocate data for zstd decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = zstd;
+	f->data = zstd;
 
 	zstd->out_block_size = out_block_size;
 	zstd->out_block = out_block;
 	zstd->dstream = dstream;
-	self->vtable = &zstd_reader_vtable;
+	f->vtable = &zstd_reader_vtable;
 
 	zstd->eof = 0;
 	zstd->in_frame = 0;
@@ -268,9 +268,9 @@ zstd_bidder_init(struct archive_read_filter *self)
 }
 
 static ssize_t
-zstd_filter_read(struct archive_read_filter *self, const void **p)
+zstd_filter_read(struct archive_read_filter *f, const void **p)
 {
-	struct zstd *zstd = self->data;
+	struct zstd *zstd = f->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	ZSTD_outBuffer out;
@@ -284,14 +284,14 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 		if (!zstd->in_frame) {
 			ret = ZSTD_initDStream(zstd->dstream);
 			if (ZSTD_isError(ret)) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Error initializing zstd decompressor: %s",
 				    ZSTD_getErrorName(ret));
 				return (ARCHIVE_FATAL);
 			}
 		}
-		in.src = __archive_read_filter_ahead(self->upstream, 1,
+		in.src = __archive_read_filter_ahead(f->upstream, 1,
 		    &avail_in);
 		if (avail_in < 0) {
 			return avail_in;
@@ -302,7 +302,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 				zstd->eof = 1;
 				break;
 			} else {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Truncated zstd input");
 				return (ARCHIVE_FATAL);
@@ -315,7 +315,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 			ret = ZSTD_decompressStream(zstd->dstream, &out, &in);
 
 			if (ZSTD_isError(ret)) {
-				archive_set_error(&self->archive->archive,
+				archive_set_error(&f->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
 				    "Zstd decompression failed: %s",
 				    ZSTD_getErrorName(ret));
@@ -323,7 +323,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 			}
 
 			/* Decompressor made some progress */
-			__archive_read_filter_consume(self->upstream, in.pos);
+			__archive_read_filter_consume(f->upstream, in.pos);
 
 			/* ret guaranteed to be > 0 if frame isn't done yet */
 			zstd->in_frame = (ret != 0);
@@ -342,9 +342,9 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
  * Clean up the decompressor.
  */
 static int
-zstd_filter_close(struct archive_read_filter *self)
+zstd_filter_close(struct archive_read_filter *f)
 {
-	struct zstd *zstd = self->data;
+	struct zstd *zstd = f->data;
 
 	ZSTD_freeDStream(zstd->dstream);
 	free(zstd->out_block);

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -54,7 +54,7 @@
 
 #if HAVE_ZSTD_H && HAVE_LIBZSTD
 
-struct private_data {
+struct zstd {
 	ZSTD_DStream	*dstream;
 	unsigned char	*out_block;
 	size_t		 out_block_size;
@@ -233,7 +233,7 @@ zstd_reader_vtable = {
 static int
 zstd_bidder_init(struct archive_read_filter *self)
 {
-	struct private_data *state;
+	struct zstd *zstd;
 	size_t out_block_size = ZSTD_DStreamOutSize();
 	void *out_block;
 	ZSTD_DStream *dstream;
@@ -241,28 +241,28 @@ zstd_bidder_init(struct archive_read_filter *self)
 	self->code = ARCHIVE_FILTER_ZSTD;
 	self->name = "zstd";
 
-	state = calloc(1, sizeof(*state));
+	zstd = calloc(1, sizeof(*zstd));
 	out_block = malloc(out_block_size);
 	dstream = ZSTD_createDStream();
 
-	if (state == NULL || out_block == NULL || dstream == NULL) {
+	if (zstd == NULL || out_block == NULL || dstream == NULL) {
 		free(out_block);
-		free(state);
+		free(zstd);
 		ZSTD_freeDStream(dstream); /* supports free on NULL */
 		archive_set_error(&self->archive->archive, ENOMEM,
 		    "Can't allocate data for zstd decompression");
 		return (ARCHIVE_FATAL);
 	}
 
-	self->data = state;
+	self->data = zstd;
 
-	state->out_block_size = out_block_size;
-	state->out_block = out_block;
-	state->dstream = dstream;
+	zstd->out_block_size = out_block_size;
+	zstd->out_block = out_block;
+	zstd->dstream = dstream;
 	self->vtable = &zstd_reader_vtable;
 
-	state->eof = 0;
-	state->in_frame = 0;
+	zstd->eof = 0;
+	zstd->in_frame = 0;
 
 	return (ARCHIVE_OK);
 }
@@ -270,19 +270,19 @@ zstd_bidder_init(struct archive_read_filter *self)
 static ssize_t
 zstd_filter_read(struct archive_read_filter *self, const void **p)
 {
-	struct private_data *state = self->data;
+	struct zstd *zstd = self->data;
 	size_t decompressed;
 	ssize_t avail_in;
 	ZSTD_outBuffer out;
 	ZSTD_inBuffer in;
 	size_t ret;
 
-	out = (ZSTD_outBuffer) { state->out_block, state->out_block_size, 0 };
+	out = (ZSTD_outBuffer) { zstd->out_block, zstd->out_block_size, 0 };
 
 	/* Try to fill the output buffer. */
-	while (out.pos < out.size && !state->eof) {
-		if (!state->in_frame) {
-			ret = ZSTD_initDStream(state->dstream);
+	while (out.pos < out.size && !zstd->eof) {
+		if (!zstd->in_frame) {
+			ret = ZSTD_initDStream(zstd->dstream);
 			if (ZSTD_isError(ret)) {
 				archive_set_error(&self->archive->archive,
 				    ARCHIVE_ERRNO_MISC,
@@ -297,9 +297,9 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 			return avail_in;
 		}
 		if (in.src == NULL && avail_in == 0) {
-			if (!state->in_frame) {
+			if (!zstd->in_frame) {
 				/* end of stream */
-				state->eof = 1;
+				zstd->eof = 1;
 				break;
 			} else {
 				archive_set_error(&self->archive->archive,
@@ -312,7 +312,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 		in.pos = 0;
 
 		{
-			ret = ZSTD_decompressStream(state->dstream, &out, &in);
+			ret = ZSTD_decompressStream(zstd->dstream, &out, &in);
 
 			if (ZSTD_isError(ret)) {
 				archive_set_error(&self->archive->archive,
@@ -326,7 +326,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 			__archive_read_filter_consume(self->upstream, in.pos);
 
 			/* ret guaranteed to be > 0 if frame isn't done yet */
-			state->in_frame = (ret != 0);
+			zstd->in_frame = (ret != 0);
 		}
 	}
 
@@ -334,7 +334,7 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 	if (decompressed == 0)
 		*p = NULL;
 	else
-		*p = state->out_block;
+		*p = zstd->out_block;
 	return (decompressed);
 }
 
@@ -344,11 +344,11 @@ zstd_filter_read(struct archive_read_filter *self, const void **p)
 static int
 zstd_filter_close(struct archive_read_filter *self)
 {
-	struct private_data *state = self->data;
+	struct zstd *zstd = self->data;
 
-	ZSTD_freeDStream(state->dstream);
-	free(state->out_block);
-	free(state);
+	ZSTD_freeDStream(zstd->dstream);
+	free(zstd->out_block);
+	free(zstd);
 
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -520,7 +520,7 @@ static int
 archive_read_format_7zip_has_encrypted_entries(struct archive_read *a)
 {
 	if (a && a->format) {
-		struct _7zip *zip = (struct _7zip *)a->format->data;
+		struct _7zip *zip = a->format->data;
 		if (zip) {
 			return zip->has_encrypted_entries;
 		}
@@ -894,7 +894,7 @@ static int
 archive_read_format_7zip_read_header(struct archive_read *a,
 	struct archive_entry *entry)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	struct _7zip_entry *zip_entry;
 	int r, ret = ARCHIVE_OK;
 	struct _7z_folder *folder = 0;
@@ -1095,11 +1095,9 @@ static int
 archive_read_format_7zip_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format->data;
 	ssize_t bytes;
 	int ret = ARCHIVE_OK;
-
-	zip = (struct _7zip *)(a->format->data);
 
 	if (zip->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
 		zip->has_encrypted_entries = 0;
@@ -1165,10 +1163,8 @@ archive_read_format_7zip_read_data(struct archive_read *a,
 static int
 archive_read_format_7zip_read_data_skip(struct archive_read *a)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format->data;
 	int r;
-
-	zip = (struct _7zip *)(a->format->data);
 
 	if (zip->pack_stream_bytes_unconsumed)
 		read_consume(a);
@@ -1194,9 +1190,8 @@ archive_read_format_7zip_read_data_skip(struct archive_read *a)
 static int
 archive_read_format_7zip_cleanup(struct archive_read *a)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format->data;
 
-	zip = (struct _7zip *)(a->format->data);
 	free_StreamsInfo(&(zip->si));
 	free(zip->entries);
 	free(zip->entry_names);
@@ -1207,14 +1202,14 @@ archive_read_format_7zip_cleanup(struct archive_read *a)
 	free(zip->sub_stream_buff[2]);
 	free(zip->tmp_stream_buff);
 	free(zip);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 
 static int
 read_consume(struct archive_read *a)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 
 	if (zip->pack_stream_bytes_unconsumed) {
 		int64_t r;
@@ -1298,7 +1293,7 @@ static Byte
 ppmd_read(void *p)
 {
 	struct archive_read *a = ((IByteIn*)p)->a;
-	struct _7zip *zip = (struct _7zip *)(a->format->data);
+	struct _7zip *zip = a->format->data;
 	Byte b;
 
 	if (zip->ppstream.avail_in == 0) {
@@ -2258,7 +2253,7 @@ free_Folder(struct _7z_folder *f)
 static int
 read_Folder(struct archive_read *a, struct _7z_folder *f)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 	size_t numInStreamsTotal = 0;
 	size_t numOutStreamsTotal = 0;
@@ -2404,7 +2399,7 @@ free_CodersInfo(struct _7z_coders_info *ci)
 static int
 read_CodersInfo(struct archive_read *a, struct _7z_coders_info *ci)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 	struct _7z_digests digest;
 	size_t dataStreamIndex, i;
@@ -2686,7 +2681,7 @@ free_StreamsInfo(struct _7z_stream_info *si)
 static int
 read_StreamsInfo(struct archive_read *a, struct _7z_stream_info *si)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 	size_t i;
 
@@ -2788,7 +2783,7 @@ static int
 read_Header(struct archive_read *a, struct _7z_header_info *h,
     int check_header_id)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 	struct _7z_folder *folders;
 	struct _7z_stream_info *si = &(zip->si);
@@ -3146,7 +3141,7 @@ read_Header(struct archive_read *a, struct _7z_header_info *h,
 static int
 read_Times(struct archive_read *a, int type)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 	struct _7zip_entry *entries = zip->entries;
 	unsigned char *timeBools = NULL;
@@ -3211,7 +3206,7 @@ failed:
 static int
 decode_encoded_header_info(struct archive_read *a, struct _7z_stream_info *si)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	int64_t pi_end;
 
 	errno = 0;
@@ -3246,7 +3241,7 @@ decode_encoded_header_info(struct archive_read *a, struct _7z_stream_info *si)
 static const unsigned char *
 header_bytes(struct archive_read *a, size_t rbytes)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const unsigned char *p;
 
 	if ((uint64_t)zip->header_bytes_remaining < rbytes)
@@ -3460,7 +3455,7 @@ static ssize_t
 get_uncompressed_data(struct archive_read *a, const void **buff, size_t size,
     size_t minimum)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	ssize_t bytes_avail;
 
 	if (zip->codec == _7Z_COPY && zip->codec2 == -1) {
@@ -3523,7 +3518,7 @@ align_size(size_t s)
 static ssize_t
 extract_pack_stream(struct archive_read *a, size_t minimum)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	ssize_t bytes_avail;
 	int r;
 
@@ -3681,7 +3676,7 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 static int
 seek_pack(struct archive_read *a)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	int64_t pack_offset;
 
 	if (zip->pack_stream_remaining == 0) {
@@ -3712,7 +3707,7 @@ static ssize_t
 read_stream(struct archive_read *a, const void **buff, size_t size,
     size_t minimum)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	int64_t skip_bytes = 0;
 	ssize_t r;
 
@@ -3831,7 +3826,7 @@ static int
 setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
     int header)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const struct _7z_coder *coder1, *coder2;
 	const char *cname = (header)?"archive header":"file content";
 	size_t i;
@@ -4099,7 +4094,7 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 static int
 skip_stream(struct archive_read *a, int64_t skip_bytes)
 {
-	struct _7zip *zip = (struct _7zip *)a->format->data;
+	struct _7zip *zip = a->format->data;
 	const void *p;
 	int64_t skipped_bytes;
 	int64_t bytes = skip_bytes;

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -135,7 +135,7 @@ archive_read_support_format_ar(struct archive *_a)
 static int
 archive_read_format_ar_cleanup(struct archive_read *a)
 {
-	struct ar *ar = (struct ar *)(a->format->data);
+	struct ar *ar = a->format->data;
 
 	free(ar->strtab);
 	free(ar);
@@ -399,7 +399,7 @@ static int
 archive_read_format_ar_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct ar *ar = (struct ar *)(a->format->data);
+	struct ar *ar = a->format->data;
 	int64_t unconsumed;
 	const void *header_data;
 	int ret;
@@ -459,7 +459,7 @@ static int
 archive_read_format_ar_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct ar *ar = (struct ar *)(a->format->data);
+	struct ar *ar = a->format->data;
 	ssize_t bytes_read;
 
 	if (ar->entry_bytes_unconsumed) {
@@ -498,7 +498,7 @@ archive_read_format_ar_read_data(struct archive_read *a,
 static int
 archive_read_format_ar_skip(struct archive_read *a)
 {
-	struct ar *ar = (struct ar *)(a->format->data);
+	struct ar *ar = a->format->data;
 
 	if (__archive_read_consume(a,
 	    ar->entry_bytes_remaining + ar->entry_padding +
@@ -515,7 +515,7 @@ archive_read_format_ar_skip(struct archive_read *a)
 static int
 ar_parse_gnu_filename_table(struct archive_read *a)
 {
-	struct ar *ar = (struct ar *)(a->format->data);
+	struct ar *ar = a->format->data;
 	char *p;
 	size_t size;
 

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -566,10 +566,9 @@ static int
 archive_read_format_cab_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct cab *cab;
+	struct cab *cab = a->format->data;
 	int ret = ARCHIVE_FAILED;
 
-	cab = (struct cab *)(a->format->data);
 	if (strcmp(key, "hdrcharset")  == 0) {
 		if (val == NULL || val[0] == 0)
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
@@ -725,8 +724,8 @@ cab_convert_path_separator_2(struct cab *cab, struct archive_entry *entry)
 static int
 cab_read_header(struct archive_read *a)
 {
+	struct cab *cab = a->format->data;
 	const char *p;
-	struct cab *cab;
 	struct cfheader *hd;
 	size_t bytes, len, maxlen, used;
 	ssize_t avail;
@@ -742,7 +741,6 @@ cab_read_header(struct archive_read *a)
 	if ((p = __archive_read_ahead(a, 42, NULL)) == NULL)
 		return (truncated_error(a));
 
-	cab = (struct cab *)(a->format->data);
 	if (cab->found_header == 0 &&
 	    p[0] == 'M' && p[1] == 'Z') {
 		/* This is an executable?  Must be self-extracting... */
@@ -1005,14 +1003,13 @@ static int
 archive_read_format_cab_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct cab *cab;
+	struct cab *cab = a->format->data;
 	struct cfheader *hd;
 	struct cffolder *prev_folder;
 	struct cffile *file;
 	struct archive_string_conv *sconv;
 	int err = ARCHIVE_OK, r;
-	
-	cab = (struct cab *)(a->format->data);
+
 	if (cab->found_header == 0) {
 		err = cab_read_header(a); 
 		if (err < ARCHIVE_WARN)
@@ -1127,7 +1124,7 @@ static int
 archive_read_format_cab_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	int r;
 
 	switch (cab->entry_cffile->folder) {
@@ -1227,7 +1224,7 @@ cab_checksum_cfdata(const void *p, size_t bytes, uint32_t seed)
 static void
 cab_checksum_update(struct archive_read *a, size_t bytes)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata = cab->entry_cfdata;
 	const unsigned char *p;
 	size_t sumbytes;
@@ -1267,7 +1264,7 @@ cab_checksum_update(struct archive_read *a, size_t bytes)
 static int
 cab_checksum_finish(struct archive_read *a)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata = cab->entry_cfdata;
 	int l;
 
@@ -1312,7 +1309,7 @@ cab_checksum_finish(struct archive_read *a)
 static int
 cab_next_cfdata(struct archive_read *a)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata = cab->entry_cfdata;
 
 	/* There are remaining bytes in current CFDATA, use it first. */
@@ -1460,7 +1457,7 @@ invalid:
 static const void *
 cab_read_ahead_cfdata(struct archive_read *a, ssize_t *avail)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	int err;
 
 	err = cab_next_cfdata(a);
@@ -1491,7 +1488,7 @@ cab_read_ahead_cfdata(struct archive_read *a, ssize_t *avail)
 static const void *
 cab_read_ahead_cfdata_none(struct archive_read *a, ssize_t *avail)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata;
 	const void *d;
 
@@ -1523,7 +1520,7 @@ cab_read_ahead_cfdata_none(struct archive_read *a, ssize_t *avail)
 static const void *
 cab_read_ahead_cfdata_deflate(struct archive_read *a, ssize_t *avail)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata;
 	const void *d;
 	int r, mszip;
@@ -1751,7 +1748,7 @@ cab_read_ahead_cfdata_deflate(struct archive_read *a, ssize_t *avail)
 static const void *
 cab_read_ahead_cfdata_lzx(struct archive_read *a, ssize_t *avail)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata;
 	const void *d;
 	int r;
@@ -1881,7 +1878,7 @@ cab_read_ahead_cfdata_lzx(struct archive_read *a, ssize_t *avail)
 static int64_t
 cab_consume_cfdata(struct archive_read *a, int64_t consumed_bytes)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata;
 	int64_t cbytes, rbytes;
 	int err;
@@ -1974,7 +1971,7 @@ cab_consume_cfdata(struct archive_read *a, int64_t consumed_bytes)
 static int64_t
 cab_minimum_consume_cfdata(struct archive_read *a, int64_t consumed_bytes)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfdata *cfdata;
 	int64_t cbytes, rbytes;
 	int err;
@@ -2031,7 +2028,7 @@ static int
 cab_read_data(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	ssize_t bytes_avail;
 
 	if (cab->entry_bytes_remaining == 0) {
@@ -2077,11 +2074,9 @@ cab_read_data(struct archive_read *a, const void **buff,
 static int
 archive_read_format_cab_read_data_skip(struct archive_read *a)
 {
-	struct cab *cab;
+	struct cab *cab = a->format->data;
 	int64_t bytes_skipped;
 	int r;
-
-	cab = (struct cab *)(a->format->data);
 
 	if (cab->end_of_archive)
 		return (ARCHIVE_EOF);
@@ -2132,7 +2127,7 @@ archive_read_format_cab_read_data_skip(struct archive_read *a)
 static int
 archive_read_format_cab_cleanup(struct archive_read *a)
 {
-	struct cab *cab = (struct cab *)(a->format->data);
+	struct cab *cab = a->format->data;
 	struct cfheader *hd = &cab->cfheader;
 	uint16_t i;
 
@@ -2154,7 +2149,7 @@ archive_read_format_cab_cleanup(struct archive_read *a)
 	archive_wstring_free(&cab->ws);
 	free(cab->uncompressed_buffer);
 	free(cab);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -261,13 +261,11 @@ archive_read_support_format_cpio(struct archive *_a)
 static int
 archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 {
+	struct cpio *cpio = a->format->data;
 	const unsigned char *p;
-	struct cpio *cpio;
 	int bid;
 
 	(void)best_bid; /* UNUSED */
-
-	cpio = (struct cpio *)(a->format->data);
 
 	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
 		return (-1);
@@ -326,10 +324,9 @@ static int
 archive_read_format_cpio_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format->data;
 	int ret = ARCHIVE_FAILED;
 
-	cpio = (struct cpio *)(a->format->data);
 	if (strcmp(key, "compat-2x")  == 0) {
 		/* Handle filenames as libarchive 2.x */
 		cpio->init_default_conversion = (val != NULL)?1:0;
@@ -364,7 +361,7 @@ static int
 archive_read_format_cpio_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format->data;
 	const void *h, *hl;
 	struct archive_string_conv *sconv;
 	size_t namelength;
@@ -372,7 +369,6 @@ archive_read_format_cpio_read_header(struct archive_read *a,
 	int is_trailer;
 	int r;
 
-	cpio = (struct cpio *)(a->format->data);
 	sconv = cpio->opt_sconv;
 	if (sconv == NULL) {
 		if (!cpio->init_default_conversion) {
@@ -473,10 +469,8 @@ static int
 archive_read_format_cpio_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
+	struct cpio *cpio = a->format->data;
 	ssize_t bytes_read;
-	struct cpio *cpio;
-
-	cpio = (struct cpio *)(a->format->data);
 
 	if (cpio->entry_bytes_unconsumed) {
 		__archive_read_consume(a, cpio->entry_bytes_unconsumed);
@@ -511,7 +505,7 @@ archive_read_format_cpio_read_data(struct archive_read *a,
 static int
 archive_read_format_cpio_skip(struct archive_read *a)
 {
-	struct cpio *cpio = (struct cpio *)(a->format->data);
+	struct cpio *cpio = a->format->data;
 	int64_t to_skip = cpio->entry_bytes_remaining + cpio->entry_padding +
 		cpio->entry_bytes_unconsumed;
 
@@ -1004,9 +998,8 @@ header_bin_be(struct archive_read *a, struct cpio *cpio,
 static int
 archive_read_format_cpio_cleanup(struct archive_read *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format->data;
 
-	cpio = (struct cpio *)(a->format->data);
         /* Free inode->name map */
         while (cpio->links_head != NULL) {
                 struct links_entry *lp = cpio->links_head->next;
@@ -1016,7 +1009,7 @@ archive_read_format_cpio_cleanup(struct archive_read *a)
                 cpio->links_head = lp;
         }
 	free(cpio);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -504,7 +504,7 @@ archive_read_support_format_iso9660(struct archive *_a)
 static int
 archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	ssize_t bytes_read;
 	const unsigned char *p;
 	int seenTerminator;
@@ -513,8 +513,6 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	   make, don't bother testing. */
 	if (best_bid > 48)
 		return (-1);
-
-	iso9660 = (struct iso9660 *)(a->format->data);
 
 	/*
 	 * Skip the first 32k (reserved area) and get the first
@@ -577,9 +575,7 @@ static int
 archive_read_format_iso9660_options(struct archive_read *a,
 		const char *key, const char *val)
 {
-	struct iso9660 *iso9660;
-
-	iso9660 = (struct iso9660 *)(a->format->data);
+	struct iso9660 *iso9660 = a->format->data;
 
 	if (strcmp(key, "joliet") == 0) {
 		if (val == NULL || strcmp(val, "off") == 0 ||
@@ -1035,12 +1031,11 @@ isRootDirectoryRecord(const unsigned char *p) {
 static int
 read_children(struct archive_read *a, struct file_info *parent)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	const unsigned char *b, *p;
 	struct file_info *multi;
 	size_t step, skip_size;
 
-	iso9660 = (struct iso9660 *)(a->format->data);
 	/* flush any remaining bytes from the last round to ensure
 	 * we're positioned */
 	if (iso9660->entry_bytes_unconsumed) {
@@ -1248,11 +1243,9 @@ static int
 archive_read_format_iso9660_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	struct file_info *file;
 	int r, rd_r = ARCHIVE_OK;
-
-	iso9660 = (struct iso9660 *)(a->format->data);
 
 	if (!a->archive.archive_format) {
 		a->archive.archive_format = ARCHIVE_FORMAT_ISO9660;
@@ -1500,7 +1493,7 @@ static int
 zisofs_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	struct zisofs  *zisofs;
 	const unsigned char *p;
 	size_t avail;
@@ -1508,7 +1501,6 @@ zisofs_read_data(struct archive_read *a,
 	size_t uncompressed_size;
 	int r;
 
-	iso9660 = (struct iso9660 *)(a->format->data);
 	zisofs = &iso9660->entry_zisofs;
 
 	p = __archive_read_ahead(a, 1, &bytes_read);
@@ -1739,10 +1731,8 @@ static int
 archive_read_format_iso9660_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
+	struct iso9660 *iso9660 = a->format->data;
 	ssize_t bytes_read;
-	struct iso9660 *iso9660;
-
-	iso9660 = (struct iso9660 *)(a->format->data);
 
 	if (iso9660->entry_bytes_unconsumed) {
 		__archive_read_consume(a, iso9660->entry_bytes_unconsumed);
@@ -1806,10 +1796,9 @@ archive_read_format_iso9660_read_data(struct archive_read *a,
 static int
 archive_read_format_iso9660_cleanup(struct archive_read *a)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	int r = ARCHIVE_OK;
 
-	iso9660 = (struct iso9660 *)(a->format->data);
 	release_files(iso9660);
 	free(iso9660->read_ce_req.reqs);
 	archive_string_free(&iso9660->pathname);
@@ -1829,7 +1818,7 @@ archive_read_format_iso9660_cleanup(struct archive_read *a)
 	free(iso9660->utf16be_path);
 	free(iso9660->utf16be_previous_path);
 	free(iso9660);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (r);
 }
 
@@ -1841,7 +1830,7 @@ static struct file_info *
 parse_file_info(struct archive_read *a, struct file_info *parent,
     const unsigned char *isodirrec, size_t reclen)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	struct file_info *file, *filep;
 	size_t name_len;
 	const unsigned char *rr_start, *rr_end;
@@ -1850,8 +1839,6 @@ parse_file_info(struct archive_read *a, struct file_info *parent,
 	uint64_t fsize, offset;
 	int32_t location;
 	int flags;
-
-	iso9660 = (struct iso9660 *)(a->format->data);
 
 	if (reclen != 0)
 		dr_len = (size_t)isodirrec[DR_length_offset];
@@ -2193,10 +2180,8 @@ static int
 parse_rockridge(struct archive_read *a, struct file_info *file,
     const unsigned char *p, const unsigned char *end)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	int entry_seen = 0;
-
-	iso9660 = (struct iso9660 *)(a->format->data);
 
 	while (p + 4 <= end  /* Enough space for another entry. */
 	    && p[0] >= 'A' && p[0] <= 'Z' /* Sanity-check 1st char of name. */
@@ -2367,12 +2352,11 @@ static int
 register_CE(struct archive_read *a, int32_t location,
     struct file_info *file)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format->data;
 	struct read_ce_queue *heap;
 	uint64_t offset, parent_offset;
 	size_t hole, parent;
 
-	iso9660 = (struct iso9660 *)(a->format->data);
 	offset = ((uint64_t)location) * (uint64_t)iso9660->logical_block_size;
 	if (((file->mode & AE_IFMT) == AE_IFREG &&
 	    offset >= file->offset) ||

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -390,10 +390,9 @@ static int
 archive_read_format_lha_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct lha *lha;
+	struct lha *lha = a->format->data;
 	int ret = ARCHIVE_FAILED;
 
-	lha = (struct lha *)(a->format->data);
 	if (strcmp(key, "hdrcharset")  == 0) {
 		if (val == NULL || val[0] == 0)
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
@@ -472,9 +471,9 @@ static int
 archive_read_format_lha_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
+	struct lha *lha = a->format->data;
 	struct archive_wstring linkname;
 	struct archive_wstring pathname;
-	struct lha *lha;
 	const unsigned char *p;
 	const char *signature;
 	int err;
@@ -485,7 +484,6 @@ archive_read_format_lha_read_header(struct archive_read *a,
 	if (a->archive.archive_format_name == NULL)
 		a->archive.archive_format_name = "lha";
 
-	lha = (struct lha *)(a->format->data);
 	lha->decompress_init = 0;
 	lha->end_of_entry = 0;
 	lha->end_of_entry_cleanup = 0;
@@ -1451,7 +1449,7 @@ invalid:
 static int
 lha_end_of_entry(struct archive_read *a)
 {
-	struct lha *lha = (struct lha *)(a->format->data);
+	struct lha *lha = a->format->data;
 	int r = ARCHIVE_EOF;
 
 	if (!lha->end_of_entry_cleanup) {
@@ -1472,7 +1470,7 @@ static int
 archive_read_format_lha_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct lha *lha = (struct lha *)(a->format->data);
+	struct lha *lha = a->format->data;
 	int r;
 
 	if (lha->entry_unconsumed) {
@@ -1505,7 +1503,7 @@ static int
 lha_read_data_none(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct lha *lha = (struct lha *)(a->format->data);
+	struct lha *lha = a->format->data;
 	ssize_t bytes_avail;
 
 	if (lha->entry_bytes_remaining == 0) {
@@ -1552,7 +1550,7 @@ static int
 lha_read_data_lzh(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct lha *lha = (struct lha *)(a->format->data);
+	struct lha *lha = a->format->data;
 	ssize_t bytes_avail;
 	int r;
 
@@ -1642,10 +1640,8 @@ lha_read_data_lzh(struct archive_read *a, const void **buff,
 static int
 archive_read_format_lha_read_data_skip(struct archive_read *a)
 {
-	struct lha *lha;
+	struct lha *lha = a->format->data;
 	int64_t bytes_skipped;
-
-	lha = (struct lha *)(a->format->data);
 
 	if (lha->entry_unconsumed) {
 		/* Consume as much as the decompressor actually used. */
@@ -1673,7 +1669,7 @@ archive_read_format_lha_read_data_skip(struct archive_read *a)
 static int
 archive_read_format_lha_cleanup(struct archive_read *a)
 {
-	struct lha *lha = (struct lha *)(a->format->data);
+	struct lha *lha = a->format->data;
 
 	lzh_decode_free(&(lha->strm));
 	archive_string_free(&(lha->dirname));
@@ -1682,7 +1678,7 @@ archive_read_format_lha_cleanup(struct archive_read *a)
 	archive_string_free(&(lha->gname));
 	archive_wstring_free(&(lha->ws));
 	free(lha);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -161,9 +161,8 @@ static int
 archive_read_format_mtree_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct mtree *mtree;
+	struct mtree *mtree = a->format->data;
 
-	mtree = (struct mtree *)(a->format->data);
 	if (strcmp(key, "checkfs")  == 0) {
 		/* Allows to read information missing from the mtree from the file system */
 		if (val == NULL || val[0] == 0) {
@@ -245,11 +244,9 @@ archive_read_support_format_mtree(struct archive *_a)
 static int
 cleanup(struct archive_read *a)
 {
-	struct mtree *mtree;
+	struct mtree *mtree = a->format->data;
 	struct mtree_entry *p, *q;
 
-	mtree = (struct mtree *)(a->format->data);
-	
 	/* Close any dangling file descriptor before freeing */
     if (mtree->fd >= 0) {
         close(mtree->fd);
@@ -270,7 +267,7 @@ cleanup(struct archive_read *a)
 
 	free(mtree->buff);
 	free(mtree);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -1069,11 +1066,9 @@ read_mtree(struct archive_read *a, struct mtree *mtree)
 static int
 read_header(struct archive_read *a, struct archive_entry *entry)
 {
-	struct mtree *mtree;
+	struct mtree *mtree = a->format->data;
 	char *p;
 	int r, use_next;
-
-	mtree = (struct mtree *)(a->format->data);
 
 	if (mtree->fd >= 0) {
 		close(mtree->fd);
@@ -1838,11 +1833,10 @@ static int
 read_data(struct archive_read *a, const void **buff, size_t *size,
     int64_t *offset)
 {
+	struct mtree *mtree = a->format->data;
 	size_t bytes_to_read;
 	ssize_t bytes_read;
-	struct mtree *mtree;
 
-	mtree = (struct mtree *)(a->format->data);
 	if (mtree->fd < 0) {
 		*buff = NULL;
 		*offset = 0;
@@ -1883,9 +1877,8 @@ read_data(struct archive_read *a, const void **buff, size_t *size,
 static int
 skip(struct archive_read *a)
 {
-	struct mtree *mtree;
+	struct mtree *mtree = a->format->data;
 
-	mtree = (struct mtree *)(a->format->data);
 	if (mtree->fd >= 0) {
 		close(mtree->fd);
 		mtree->fd = -1;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -498,7 +498,7 @@ static const uint32_t cache_masks[] = {
 static int
 rar_br_fillup(struct archive_read *a, struct rar_br *br)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   int n = CACHE_BITS - br->cache_avail;
 
   for (;;) {
@@ -593,7 +593,7 @@ rar_br_fillup(struct archive_read *a, struct rar_br *br)
 static int
 rar_br_preparation(struct archive_read *a, struct rar_br *br)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
 
   if (rar->bytes_remaining > 0) {
     br->next_in = rar_read_ahead(a, 1, &(br->avail_in));
@@ -708,7 +708,7 @@ static Byte
 ppmd_read(void *p)
 {
   struct archive_read *a = ((IByteIn*)p)->a;
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   struct rar_br *br = &(rar->br);
   Byte b;
   if (!rar_br_read_ahead(a, br, 8))
@@ -776,7 +776,7 @@ static int
 archive_read_format_rar_has_encrypted_entries(struct archive_read *_a)
 {
   if (_a && _a->format) {
-    struct rar * rar = (struct rar *)_a->format->data;
+    struct rar *rar = _a->format->data;
     if (rar) {
       return rar->has_encrypted_entries;
     }
@@ -876,10 +876,9 @@ static int
 archive_read_format_rar_options(struct archive_read *a,
     const char *key, const char *val)
 {
-  struct rar *rar;
+  struct rar *rar = a->format->data;
   int ret = ARCHIVE_FAILED;
 
-  rar = (struct rar *)(a->format->data);
   if (strcmp(key, "hdrcharset")  == 0) {
     if (val == NULL || val[0] == 0)
       archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
@@ -906,9 +905,9 @@ static int
 archive_read_format_rar_read_header(struct archive_read *a,
                                     struct archive_entry *entry)
 {
+  struct rar *rar = a->format->data;
   const void *h;
   const char *p;
-  struct rar *rar;
   int64_t skip;
   char head_type;
   int ret;
@@ -918,8 +917,6 @@ archive_read_format_rar_read_header(struct archive_read *a,
   a->archive.archive_format = ARCHIVE_FORMAT_RAR;
   if (a->archive.archive_format_name == NULL)
     a->archive.archive_format_name = "RAR";
-
-  rar = (struct rar *)(a->format->data);
 
   /*
    * It should be sufficient to call archive_read_next_header() for
@@ -1099,7 +1096,7 @@ static int
 archive_read_format_rar_read_data(struct archive_read *a, const void **buff,
                                   size_t *size, int64_t *offset)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   int ret;
 
   if (rar->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
@@ -1150,11 +1147,9 @@ archive_read_format_rar_read_data(struct archive_read *a, const void **buff,
 static int
 archive_read_format_rar_read_data_skip(struct archive_read *a)
 {
-  struct rar *rar;
+  struct rar *rar = a->format->data;
   int64_t bytes_skipped;
   int ret;
-
-  rar = (struct rar *)(a->format->data);
 
   if (rar->bytes_unconsumed > 0) {
       /* Consume as much as the decompressor actually used. */
@@ -1188,9 +1183,9 @@ static int64_t
 archive_read_format_rar_seek_data(struct archive_read *a, int64_t offset,
     int whence)
 {
+  struct rar *rar = a->format->data;
   int64_t client_offset, ret;
   size_t i;
-  struct rar *rar = (struct rar *)(a->format->data);
 
   if (rar->compression_method == COMPRESS_METHOD_STORE)
   {
@@ -1341,9 +1336,8 @@ archive_read_format_rar_seek_data(struct archive_read *a, int64_t offset,
 static int
 archive_read_format_rar_cleanup(struct archive_read *a)
 {
-  struct rar *rar;
+  struct rar *rar = a->format->data;
 
-  rar = (struct rar *)(a->format->data);
   free_codes(a);
   clear_filters(&rar->filters);
   free(rar->filename);
@@ -1353,7 +1347,7 @@ archive_read_format_rar_cleanup(struct archive_read *a)
   free(rar->lzss.window);
   __archive_ppmd7_functions.Ppmd7_Free(&rar->ppmd7_context);
   free(rar);
-  (a->format->data) = NULL;
+  a->format->data = NULL;
   return (ARCHIVE_OK);
 }
 
@@ -1361,9 +1355,9 @@ static int
 read_header(struct archive_read *a, struct archive_entry *entry,
             char head_type)
 {
+  struct rar *rar = a->format->data;
   const void *h;
   const char *p, *endp;
-  struct rar *rar;
   struct rar_header rar_header;
   struct rar_file_header file_header;
   int64_t header_size;
@@ -1378,8 +1372,6 @@ read_header(struct archive_read *a, struct archive_entry *entry,
   int ret = (ARCHIVE_OK), ret2;
   char *newptr;
   size_t newsize;
-
-  rar = (struct rar *)(a->format->data);
 
   /* Setup a string conversion object for non-rar-unicode filenames. */
   sconv = rar->opt_sconv;
@@ -1963,12 +1955,11 @@ static int
 read_symlink_stored(struct archive_read *a, struct archive_entry *entry,
                     struct archive_string_conv *sconv)
 {
+  struct rar *rar = a->format->data;
   const void *h;
   const char *p;
-  struct rar *rar;
   int ret = (ARCHIVE_OK);
 
-  rar = (struct rar *)(a->format->data);
   if ((uintmax_t)rar->packed_size > SIZE_MAX)
   {
     archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
@@ -2005,10 +1996,9 @@ static int
 read_data_stored(struct archive_read *a, const void **buff, size_t *size,
                  int64_t *offset)
 {
-  struct rar *rar;
+  struct rar *rar = a->format->data;
   ssize_t bytes_avail;
 
-  rar = (struct rar *)(a->format->data);
   if (rar->bytes_remaining == 0 &&
     !(rar->main_flags & MHD_VOLUME && rar->file_flags & FHD_SPLIT_AFTER))
   {
@@ -2053,12 +2043,10 @@ read_data_compressed(struct archive_read *a, const void **buff, size_t *size,
   if (looper++ > MAX_COMPRESS_DEPTH)
     return (ARCHIVE_FAILED);
 
-  struct rar *rar;
+  struct rar *rar = a->format->data;
   int64_t start, end;
   size_t bs;
   int ret = (ARCHIVE_OK), sym, code, lzss_offset, length, i;
-
-  rar = (struct rar *)(a->format->data);
 
   do {
     if (!rar->valid)
@@ -2304,11 +2292,11 @@ ending_block:
 static int
 parse_codes(struct archive_read *a)
 {
+  struct rar *rar = a->format->data;
   int i, j, val, n, r;
   unsigned char bitlengths[MAX_SYMBOLS], zerocount, ppmd_flags;
   unsigned int maxorder;
   struct huffman_code precode;
-  struct rar *rar = (struct rar *)(a->format->data);
   struct rar_br *br = &(rar->br);
 
   free_codes(a);
@@ -2590,7 +2578,7 @@ truncated_data:
 static void
 free_codes(struct archive_read *a)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   free(rar->maincode.tree);
   free(rar->offsetcode.tree);
   free(rar->lowoffsetcode.tree);
@@ -2609,10 +2597,10 @@ free_codes(struct archive_read *a)
 static int
 read_next_symbol(struct archive_read *a, struct huffman_code *code)
 {
+  struct rar *rar = a->format->data;
   unsigned char bit;
   unsigned int bits;
   int length, value, node;
-  struct rar *rar;
   struct rar_br *br;
 
   if (!code->table)
@@ -2621,7 +2609,6 @@ read_next_symbol(struct archive_read *a, struct huffman_code *code)
       return -1;
   }
 
-  rar = (struct rar *)(a->format->data);
   br = &(rar->br);
 
   /* Look ahead (peek) at bits */
@@ -2964,9 +2951,9 @@ expand(struct archive_read *a, int64_t *end)
   static const unsigned char shortbits[] =
     { 2, 2, 3, 4, 5, 6, 6, 6 };
 
+  struct rar *rar = a->format->data;
   int symbol, offs, len, offsindex, lensymbol, i, offssymbol, lowoffsetsymbol;
   unsigned char newfile;
-  struct rar *rar = (struct rar *)(a->format->data);
   struct rar_br *br = &(rar->br);
 
   if (rar->filters.filterstart < *end)
@@ -3154,8 +3141,8 @@ static int
 copy_from_lzss_window(struct archive_read *a, uint8_t *buffer,
                       int64_t startpos, int length)
 {
+  struct rar *rar = a->format->data;
   int windowoffs, firstpart;
-  struct rar *rar = (struct rar *)(a->format->data);
 
   windowoffs = lzss_offset_for_position(&rar->lzss, startpos);
   firstpart = lzss_size(&rar->lzss) - windowoffs;
@@ -3182,8 +3169,8 @@ static int
 copy_from_lzss_window_to_unp(struct archive_read *a, const void **buffer,
                              int64_t startpos, size_t length)
 {
+  struct rar *rar = a->format->data;
   int windowoffs, firstpart;
-  struct rar *rar = (struct rar *)(a->format->data);
 
   if (length > rar->unp_buffer_size)
   {
@@ -3239,7 +3226,7 @@ fatal:
 static const void *
 rar_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   const void *h;
   int ret;
 
@@ -3276,7 +3263,7 @@ again:
 static int
 parse_filter(struct archive_read *a, const uint8_t *bytes, uint16_t length, uint8_t flags)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   struct rar_filters *filters = &rar->filters;
 
   struct memory_bit_reader br = { 0 };
@@ -3444,7 +3431,7 @@ create_filter(struct rar_program_code *prog, const uint8_t *globaldata, uint32_t
 static int
 run_filters(struct archive_read *a)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   struct rar_filters *filters = &rar->filters;
   struct rar_filter *filter = filters->stack;
   struct rar_filter *f;
@@ -3664,7 +3651,7 @@ membr_fill(struct memory_bit_reader *br, int bits)
 static int
 read_filter(struct archive_read *a, int64_t *end)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   uint8_t flags, val, *code;
   uint16_t length, i;
 
@@ -3917,7 +3904,7 @@ execute_filter(struct archive_read *a, struct rar_filter *filter, struct rar_vir
 static int
 rar_decode_byte(struct archive_read *a, uint8_t *byte)
 {
-  struct rar *rar = (struct rar *)(a->format->data);
+  struct rar *rar = a->format->data;
   struct rar_br *br = &(rar->br);
   if (!rar_br_read_ahead(a, br, 8))
     return 0;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -372,10 +372,10 @@ struct rar5 {
 static void rar5_signature(char *buf);
 static int verify_global_checksums(struct archive_read* a);
 static int rar5_read_data_skip(struct archive_read *a);
-static int push_data_ready(struct archive_read* a, struct rar5* rar,
+static int push_data_ready(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* buf, size_t size, int64_t offset);
-static void clear_data_ready_stack(struct rar5* rar);
-static void rar5_deinit(struct rar5* rar);
+static void clear_data_ready_stack(struct rar5 *rar5);
+static void rar5_deinit(struct rar5 *rar5);
 
 /* CDE_xxx = Circular Double Ended (Queue) return values. */
 enum CDE_RETURN_VALUES {
@@ -529,28 +529,28 @@ static void circular_memcpy(uint8_t* dst, uint8_t* window, const ssize_t mask,
 	}
 }
 
-static uint32_t read_filter_data(struct rar5* rar, uint32_t offset) {
+static uint32_t read_filter_data(struct rar5 *rar5, uint32_t offset) {
 	uint8_t linear_buf[4];
-	circular_memcpy(linear_buf, rar->cstate.window_buf,
-	    rar->cstate.window_mask, offset, offset + 4);
+	circular_memcpy(linear_buf, rar5->cstate.window_buf,
+	    rar5->cstate.window_mask, offset, offset + 4);
 	return archive_le32dec(linear_buf);
 }
 
-static void write_filter_data(struct rar5* rar, uint32_t offset,
+static void write_filter_data(struct rar5 *rar5, uint32_t offset,
     uint32_t value)
 {
-	archive_le32enc(&rar->cstate.filtered_buf[offset], value);
+	archive_le32enc(&rar5->cstate.filtered_buf[offset], value);
 }
 
 /* Allocates a new filter descriptor and adds it to the filter array. */
-static struct filter_info* add_new_filter(struct rar5* rar) {
+static struct filter_info* add_new_filter(struct rar5 *rar5) {
 	struct filter_info* f = calloc(1, sizeof(*f));
 
 	if(!f) {
 		return NULL;
 	}
 
-	if (CDE_OK != cdeque_push_back(&rar->cstate.filters, cdeque_filter(f))) {
+	if (CDE_OK != cdeque_push_back(&rar5->cstate.filters, cdeque_filter(f))) {
 		free(f);
 		return NULL;
 	}
@@ -558,7 +558,7 @@ static struct filter_info* add_new_filter(struct rar5* rar) {
 	return f;
 }
 
-static int run_delta_filter(struct rar5* rar, struct filter_info* flt) {
+static int run_delta_filter(struct rar5 *rar5, struct filter_info* flt) {
 	int i;
 	ssize_t dest_pos, src_pos = 0;
 
@@ -570,12 +570,12 @@ static int run_delta_filter(struct rar5* rar, struct filter_info* flt) {
 		{
 			uint8_t byte;
 
-			byte = rar->cstate.window_buf[
-			    (rar->cstate.solid_offset + flt->block_start +
-			    src_pos) & rar->cstate.window_mask];
+			byte = rar5->cstate.window_buf[
+			    (rar5->cstate.solid_offset + flt->block_start +
+			    src_pos) & rar5->cstate.window_mask];
 
 			prev_byte -= byte;
-			rar->cstate.filtered_buf[dest_pos] = prev_byte;
+			rar5->cstate.filtered_buf[dest_pos] = prev_byte;
 			src_pos++;
 		}
 	}
@@ -583,21 +583,21 @@ static int run_delta_filter(struct rar5* rar, struct filter_info* flt) {
 	return ARCHIVE_OK;
 }
 
-static int run_e8e9_filter(struct rar5* rar, struct filter_info* flt,
+static int run_e8e9_filter(struct rar5 *rar5, struct filter_info* flt,
 		int extended)
 {
 	const uint32_t file_size = 0x1000000;
 	ssize_t i;
 
-	circular_memcpy(rar->cstate.filtered_buf,
-	    rar->cstate.window_buf, rar->cstate.window_mask,
-	    rar->cstate.solid_offset + flt->block_start,
-	    rar->cstate.solid_offset + flt->block_start + flt->block_length);
+	circular_memcpy(rar5->cstate.filtered_buf,
+	    rar5->cstate.window_buf, rar5->cstate.window_mask,
+	    rar5->cstate.solid_offset + flt->block_start,
+	    rar5->cstate.solid_offset + flt->block_start + flt->block_length);
 
 	for(i = 0; i < flt->block_length - 4;) {
-		uint8_t b = rar->cstate.window_buf[
-		    (rar->cstate.solid_offset + flt->block_start +
-		    i++) & rar->cstate.window_mask];
+		uint8_t b = rar5->cstate.window_buf[
+		    (rar5->cstate.solid_offset + flt->block_start +
+		    i++) & rar5->cstate.window_mask];
 
 		/*
 		 * 0xE8 = x86's call <relative_addr_uint32> (function call)
@@ -608,19 +608,19 @@ static int run_e8e9_filter(struct rar5* rar, struct filter_info* flt,
 			uint32_t addr;
 			uint32_t offset = (i + flt->block_start) % file_size;
 
-			addr = read_filter_data(rar,
-			    (uint32_t)(rar->cstate.solid_offset +
-			    flt->block_start + i) & rar->cstate.window_mask);
+			addr = read_filter_data(rar5,
+			    (uint32_t)(rar5->cstate.solid_offset +
+			    flt->block_start + i) & rar5->cstate.window_mask);
 
 			if(addr & 0x80000000) {
 				if(((addr + offset) & 0x80000000) == 0) {
-					write_filter_data(rar, (uint32_t)i,
+					write_filter_data(rar5, (uint32_t)i,
 					    addr + file_size);
 				}
 			} else {
 				if((addr - file_size) & 0x80000000) {
 					uint32_t naddr = addr - offset;
-					write_filter_data(rar, (uint32_t)i,
+					write_filter_data(rar5, (uint32_t)i,
 					    naddr);
 				}
 			}
@@ -632,29 +632,29 @@ static int run_e8e9_filter(struct rar5* rar, struct filter_info* flt,
 	return ARCHIVE_OK;
 }
 
-static int run_arm_filter(struct rar5* rar, struct filter_info* flt) {
+static int run_arm_filter(struct rar5 *rar5, struct filter_info* flt) {
 	ssize_t i = 0;
 	uint32_t offset;
 
-	circular_memcpy(rar->cstate.filtered_buf,
-	    rar->cstate.window_buf, rar->cstate.window_mask,
-	    rar->cstate.solid_offset + flt->block_start,
-	    rar->cstate.solid_offset + flt->block_start + flt->block_length);
+	circular_memcpy(rar5->cstate.filtered_buf,
+	    rar5->cstate.window_buf, rar5->cstate.window_mask,
+	    rar5->cstate.solid_offset + flt->block_start,
+	    rar5->cstate.solid_offset + flt->block_start + flt->block_length);
 
 	for(i = 0; i < flt->block_length - 3; i += 4) {
-		uint8_t* b = &rar->cstate.window_buf[
-		    (rar->cstate.solid_offset +
-		    flt->block_start + i + 3) & rar->cstate.window_mask];
+		uint8_t* b = &rar5->cstate.window_buf[
+		    (rar5->cstate.solid_offset +
+		    flt->block_start + i + 3) & rar5->cstate.window_mask];
 
 		if(*b == 0xEB) {
 			/* 0xEB = ARM's BL (branch + link) instruction. */
-			offset = read_filter_data(rar,
-			    (rar->cstate.solid_offset + flt->block_start + i) &
-			     (uint32_t)rar->cstate.window_mask) & 0x00ffffff;
+			offset = read_filter_data(rar5,
+			    (rar5->cstate.solid_offset + flt->block_start + i) &
+			     (uint32_t)rar5->cstate.window_mask) & 0x00ffffff;
 
 			offset -= (uint32_t) ((i + flt->block_start) / 4);
 			offset = (offset & 0x00ffffff) | 0xeb000000;
-			write_filter_data(rar, (uint32_t)i, offset);
+			write_filter_data(rar5, (uint32_t)i, offset);
 		}
 	}
 
@@ -662,14 +662,14 @@ static int run_arm_filter(struct rar5* rar, struct filter_info* flt) {
 }
 
 static int run_filter(struct archive_read* a, struct filter_info* flt) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 
-	clear_data_ready_stack(rar);
-	free(rar->cstate.filtered_buf);
+	clear_data_ready_stack(rar5);
+	free(rar5->cstate.filtered_buf);
 
-	rar->cstate.filtered_buf = malloc(flt->block_length);
-	if(!rar->cstate.filtered_buf) {
+	rar5->cstate.filtered_buf = malloc(flt->block_length);
+	if(!rar5->cstate.filtered_buf) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory for filter data");
 		return ARCHIVE_FATAL;
@@ -677,18 +677,18 @@ static int run_filter(struct archive_read* a, struct filter_info* flt) {
 
 	switch(flt->type) {
 		case FILTER_DELTA:
-			ret = run_delta_filter(rar, flt);
+			ret = run_delta_filter(rar5, flt);
 			break;
 
 		case FILTER_E8:
 			/* fallthrough */
 		case FILTER_E8E9:
-			ret = run_e8e9_filter(rar, flt,
+			ret = run_e8e9_filter(rar5, flt,
 			    flt->type == FILTER_E8E9);
 			break;
 
 		case FILTER_ARM:
-			ret = run_arm_filter(rar, flt);
+			ret = run_arm_filter(rar5, flt);
 			break;
 
 		default:
@@ -704,8 +704,8 @@ static int run_filter(struct archive_read* a, struct filter_info* flt) {
 		return ret;
 	}
 
-	if(ARCHIVE_OK != push_data_ready(a, rar, rar->cstate.filtered_buf,
-	    flt->block_length, rar->cstate.last_write_ptr))
+	if(ARCHIVE_OK != push_data_ready(a, rar5, rar5->cstate.filtered_buf,
+	    flt->block_length, rar5->cstate.last_write_ptr))
 	{
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 		    "Stack overflow when submitting unpacked data");
@@ -713,7 +713,7 @@ static int run_filter(struct archive_read* a, struct filter_info* flt) {
 		return ARCHIVE_FATAL;
 	}
 
-	rar->cstate.last_write_ptr += flt->block_length;
+	rar5->cstate.last_write_ptr += flt->block_length;
 	return ARCHIVE_OK;
 }
 
@@ -721,15 +721,15 @@ static int run_filter(struct archive_read* a, struct filter_info* flt) {
  * Next call of `use_data` will use the pointer, size and offset arguments
  * that are specified here. These arguments are pushed to the FIFO stack here,
  * and popped from the stack by the `use_data` function. */
-static void push_data(struct archive_read* a, struct rar5* rar,
+static void push_data(struct archive_read* a, struct rar5 *rar5,
     const uint8_t* buf, int64_t idx_begin, int64_t idx_end)
 {
-	const ssize_t wmask = rar->cstate.window_mask;
-	const ssize_t solid_write_ptr = (rar->cstate.solid_offset +
-	    rar->cstate.last_write_ptr) & wmask;
+	const ssize_t wmask = rar5->cstate.window_mask;
+	const ssize_t solid_write_ptr = (rar5->cstate.solid_offset +
+	    rar5->cstate.last_write_ptr) & wmask;
 
-	idx_begin += rar->cstate.solid_offset;
-	idx_end += rar->cstate.solid_offset;
+	idx_begin += rar5->cstate.solid_offset;
+	idx_end += rar5->cstate.solid_offset;
 
 	/* Check if our unpacked data is wrapped inside the window circular
 	 * buffer.  If it's not wrapped, it can be copied out by using
@@ -739,57 +739,57 @@ static void push_data(struct archive_read* a, struct rar5* rar,
 	if((idx_begin & wmask) > (idx_end & wmask)) {
 		/* The data is wrapped (begin offset sis bigger than end
 		 * offset). */
-		const ssize_t frag1_size = rar->cstate.window_size -
+		const ssize_t frag1_size = rar5->cstate.window_size -
 		    (idx_begin & wmask);
 		const ssize_t frag2_size = idx_end & wmask;
 
 		/* Copy the first part of the buffer first. */
-		push_data_ready(a, rar, buf + solid_write_ptr, frag1_size,
-		    rar->cstate.last_write_ptr);
+		push_data_ready(a, rar5, buf + solid_write_ptr, frag1_size,
+		    rar5->cstate.last_write_ptr);
 
 		/* Copy the second part of the buffer. */
-		push_data_ready(a, rar, buf, frag2_size,
-		    rar->cstate.last_write_ptr + frag1_size);
+		push_data_ready(a, rar5, buf, frag2_size,
+		    rar5->cstate.last_write_ptr + frag1_size);
 
-		rar->cstate.last_write_ptr += frag1_size + frag2_size;
+		rar5->cstate.last_write_ptr += frag1_size + frag2_size;
 	} else {
 		/* Data is not wrapped, so we can just use one call to copy the
 		 * data. */
-		push_data_ready(a, rar,
+		push_data_ready(a, rar5,
 		    buf + solid_write_ptr, (idx_end - idx_begin) & wmask,
-		    rar->cstate.last_write_ptr);
+		    rar5->cstate.last_write_ptr);
 
-		rar->cstate.last_write_ptr += idx_end - idx_begin;
+		rar5->cstate.last_write_ptr += idx_end - idx_begin;
 	}
 }
 
 /* Convenience function that submits the data to the user. It uses the
  * unpack window buffer as a source location. */
-static void push_window_data(struct archive_read* a, struct rar5* rar,
+static void push_window_data(struct archive_read* a, struct rar5 *rar5,
     int64_t idx_begin, int64_t idx_end)
 {
-	push_data(a, rar, rar->cstate.window_buf, idx_begin, idx_end);
+	push_data(a, rar5, rar5->cstate.window_buf, idx_begin, idx_end);
 }
 
 static int apply_filters(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	struct filter_info* flt;
 	int ret;
 
-	rar->cstate.all_filters_applied = 0;
+	rar5->cstate.all_filters_applied = 0;
 
 	/* Get the first filter that can be applied to our data. The data
 	 * needs to be fully unpacked before the filter can be run. */
-	if(CDE_OK == cdeque_front(&rar->cstate.filters,
+	if(CDE_OK == cdeque_front(&rar5->cstate.filters,
 	    cdeque_filter_p(&flt))) {
 		/* Check if our unpacked data fully covers this filter's
 		 * range. */
-		if(rar->cstate.write_ptr > flt->block_start &&
-		    rar->cstate.write_ptr >= flt->block_start +
+		if(rar5->cstate.write_ptr > flt->block_start &&
+		    rar5->cstate.write_ptr >= flt->block_start +
 		    flt->block_length) {
 			/* Check if we have some data pending to be written
 			 * right before the filter's start offset. */
-			if(rar->cstate.last_write_ptr == flt->block_start) {
+			if(rar5->cstate.last_write_ptr == flt->block_start) {
 				/* Run the filter specified by descriptor
 				 * `flt`. */
 				ret = run_filter(a, flt);
@@ -801,15 +801,15 @@ static int apply_filters(struct archive_read* a) {
 				/* Filter descriptor won't be needed anymore
 				 * after it's used, * so remove it from the
 				 * filter list and free its memory. */
-				(void) cdeque_pop_front(&rar->cstate.filters,
+				(void) cdeque_pop_front(&rar5->cstate.filters,
 				    cdeque_filter_p(&flt));
 
 				free(flt);
 			} else {
 				/* We can't run filters yet, dump the memory
 				 * right before the filter. */
-				push_window_data(a, rar,
-				    rar->cstate.last_write_ptr,
+				push_window_data(a, rar5,
+				    rar5->cstate.last_write_ptr,
 				    flt->block_start);
 			}
 
@@ -819,12 +819,12 @@ static int apply_filters(struct archive_read* a) {
 		}
 	}
 
-	rar->cstate.all_filters_applied = 1;
+	rar5->cstate.all_filters_applied = 1;
 	return ARCHIVE_OK;
 }
 
-static void dist_cache_push(struct rar5* rar, int value) {
-	int* q = rar->cstate.dist_cache;
+static void dist_cache_push(struct rar5 *rar5, int value) {
+	int* q = rar5->cstate.dist_cache;
 
 	q[3] = q[2];
 	q[2] = q[1];
@@ -832,8 +832,8 @@ static void dist_cache_push(struct rar5* rar, int value) {
 	q[0] = value;
 }
 
-static int dist_cache_touch(struct rar5* rar, int idx) {
-	int* q = rar->cstate.dist_cache;
+static int dist_cache_touch(struct rar5 *rar5, int idx) {
+	int* q = rar5->cstate.dist_cache;
 	int i, dist = q[idx];
 
 	for(i = idx; i > 0; i--)
@@ -843,8 +843,8 @@ static int dist_cache_touch(struct rar5* rar, int idx) {
 	return dist;
 }
 
-static void free_filters(struct rar5* rar) {
-	struct cdeque* d = &rar->cstate.filters;
+static void free_filters(struct rar5 *rar5) {
+	struct cdeque* d = &rar5->cstate.filters;
 
 	/* Free any remaining filters. All filters should be naturally
 	 * consumed by the unpacking function, so remaining filters after
@@ -864,28 +864,28 @@ static void free_filters(struct rar5* rar) {
 	cdeque_clear(d);
 
 	/* Also clear out the variables needed for sanity checking. */
-	rar->cstate.last_block_start = 0;
-	rar->cstate.last_block_length = 0;
+	rar5->cstate.last_block_start = 0;
+	rar5->cstate.last_block_length = 0;
 }
 
-static void reset_file_context(struct rar5* rar) {
-	memset(&rar->file, 0, sizeof(rar->file));
-	blake2sp_init(&rar->file.b2state, 32);
+static void reset_file_context(struct rar5 *rar5) {
+	memset(&rar5->file, 0, sizeof(rar5->file));
+	blake2sp_init(&rar5->file.b2state, 32);
 
-	if(rar->main.solid) {
-		rar->cstate.solid_offset += rar->cstate.write_ptr;
+	if(rar5->main.solid) {
+		rar5->cstate.solid_offset += rar5->cstate.write_ptr;
 	} else {
-		rar->cstate.solid_offset = 0;
+		rar5->cstate.solid_offset = 0;
 	}
 
-	rar->cstate.write_ptr = 0;
-	rar->cstate.last_write_ptr = 0;
-	rar->cstate.last_unstore_ptr = 0;
+	rar5->cstate.write_ptr = 0;
+	rar5->cstate.last_write_ptr = 0;
+	rar5->cstate.last_unstore_ptr = 0;
 
-	rar->file.redir_type = REDIR_TYPE_NONE;
-	rar->file.redir_flags = 0;
+	rar5->file.redir_type = REDIR_TYPE_NONE;
+	rar5->file.redir_flags = 0;
 
-	free_filters(rar);
+	free_filters(rar5);
 }
 
 static inline int get_archive_read(struct archive* a,
@@ -1031,47 +1031,47 @@ static int read_var_sized(struct archive_read* a, size_t* pvalue,
 	return ret;
 }
 
-static int read_bits_32(struct archive_read* a, struct rar5* rar,
+static int read_bits_32(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* p, uint32_t* value)
 {
-	if(rar->bits.in_addr >= rar->cstate.cur_block_size) {
+	if(rar5->bits.in_addr >= rar5->cstate.cur_block_size) {
 		archive_set_error(&a->archive,
 			ARCHIVE_ERRNO_PROGRAMMER,
 			"Premature end of stream during extraction of data (#1)");
 		return ARCHIVE_FATAL;
 	}
 
-	uint32_t bits = archive_be32dec(p + rar->bits.in_addr);
-	bits <<= rar->bits.bit_addr;
-	bits |= p[rar->bits.in_addr + 4] >> (8 - rar->bits.bit_addr);
+	uint32_t bits = archive_be32dec(p + rar5->bits.in_addr);
+	bits <<= rar5->bits.bit_addr;
+	bits |= p[rar5->bits.in_addr + 4] >> (8 - rar5->bits.bit_addr);
 	*value = bits;
 	return ARCHIVE_OK;
 }
 
-static int read_bits_16(struct archive_read* a, struct rar5* rar,
+static int read_bits_16(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* p, uint16_t* value)
 {
-	if(rar->bits.in_addr >= rar->cstate.cur_block_size) {
+	if(rar5->bits.in_addr >= rar5->cstate.cur_block_size) {
 		archive_set_error(&a->archive,
 			ARCHIVE_ERRNO_PROGRAMMER,
 			"Premature end of stream during extraction of data (#2)");
 		return ARCHIVE_FATAL;
 	}
 
-	uint32_t bits = archive_be24dec(p + (unsigned)rar->bits.in_addr);
-	bits >>= (8 - rar->bits.bit_addr);
+	uint32_t bits = archive_be24dec(p + (unsigned)rar5->bits.in_addr);
+	bits >>= (8 - rar5->bits.bit_addr);
 	*value = bits & 0xffff;
 	return ARCHIVE_OK;
 }
 
-static void skip_bits(struct rar5* rar, int bits) {
-	const int new_bits = rar->bits.bit_addr + bits;
-	rar->bits.in_addr += new_bits >> 3;
-	rar->bits.bit_addr = new_bits & 7;
+static void skip_bits(struct rar5 *rar5, int bits) {
+	const int new_bits = rar5->bits.bit_addr + bits;
+	rar5->bits.in_addr += new_bits >> 3;
+	rar5->bits.bit_addr = new_bits & 7;
 }
 
 /* n = up to 16 */
-static int read_consume_bits(struct archive_read* a, struct rar5* rar,
+static int read_consume_bits(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* p, int n, int* value)
 {
 	uint16_t v;
@@ -1083,14 +1083,14 @@ static int read_consume_bits(struct archive_read* a, struct rar5* rar,
 		return ARCHIVE_FATAL;
 	}
 
-	ret = read_bits_16(a, rar, p, &v);
+	ret = read_bits_16(a, rar5, p, &v);
 	if(ret != ARCHIVE_OK)
 		return ret;
 
 	num = (int) v;
 	num >>= 16 - n;
 
-	skip_bits(rar, n);
+	skip_bits(rar5, n);
 
 	if(value)
 		*value = num;
@@ -1205,11 +1205,11 @@ static void init_header(struct archive_read* a) {
 	a->archive.archive_format_name = "RAR5";
 }
 
-static void init_window_mask(struct rar5* rar) {
-	if (rar->cstate.window_size)
-		rar->cstate.window_mask = rar->cstate.window_size - 1;
+static void init_window_mask(struct rar5 *rar5) {
+	if (rar5->cstate.window_size)
+		rar5->cstate.window_mask = rar5->cstate.window_size - 1;
 	else
-		rar->cstate.window_mask = 0;
+		rar5->cstate.window_mask = 0;
 }
 
 enum HEADER_FLAGS {
@@ -1223,7 +1223,7 @@ enum HEADER_FLAGS {
 };
 
 static int process_main_locator_extra_block(struct archive_read* a,
-    struct rar5* rar)
+    struct rar5 *rar5)
 {
 	uint64_t locator_flags;
 
@@ -1236,7 +1236,7 @@ static int process_main_locator_extra_block(struct archive_read* a,
 	}
 
 	if(locator_flags & QLIST) {
-		if(!read_var(a, &rar->qlist_offset, NULL)) {
+		if(!read_var(a, &rar5->qlist_offset, NULL)) {
 			return ARCHIVE_EOF;
 		}
 
@@ -1244,7 +1244,7 @@ static int process_main_locator_extra_block(struct archive_read* a,
 	}
 
 	if(locator_flags & RECOVERY) {
-		if(!read_var(a, &rar->rr_offset, NULL)) {
+		if(!read_var(a, &rar5->rr_offset, NULL)) {
 			return ARCHIVE_EOF;
 		}
 
@@ -1254,7 +1254,7 @@ static int process_main_locator_extra_block(struct archive_read* a,
 	return ARCHIVE_OK;
 }
 
-static int parse_file_extra_hash(struct archive_read* a, struct rar5* rar,
+static int parse_file_extra_hash(struct archive_read* a, struct rar5 *rar5,
     int64_t* extra_data_size)
 {
 	size_t hash_type = 0;
@@ -1276,13 +1276,13 @@ static int parse_file_extra_hash(struct archive_read* a, struct rar5* rar,
 	 * CRC32. */
 	if(hash_type == BLAKE2sp) {
 		const uint8_t* p;
-		const int hash_size = sizeof(rar->file.blake2sp);
+		const int hash_size = sizeof(rar5->file.blake2sp);
 
 		if(!read_ahead(a, hash_size, &p))
 			return ARCHIVE_EOF;
 
-		rar->file.has_blake2 = 1;
-		memcpy(&rar->file.blake2sp, p, hash_size);
+		rar5->file.has_blake2 = 1;
+		memcpy(&rar5->file.blake2sp, p, hash_size);
 
 		if(ARCHIVE_OK != consume(a, hash_size)) {
 			return ARCHIVE_EOF;
@@ -1375,7 +1375,7 @@ static int parse_file_extra_version(struct archive_read* a,
 }
 
 static int parse_file_extra_htime(struct archive_read* a,
-    struct archive_entry* e, struct rar5* rar, int64_t* extra_data_size)
+    struct archive_entry* e, struct rar5 *rar5, int64_t* extra_data_size)
 {
 	char unix_time, has_unix_ns, has_mtime, has_ctime, has_atime;
 	size_t flags = 0;
@@ -1402,39 +1402,39 @@ static int parse_file_extra_htime(struct archive_read* a,
 	has_mtime = flags & HAS_MTIME;
 	has_atime = flags & HAS_ATIME;
 	has_ctime = flags & HAS_CTIME;
-	rar->file.e_atime_ns = rar->file.e_ctime_ns = rar->file.e_mtime_ns = 0;
+	rar5->file.e_atime_ns = rar5->file.e_ctime_ns = rar5->file.e_mtime_ns = 0;
 
 	if(has_mtime) {
-		parse_htime_item(a, unix_time, &rar->file.e_mtime,
-		    &rar->file.e_mtime_ns, extra_data_size);
+		parse_htime_item(a, unix_time, &rar5->file.e_mtime,
+		    &rar5->file.e_mtime_ns, extra_data_size);
 	}
 
 	if(has_ctime) {
-		parse_htime_item(a, unix_time, &rar->file.e_ctime,
-		    &rar->file.e_ctime_ns, extra_data_size);
+		parse_htime_item(a, unix_time, &rar5->file.e_ctime,
+		    &rar5->file.e_ctime_ns, extra_data_size);
 	}
 
 	if(has_atime) {
-		parse_htime_item(a, unix_time, &rar->file.e_atime,
-		    &rar->file.e_atime_ns, extra_data_size);
+		parse_htime_item(a, unix_time, &rar5->file.e_atime,
+		    &rar5->file.e_atime_ns, extra_data_size);
 	}
 
 	if(has_mtime && has_unix_ns) {
-		if(!read_u32(a, &rar->file.e_mtime_ns))
+		if(!read_u32(a, &rar5->file.e_mtime_ns))
 			return ARCHIVE_EOF;
 
 		*extra_data_size -= 4;
 	}
 
 	if(has_ctime && has_unix_ns) {
-		if(!read_u32(a, &rar->file.e_ctime_ns))
+		if(!read_u32(a, &rar5->file.e_ctime_ns))
 			return ARCHIVE_EOF;
 
 		*extra_data_size -= 4;
 	}
 
 	if(has_atime && has_unix_ns) {
-		if(!read_u32(a, &rar->file.e_atime_ns))
+		if(!read_u32(a, &rar5->file.e_atime_ns))
 			return ARCHIVE_EOF;
 
 		*extra_data_size -= 4;
@@ -1443,35 +1443,35 @@ static int parse_file_extra_htime(struct archive_read* a,
 	/* The seconds and nanoseconds are either together, or separated in two
 	 * fields so we parse them, then set the archive_entry's times. */
 	if(has_mtime) {
-		archive_entry_set_mtime(e, rar->file.e_mtime, rar->file.e_mtime_ns);
+		archive_entry_set_mtime(e, rar5->file.e_mtime, rar5->file.e_mtime_ns);
 	}
 
 	if(has_ctime) {
-		archive_entry_set_ctime(e, rar->file.e_ctime, rar->file.e_ctime_ns);
+		archive_entry_set_ctime(e, rar5->file.e_ctime, rar5->file.e_ctime_ns);
 	}
 
 	if(has_atime) {
-		archive_entry_set_atime(e, rar->file.e_atime, rar->file.e_atime_ns);
+		archive_entry_set_atime(e, rar5->file.e_atime, rar5->file.e_atime_ns);
 	}
 
 	return ARCHIVE_OK;
 }
 
 static int parse_file_extra_redir(struct archive_read* a,
-    struct archive_entry* e, struct rar5* rar, int64_t* extra_data_size)
+    struct archive_entry* e, struct rar5 *rar5, int64_t* extra_data_size)
 {
 	uint64_t value_size = 0;
 	size_t target_size = 0;
 	char target_utf8_buf[MAX_NAME_IN_BYTES];
 	const uint8_t* p;
 
-	if(!read_var(a, &rar->file.redir_type, &value_size))
+	if(!read_var(a, &rar5->file.redir_type, &value_size))
 		return ARCHIVE_EOF;
 	if(ARCHIVE_OK != consume(a, (int64_t)value_size))
 		return ARCHIVE_EOF;
 	*extra_data_size -= value_size;
 
-	if(!read_var(a, &rar->file.redir_flags, &value_size))
+	if(!read_var(a, &rar5->file.redir_flags, &value_size))
 		return ARCHIVE_EOF;
 	if(ARCHIVE_OK != consume(a, (int64_t)value_size))
 		return ARCHIVE_EOF;
@@ -1502,12 +1502,12 @@ static int parse_file_extra_redir(struct archive_read* a,
 	if(ARCHIVE_OK != consume(a, (int64_t)target_size))
 		return ARCHIVE_EOF;
 
-	switch(rar->file.redir_type) {
+	switch(rar5->file.redir_type) {
 		case REDIR_TYPE_UNIXSYMLINK:
 		case REDIR_TYPE_WINSYMLINK:
 			archive_entry_set_filetype(e, AE_IFLNK);
 			archive_entry_update_symlink_utf8(e, target_utf8_buf);
-			if (rar->file.redir_flags & REDIR_SYMLINK_IS_DIR) {
+			if (rar5->file.redir_flags & REDIR_SYMLINK_IS_DIR) {
 				archive_entry_set_symlink_type(e,
 					AE_SYMLINK_TYPE_DIRECTORY);
 			} else {
@@ -1609,7 +1609,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 }
 
 static int process_head_file_extra(struct archive_read* a,
-    struct archive_entry* e, struct rar5* rar, int64_t extra_data_size)
+    struct archive_entry* e, struct rar5 *rar5, int64_t extra_data_size)
 {
 	uint64_t extra_field_size;
 	uint64_t extra_field_id = 0;
@@ -1639,15 +1639,15 @@ static int process_head_file_extra(struct archive_read* a,
 
 		switch(extra_field_id) {
 			case EX_HASH:
-				ret = parse_file_extra_hash(a, rar,
+				ret = parse_file_extra_hash(a, rar5,
 				    &extra_data_size);
 				break;
 			case EX_HTIME:
-				ret = parse_file_extra_htime(a, e, rar,
+				ret = parse_file_extra_htime(a, e, rar5,
 				    &extra_data_size);
 				break;
 			case EX_REDIR:
-				ret = parse_file_extra_redir(a, e, rar,
+				ret = parse_file_extra_redir(a, e, rar5,
 				    &extra_data_size);
 				break;
 			case EX_UOWNER:
@@ -1661,8 +1661,8 @@ static int process_head_file_extra(struct archive_read* a,
 			case EX_CRYPT:
 				/* Mark the entry as encrypted */
 				archive_entry_set_is_data_encrypted(e, 1);
-				rar->has_encrypted_entries = 1;
-				rar->cstate.data_encrypted = 1;
+				rar5->has_encrypted_entries = 1;
+				rar5->cstate.data_encrypted = 1;
 				/* fallthrough */
 			case EX_SUBDATA:
 				/* fallthrough */
@@ -1724,7 +1724,7 @@ static int file_entry_sanity_checks(struct archive_read* a,
 	return ARCHIVE_OK;
 }
 
-static int process_head_file(struct archive_read* a, struct rar5* rar,
+static int process_head_file(struct archive_read* a, struct rar5 *rar5,
     struct archive_entry* entry, size_t block_flags)
 {
 	int64_t extra_data_size = 0;
@@ -1763,8 +1763,8 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	archive_entry_clear(entry);
 
 	/* Do not reset file context if we're switching archives. */
-	if(!rar->cstate.switch_multivolume) {
-		reset_file_context(rar);
+	if(!rar5->cstate.switch_multivolume) {
+		reset_file_context(rar5);
 	}
 
 	if(block_flags & HFL_EXTRA_DATA) {
@@ -1787,9 +1787,9 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 			return ARCHIVE_FATAL;
 		}
 
-		rar->file.bytes_remaining = data_size;
+		rar5->file.bytes_remaining = data_size;
 	} else {
-		rar->file.bytes_remaining = 0;
+		rar5->file.bytes_remaining = 0;
 	}
 
 	if(!read_var_sized(a, &file_flags, NULL))
@@ -1804,9 +1804,9 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 		return ARCHIVE_FATAL;
 	}
 
-	rar->file.dir = (uint8_t) ((file_flags & DIRECTORY) > 0);
+	rar5->file.dir = (uint8_t) ((file_flags & DIRECTORY) > 0);
 
-	sanity_ret = file_entry_sanity_checks(a, block_flags, rar->file.dir,
+	sanity_ret = file_entry_sanity_checks(a, block_flags, rar5->file.dir,
 		unpacked_size, data_size);
 
 	if (sanity_ret != ARCHIVE_OK) {
@@ -1833,19 +1833,19 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	c_version = (int) (compression_info & 0x3f);
 
 	/* RAR5 seems to limit the dictionary size to 64MB. */
-	window_size = (rar->file.dir > 0) ?
+	window_size = (rar5->file.dir > 0) ?
 		0 :
 		g_unpack_window_size << ((compression_info >> 10) & 15);
-	rar->cstate.method = c_method;
-	rar->cstate.version = c_version + 50;
-	rar->file.solid = (compression_info & SOLID) > 0;
+	rar5->cstate.method = c_method;
+	rar5->cstate.version = c_version + 50;
+	rar5->file.solid = (compression_info & SOLID) > 0;
 
 	/* Archives which declare solid files without initializing the window
 	 * buffer first are invalid, unless previous data was encrypted, in
 	 * which case we may never have had the chance */
 
-	if(rar->file.solid > 0 && rar->cstate.data_encrypted == 0 &&
-	    rar->cstate.window_buf == NULL) {
+	if(rar5->file.solid > 0 && rar5->cstate.data_encrypted == 0 &&
+	    rar5->cstate.window_buf == NULL) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 				  "Declared solid file, but no window buffer "
 				  "initialized yet");
@@ -1855,18 +1855,18 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	/* Check if window_size is a sane value. Also, if the file is not
 	 * declared as a directory, disallow window_size == 0. */
 	if(window_size > (64 * 1024 * 1024) ||
-	    (rar->file.dir == 0 && window_size == 0))
+	    (rar5->file.dir == 0 && window_size == 0))
 	{
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Declared dictionary size is not supported");
 		return ARCHIVE_FATAL;
 	}
 
-	if(rar->file.solid > 0) {
+	if(rar5->file.solid > 0) {
 		/* Re-check if current window size is the same as previous
 		 * window size (for solid files only). */
-		if(rar->file.solid_window_size > 0 &&
-		    rar->file.solid_window_size != (ssize_t) window_size)
+		if(rar5->file.solid_window_size > 0 &&
+		    rar5->file.solid_window_size != (ssize_t) window_size)
 		{
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Window size for this solid file doesn't match "
@@ -1875,23 +1875,23 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 		}
 	}
 	else
-		rar->cstate.data_encrypted = 0; /* Reset for new buffer */
+		rar5->cstate.data_encrypted = 0; /* Reset for new buffer */
 
-	if(rar->cstate.window_size < (ssize_t) window_size &&
-	    rar->cstate.window_buf)
+	if(rar5->cstate.window_size < (ssize_t) window_size &&
+	    rar5->cstate.window_buf)
 	{
 		/* The `data_ready` stack contains pointers to the `window_buf` or
 		 * `filtered_buf` buffers.  Since we're about to reallocate the first
 		 * buffer, some of those pointers could become invalid. Therefore, we
 		 * need to dispose of all entries from the stack before attempting the
 		 * realloc. */
-		clear_data_ready_stack(rar);
+		clear_data_ready_stack(rar5);
 
 		/* If window_buf has been allocated before, reallocate it, so
 		 * that its size will match new window_size. */
 
 		uint8_t* new_window_buf =
-			realloc(rar->cstate.window_buf, (size_t) window_size);
+			realloc(rar5->cstate.window_buf, (size_t) window_size);
 
 		if(!new_window_buf) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
@@ -1900,23 +1900,23 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 			return ARCHIVE_FATAL;
 		}
 
-		rar->cstate.window_buf = new_window_buf;
+		rar5->cstate.window_buf = new_window_buf;
 	}
 
 	/* Values up to 64M should fit into ssize_t on every
 	 * architecture. */
-	rar->cstate.window_size = (ssize_t) window_size;
+	rar5->cstate.window_size = (ssize_t) window_size;
 
-	if(rar->file.solid > 0 && rar->file.solid_window_size == 0) {
+	if(rar5->file.solid > 0 && rar5->file.solid_window_size == 0) {
 		/* Solid files have to have the same window_size across
 		   whole archive. Remember the window_size parameter
 		   for first solid file found. */
-		rar->file.solid_window_size = rar->cstate.window_size;
+		rar5->file.solid_window_size = rar5->cstate.window_size;
 	}
 
-	init_window_mask(rar);
+	init_window_mask(rar5);
 
-	rar->file.service = 0;
+	rar5->file.service = 0;
 
 	if(!read_var_sized(a, &host_os, NULL))
 		return ARCHIVE_EOF;
@@ -1999,7 +1999,7 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	archive_entry_update_pathname_utf8(entry, name_utf8_buf);
 
 	if(extra_data_size > 0) {
-		int ret = process_head_file_extra(a, entry, rar,
+		int ret = process_head_file_extra(a, entry, rar5,
 		    extra_data_size);
 
 		/*
@@ -2018,8 +2018,8 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	}
 
 	if((file_flags & UNKNOWN_UNPACKED_SIZE) == 0) {
-		rar->file.unpacked_size = (ssize_t) unpacked_size;
-		if(rar->file.redir_type == REDIR_TYPE_NONE)
+		rar5->file.unpacked_size = (ssize_t) unpacked_size;
+		if(rar5->file.redir_type == REDIR_TYPE_NONE)
 			archive_entry_set_size(entry, unpacked_size);
 	}
 
@@ -2028,18 +2028,18 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	}
 
 	if(file_flags & CRC32) {
-		rar->file.stored_crc32 = crc;
+		rar5->file.stored_crc32 = crc;
 	}
 
-	if(!rar->cstate.switch_multivolume) {
+	if(!rar5->cstate.switch_multivolume) {
 		/* Do not reinitialize unpacking state if we're switching
 		 * archives. */
-		rar->cstate.block_parsing_finished = 1;
-		rar->cstate.all_filters_applied = 1;
-		rar->cstate.initialized = 0;
+		rar5->cstate.block_parsing_finished = 1;
+		rar5->cstate.all_filters_applied = 1;
+		rar5->cstate.initialized = 0;
 	}
 
-	if(rar->generic.split_before > 0) {
+	if(rar5->generic.split_before > 0) {
 		/* If now we're standing on a header that has a 'split before'
 		 * mark, it means we're standing on a 'continuation' file
 		 * header. Signal the caller that if it wants to move to
@@ -2052,15 +2052,15 @@ static int process_head_file(struct archive_read* a, struct rar5* rar,
 	}
 }
 
-static int process_head_service(struct archive_read* a, struct rar5* rar,
+static int process_head_service(struct archive_read* a, struct rar5 *rar5,
     struct archive_entry* entry, size_t block_flags)
 {
 	/* Process this SERVICE block the same way as FILE blocks. */
-	int ret = process_head_file(a, rar, entry, block_flags);
+	int ret = process_head_file(a, rar5, entry, block_flags);
 	if(ret != ARCHIVE_OK)
 		return ret;
 
-	rar->file.service = 1;
+	rar5->file.service = 1;
 
 	/* But skip the data part automatically. It's no use for the user
 	 * anyway.  It contains only service data, not even needed to
@@ -2073,7 +2073,7 @@ static int process_head_service(struct archive_read* a, struct rar5* rar,
 	return ARCHIVE_RETRY;
 }
 
-static int process_head_main(struct archive_read* a, struct rar5* rar,
+static int process_head_main(struct archive_read* a, struct rar5 *rar5,
     struct archive_entry* entry, size_t block_flags)
 {
 	int ret;
@@ -2109,8 +2109,8 @@ static int process_head_main(struct archive_read* a, struct rar5* rar,
 		return ARCHIVE_EOF;
 	}
 
-	rar->main.volume = (archive_flags & VOLUME) > 0;
-	rar->main.solid = (archive_flags & SOLID) > 0;
+	rar5->main.volume = (archive_flags & VOLUME) > 0;
+	rar5->main.solid = (archive_flags & SOLID) > 0;
 
 	if(archive_flags & VOLUME_NUMBER) {
 		size_t v = 0;
@@ -2125,13 +2125,13 @@ static int process_head_main(struct archive_read* a, struct rar5* rar,
 			return ARCHIVE_FATAL;
 		}
 
-		rar->main.vol_no = (unsigned int) v;
+		rar5->main.vol_no = (unsigned int) v;
 	} else {
-		rar->main.vol_no = 0;
+		rar5->main.vol_no = 0;
 	}
 
-	if(rar->vol.expected_vol_no > 0 &&
-		rar->main.vol_no != rar->vol.expected_vol_no)
+	if(rar5->vol.expected_vol_no > 0 &&
+		rar5->main.vol_no != rar5->vol.expected_vol_no)
 	{
 		/* Returning EOF instead of FATAL because of strange
 		 * libarchive behavior. When opening multiple files via
@@ -2162,7 +2162,7 @@ static int process_head_main(struct archive_read* a, struct rar5* rar,
 
 	switch(extra_field_id) {
 		case LOCATOR:
-			ret = process_main_locator_extra_block(a, rar);
+			ret = process_main_locator_extra_block(a, rar5);
 			if(ret != ARCHIVE_OK) {
 				/* Error while parsing main locator extra
 				 * block. */
@@ -2182,25 +2182,25 @@ static int process_head_main(struct archive_read* a, struct rar5* rar,
 }
 
 static int skip_unprocessed_bytes(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 
-	if(rar->file.bytes_remaining) {
+	if(rar5->file.bytes_remaining) {
 		/* Use different skipping method in block merging mode than in
 		 * normal mode. If merge mode is active, rar5_read_data_skip
 		 * can't be used, because it could allow recursive use of
 		 * merge_block() * function, and this function doesn't support
 		 * recursive use. */
-		if(rar->merge_mode) {
+		if(rar5->merge_mode) {
 			/* Discard whole merged block. This is valid in solid
 			 * mode as well, because the code will discard blocks
 			 * only if those blocks are safe to discard (i.e.
 			 * they're not FILE blocks).  */
-			ret = consume(a, rar->file.bytes_remaining);
+			ret = consume(a, rar5->file.bytes_remaining);
 			if(ret != ARCHIVE_OK) {
 				return ret;
 			}
-			rar->file.bytes_remaining = 0;
+			rar5->file.bytes_remaining = 0;
 		} else {
 			/* If we're not in merge mode, use safe skipping code.
 			 * This will ensure we'll handle solid archives
@@ -2294,7 +2294,7 @@ static int process_base_block(struct archive_read* a,
 {
 	const size_t SMALLEST_RAR5_BLOCK_SIZE = 3;
 
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	uint32_t hdr_crc, computed_crc;
 	size_t raw_hdr_size = 0, hdr_size_len, hdr_size;
 	size_t header_id = 0;
@@ -2377,16 +2377,16 @@ static int process_base_block(struct archive_read* a,
 	if(!read_var_sized(a, &header_flags, NULL))
 		return ARCHIVE_EOF;
 
-	rar->generic.split_after = (header_flags & HFL_SPLIT_AFTER) > 0;
-	rar->generic.split_before = (header_flags & HFL_SPLIT_BEFORE) > 0;
-	rar->generic.size = (int)hdr_size;
-	rar->generic.last_header_id = (int)header_id;
-	rar->main.endarc = 0;
+	rar5->generic.split_after = (header_flags & HFL_SPLIT_AFTER) > 0;
+	rar5->generic.split_before = (header_flags & HFL_SPLIT_BEFORE) > 0;
+	rar5->generic.size = (int)hdr_size;
+	rar5->generic.last_header_id = (int)header_id;
+	rar5->main.endarc = 0;
 
 	/* Those are possible header ids in RARv5. */
 	switch(header_id) {
 		case HEAD_MAIN:
-			ret = process_head_main(a, rar, entry, header_flags);
+			ret = process_head_main(a, rar5, entry, header_flags);
 
 			/* Main header doesn't have any files in it, so it's
 			 * pointless to return to the caller. Retry to next
@@ -2399,28 +2399,28 @@ static int process_base_block(struct archive_read* a,
 
 			return ret;
 		case HEAD_SERVICE:
-			ret = process_head_service(a, rar, entry, header_flags);
+			ret = process_head_service(a, rar5, entry, header_flags);
 			return ret;
 		case HEAD_FILE:
-			ret = process_head_file(a, rar, entry, header_flags);
+			ret = process_head_file(a, rar5, entry, header_flags);
 			return ret;
 		case HEAD_CRYPT:
 			archive_entry_set_is_metadata_encrypted(entry, 1);
 			archive_entry_set_is_data_encrypted(entry, 1);
-			rar->has_encrypted_entries = 1;
-			rar->headers_are_encrypted = 1;
+			rar5->has_encrypted_entries = 1;
+			rar5->headers_are_encrypted = 1;
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Encryption is not supported");
 			return ARCHIVE_FATAL;
 		case HEAD_ENDARC:
-			rar->main.endarc = 1;
+			rar5->main.endarc = 1;
 
 			/* After encountering an end of file marker, we need
 			 * to take into consideration if this archive is
 			 * continued in another file (i.e. is it part01.rar:
 			 * is there a part02.rar?) */
-			if(rar->main.volume) {
+			if(rar5->main.volume) {
 				/* In case there is part02.rar, position the
 				 * read pointer in a proper place, so we can
 				 * resume parsing. */
@@ -2428,7 +2428,7 @@ static int process_base_block(struct archive_read* a,
 				if(ret == ARCHIVE_FATAL) {
 					return ARCHIVE_EOF;
 				} else {
-					if(rar->vol.expected_vol_no ==
+					if(rar5->vol.expected_vol_no ==
 					    UINT_MAX) {
 						archive_set_error(&a->archive,
 						    ARCHIVE_ERRNO_FILE_FORMAT,
@@ -2436,8 +2436,8 @@ static int process_base_block(struct archive_read* a,
 							return ARCHIVE_FATAL;
 					}
 
-					rar->vol.expected_vol_no =
-					    rar->main.vol_no + 1;
+					rar5->vol.expected_vol_no =
+					    rar5->main.vol_no + 1;
 					return ARCHIVE_OK;
 				}
 			} else {
@@ -2470,7 +2470,7 @@ static int process_base_block(struct archive_read* a,
 }
 
 static int skip_base_block(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 
 	/* Create a new local archive_entry structure that will be operated on
@@ -2487,7 +2487,7 @@ static int skip_base_block(struct archive_read* a) {
 	if(ret == ARCHIVE_FATAL)
 		return ret;
 
-	if(rar->generic.last_header_id == 2 && rar->generic.split_before > 0)
+	if(rar5->generic.last_header_id == 2 && rar5->generic.split_before > 0)
 		return ARCHIVE_OK;
 
 	if(ret == ARCHIVE_OK)
@@ -2555,76 +2555,77 @@ fatal:
 static int rar5_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 
 	/*
 	 * It should be sufficient to call archive_read_next_header() for
 	 * a reader to determine if an entry is encrypted or not.
 	 */
-	if (rar->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
-		rar->has_encrypted_entries = 0;
+	if (rar5->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
+		rar5->has_encrypted_entries = 0;
 	}
 
-	if(rar->header_initialized == 0) {
+	if(rar5->header_initialized == 0) {
 		init_header(a);
 		if ((ret = try_skip_sfx(a)) < ARCHIVE_WARN)
 			return ret;
-		rar->header_initialized = 1;
+		rar5->header_initialized = 1;
 	}
 
-	if(rar->skipped_magic == 0) {
+	if(rar5->skipped_magic == 0) {
 		if(ARCHIVE_OK != consume(a, sizeof(rar5_signature_xor))) {
 			return ARCHIVE_EOF;
 		}
 
-		rar->skipped_magic = 1;
+		rar5->skipped_magic = 1;
 	}
 
 	do {
 		ret = process_base_block(a, entry);
 	} while(ret == ARCHIVE_RETRY ||
-			(rar->main.endarc > 0 && ret == ARCHIVE_OK));
+			(rar5->main.endarc > 0 && ret == ARCHIVE_OK));
 
 	return ret;
 }
 
-static int init_unpack(struct rar5* rar) {
-	rar->file.calculated_crc32 = 0;
-	init_window_mask(rar);
+static int init_unpack(struct rar5 *rar5) {
+	rar5->file.calculated_crc32 = 0;
+	init_window_mask(rar5);
 
-	free(rar->cstate.window_buf);
-	free(rar->cstate.filtered_buf);
+	free(rar5->cstate.window_buf);
+	free(rar5->cstate.filtered_buf);
 
-	rar->cstate.window_buf = NULL;
-	rar->cstate.filtered_buf = NULL;
+	rar5->cstate.window_buf = NULL;
+	rar5->cstate.filtered_buf = NULL;
 
-	if(rar->cstate.window_size > 0) {
-		rar->cstate.window_buf = calloc(1, rar->cstate.window_size);
-		if(rar->cstate.window_buf == NULL)
+	if(rar5->cstate.window_size > 0) {
+		rar5->cstate.window_buf = calloc(1, rar5->cstate.window_size);
+		if(rar5->cstate.window_buf == NULL)
 			return ARCHIVE_FATAL;
-		rar->cstate.filtered_buf = calloc(1, rar->cstate.window_size);
-		if(rar->cstate.filtered_buf == NULL)
+		rar5->cstate.filtered_buf = calloc(1,
+		    rar5->cstate.window_size);
+		if(rar5->cstate.filtered_buf == NULL)
 			return ARCHIVE_FATAL;
 	}
 
-	clear_data_ready_stack(rar);
+	clear_data_ready_stack(rar5);
 
-	rar->cstate.write_ptr = 0;
-	rar->cstate.last_write_ptr = 0;
+	rar5->cstate.write_ptr = 0;
+	rar5->cstate.last_write_ptr = 0;
 
-	memset(&rar->cstate.bd, 0, sizeof(rar->cstate.bd));
-	memset(&rar->cstate.ld, 0, sizeof(rar->cstate.ld));
-	memset(&rar->cstate.dd, 0, sizeof(rar->cstate.dd));
-	memset(&rar->cstate.ldd, 0, sizeof(rar->cstate.ldd));
-	memset(&rar->cstate.rd, 0, sizeof(rar->cstate.rd));
+	memset(&rar5->cstate.bd, 0, sizeof(rar5->cstate.bd));
+	memset(&rar5->cstate.ld, 0, sizeof(rar5->cstate.ld));
+	memset(&rar5->cstate.dd, 0, sizeof(rar5->cstate.dd));
+	memset(&rar5->cstate.ldd, 0, sizeof(rar5->cstate.ldd));
+	memset(&rar5->cstate.rd, 0, sizeof(rar5->cstate.rd));
 	return ARCHIVE_OK;
 }
 
-static void update_crc(struct rar5* rar, const uint8_t* p, size_t to_read) {
+static void update_crc(struct rar5 *rar5, const uint8_t* p, size_t to_read) {
     int verify_crc;
 
-	if(rar->skip_mode) {
+	if(rar5->skip_mode) {
 #if defined CHECK_CRC_ON_SOLID_SKIP
 		verify_crc = 1;
 #else
@@ -2636,17 +2637,19 @@ static void update_crc(struct rar5* rar, const uint8_t* p, size_t to_read) {
 	if(verify_crc) {
 		/* Don't update CRC32 if the file doesn't have the
 		 * `stored_crc32` info filled in. */
-		if(rar->file.stored_crc32 > 0) {
-			rar->file.calculated_crc32 =
-				crc32(rar->file.calculated_crc32, p, (unsigned int)to_read);
+		if(rar5->file.stored_crc32 > 0) {
+			rar5->file.calculated_crc32 =
+				crc32(rar5->file.calculated_crc32, p,
+				    (unsigned int)to_read);
 		}
 
 		/* Check if the file uses an optional BLAKE2sp checksum
 		 * algorithm. */
-		if(rar->file.has_blake2 > 0) {
+		if(rar5->file.has_blake2 > 0) {
 			/* Return value of the `update` function is always 0,
 			 * so we can explicitly ignore it here. */
-			(void) blake2sp_update(&rar->file.b2state, p, to_read);
+			(void) blake2sp_update(&rar5->file.b2state, p,
+			    to_read);
 		}
 	}
 }
@@ -2730,12 +2733,12 @@ static int create_decode_tables(uint8_t* bit_length,
 static int decode_number(struct archive_read* a, struct decode_table* table,
     const uint8_t* p, uint16_t* num)
 {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int i, bits, dist, ret;
 	uint16_t bitfield;
 	uint32_t pos;
 
-	if(ARCHIVE_OK != (ret = read_bits_16(a, rar, p, &bitfield))) {
+	if(ARCHIVE_OK != (ret = read_bits_16(a, rar5, p, &bitfield))) {
 		return ret;
 	}
 
@@ -2743,7 +2746,7 @@ static int decode_number(struct archive_read* a, struct decode_table* table,
 
 	if(bitfield < table->decode_len[table->quick_bits]) {
 		int code = bitfield >> (16 - table->quick_bits);
-		skip_bits(rar, table->quick_len[code]);
+		skip_bits(rar5, table->quick_len[code]);
 		*num = table->quick_num[code];
 		return ARCHIVE_OK;
 	}
@@ -2757,7 +2760,7 @@ static int decode_number(struct archive_read* a, struct decode_table* table,
 		}
 	}
 
-	skip_bits(rar, bits);
+	skip_bits(rar5, bits);
 
 	dist = bitfield - table->decode_len[bits - 1];
 	dist >>= (16 - bits);
@@ -2771,7 +2774,7 @@ static int decode_number(struct archive_read* a, struct decode_table* table,
 }
 
 /* Reads and parses Huffman tables from the beginning of the block. */
-static int parse_tables(struct archive_read* a, struct rar5* rar,
+static int parse_tables(struct archive_read* a, struct rar5 *rar5,
     const uint8_t* p)
 {
 	int ret, value, i, w, idx = 0;
@@ -2785,7 +2788,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 	/* The data for table generation is compressed using a simple RLE-like
 	 * algorithm when storing zeroes, so we need to unpack it first. */
 	for(w = 0, i = 0; w < HUFF_BC;) {
-		if(i >= rar->cstate.cur_block_size) {
+		if(i >= rar5->cstate.cur_block_size) {
 			/* Truncated data, can't continue. */
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
@@ -2829,10 +2832,10 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 		}
 	}
 
-	rar->bits.in_addr = i;
-	rar->bits.bit_addr = nibble_shift ^ 4;
+	rar5->bits.in_addr = i;
+	rar5->bits.bit_addr = nibble_shift ^ 4;
 
-	ret = create_decode_tables(bit_length, &rar->cstate.bd, HUFF_BC);
+	ret = create_decode_tables(bit_length, &rar5->cstate.bd, HUFF_BC);
 	if(ret != ARCHIVE_OK) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Decoding huffman tables failed");
@@ -2842,7 +2845,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 	for(i = 0; i < HUFF_TABLE_SIZE;) {
 		uint16_t num;
 
-		ret = decode_number(a, &rar->cstate.bd, p, &num);
+		ret = decode_number(a, &rar5->cstate.bd, p, &num);
 		if(ret != ARCHIVE_OK) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
@@ -2858,17 +2861,17 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 			/* 16..17: repeat previous code */
 			uint16_t n;
 
-			if(ARCHIVE_OK != (ret = read_bits_16(a, rar, p, &n)))
+			if(ARCHIVE_OK != (ret = read_bits_16(a, rar5, p, &n)))
 				return ret;
 
 			if(num == 16) {
 				n >>= 13;
 				n += 3;
-				skip_bits(rar, 3);
+				skip_bits(rar5, 3);
 			} else {
 				n >>= 9;
 				n += 11;
-				skip_bits(rar, 7);
+				skip_bits(rar5, 7);
 			}
 
 			if(i > 0) {
@@ -2887,17 +2890,17 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 			/* other codes: fill with zeroes `n` times */
 			uint16_t n;
 
-			if(ARCHIVE_OK != (ret = read_bits_16(a, rar, p, &n)))
+			if(ARCHIVE_OK != (ret = read_bits_16(a, rar5, p, &n)))
 				return ret;
 
 			if(num == 18) {
 				n >>= 13;
 				n += 3;
-				skip_bits(rar, 3);
+				skip_bits(rar5, 3);
 			} else {
 				n >>= 9;
 				n += 11;
-				skip_bits(rar, 7);
+				skip_bits(rar5, 7);
 			}
 
 			while(n-- > 0 && i < HUFF_TABLE_SIZE)
@@ -2905,7 +2908,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 		}
 	}
 
-	ret = create_decode_tables(&table[idx], &rar->cstate.ld, HUFF_NC);
+	ret = create_decode_tables(&table[idx], &rar5->cstate.ld, HUFF_NC);
 	if(ret != ARCHIVE_OK) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		     "Failed to create literal table");
@@ -2914,7 +2917,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 
 	idx += HUFF_NC;
 
-	ret = create_decode_tables(&table[idx], &rar->cstate.dd, HUFF_DC);
+	ret = create_decode_tables(&table[idx], &rar5->cstate.dd, HUFF_DC);
 	if(ret != ARCHIVE_OK) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Failed to create distance table");
@@ -2923,7 +2926,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 
 	idx += HUFF_DC;
 
-	ret = create_decode_tables(&table[idx], &rar->cstate.ldd, HUFF_LDC);
+	ret = create_decode_tables(&table[idx], &rar5->cstate.ldd, HUFF_LDC);
 	if(ret != ARCHIVE_OK) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Failed to create lower bits of distances table");
@@ -2932,7 +2935,7 @@ static int parse_tables(struct archive_read* a, struct rar5* rar,
 
 	idx += HUFF_LDC;
 
-	ret = create_decode_tables(&table[idx], &rar->cstate.rd, HUFF_RC);
+	ret = create_decode_tables(&table[idx], &rar5->cstate.rd, HUFF_RC);
 	if(ret != ARCHIVE_OK) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Failed to create repeating distances table");
@@ -3006,13 +3009,13 @@ static int parse_block_header(struct archive_read* a, const uint8_t* p,
 }
 
 /* Convenience function used during filter processing. */
-static int parse_filter_data(struct archive_read* a, struct rar5* rar,
+static int parse_filter_data(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* p, uint32_t* filter_data)
 {
 	int i, bytes, ret;
 	uint32_t data = 0;
 
-	if(ARCHIVE_OK != (ret = read_consume_bits(a, rar, p, 2, &bytes)))
+	if(ARCHIVE_OK != (ret = read_consume_bits(a, rar5, p, 2, &bytes)))
 		return ret;
 
 	bytes++;
@@ -3020,14 +3023,14 @@ static int parse_filter_data(struct archive_read* a, struct rar5* rar,
 	for(i = 0; i < bytes; i++) {
 		uint16_t byte;
 
-		if(ARCHIVE_OK != (ret = read_bits_16(a, rar, p, &byte))) {
+		if(ARCHIVE_OK != (ret = read_bits_16(a, rar5, p, &byte))) {
 			return ret;
 		}
 
 		/* Cast to uint32_t will ensure the shift operation will not
 		 * produce undefined result. */
 		data += ((uint32_t) byte >> 8) << (i * 8);
-		skip_bits(rar, 8);
+		skip_bits(rar5, 8);
 	}
 
 	*filter_data = data;
@@ -3035,12 +3038,12 @@ static int parse_filter_data(struct archive_read* a, struct rar5* rar,
 }
 
 /* Function is used during sanity checking. */
-static int is_valid_filter_block_start(struct rar5* rar,
+static int is_valid_filter_block_start(struct rar5 *rar5,
     uint32_t start)
 {
-	const int64_t block_start = (ssize_t) start + rar->cstate.write_ptr;
-	const int64_t last_bs = rar->cstate.last_block_start;
-	const ssize_t last_bl = rar->cstate.last_block_length;
+	const int64_t block_start = (ssize_t) start + rar5->cstate.write_ptr;
+	const int64_t last_bs = rar5->cstate.last_block_start;
+	const ssize_t last_bl = rar5->cstate.last_block_length;
 
 	if(last_bs == 0 || last_bl == 0) {
 		/* We didn't have any filters yet, so accept this offset. */
@@ -3060,32 +3063,32 @@ static int is_valid_filter_block_start(struct rar5* rar,
 /* The function will create a new filter, read its parameters from the input
  * stream and add it to the filter collection. */
 static int parse_filter(struct archive_read* ar, const uint8_t* p) {
-	struct rar5 *rar = ar->format->data;
+	struct rar5 *rar5 = ar->format->data;
 	uint32_t block_start, block_length;
 	uint16_t filter_type;
 	struct filter_info* filt = NULL;
 	int ret;
 
 	/* Read the parameters from the input stream. */
-	if(ARCHIVE_OK != (ret = parse_filter_data(ar, rar, p, &block_start)))
+	if(ARCHIVE_OK != (ret = parse_filter_data(ar, rar5, p, &block_start)))
 		return ret;
 
-	if(ARCHIVE_OK != (ret = parse_filter_data(ar, rar, p, &block_length)))
+	if(ARCHIVE_OK != (ret = parse_filter_data(ar, rar5, p, &block_length)))
 		return ret;
 
-	if(ARCHIVE_OK != (ret = read_bits_16(ar, rar, p, &filter_type)))
+	if(ARCHIVE_OK != (ret = read_bits_16(ar, rar5, p, &filter_type)))
 		return ret;
 
 	filter_type >>= 13;
-	skip_bits(rar, 3);
+	skip_bits(rar5, 3);
 
 	/* Perform some sanity checks on this filter parameters. */
 
 	if(block_length < 4 ||
 	    block_length > 0x400000 ||
-	    !is_valid_filter_block_start(rar, block_start) ||
-	    (rar->cstate.window_size > 0 &&
-	     (ssize_t)block_length > rar->cstate.window_size >> 1))
+	    !is_valid_filter_block_start(rar5, block_start) ||
+	    (rar5->cstate.window_size > 0 &&
+	     (ssize_t)block_length > rar5->cstate.window_size >> 1))
 	{
 		archive_set_error(&ar->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Invalid filter encountered");
@@ -3093,7 +3096,7 @@ static int parse_filter(struct archive_read* ar, const uint8_t* p) {
 	}
 
 	/* Allocate a new filter. */
-	filt = add_new_filter(rar);
+	filt = add_new_filter(rar5);
 	if(filt == NULL) {
 		archive_set_error(&ar->archive, ENOMEM,
 		    "Can't allocate memory for a filter descriptor");
@@ -3101,11 +3104,11 @@ static int parse_filter(struct archive_read* ar, const uint8_t* p) {
 	}
 
 	filt->type = filter_type;
-	filt->block_start = rar->cstate.write_ptr + block_start;
+	filt->block_start = rar5->cstate.write_ptr + block_start;
 	filt->block_length = block_length;
 
-	rar->cstate.last_block_start = filt->block_start;
-	rar->cstate.last_block_length = filt->block_length;
+	rar5->cstate.last_block_start = filt->block_start;
+	rar5->cstate.last_block_length = filt->block_length;
 
 	/* Read some more data in case this is a DELTA filter. Other filter
 	 * types don't require any additional data over what was already
@@ -3113,7 +3116,7 @@ static int parse_filter(struct archive_read* ar, const uint8_t* p) {
 	if(filter_type == FILTER_DELTA) {
 		int channels;
 
-		if(ARCHIVE_OK != (ret = read_consume_bits(ar, rar, p, 5, &channels)))
+		if(ARCHIVE_OK != (ret = read_consume_bits(ar, rar5, p, 5, &channels)))
 			return ret;
 
 		filt->channels = channels + 1;
@@ -3122,7 +3125,7 @@ static int parse_filter(struct archive_read* ar, const uint8_t* p) {
 	return ARCHIVE_OK;
 }
 
-static int decode_code_length(struct archive_read* a, struct rar5* rar,
+static int decode_code_length(struct archive_read* a, struct rar5 *rar5,
 	const uint8_t* p, uint16_t code)
 {
 	int lbits, length = 2;
@@ -3138,7 +3141,7 @@ static int decode_code_length(struct archive_read* a, struct rar5* rar,
 	if(lbits > 0) {
 		int add;
 
-		if(ARCHIVE_OK != read_consume_bits(a, rar, p, lbits, &add))
+		if(ARCHIVE_OK != read_consume_bits(a, rar5, p, lbits, &add))
 			return -1;
 
 		length += add;
@@ -3148,20 +3151,20 @@ static int decode_code_length(struct archive_read* a, struct rar5* rar,
 }
 
 static int copy_string(struct archive_read* a, int len, int dist) {
-	struct rar5 *rar = a->format->data;
-	const ssize_t cmask = rar->cstate.window_mask;
-	const uint64_t write_ptr = rar->cstate.write_ptr +
-	    rar->cstate.solid_offset;
+	struct rar5 *rar5 = a->format->data;
+	const ssize_t cmask = rar5->cstate.window_mask;
+	const uint64_t write_ptr = rar5->cstate.write_ptr +
+	    rar5->cstate.solid_offset;
 	int i;
 
-	if (rar->cstate.window_buf == NULL)
+	if (rar5->cstate.window_buf == NULL)
 		return ARCHIVE_FATAL;
 
-	if (rar->cstate.write_ptr > rar->file.unpacked_size ||
-	    len > rar->file.unpacked_size - rar->cstate.write_ptr) {
+	if (rar5->cstate.write_ptr > rar5->file.unpacked_size ||
+	    len > rar5->file.unpacked_size - rar5->cstate.write_ptr) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Uncompressed data exceeds declared size");
-		return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+		return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 	}
 
 	/* The unpacker spends most of the time in this function. It would be
@@ -3174,26 +3177,26 @@ static int copy_string(struct archive_read* a, int len, int dist) {
 	for(i = 0; i < len; i++) {
 		const ssize_t write_idx = (write_ptr + i) & cmask;
 		const ssize_t read_idx = (write_ptr + i - dist) & cmask;
-		rar->cstate.window_buf[write_idx] =
-		    rar->cstate.window_buf[read_idx];
+		rar5->cstate.window_buf[write_idx] =
+		    rar5->cstate.window_buf[read_idx];
 	}
 
-	rar->cstate.write_ptr += len;
+	rar5->cstate.write_ptr += len;
 	return ARCHIVE_OK;
 }
 
 static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	uint16_t num;
 	int ret;
 
-	const uint64_t cmask = rar->cstate.window_mask;
-	const struct compressed_block_header* hdr = &rar->last_block_hdr;
+	const uint64_t cmask = rar5->cstate.window_mask;
+	const struct compressed_block_header* hdr = &rar5->last_block_hdr;
 	const uint8_t bit_size = 1 + bf_bit_size(hdr);
 
 	while(1) {
-		if(rar->cstate.write_ptr - rar->cstate.last_write_ptr >
-		    (rar->cstate.window_size >> 1)) {
+		if(rar5->cstate.write_ptr - rar5->cstate.last_write_ptr >
+		    (rar5->cstate.window_size >> 1)) {
 			/* Don't allow growing data by more than half of the
 			 * window size at a time. In such case, break the loop;
 			 *  next call to this function will continue processing
@@ -3201,18 +3204,18 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 			break;
 		}
 
-		if(rar->bits.in_addr > rar->cstate.cur_block_size - 1 ||
-		    (rar->bits.in_addr == rar->cstate.cur_block_size - 1 &&
-		    rar->bits.bit_addr >= bit_size))
+		if(rar5->bits.in_addr > rar5->cstate.cur_block_size - 1 ||
+		    (rar5->bits.in_addr == rar5->cstate.cur_block_size - 1 &&
+		    rar5->bits.bit_addr >= bit_size))
 		{
 			/* If the program counter is here, it means the
 			 * function has finished processing the block. */
-			rar->cstate.block_parsing_finished = 1;
+			rar5->cstate.block_parsing_finished = 1;
 			break;
 		}
 
 		/* Decode the next literal. */
-		if(ARCHIVE_OK != decode_number(a, &rar->cstate.ld, p, &num)) {
+		if(ARCHIVE_OK != decode_number(a, &rar5->cstate.ld, p, &num)) {
 			return ARCHIVE_EOF;
 		}
 
@@ -3235,22 +3238,22 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 			int64_t write_idx;
 
 			/* A literal write emits one byte; copy_string() checks len. */
-			if(rar->cstate.write_ptr >= rar->file.unpacked_size) {
+			if(rar5->cstate.write_ptr >= rar5->file.unpacked_size) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
 				    "Uncompressed data exceeds declared size");
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+				return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 			}
 
-			write_idx = rar->cstate.solid_offset +
-			    rar->cstate.write_ptr++;
+			write_idx = rar5->cstate.solid_offset +
+			    rar5->cstate.write_ptr++;
 
-			rar->cstate.window_buf[write_idx & cmask] =
+			rar5->cstate.window_buf[write_idx & cmask] =
 			    (uint8_t) num;
 			continue;
 		} else if(num >= 262) {
 			uint16_t dist_slot;
-			int len = decode_code_length(a, rar, p, num - 262),
+			int len = decode_code_length(a, rar5, p, num - 262),
 				dbits,
 				dist = 1;
 
@@ -3259,17 +3262,17 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 				    ARCHIVE_ERRNO_PROGRAMMER,
 				    "Failed to decode the code length");
 
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+				return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 			}
 
-			if(ARCHIVE_OK != decode_number(a, &rar->cstate.dd, p,
+			if(ARCHIVE_OK != decode_number(a, &rar5->cstate.dd, p,
 			    &dist_slot))
 			{
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_PROGRAMMER,
 				    "Failed to decode the distance slot");
 
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+				return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 			}
 
 			if(dist_slot < 4) {
@@ -3293,28 +3296,28 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 
 					if(dbits > 4) {
 						if(ARCHIVE_OK != (ret = read_bits_32(
-						    a, rar, p, &add))) {
+						    a, rar5, p, &add))) {
 							/* Return EOF if we
 							 * can't read more
 							 * data. */
 							return ret;
 						}
 
-						skip_bits(rar, dbits - 4);
+						skip_bits(rar5, dbits - 4);
 						add = (add >> (
 						    36 - dbits)) << 4;
 						dist += add;
 					}
 
 					if(ARCHIVE_OK != decode_number(a,
-					    &rar->cstate.ldd, p, &low_dist))
+					    &rar5->cstate.ldd, p, &low_dist))
 					{
 						archive_set_error(&a->archive,
 						    ARCHIVE_ERRNO_PROGRAMMER,
 						    "Failed to decode the "
 						    "distance slot");
 
-						return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+						return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 					}
 
 					if(dist >= INT_MAX - low_dist - 1) {
@@ -3324,7 +3327,7 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 						    ARCHIVE_ERRNO_FILE_FORMAT,
 						    "Distance pointer "
 						    "overflow");
-						return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+						return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 					}
 
 					dist += low_dist;
@@ -3332,7 +3335,7 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 					/* dbits is one of [0,1,2,3] */
 					int add;
 
-					if(ARCHIVE_OK != (ret = read_consume_bits(a, rar,
+					if(ARCHIVE_OK != (ret = read_consume_bits(a, rar5,
 					     p, dbits, &add))) {
 						/* Return EOF if we can't read
 						 * more data. */
@@ -3355,8 +3358,8 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 				}
 			}
 
-			dist_cache_push(rar, dist);
-			rar->cstate.last_len = len;
+			dist_cache_push(rar5, dist);
+			rar5->cstate.last_len = len;
 
 			ret = copy_string(a, len, dist);
 			if(ret != ARCHIVE_OK)
@@ -3371,10 +3374,10 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 
 			continue;
 		} else if(num == 257) {
-			if(rar->cstate.last_len != 0) {
+			if(rar5->cstate.last_len != 0) {
 				ret = copy_string(a,
-				    rar->cstate.last_len,
-				    rar->cstate.dist_cache[0]);
+				    rar5->cstate.last_len,
+				    rar5->cstate.dist_cache[0]);
 				if(ret != ARCHIVE_OK)
 					return ret;
 			}
@@ -3383,22 +3386,22 @@ static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
 		} else {
 			/* num < 262 */
 			const int idx = num - 258;
-			const int dist = dist_cache_touch(rar, idx);
+			const int dist = dist_cache_touch(rar5, idx);
 
 			uint16_t len_slot;
 			int len;
 
-			if(ARCHIVE_OK != decode_number(a, &rar->cstate.rd, p,
+			if(ARCHIVE_OK != decode_number(a, &rar5->cstate.rd, p,
 			    &len_slot)) {
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+				return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 			}
 
-			len = decode_code_length(a, rar, p, len_slot);
+			len = decode_code_length(a, rar5, p, len_slot);
 			if (len == -1) {
-				return rar->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
+				return rar5->main.solid ? ARCHIVE_FATAL : ARCHIVE_FAILED;
 			}
 
-			rar->cstate.last_len = len;
+			rar5->cstate.last_len = len;
 
 			ret = copy_string(a, len, dist);
 			if(ret != ARCHIVE_OK)
@@ -3460,7 +3463,7 @@ static int scan_for_signature(struct archive_read* a) {
 /* This function will switch the multivolume archive file to another file,
  * i.e. from part03 to part 04. */
 static int advance_multivolume(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int lret;
 
 	/* A small state machine that will skip unnecessary data, needed to
@@ -3468,7 +3471,7 @@ static int advance_multivolume(struct archive_read* a) {
 	 * we want to be an stream-oriented (instead of file-oriented)
 	 * unpacker.
 	 *
-	 * The state machine starts with `rar->main.endarc` == 0. It also
+	 * The state machine starts with `rar5->main.endarc` == 0. It also
 	 * assumes that current stream pointer points to some base block
 	 * header.
 	 *
@@ -3477,10 +3480,10 @@ static int advance_multivolume(struct archive_read* a) {
 	 */
 
 	while(1) {
-		if(rar->main.endarc == 1) {
+		if(rar5->main.endarc == 1) {
 			int looping = 1;
 
-			rar->main.endarc = 0;
+			rar5->main.endarc = 0;
 
 			while(looping) {
 				lret = skip_base_block(a);
@@ -3518,7 +3521,7 @@ static int advance_multivolume(struct archive_read* a) {
 				/* If there was an error during skipping, or we
 				 * have just skipped a FILE base block... */
 
-				if(rar->main.endarc == 0) {
+				if(rar5->main.endarc == 0) {
 					return lret;
 				} else {
 					continue;
@@ -3537,12 +3540,12 @@ static int advance_multivolume(struct archive_read* a) {
 static int merge_block(struct archive_read* a, ssize_t block_size,
     const uint8_t** p)
 {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	ssize_t cur_block_size, partial_offset = 0;
 	const uint8_t* lp;
 	int ret;
 
-	if(rar->merge_mode) {
+	if(rar5->merge_mode) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 		    "Recursive merge is not allowed");
 
@@ -3550,27 +3553,27 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 	}
 
 	/* Set a flag that we're in the switching mode. */
-	rar->cstate.switch_multivolume = 1;
+	rar5->cstate.switch_multivolume = 1;
 
 	/* Reallocate the memory which will hold the whole block. */
-	if(rar->vol.push_buf)
-		free((void*) rar->vol.push_buf);
+	if(rar5->vol.push_buf)
+		free((void*) rar5->vol.push_buf);
 
 	/* Increasing the allocation block by 8 is due to bit reading functions,
 	 * which are using additional 2 or 4 bytes. Allocating the block size
 	 * by exact value would make bit reader perform reads from invalid
 	 * memory block when reading the last byte from the buffer. */
-	rar->vol.push_buf = malloc(block_size + 8);
-	if(!rar->vol.push_buf) {
+	rar5->vol.push_buf = malloc(block_size + 8);
+	if(!rar5->vol.push_buf) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory for a merge block buffer");
-		rar->cstate.switch_multivolume = 0;
+		rar5->cstate.switch_multivolume = 0;
 		return ARCHIVE_FATAL;
 	}
 
 	/* Valgrind complains if the extension block for bit reader is not
 	 * initialized, so initialize it. */
-	memset(&rar->vol.push_buf[block_size], 0, 8);
+	memset(&rar5->vol.push_buf[block_size], 0, 8);
 
 	/* A single block can span across multiple multivolume archive files,
 	 * so we use a loop here. This loop will consume enough multivolume
@@ -3579,7 +3582,7 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 	while(1) {
 		/* Get the size of current block chunk in this multivolume
 		 * archive file and read it. */
-		cur_block_size = rar5_min(rar->file.bytes_remaining,
+		cur_block_size = rar5_min(rar5->file.bytes_remaining,
 		    block_size - partial_offset);
 
 		if(cur_block_size < 1) {
@@ -3589,12 +3592,12 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Encountered invalid block size during block merge");
-			rar->cstate.switch_multivolume = 0;
+			rar5->cstate.switch_multivolume = 0;
 			return ARCHIVE_FATAL;
 		}
 
 		if(!read_ahead(a, cur_block_size, &lp)) {
-			rar->cstate.switch_multivolume = 0;
+			rar5->cstate.switch_multivolume = 0;
 			return ARCHIVE_EOF;
 		}
 
@@ -3604,27 +3607,27 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_PROGRAMMER,
 			    "Consumed too much data when merging blocks");
-			rar->cstate.switch_multivolume = 0;
+			rar5->cstate.switch_multivolume = 0;
 			return ARCHIVE_FATAL;
 		}
 
 		/* Merge previous block chunk with current block chunk,
 		 * or create first block chunk if this is our first
 		 * iteration. */
-		memcpy(&rar->vol.push_buf[partial_offset], lp, cur_block_size);
+		memcpy(&rar5->vol.push_buf[partial_offset], lp, cur_block_size);
 
 		/* Advance the stream read pointer by this block chunk size. */
 		if(ARCHIVE_OK != consume(a, cur_block_size)) {
 			/* Data was copied but stream pointer didn't advance;
 			 * stream position is unrecoverable. */
-			rar->cstate.switch_multivolume = 0;
+			rar5->cstate.switch_multivolume = 0;
 			return ARCHIVE_FATAL;
 		}
 
 		/* Update the pointers. `partial_offset` contains information
 		 * about the sum of merged block chunks. */
 		partial_offset += cur_block_size;
-		rar->file.bytes_remaining -= cur_block_size;
+		rar5->file.bytes_remaining -= cur_block_size;
 
 		/* If `partial_offset` is the same as `block_size`, this means
 		 * we've merged all block chunks and we have a valid full
@@ -3635,18 +3638,18 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 
 		/* If we don't have any bytes to read, this means we should
 		 * switch to another multivolume archive file. */
-		if(rar->file.bytes_remaining == 0) {
-			rar->merge_mode++;
+		if(rar5->file.bytes_remaining == 0) {
+			rar5->merge_mode++;
 			ret = advance_multivolume(a);
-			rar->merge_mode--;
+			rar5->merge_mode--;
 			if(ret != ARCHIVE_OK) {
-				rar->cstate.switch_multivolume = 0;
+				rar5->cstate.switch_multivolume = 0;
 				return ret;
 			}
 		}
 	}
 
-	*p = rar->vol.push_buf;
+	*p = rar5->vol.push_buf;
 
 	/* If we're here, we can resume unpacking by processing the block
 	 * pointed to by the `*p` memory pointer. */
@@ -3655,19 +3658,19 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 }
 
 static int process_block(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	const uint8_t* p;
 	int ret;
 
 	/* If we don't have any data to be processed, this most probably means
 	 * we need to switch to the next volume. */
-	if(rar->main.volume && rar->file.bytes_remaining == 0) {
+	if(rar5->main.volume && rar5->file.bytes_remaining == 0) {
 		ret = advance_multivolume(a);
 		if(ret != ARCHIVE_OK)
 			return ret;
 	}
 
-	if(rar->cstate.block_parsing_finished) {
+	if(rar5->cstate.block_parsing_finished) {
 		ssize_t block_size;
 		ssize_t to_skip;
 		ssize_t cur_block_size;
@@ -3687,7 +3690,7 @@ static int process_block(struct archive_read* a) {
 		 * `parse_block_header` as the second argument. */
 
 		ret = parse_block_header(a, p, &block_size,
-		    &rar->last_block_hdr);
+		    &rar5->last_block_hdr);
 		if(ret != ARCHIVE_OK) {
 			return ret;
 		}
@@ -3695,11 +3698,11 @@ static int process_block(struct archive_read* a) {
 		/* Skip block header. Next data is huffman tables,
 		 * if present. */
 		to_skip = sizeof(struct compressed_block_header) +
-			bf_byte_count(&rar->last_block_hdr) + 1;
+			bf_byte_count(&rar5->last_block_hdr) + 1;
 
 		/* If the block header's to_skip value exceeds the declared
 		 * remaining data, the archive is malformed. */
-		if(to_skip > rar->file.bytes_remaining) {
+		if(to_skip > rar5->file.bytes_remaining) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Block header size exceeds remaining file data");
@@ -3709,7 +3712,7 @@ static int process_block(struct archive_read* a) {
 		if(ARCHIVE_OK != consume(a, to_skip))
 			return ARCHIVE_EOF;
 
-		rar->file.bytes_remaining -= to_skip;
+		rar5->file.bytes_remaining -= to_skip;
 
 		/* The block size gives information about the whole block size,
 		 * but the block could be stored in split form when using
@@ -3718,9 +3721,9 @@ static int process_block(struct archive_read* a) {
 		 * part of the data will be in another file. */
 
 		cur_block_size =
-			rar5_min(rar->file.bytes_remaining, block_size);
+			rar5_min(rar5->file.bytes_remaining, block_size);
 
-		if(block_size > rar->file.bytes_remaining) {
+		if(block_size > rar5->file.bytes_remaining) {
 			/* If current blocks' size is bigger than our data
 			 * size, this means we have a multivolume archive.
 			 * In this case, skip all base headers until the end
@@ -3744,7 +3747,7 @@ static int process_block(struct archive_read* a) {
 			 * the *whole* block (merged from partial blocks
 			 * stored in multiple archives files). */
 		} else {
-			rar->cstate.switch_multivolume = 0;
+			rar5->cstate.switch_multivolume = 0;
 
 			/* Read the whole block size into memory. This can take
 			 * up to  8 megabytes of memory in theoretical cases.
@@ -3756,16 +3759,16 @@ static int process_block(struct archive_read* a) {
 			}
 		}
 
-		rar->cstate.block_buf = p;
-		rar->cstate.cur_block_size = cur_block_size;
-		rar->cstate.block_parsing_finished = 0;
+		rar5->cstate.block_buf = p;
+		rar5->cstate.cur_block_size = cur_block_size;
+		rar5->cstate.block_parsing_finished = 0;
 
-		rar->bits.in_addr = 0;
-		rar->bits.bit_addr = 0;
+		rar5->bits.in_addr = 0;
+		rar5->bits.bit_addr = 0;
 
-		if(bf_is_table_present(&rar->last_block_hdr)) {
+		if(bf_is_table_present(&rar5->last_block_hdr)) {
 			/* Load Huffman tables. */
-			ret = parse_tables(a, rar, p);
+			ret = parse_tables(a, rar5, p);
 			if(ret != ARCHIVE_OK) {
 				/* Error during decompression of Huffman
 				 * tables. */
@@ -3774,7 +3777,7 @@ static int process_block(struct archive_read* a) {
 		}
 	} else {
 		/* Block parsing not finished, reuse previous memory buffer. */
-		p = rar->cstate.block_buf;
+		p = rar5->cstate.block_buf;
 	}
 
 	/* Uncompress the block, or a part of it, depending on how many bytes
@@ -3787,22 +3790,22 @@ static int process_block(struct archive_read* a) {
 		return ret;
 	}
 
-	if(rar->cstate.block_parsing_finished &&
-	    rar->cstate.switch_multivolume == 0 &&
-	    rar->cstate.cur_block_size > 0)
+	if(rar5->cstate.block_parsing_finished &&
+	    rar5->cstate.switch_multivolume == 0 &&
+	    rar5->cstate.cur_block_size > 0)
 	{
 		/* If we're processing a normal block, consume the whole
 		 * block. We can do this because we've already read the whole
 		 * block to memory. */
-		if(ARCHIVE_OK != consume(a, rar->cstate.cur_block_size))
+		if(ARCHIVE_OK != consume(a, rar5->cstate.cur_block_size))
 			return ARCHIVE_FATAL;
 
-		rar->file.bytes_remaining -= rar->cstate.cur_block_size;
-	} else if(rar->cstate.switch_multivolume) {
+		rar5->file.bytes_remaining -= rar5->cstate.cur_block_size;
+	} else if(rar5->cstate.switch_multivolume) {
 		/* Don't consume the block if we're doing multivolume
 		 * processing. The volume switching function will consume
 		 * the proper count of bytes instead. */
-		rar->cstate.switch_multivolume = 0;
+		rar5->cstate.switch_multivolume = 0;
 	}
 
 	return ARCHIVE_OK;
@@ -3812,13 +3815,13 @@ static int process_block(struct archive_read* a) {
  *
  * Returns ARCHIVE_OK when those arguments can be used, ARCHIVE_RETRY
  * when there is no data on the stack. */
-static int use_data(struct rar5* rar, const void** buf, size_t* size,
+static int use_data(struct rar5 *rar5, const void** buf, size_t* size,
     int64_t* offset)
 {
 	int i;
 
-	for(i = 0; i < rar5_countof(rar->cstate.dready); i++) {
-		struct data_ready *d = &rar->cstate.dready[i];
+	for(i = 0; i < rar5_countof(rar5->cstate.dready); i++) {
+		struct data_ready *d = &rar5->cstate.dready[i];
 
 		if(d->used) {
 			if(buf)    *buf = d->buf;
@@ -3833,14 +3836,14 @@ static int use_data(struct rar5* rar, const void** buf, size_t* size,
 	return ARCHIVE_RETRY;
 }
 
-static void clear_data_ready_stack(struct rar5* rar) {
-	memset(&rar->cstate.dready, 0, sizeof(rar->cstate.dready));
+static void clear_data_ready_stack(struct rar5 *rar5) {
+	memset(&rar5->cstate.dready, 0, sizeof(rar5->cstate.dready));
 }
 
-/* Pushes the `buf`, `size` and `offset` arguments to the rar->cstate.dready
+/* Pushes the `buf`, `size` and `offset` arguments to the rar5->cstate.dready
  * FIFO stack. Those values will be popped from this stack by the `use_data`
  * function. */
-static int push_data_ready(struct archive_read* a, struct rar5* rar,
+static int push_data_ready(struct archive_read* a, struct rar5 *rar5,
     const uint8_t* buf, size_t size, int64_t offset)
 {
 	int i;
@@ -3851,18 +3854,18 @@ static int push_data_ready(struct archive_read* a, struct rar5* rar,
 	 * because we're interested only in the side effect: building up the
 	 * internal window circular buffer. This window buffer will be used
 	 * later during unpacking of requested data. */
-	if(rar->skip_mode)
+	if(rar5->skip_mode)
 		return ARCHIVE_OK;
 
 	/* Sanity check. */
-	if(offset != rar->file.last_offset + rar->file.last_size) {
+	if(offset != rar5->file.last_offset + rar5->file.last_size) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 		    "Sanity check error: output stream is not continuous");
 		return ARCHIVE_FATAL;
 	}
 
-	for(i = 0; i < rar5_countof(rar->cstate.dready); i++) {
-		struct data_ready* d = &rar->cstate.dready[i];
+	for(i = 0; i < rar5_countof(rar5->cstate.dready); i++) {
+		struct data_ready* d = &rar5->cstate.dready[i];
 		if(!d->used) {
 			d->used = 1;
 			d->buf = buf;
@@ -3870,21 +3873,21 @@ static int push_data_ready(struct archive_read* a, struct rar5* rar,
 			d->offset = offset;
 
 			/* These fields are used only in sanity checking. */
-			rar->file.last_offset = offset;
-			rar->file.last_size = size;
+			rar5->file.last_offset = offset;
+			rar5->file.last_size = size;
 
 			/* Calculate the checksum of this new block before
 			 * submitting data to libarchive's engine. */
-			update_crc(rar, d->buf, d->size);
+			update_crc(rar5, d->buf, d->size);
 
 			return ARCHIVE_OK;
 		}
 	}
 
-	/* Program counter will reach this code if the `rar->cstate.data_ready`
-	 * stack will be filled up so that no new entries will be allowed. The
-	 * code shouldn't allow such situation to occur. So we treat this case
-	 * as an internal error. */
+	/* Program counter will reach this code if the
+	 * `rar5->cstate.data_ready` stack will be filled up so that no new
+	 * entries will be allowed. The code shouldn't allow such situation to
+	 * occur. So we treat this case as an internal error. */
 
 	archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 	    "Premature end of data_ready stack");
@@ -3934,23 +3937,23 @@ static int push_data_ready(struct archive_read* a, struct rar5* rar,
  * */
 
 static int do_uncompress_file(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 	int64_t max_end_pos;
 
-	if(!rar->cstate.initialized) {
+	if(!rar5->cstate.initialized) {
 		/* Don't perform full context reinitialization if we're
 		 * processing a solid archive. */
-		if(!rar->main.solid || !rar->cstate.window_buf) {
-			if((ret = init_unpack(rar)) != ARCHIVE_OK)
+		if(!rar5->main.solid || !rar5->cstate.window_buf) {
+			if((ret = init_unpack(rar5)) != ARCHIVE_OK)
 				return ret;
 		}
 
-		rar->cstate.initialized = 1;
+		rar5->cstate.initialized = 1;
 	}
 
 	/* Don't allow extraction if window_size is invalid. */
-	if(rar->cstate.window_size == 0) {
+	if(rar5->cstate.window_size == 0) {
 		archive_set_error(&a->archive,
 			ARCHIVE_ERRNO_FILE_FORMAT,
 			"Invalid window size declaration in this file");
@@ -3959,7 +3962,7 @@ static int do_uncompress_file(struct archive_read* a) {
 		return ARCHIVE_FAILED;
 	}
 
-	if(rar->cstate.all_filters_applied == 1) {
+	if(rar5->cstate.all_filters_applied == 1) {
 		/* We use while(1) here, but standard case allows for just 1
 		 * iteration. The loop will iterate if process_block() didn't
 		 * generate any data at all. This can happen if the block
@@ -3970,12 +3973,12 @@ static int do_uncompress_file(struct archive_read* a) {
 			if(ret != ARCHIVE_OK)
 				return ret;
 
-			if(rar->cstate.last_write_ptr ==
-			    rar->cstate.write_ptr) {
+			if(rar5->cstate.last_write_ptr ==
+			    rar5->cstate.write_ptr) {
 				/* The block didn't generate any new data,
 				 * so just process a new block if this one
 				 * wasn't the last block in the file. */
-				if (bf_is_last_block(&rar->last_block_hdr)) {
+				if (bf_is_last_block(&rar5->last_block_hdr)) {
 					return ARCHIVE_EOF;
 				}
 
@@ -3997,13 +4000,13 @@ static int do_uncompress_file(struct archive_read* a) {
 		return ret;
 	}
 
-	if(cdeque_size(&rar->cstate.filters) > 0) {
+	if(cdeque_size(&rar5->cstate.filters) > 0) {
 		/* Check if we can write something before hitting first
 		 * filter. */
 		struct filter_info* flt;
 
 		/* Get the block_start offset from the first filter. */
-		if(CDE_OK != cdeque_front(&rar->cstate.filters,
+		if(CDE_OK != cdeque_front(&rar5->cstate.filters,
 		    cdeque_filter_p(&flt)))
 		{
 			archive_set_error(&a->archive,
@@ -4013,15 +4016,15 @@ static int do_uncompress_file(struct archive_read* a) {
 		}
 
 		max_end_pos = rar5_min(flt->block_start,
-		    rar->cstate.write_ptr);
+		    rar5->cstate.write_ptr);
 	} else {
 		/* There are no filters defined, or all filters were applied.
 		 * This means we can just store the data without any
 		 * postprocessing. */
-		max_end_pos = rar->cstate.write_ptr;
+		max_end_pos = rar5->cstate.write_ptr;
 	}
 
-	if(max_end_pos == rar->cstate.last_write_ptr) {
+	if(max_end_pos == rar5->cstate.last_write_ptr) {
 		/* We can't write anything yet. The block uncompression
 		 * function did not generate enough data, and no filter can be
 		 * applied. At the same time we don't have any data that can be
@@ -4038,9 +4041,9 @@ static int do_uncompress_file(struct archive_read* a) {
 		 * So let's do it. The push_window_data() function will
 		 * effectively return the selected data block to the user
 		 * application. */
-		push_window_data(a, rar, rar->cstate.last_write_ptr,
+		push_window_data(a, rar5, rar5->cstate.last_write_ptr,
 		    max_end_pos);
-		rar->cstate.last_write_ptr = max_end_pos;
+		rar5->cstate.last_write_ptr = max_end_pos;
 	}
 
 	return ARCHIVE_OK;
@@ -4061,19 +4064,19 @@ static int uncompress_file(struct archive_read* a) {
 
 
 static int do_unstore_file(struct archive_read* a,
-    struct rar5* rar, const void** buf, size_t* size, int64_t* offset)
+    struct rar5 *rar5, const void** buf, size_t* size, int64_t* offset)
 {
 	size_t to_read;
 	const uint8_t* p;
 
-	if(rar->file.bytes_remaining == 0 && rar->main.volume > 0 &&
-	    rar->generic.split_after > 0)
+	if(rar5->file.bytes_remaining == 0 && rar5->main.volume > 0 &&
+	    rar5->generic.split_after > 0)
 	{
 		int ret;
 
-		rar->cstate.switch_multivolume = 1;
+		rar5->cstate.switch_multivolume = 1;
 		ret = advance_multivolume(a);
-		rar->cstate.switch_multivolume = 0;
+		rar5->cstate.switch_multivolume = 0;
 
 		if(ret != ARCHIVE_OK) {
 			/* Failed to advance to next multivolume archive
@@ -4082,7 +4085,7 @@ static int do_unstore_file(struct archive_read* a,
 		}
 	}
 
-	to_read = rar5_min(rar->file.bytes_remaining, 64 * 1024);
+	to_read = rar5_min(rar5->file.bytes_remaining, 64 * 1024);
 	if(to_read == 0) {
 		return ARCHIVE_EOF;
 	}
@@ -4099,16 +4102,16 @@ static int do_unstore_file(struct archive_read* a,
 
 	if(buf)    *buf = p;
 	if(size)   *size = to_read;
-	if(offset) *offset = rar->cstate.last_unstore_ptr;
+	if(offset) *offset = rar5->cstate.last_unstore_ptr;
 
-	rar->file.bytes_remaining -= to_read;
-	rar->cstate.last_unstore_ptr += to_read;
+	rar5->file.bytes_remaining -= to_read;
+	rar5->cstate.last_unstore_ptr += to_read;
 
-	update_crc(rar, p, to_read);
+	update_crc(rar5, p, to_read);
 	return ARCHIVE_OK;
 }
 
-static int do_unpack(struct archive_read* a, struct rar5* rar,
+static int do_unpack(struct archive_read* a, struct rar5 *rar5,
     const void** buf, size_t* size, int64_t* offset)
 {
 	enum COMPRESSION_METHOD {
@@ -4116,12 +4119,12 @@ static int do_unpack(struct archive_read* a, struct rar5* rar,
 		BEST = 5
 	};
 
-	if(rar->file.service > 0) {
-		return do_unstore_file(a, rar, buf, size, offset);
+	if(rar5->file.service > 0) {
+		return do_unstore_file(a, rar5, buf, size, offset);
 	} else {
-		switch(rar->cstate.method) {
+		switch(rar5->cstate.method) {
 			case STORE:
-				return do_unstore_file(a, rar, buf, size,
+				return do_unstore_file(a, rar5, buf, size,
 				    offset);
 			case FASTEST:
 				/* fallthrough */
@@ -4138,13 +4141,13 @@ static int do_unpack(struct archive_read* a, struct rar5* rar,
 				 * accordingly. At this point the decoder doesn't have any
 				 * pending uncompressed data blocks, so the current position in
 				 * the output file should be last_write_ptr. */
-				if (offset) *offset = rar->cstate.last_write_ptr;
+				if (offset) *offset = rar5->cstate.last_write_ptr;
 				return uncompress_file(a);
 			default:
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
 				    "Compression method not supported: 0x%x",
-				    (unsigned int)rar->cstate.method);
+				    (unsigned int)rar5->cstate.method);
 
 				return ARCHIVE_FATAL;
 		}
@@ -4157,7 +4160,7 @@ static int do_unpack(struct archive_read* a, struct rar5* rar,
 }
 
 static int verify_checksums(struct archive_read* a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int verify_crc;
 
 	/* Check checksums only when actually unpacking the data. There's no
@@ -4165,7 +4168,7 @@ static int verify_checksums(struct archive_read* a) {
 	 * (skipping in solid archives is the same thing as unpacking compressed
 	 * data and discarding the result). */
 
-	if(!rar->skip_mode) {
+	if(!rar5->skip_mode) {
 		/* Always check checksums if we're not in skip mode */
 		verify_crc = 1;
 	} else {
@@ -4189,20 +4192,20 @@ static int verify_checksums(struct archive_read* a) {
 		 * process is already over and we can check if calculated
 		 * checksum (CRC32 or BLAKE2sp) is the same as what is stored
 		 * in the archive. */
-		if(rar->file.stored_crc32 > 0) {
+		if(rar5->file.stored_crc32 > 0) {
 			/* Check CRC32 only when the file contains a CRC32
 			 * value for this file. */
 
-			if(rar->file.calculated_crc32 !=
-			    rar->file.stored_crc32) {
+			if(rar5->file.calculated_crc32 !=
+			    rar5->file.stored_crc32) {
 				/* Checksums do not match; the unpacked file
 				 * is corrupted. */
 
 				DEBUG_CODE {
 					printf("Checksum error: CRC32 "
 					    "(was: %08" PRIx32 ", expected: %08" PRIx32 ")\n",
-					    rar->file.calculated_crc32,
-					    rar->file.stored_crc32);
+					    rar5->file.calculated_crc32,
+					    rar5->file.stored_crc32);
 				}
 
 #ifndef DONT_FAIL_ON_CRC_ERROR
@@ -4215,13 +4218,13 @@ static int verify_checksums(struct archive_read* a) {
 				DEBUG_CODE {
 					printf("Checksum OK: CRC32 "
 					    "(%08" PRIx32 "/%08" PRIx32 ")\n",
-					    rar->file.stored_crc32,
-					    rar->file.calculated_crc32);
+					    rar5->file.stored_crc32,
+					    rar5->file.calculated_crc32);
 				}
 			}
 		}
 
-		if(rar->file.has_blake2 > 0) {
+		if(rar5->file.has_blake2 > 0) {
 			/* BLAKE2sp is an optional checksum algorithm that is
 			 * added to RARv5 archives when using the `-htb` switch
 			 *  during creation of archive.
@@ -4236,9 +4239,9 @@ static int verify_checksums(struct archive_read* a) {
  			 * This is why we're explicitly ignoring it. */
 
 			uint8_t b2_buf[32];
-			(void) blake2sp_final(&rar->file.b2state, b2_buf, 32);
+			(void) blake2sp_final(&rar5->file.b2state, b2_buf, 32);
 
-			if(memcmp(&rar->file.blake2sp, b2_buf, 32) != 0) {
+			if(memcmp(&rar5->file.blake2sp, b2_buf, 32) != 0) {
 #ifndef DONT_FAIL_ON_CRC_ERROR
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_FILE_FORMAT,
@@ -4272,23 +4275,23 @@ static void rar5_signature(char *buf) {
 
 static int rar5_read_data(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 	int ret;
 
 	if (size)
 		*size = 0;
 
-	if (rar->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
-		rar->has_encrypted_entries = 0;
+	if (rar5->has_encrypted_entries == ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
+		rar5->has_encrypted_entries = 0;
 	}
 
-	if (rar->headers_are_encrypted || rar->cstate.data_encrypted) {
+	if (rar5->headers_are_encrypted || rar5->cstate.data_encrypted) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Reading encrypted data is not currently supported");
 		return ARCHIVE_FAILED;
 	}
 
-	if(rar->file.dir > 0) {
+	if(rar5->file.dir > 0) {
 		/* Don't process any data if this file entry was declared
 		 * as a directory. This is needed, because entries marked as
 		 * directory doesn't have any dictionary buffer allocated, so
@@ -4298,28 +4301,28 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 		return ARCHIVE_FATAL;
 	}
 
-	if(!rar->skip_mode && (rar->cstate.last_write_ptr > rar->file.unpacked_size)) {
+	if(!rar5->skip_mode && (rar5->cstate.last_write_ptr > rar5->file.unpacked_size)) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
 		    "Unpacker has written too many bytes");
 		return ARCHIVE_FATAL;
 	}
 
-	ret = use_data(rar, buff, size, offset);
+	ret = use_data(rar5, buff, size, offset);
 	if(ret == ARCHIVE_OK) {
 		return ret;
 	}
 
-	if(rar->file.eof == 1) {
+	if(rar5->file.eof == 1) {
 		return ARCHIVE_EOF;
 	}
 
-	ret = do_unpack(a, rar, buff, size, offset);
+	ret = do_unpack(a, rar5, buff, size, offset);
 	if(ret != ARCHIVE_OK) {
 		return ret;
 	}
 
-	if(rar->file.bytes_remaining == 0 &&
-			rar->cstate.last_write_ptr == rar->file.unpacked_size)
+	if(rar5->file.bytes_remaining == 0 &&
+			rar5->cstate.last_write_ptr == rar5->file.unpacked_size)
 	{
 		/* If all bytes of current file were processed, run
 		 * finalization.
@@ -4329,7 +4332,7 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 		 * value in the last `archive_read_data` call to signal an error
 		 * to the user. */
 
-		rar->file.eof = 1;
+		rar5->file.eof = 1;
 		return verify_global_checksums(a);
 	}
 
@@ -4337,9 +4340,9 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 }
 
 static int rar5_read_data_skip(struct archive_read *a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 
-	if(rar->main.solid && (rar->cstate.data_encrypted == 0)) {
+	if(rar5->main.solid && (rar5->cstate.data_encrypted == 0)) {
 		/* In solid archives, instead of skipping the data, we need to
 		 * extract it, and dispose the result. The side effect of this
 		 * operation will be setting up the initial window buffer state
@@ -4351,7 +4354,7 @@ static int rar5_read_data_skip(struct archive_read *a) {
 		int ret;
 
 		/* Make sure to process all blocks in the compressed stream. */
-		while(rar->file.bytes_remaining > 0) {
+		while(rar5->file.bytes_remaining > 0) {
 			/* Setting the "skip mode" will allow us to skip
 			 * checksum checks during data skipping. Checking the
 			 * checksum of skipped data isn't really necessary and
@@ -4360,14 +4363,14 @@ static int rar5_read_data_skip(struct archive_read *a) {
 			 * This is incremented instead of setting to 1 because
 			 * this data skipping function can be called
 			 * recursively. */
-			rar->skip_mode++;
+			rar5->skip_mode++;
 
 			/* We're disposing 1 block of data, so we use triple
 			 * NULLs in arguments. */
 			ret = rar5_read_data(a, NULL, NULL, NULL);
 
 			/* Turn off "skip mode". */
-			rar->skip_mode--;
+			rar5->skip_mode--;
 
 			if(ret < 0 || ret == ARCHIVE_EOF) {
 				/* Propagate any potential error conditions
@@ -4380,11 +4383,11 @@ static int rar5_read_data_skip(struct archive_read *a) {
 		 * stream. Each file in non-solid archives starts from an empty
 		 * window buffer. */
 
-		if(ARCHIVE_OK != consume(a, rar->file.bytes_remaining)) {
+		if(ARCHIVE_OK != consume(a, rar5->file.bytes_remaining)) {
 			return ARCHIVE_FATAL;
 		}
 
-		rar->file.bytes_remaining = 0;
+		rar5->file.bytes_remaining = 0;
 	}
 
 	return ARCHIVE_OK;
@@ -4403,18 +4406,18 @@ static int64_t rar5_seek_data(struct archive_read *a, int64_t offset,
 }
 
 static int rar5_cleanup(struct archive_read *a) {
-	struct rar5 *rar = a->format->data;
+	struct rar5 *rar5 = a->format->data;
 
-	free(rar->cstate.window_buf);
-	free(rar->cstate.filtered_buf);
-	clear_data_ready_stack(rar);
+	free(rar5->cstate.window_buf);
+	free(rar5->cstate.filtered_buf);
+	clear_data_ready_stack(rar5);
 
-	free(rar->vol.push_buf);
+	free(rar5->vol.push_buf);
 
-	free_filters(rar);
-	rar5_deinit(rar);
+	free_filters(rar5);
+	rar5_deinit(rar5);
 
-	free(rar);
+	free(rar5);
 	a->format->data = NULL;
 
 	return ARCHIVE_OK;
@@ -4428,9 +4431,9 @@ static int rar5_capabilities(struct archive_read * a) {
 
 static int rar5_has_encrypted_entries(struct archive_read *_a) {
 	if (_a && _a->format) {
-		struct rar5 *rar = _a->format->data;
-		if (rar) {
-			return rar->has_encrypted_entries;
+		struct rar5 *rar5 = _a->format->data;
+		if (rar5) {
+			return rar5->has_encrypted_entries;
 		}
 	}
 
@@ -4438,50 +4441,50 @@ static int rar5_has_encrypted_entries(struct archive_read *_a) {
 }
 
 /* Must match deallocations in rar5_deinit */
-static int rar5_init(struct rar5* rar) {
-	memset(rar, 0, sizeof(struct rar5));
+static int rar5_init(struct rar5 *rar5) {
+	memset(rar5, 0, sizeof(struct rar5));
 
-	if(CDE_OK != cdeque_init(&rar->cstate.filters, 8192))
+	if(CDE_OK != cdeque_init(&rar5->cstate.filters, 8192))
 		return ARCHIVE_FATAL;
 
 	/*
 	 * Until enough data has been read, we cannot tell about
 	 * any encrypted entries yet.
 	 */
-	rar->has_encrypted_entries = ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW;
+	rar5->has_encrypted_entries = ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW;
 
 	return ARCHIVE_OK;
 }
 
 /* Must match allocations in rar5_init */
-static void rar5_deinit(struct rar5* rar) {
-	cdeque_free(&rar->cstate.filters);
+static void rar5_deinit(struct rar5 *rar5) {
+	cdeque_free(&rar5->cstate.filters);
 }
 
 int archive_read_support_format_rar5(struct archive *_a) {
 	struct archive_read* ar;
 	int ret;
-	struct rar5* rar;
+	struct rar5 *rar5;
 
 	if(ARCHIVE_OK != (ret = get_archive_read(_a, &ar)))
 		return ret;
 
-	rar = malloc(sizeof(*rar));
-	if(rar == NULL) {
+	rar5 = malloc(sizeof(*rar5));
+	if(rar5 == NULL) {
 		archive_set_error(&ar->archive, ENOMEM,
 		    "Can't allocate rar5 data");
 		return ARCHIVE_FATAL;
 	}
 
-	if(ARCHIVE_OK != rar5_init(rar)) {
+	if(ARCHIVE_OK != rar5_init(rar5)) {
 		archive_set_error(&ar->archive, ENOMEM,
 		    "Can't allocate rar5 filter buffer");
-		free(rar);
+		free(rar5);
 		return ARCHIVE_FATAL;
 	}
 
 	ret = __archive_read_register_format(ar,
-	    rar,
+	    rar5,
 	    "rar5",
 	    rar5_bid,
 	    rar5_options,
@@ -4494,8 +4497,8 @@ int archive_read_support_format_rar5(struct archive *_a) {
 	    rar5_has_encrypted_entries);
 
 	if(ret != ARCHIVE_OK) {
-		rar5_deinit(rar);
-		free(rar);
+		rar5_deinit(rar5);
+		free(rar5);
 	}
 
 	return ARCHIVE_OK;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -514,10 +514,6 @@ uint8_t bf_is_last_block(const struct compressed_block_header* hdr) {
 	return (hdr->block_flags_u8 >> 6) & 1;
 }
 
-static inline struct rar5* get_context(struct archive_read* a) {
-	return (struct rar5*) a->format->data;
-}
-
 /* Convenience functions used by filter implementations. */
 static void circular_memcpy(uint8_t* dst, uint8_t* window, const ssize_t mask,
     int64_t start, int64_t end)
@@ -666,8 +662,8 @@ static int run_arm_filter(struct rar5* rar, struct filter_info* flt) {
 }
 
 static int run_filter(struct archive_read* a, struct filter_info* flt) {
+	struct rar5 *rar = a->format->data;
 	int ret;
-	struct rar5* rar = get_context(a);
 
 	clear_data_ready_stack(rar);
 	free(rar->cstate.filtered_buf);
@@ -776,8 +772,8 @@ static void push_window_data(struct archive_read* a, struct rar5* rar,
 }
 
 static int apply_filters(struct archive_read* a) {
+	struct rar5 *rar = a->format->data;
 	struct filter_info* flt;
-	struct rar5* rar = get_context(a);
 	int ret;
 
 	rar->cstate.all_filters_applied = 0;
@@ -2186,7 +2182,7 @@ static int process_head_main(struct archive_read* a, struct rar5* rar,
 }
 
 static int skip_unprocessed_bytes(struct archive_read* a) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	int ret;
 
 	if(rar->file.bytes_remaining) {
@@ -2298,7 +2294,7 @@ static int process_base_block(struct archive_read* a,
 {
 	const size_t SMALLEST_RAR5_BLOCK_SIZE = 3;
 
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	uint32_t hdr_crc, computed_crc;
 	size_t raw_hdr_size = 0, hdr_size_len, hdr_size;
 	size_t header_id = 0;
@@ -2474,8 +2470,8 @@ static int process_base_block(struct archive_read* a,
 }
 
 static int skip_base_block(struct archive_read* a) {
+	struct rar5 *rar = a->format->data;
 	int ret;
-	struct rar5* rar = get_context(a);
 
 	/* Create a new local archive_entry structure that will be operated on
 	 * by header reader; operations on this archive_entry will be discarded.
@@ -2559,7 +2555,7 @@ fatal:
 static int rar5_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	int ret;
 
 	/*
@@ -2734,10 +2730,10 @@ static int create_decode_tables(uint8_t* bit_length,
 static int decode_number(struct archive_read* a, struct decode_table* table,
     const uint8_t* p, uint16_t* num)
 {
+	struct rar5 *rar = a->format->data;
 	int i, bits, dist, ret;
 	uint16_t bitfield;
 	uint32_t pos;
-	struct rar5* rar = get_context(a);
 
 	if(ARCHIVE_OK != (ret = read_bits_16(a, rar, p, &bitfield))) {
 		return ret;
@@ -3064,10 +3060,10 @@ static int is_valid_filter_block_start(struct rar5* rar,
 /* The function will create a new filter, read its parameters from the input
  * stream and add it to the filter collection. */
 static int parse_filter(struct archive_read* ar, const uint8_t* p) {
+	struct rar5 *rar = ar->format->data;
 	uint32_t block_start, block_length;
 	uint16_t filter_type;
 	struct filter_info* filt = NULL;
-	struct rar5* rar = get_context(ar);
 	int ret;
 
 	/* Read the parameters from the input stream. */
@@ -3152,7 +3148,7 @@ static int decode_code_length(struct archive_read* a, struct rar5* rar,
 }
 
 static int copy_string(struct archive_read* a, int len, int dist) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	const ssize_t cmask = rar->cstate.window_mask;
 	const uint64_t write_ptr = rar->cstate.write_ptr +
 	    rar->cstate.solid_offset;
@@ -3187,7 +3183,7 @@ static int copy_string(struct archive_read* a, int len, int dist) {
 }
 
 static int do_uncompress_block(struct archive_read* a, const uint8_t* p) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	uint16_t num;
 	int ret;
 
@@ -3464,8 +3460,8 @@ static int scan_for_signature(struct archive_read* a) {
 /* This function will switch the multivolume archive file to another file,
  * i.e. from part03 to part 04. */
 static int advance_multivolume(struct archive_read* a) {
+	struct rar5 *rar = a->format->data;
 	int lret;
-	struct rar5* rar = get_context(a);
 
 	/* A small state machine that will skip unnecessary data, needed to
 	 * switch from one multivolume to another. Such skipping is needed if
@@ -3541,7 +3537,7 @@ static int advance_multivolume(struct archive_read* a) {
 static int merge_block(struct archive_read* a, ssize_t block_size,
     const uint8_t** p)
 {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	ssize_t cur_block_size, partial_offset = 0;
 	const uint8_t* lp;
 	int ret;
@@ -3659,8 +3655,8 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 }
 
 static int process_block(struct archive_read* a) {
+	struct rar5 *rar = a->format->data;
 	const uint8_t* p;
-	struct rar5* rar = get_context(a);
 	int ret;
 
 	/* If we don't have any data to be processed, this most probably means
@@ -3938,7 +3934,7 @@ static int push_data_ready(struct archive_read* a, struct rar5* rar,
  * */
 
 static int do_uncompress_file(struct archive_read* a) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 	int ret;
 	int64_t max_end_pos;
 
@@ -4161,8 +4157,8 @@ static int do_unpack(struct archive_read* a, struct rar5* rar,
 }
 
 static int verify_checksums(struct archive_read* a) {
+	struct rar5 *rar = a->format->data;
 	int verify_crc;
-	struct rar5* rar = get_context(a);
 
 	/* Check checksums only when actually unpacking the data. There's no
 	 * need to calculate checksum when we're skipping data in solid archives
@@ -4276,8 +4272,8 @@ static void rar5_signature(char *buf) {
 
 static int rar5_read_data(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset) {
+	struct rar5 *rar = a->format->data;
 	int ret;
-	struct rar5* rar = get_context(a);
 
 	if (size)
 		*size = 0;
@@ -4341,7 +4337,7 @@ static int rar5_read_data(struct archive_read *a, const void **buff,
 }
 
 static int rar5_read_data_skip(struct archive_read *a) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 
 	if(rar->main.solid && (rar->cstate.data_encrypted == 0)) {
 		/* In solid archives, instead of skipping the data, we need to
@@ -4407,7 +4403,7 @@ static int64_t rar5_seek_data(struct archive_read *a, int64_t offset,
 }
 
 static int rar5_cleanup(struct archive_read *a) {
-	struct rar5* rar = get_context(a);
+	struct rar5 *rar = a->format->data;
 
 	free(rar->cstate.window_buf);
 	free(rar->cstate.filtered_buf);
@@ -4432,7 +4428,7 @@ static int rar5_capabilities(struct archive_read * a) {
 
 static int rar5_has_encrypted_entries(struct archive_read *_a) {
 	if (_a && _a->format) {
-		struct rar5 *rar = (struct rar5 *)_a->format->data;
+		struct rar5 *rar = _a->format->data;
 		if (rar) {
 			return rar->has_encrypted_entries;
 		}

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -38,7 +38,7 @@
 #include "archive_private.h"
 #include "archive_read_private.h"
 
-struct raw_info {
+struct raw {
 	int64_t offset; /* Current position in the file. */
 	int64_t unconsumed;
 	int     end_of_file;
@@ -56,21 +56,21 @@ int
 archive_read_support_format_raw(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct raw_info *info;
+	struct raw *raw;
 	int r;
 
 	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_read_support_format_raw");
 
-	info = calloc(1, sizeof(*info));
-	if (info == NULL) {
+	raw = calloc(1, sizeof(*raw));
+	if (raw == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate raw_info data");
+		    "Can't allocate raw data");
 		return (ARCHIVE_FATAL);
 	}
 
 	r = __archive_read_register_format(a,
-	    info,
+	    raw,
 	    "raw",
 	    archive_read_format_raw_bid,
 	    NULL,
@@ -82,7 +82,7 @@ archive_read_support_format_raw(struct archive *_a)
 	    NULL,
 	    NULL);
 	if (r != ARCHIVE_OK)
-		free(info);
+		free(raw);
 	return (r);
 }
 
@@ -108,9 +108,9 @@ static int
 archive_read_format_raw_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct raw_info *info = a->format->data;
+	struct raw *raw = a->format->data;
 
-	if (info->end_of_file)
+	if (raw->end_of_file)
 		return (ARCHIVE_EOF);
 
 	a->archive.archive_format = ARCHIVE_FORMAT_RAW;
@@ -128,24 +128,24 @@ static int
 archive_read_format_raw_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct raw_info *info = a->format->data;
+	struct raw *raw = a->format->data;
 	ssize_t avail;
 
 	/* Consume the bytes we read last time. */
-	if (info->unconsumed) {
-		__archive_read_consume(a, info->unconsumed);
-		info->unconsumed = 0;
+	if (raw->unconsumed) {
+		__archive_read_consume(a, raw->unconsumed);
+		raw->unconsumed = 0;
 	}
 
-	if (info->end_of_file)
+	if (raw->end_of_file)
 		return (ARCHIVE_EOF);
 
 	/* Get whatever bytes are immediately available. */
 	*buff = __archive_read_ahead(a, 1, &avail);
 	if (avail > 0) {
 		/* Return the bytes we just read */
-		*offset = info->offset;
-		if (archive_ckd_add_i64(&info->offset, info->offset, avail)) {
+		*offset = raw->offset;
+		if (archive_ckd_add_i64(&raw->offset, raw->offset, avail)) {
 			avail = INT64_MAX - *offset;
 			if (avail == 0) {
 				*size = 0;
@@ -153,18 +153,18 @@ archive_read_format_raw_read_data(struct archive_read *a,
 			}
 		}
 		*size = avail;
-		info->unconsumed = avail;
+		raw->unconsumed = avail;
 		return (ARCHIVE_OK);
 	} else if (0 == avail) {
 		/* Record and return end-of-file. */
-		info->end_of_file = 1;
+		raw->end_of_file = 1;
 		*size = 0;
-		*offset = info->offset;
+		*offset = raw->offset;
 		return (ARCHIVE_EOF);
 	} else {
 		/* Record and return an error. */
 		*size = 0;
-		*offset = info->offset;
+		*offset = raw->offset;
 		return ((int)avail);
 	}
 }
@@ -172,23 +172,23 @@ archive_read_format_raw_read_data(struct archive_read *a,
 static int
 archive_read_format_raw_read_data_skip(struct archive_read *a)
 {
-	struct raw_info *info = a->format->data;
+	struct raw *raw = a->format->data;
 
 	/* Consume the bytes we read last time. */
-	if (info->unconsumed) {
-		__archive_read_consume(a, info->unconsumed);
-		info->unconsumed = 0;
+	if (raw->unconsumed) {
+		__archive_read_consume(a, raw->unconsumed);
+		raw->unconsumed = 0;
 	}
-	info->end_of_file = 1;
+	raw->end_of_file = 1;
 	return (ARCHIVE_OK);
 }
 
 static int
 archive_read_format_raw_cleanup(struct archive_read *a)
 {
-	struct raw_info *info = a->format->data;
+	struct raw *raw = a->format->data;
 
-	free(info);
+	free(raw);
 	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -55,8 +55,8 @@ static int	archive_read_format_raw_read_header(struct archive_read *,
 int
 archive_read_support_format_raw(struct archive *_a)
 {
-	struct raw_info *info;
 	struct archive_read *a = (struct archive_read *)_a;
+	struct raw_info *info;
 	int r;
 
 	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
@@ -108,9 +108,8 @@ static int
 archive_read_format_raw_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct raw_info *info;
+	struct raw_info *info = a->format->data;
 
-	info = (struct raw_info *)(a->format->data);
 	if (info->end_of_file)
 		return (ARCHIVE_EOF);
 
@@ -129,10 +128,8 @@ static int
 archive_read_format_raw_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct raw_info *info;
+	struct raw_info *info = a->format->data;
 	ssize_t avail;
-
-	info = (struct raw_info *)(a->format->data);
 
 	/* Consume the bytes we read last time. */
 	if (info->unconsumed) {
@@ -175,7 +172,7 @@ archive_read_format_raw_read_data(struct archive_read *a,
 static int
 archive_read_format_raw_read_data_skip(struct archive_read *a)
 {
-	struct raw_info *info = (struct raw_info *)(a->format->data);
+	struct raw_info *info = a->format->data;
 
 	/* Consume the bytes we read last time. */
 	if (info->unconsumed) {
@@ -189,9 +186,8 @@ archive_read_format_raw_read_data_skip(struct archive_read *a)
 static int
 archive_read_format_raw_cleanup(struct archive_read *a)
 {
-	struct raw_info *info;
+	struct raw_info *info = a->format->data;
 
-	info = (struct raw_info *)(a->format->data);
 	free(info);
 	a->format->data = NULL;
 	return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -300,9 +300,8 @@ archive_read_support_format_tar(struct archive *_a)
 static int
 archive_read_format_tar_cleanup(struct archive_read *a)
 {
-	struct tar *tar;
+	struct tar *tar = a->format->data;
 
-	tar = (struct tar *)(a->format->data);
 	gnu_clear_sparse_list(tar);
 	archive_string_free(&tar->entry_pathname);
 	archive_string_free(&tar->entry_pathname_override);
@@ -312,7 +311,7 @@ archive_read_format_tar_cleanup(struct archive_read *a)
 	archive_string_free(&tar->line);
 	archive_string_free(&tar->localname);
 	free(tar);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -439,10 +438,9 @@ static int
 archive_read_format_tar_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct tar *tar;
+	struct tar *tar = a->format->data;
 	int ret = ARCHIVE_FAILED;
 
-	tar = (struct tar *)(a->format->data);
 	if (strcmp(key, "compat-2x")  == 0) {
 		/* Handle UTF-8 filenames as libarchive 2.x */
 		tar->compat_2x = (val != NULL && val[0] != 0);
@@ -525,14 +523,12 @@ archive_read_format_tar_read_header(struct archive_read *a,
 	 * probably not worthwhile just to support the relatively
 	 * obscure tar->cpio conversion case.
 	 */
-	struct tar *tar;
+	struct tar *tar = a->format->data;
 	const char *p;
 	const wchar_t *wp;
 	int r;
 	size_t l;
 	int64_t unconsumed = 0;
-
-	tar = (struct tar *)(a->format->data);
 
 	/* Assign default device/inode values. */
 	archive_entry_set_dev(entry, 1 + tar->default_dev); /* Don't use zero. */
@@ -609,11 +605,9 @@ static int
 archive_read_format_tar_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
+	struct tar *tar = a->format->data;
 	ssize_t bytes_read;
-	struct tar *tar;
 	struct sparse_block *p;
-
-	tar = (struct tar *)(a->format->data);
 
 	for (;;) {
 		/* Remove exhausted entries from sparse list. */
@@ -673,10 +667,8 @@ archive_read_format_tar_read_data(struct archive_read *a,
 static int
 archive_read_format_tar_skip(struct archive_read *a)
 {
+	struct tar *tar = a->format->data;
 	int64_t request;
-	struct tar* tar;
-
-	tar = (struct tar *)(a->format->data);
 
 	request = tar->entry_bytes_remaining + tar->entry_padding +
 	    tar->entry_bytes_unconsumed;

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -105,7 +105,7 @@ typedef struct {
 	char *str;
 } warc_strbuf_t;
 
-struct warc_s {
+struct warc {
 	/* Content length of the current record */
 	int64_t cntlen;
 	/* Bytes processed from the current record */
@@ -143,20 +143,20 @@ int
 archive_read_support_format_warc(struct archive *_a)
 {
 	struct archive_read *a = (struct archive_read *)_a;
-	struct warc_s *w;
+	struct warc *warc;
 	int r;
 
 	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_read_support_format_warc");
 
-	if ((w = calloc(1, sizeof(*w))) == NULL) {
+	if ((warc = calloc(1, sizeof(*warc))) == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate warc data");
 		return (ARCHIVE_FATAL);
 	}
 
 	r = __archive_read_register_format(a,
-	    w,
+	    warc,
 	    "warc",
 	    archive_read_format_warc_bid,
 	    NULL,
@@ -169,7 +169,7 @@ archive_read_support_format_warc(struct archive *_a)
 	    NULL);
 
 	if (r != ARCHIVE_OK) {
-		free(w);
+		free(warc);
 		return (r);
 	}
 	return (ARCHIVE_OK);
@@ -178,13 +178,13 @@ archive_read_support_format_warc(struct archive *_a)
 static int
 archive_read_format_warc_cleanup(struct archive_read *a)
 {
-	struct warc_s *w = a->format->data;
+	struct warc *warc = a->format->data;
 
-	if (w->pool.len > 0U) {
-		free(w->pool.str);
+	if (warc->pool.len > 0U) {
+		free(warc->pool.str);
 	}
-	archive_string_free(&w->sver);
-	free(w);
+	archive_string_free(&warc->sver);
+	free(warc);
 	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
@@ -220,7 +220,7 @@ archive_read_format_warc_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
 #define HDR_PROBE_LEN		(12U)
-	struct warc_s *w = a->format->data;
+	struct warc *warc = a->format->data;
 	unsigned int ver;
 	const char *buf;
 	ssize_t nrd;
@@ -295,18 +295,18 @@ start_over:
 
 	/* Report this archive as WARC. */
 	a->archive.archive_format = ARCHIVE_FORMAT_WARC;
-	if (ver != w->pver) {
+	if (ver != warc->pver) {
 		/* Format this entry's WARC version. */
-		archive_string_sprintf(&w->sver,
+		archive_string_sprintf(&warc->sver,
 			"WARC/%u.%u", ver / 10000, (ver % 10000) / 100);
 		/* Remember the version for later entries. */
-		w->pver = ver;
+		warc->pver = ver;
 	}
 	/* Parse the record type. */
 	ftyp = warc_read_type(buf, eoh - buf);
 	/* Save content state for subsequent read calls. */
-	w->cntlen = cntlen;
-	w->cntoff = 0;
+	warc->cntlen = cntlen;
+	warc->cntoff = 0;
 	mtime = 0;/* Avoid compiler warnings on some platforms. */
 
 	switch (ftyp) {
@@ -324,21 +324,21 @@ start_over:
 		}
 		/* Copy the name into the reusable string pool to avoid a malloc/free
 		 * roundtrip for each entry. */
-		if (fnam.len + 1U > w->pool.len) {
-			w->pool.len = ((fnam.len + 64U) / 64U) * 64U;
-			tmp = realloc(w->pool.str, w->pool.len);
+		if (fnam.len + 1U > warc->pool.len) {
+			warc->pool.len = ((fnam.len + 64U) / 64U) * 64U;
+			tmp = realloc(warc->pool.str, warc->pool.len);
 			if (tmp == NULL) {
 				archive_set_error(
 					&a->archive, ENOMEM,
 					"Out of memory");
 				return (ARCHIVE_FATAL);
 			}
-			w->pool.str = tmp;
+			warc->pool.str = tmp;
 		}
-		memcpy(w->pool.str, fnam.str, fnam.len);
-		w->pool.str[fnam.len] = '\0';
+		memcpy(warc->pool.str, fnam.str, fnam.len);
+		warc->pool.str[fnam.len] = '\0';
 		/* Hide the pool implementation behind the parsed string. */
-		fnam.str = w->pool.str;
+		fnam.str = warc->pool.str;
 
 		/* Use a Last-Modified record header when present; otherwise fall back
 		 * to WARC-Date. */
@@ -399,20 +399,20 @@ static int
 archive_read_format_warc_read_data(struct archive_read *a, const void **buf,
     size_t *bsz, int64_t *off)
 {
-	struct warc_s *w = a->format->data;
+	struct warc *warc = a->format->data;
 	const char *rab;
 	ssize_t nrd;
 
-	if (w->unconsumed) {
-		__archive_read_consume(a, w->unconsumed);
-		w->unconsumed = 0;
+	if (warc->unconsumed) {
+		__archive_read_consume(a, warc->unconsumed);
+		warc->unconsumed = 0;
 	}
 
-	if (w->cntoff >= w->cntlen) {
+	if (warc->cntoff >= warc->cntlen) {
 		/* No data is available to return for this entry. */
 		*buf = NULL;
 		*bsz = 0U;
-		*off = w->cntoff;
+		*off = warc->cntoff;
 		return (ARCHIVE_EOF);
 	}
 
@@ -425,35 +425,35 @@ archive_read_format_warc_read_data(struct archive_read *a, const void **buf,
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Truncated WARC file data");
 		return (ARCHIVE_FATAL);
-	} else if ((int64_t)nrd > w->cntlen - w->cntoff) {
+	} else if ((int64_t)nrd > warc->cntlen - warc->cntoff) {
 		/* Clamp reads to Content-Length. */
-		nrd = w->cntlen - w->cntoff;
+		nrd = warc->cntlen - warc->cntoff;
 	}
-	*off = w->cntoff;
+	*off = warc->cntoff;
 	*bsz = nrd;
 	*buf = rab;
 
-	w->cntoff += nrd;
-	w->unconsumed = nrd;
+	warc->cntoff += nrd;
+	warc->unconsumed = nrd;
 	return (ARCHIVE_OK);
 }
 
 static int
 archive_read_format_warc_skip(struct archive_read *a)
 {
-	struct warc_s *w = a->format->data;
+	struct warc *warc = a->format->data;
 
-	if (w->cntoff > w->cntlen)
+	if (warc->cntoff > warc->cntlen)
 		return (ARCHIVE_FATAL);
-	if (w->unconsumed) {
-		__archive_read_consume(a, w->unconsumed);
-		w->unconsumed = 0;
+	if (warc->unconsumed) {
+		__archive_read_consume(a, warc->unconsumed);
+		warc->unconsumed = 0;
 	}
-	if (__archive_read_consume(a, w->cntlen - w->cntoff) < 0 ||
+	if (__archive_read_consume(a, warc->cntlen - warc->cntoff) < 0 ||
 	    __archive_read_consume(a, 4U/*\r\n\r\n separator*/) < 0)
 		return (ARCHIVE_FATAL);
-	w->cntlen = 0;
-	w->cntoff = 0;
+	warc->cntlen = 0;
+	warc->cntoff = 0;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -536,7 +536,7 @@ xar_bid(struct archive_read *a, int best_bid)
 static int
 read_toc(struct archive_read *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	struct xar_file *file;
 	const unsigned char *b;
 	uint64_t toc_compressed_size;
@@ -544,8 +544,6 @@ read_toc(struct archive_read *a)
 	uint32_t toc_chksum_alg;
 	ssize_t bytes;
 	int r;
-
-	xar = (struct xar *)(a->format->data);
 
 	/*
 	 * Read xar header.
@@ -674,12 +672,11 @@ read_toc(struct archive_read *a)
 static int
 xar_read_header(struct archive_read *a, struct archive_entry *entry)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	struct xar_file *file;
 	struct xattr *xattr;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	r = ARCHIVE_OK;
 
 	if (xar->offset == 0) {
@@ -878,11 +875,9 @@ static int
 xar_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	size_t used = 0;
 	int r;
-
-	xar = (struct xar *)(a->format->data);
 
 	if (xar->entry_unconsumed) {
 		__archive_read_consume(a, xar->entry_unconsumed);
@@ -941,10 +936,9 @@ abort_read_data:
 static int
 xar_read_data_skip(struct archive_read *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	int64_t bytes_skipped;
 
-	xar = (struct xar *)(a->format->data);
 	if (xar->end_of_file)
 		return (ARCHIVE_EOF);
 	bytes_skipped = __archive_read_consume(a, xar->entry_remaining +
@@ -959,12 +953,11 @@ xar_read_data_skip(struct archive_read *a)
 static int
 xar_cleanup(struct archive_read *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	struct hdlink *hdlink;
 	size_t i;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	checksum_cleanup(a);
 	r = decompression_cleanup(a);
 	hdlink = xar->hdlink_list;
@@ -994,9 +987,8 @@ xar_cleanup(struct archive_read *a)
 static int
 move_reading_point(struct archive_read *a, uint64_t offset)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 
-	xar = (struct xar *)(a->format->data);
 	if (xar->offset - xar->h_base != offset) {
 		/* Seek forward to the start of file contents. */
 		int64_t step;
@@ -1398,9 +1390,8 @@ _checksum_final(struct chksumwork *sumwrk, const void *val, size_t len)
 static void
 checksum_init(struct archive_read *a, int a_sum_alg, int e_sum_alg)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 
-	xar = (struct xar *)(a->format->data);
 	_checksum_init(&(xar->a_sumwrk), a_sum_alg);
 	_checksum_init(&(xar->e_sumwrk), e_sum_alg);
 }
@@ -1409,9 +1400,8 @@ static void
 checksum_update(struct archive_read *a, const void *abuff, size_t asize,
     const void *ebuff, size_t esize)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 
-	xar = (struct xar *)(a->format->data);
 	_checksum_update(&(xar->a_sumwrk), abuff, asize);
 	_checksum_update(&(xar->e_sumwrk), ebuff, esize);
 }
@@ -1420,10 +1410,9 @@ static int
 checksum_final(struct archive_read *a, const void *a_sum_val,
     size_t a_sum_len, const void *e_sum_val, size_t e_sum_len)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	r = _checksum_final(&(xar->a_sumwrk), a_sum_val, a_sum_len);
 	if (r == ARCHIVE_OK)
 		r = _checksum_final(&(xar->e_sumwrk), e_sum_val, e_sum_len);
@@ -1436,11 +1425,10 @@ checksum_final(struct archive_read *a, const void *a_sum_val,
 static int
 decompression_init(struct archive_read *a, enum enctype encoding)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	const char *detail;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	xar->rd_encoding = encoding;
 	switch (encoding) {
 	case NONE:
@@ -1576,12 +1564,11 @@ static int
 decompress(struct archive_read *a, const void **buff, size_t *outbytes,
     const void *b, size_t *used)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	void *outbuff;
 	size_t avail_in, avail_out;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	avail_in = *used;
 	outbuff = (void *)(uintptr_t)*buff;
 	if (outbuff == NULL) {
@@ -1704,10 +1691,9 @@ decompress(struct archive_read *a, const void **buff, size_t *outbytes,
 static int
 decompression_cleanup(struct archive_read *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	int r;
 
-	xar = (struct xar *)(a->format->data);
 	r = ARCHIVE_OK;
 	if (xar->stream_valid) {
 		if (inflateEnd(&(xar->stream)) != Z_OK) {
@@ -1736,9 +1722,7 @@ decompression_cleanup(struct archive_read *a)
 
 static void
 checksum_cleanup(struct archive_read *a) {
-	struct xar *xar;
-
-	xar = (struct xar *)(a->format->data);
+	struct xar *xar = a->format->data;
 
 	_checksum_final(&(xar->a_sumwrk), NULL, 0);
 	_checksum_final(&(xar->e_sumwrk), NULL, 0);
@@ -1960,10 +1944,8 @@ unknowntag_end(struct xar *xar, const char *name)
 static int
 xml_start(struct archive_read *a, const char *name, struct xmlattr_list *list)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	struct xmlattr *attr;
-
-	xar = (struct xar *)(a->format->data);
 
 #if DEBUG
 	fprintf(stderr, "xml_sta:[%s]\n", name);
@@ -2256,11 +2238,8 @@ xml_start(struct archive_read *a, const char *name, struct xmlattr_list *list)
 static void
 xml_end(void *userData, const char *name)
 {
-	struct archive_read *a;
-	struct xar *xar;
-
-	a = (struct archive_read *)userData;
-	xar = (struct xar *)(a->format->data);
+	struct archive_read *a = (struct archive_read *)userData;
+	struct xar *xar = a->format->data;
 
 #if DEBUG
 	fprintf(stderr, "xml_end:[%s]\n", name);
@@ -2682,13 +2661,10 @@ is_string(const char *known, const char *data, size_t len)
 static int
 xml_data(void *userData, const char *s, size_t len)
 {
+	struct archive_read *a = (struct archive_read *)userData;
+	struct xar *xar = a->format->data;
 	uint64_t val;
-	struct archive_read *a;
-	struct xar *xar;
 	int r;
-
-	a = (struct archive_read *)userData;
-	xar = (struct xar *)(a->format->data);
 
 #if DEBUG
 	{
@@ -3169,15 +3145,12 @@ xml2_xmlattr_setup(struct archive_read *a,
 static int
 xml2_read_cb(void *context, char *buffer, int len)
 {
-	struct archive_read *a;
-	struct xar *xar;
+	struct archive_read *a = (struct archive_read *)context;
+	struct xar *xar = a->format->data;
 	const void *d;
 	size_t outbytes;
 	size_t used = 0;
 	int r;
-
-	a = (struct archive_read *)context;
-	xar = (struct xar *)(a->format->data);
 
 	if (xar->toc_remaining <= 0)
 		return (0);
@@ -3207,10 +3180,9 @@ static void
 xml2_error_hdr(void *arg, const char *msg, xmlParserSeverities severity,
     xmlTextReaderLocatorPtr locator)
 {
-	struct archive_read *a;
+	struct archive_read *a = (struct archive_read *)arg;
 
 	(void)locator; /* UNUSED */
-	a = (struct archive_read *)arg;
 	switch (severity) {
 	case XML_PARSER_SEVERITY_VALIDITY_WARNING:
 	case XML_PARSER_SEVERITY_WARNING:
@@ -3360,14 +3332,12 @@ expat_data_cb(void *userData, const XML_Char *s, int len)
 static int
 expat_read_toc(struct archive_read *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format->data;
 	XML_Parser parser;
 	struct expat_userData ud;
 
 	ud.state = ARCHIVE_OK;
 	ud.archive = a;
-
-	xar = (struct xar *)(a->format->data);
 
 	/* Initialize XML Parser library. */
 	parser = XML_ParserCreate(NULL);
@@ -3452,15 +3422,12 @@ static HRESULT STDMETHODCALLTYPE
 asaRead(ISequentialStream *this, void *pv, ULONG cb, ULONG *pcbRead)
 {
 	struct ArchiveStreamAdapter *asa = (struct ArchiveStreamAdapter *)this;
-	struct archive_read *a;
-	struct xar *xar;
+	struct archive_read *a = asa->a;
+	struct xar *xar = a->format->data;
 	const void *d = pv;
 	size_t outbytes = cb;
 	size_t used = 0;
 	int r;
-
-	a = asa->a;
-	xar = (struct xar *)(a->format->data);
 
 	*pcbRead = 0;
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -291,7 +291,7 @@ static Byte
 ppmd_read(void* p) {
 	/* Get the handle to current decompression context. */
 	struct archive_read *a = ((IByteIn*)p)->a;
-	struct zip *zip = (struct zip*) a->format->data;
+	struct zip *zip = a->format->data;
 
 	/* Fetch next byte. */
 	const uint8_t* data = __archive_read_ahead(a, 1, NULL);
@@ -437,7 +437,7 @@ static int
 zipx_read_header_and_decrypt(struct archive_read *a, const void **buf, size_t in_len,
     size_t *out_len, size_t *consumed)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	const void *raw;
 	ssize_t bytes_avail;
 	size_t to_decrypt;
@@ -656,8 +656,8 @@ static int
 process_extra(struct archive_read *a, struct archive_entry *entry,
      const char *p, size_t extra_length, struct zip_entry* zip_entry)
 {
+	struct zip *zip = a->format->data;
 	unsigned offset = 0;
-	struct zip *zip = (struct zip *)(a->format->data);
 
 	if (extra_length == 0) {
 		return ARCHIVE_OK;
@@ -1483,7 +1483,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 static int
 check_authentication_code(struct archive_read *a, const void *_p)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 
 	/* Check authentication code. */
 	if (zip->hctx_valid) {
@@ -1807,7 +1807,7 @@ static int
 zip_read_data_none(struct archive_read *a, const void **_buff,
     size_t *size, int64_t *offset)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 	const char *buff;
 	ssize_t bytes_avail;
 	ssize_t trailing_extra;
@@ -1815,7 +1815,6 @@ zip_read_data_none(struct archive_read *a, const void **_buff,
 
 	(void)offset; /* UNUSED */
 
-	zip = (struct zip *)(a->format->data);
 	trailing_extra = zip->hctx_valid ? AUTH_CODE_SIZE : 0;
 
 	if (zip->entry->zip_flags & ZIP_LENGTH_AT_END) {
@@ -2126,7 +2125,7 @@ static int
 zip_read_data_zipx_xz(struct archive_read *a, const void **buff,
 	size_t *size, int64_t *offset)
 {
-	struct zip* zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	int ret;
 	lzma_ret lz_ret;
 	const void* compressed_buf;
@@ -2226,7 +2225,7 @@ static int
 zip_read_data_zipx_lzma_alone(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip* zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	int ret;
 	lzma_ret lz_ret;
 	const void* compressed_buf;
@@ -2496,7 +2495,7 @@ static int
 zip_read_data_zipx_ppmd(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip* zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	int ret;
 	size_t consumed_bytes = 0;
 
@@ -2615,7 +2614,7 @@ static int
 zip_read_data_zipx_bzip2(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	ssize_t bytes_avail = 0, to_consume;
 	const void *compressed_buff;
 	const void *sp;
@@ -2766,7 +2765,7 @@ static int
 zip_read_data_zipx_zstd(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	ssize_t bytes_avail = 0, to_consume;
 	const void *compressed_buff;
 	const void *sp;
@@ -2888,15 +2887,13 @@ static int
 zip_read_data_deflate(struct archive_read *a, const void **buff,
     size_t *size, int64_t *offset)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 	ssize_t bytes_avail, to_consume = 0;
 	const void *compressed_buff;
 	const void *sp;
 	int r;
 
 	(void)offset; /* UNUSED */
-
-	zip = (struct zip *)(a->format->data);
 
 	/* If the buffer hasn't been allocated, allocate it now. */
 	if (zip->uncompressed_buffer == NULL) {
@@ -2990,7 +2987,7 @@ zip_read_data_deflate(struct archive_read *a, const void **buff,
 static int
 read_decryption_header(struct archive_read *a)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	const char *p;
 	unsigned int remaining_size;
 	unsigned int ts;
@@ -3184,7 +3181,7 @@ nomem:
 static int
 zip_alloc_decryption_buffer(struct archive_read *a)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	size_t bs = 256 * 1024;
 
 	if (zip->decrypted_buffer == NULL) {
@@ -3203,7 +3200,7 @@ zip_alloc_decryption_buffer(struct archive_read *a)
 static int
 init_traditional_PKWARE_decryption(struct archive_read *a)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	const void *p;
 	int retry;
 	int r;
@@ -3275,7 +3272,7 @@ init_traditional_PKWARE_decryption(struct archive_read *a)
 static int
 init_WinZip_AES_decryption(struct archive_read *a)
 {
-	struct zip *zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 	const void *p;
 	const uint8_t *pv;
 	size_t key_len, salt_len;
@@ -3369,8 +3366,8 @@ static int
 archive_read_format_zip_read_data(struct archive_read *a,
     const void **buff, size_t *size, int64_t *offset)
 {
+	struct zip *zip = a->format->data;
 	int r;
-	struct zip *zip = (struct zip *)(a->format->data);
 
 	if (zip->has_encrypted_entries ==
 			ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW) {
@@ -3514,10 +3511,8 @@ archive_read_format_zip_read_data(struct archive_read *a,
 static int
 archive_read_format_zip_cleanup(struct archive_read *a)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 	struct zip_entry *zip_entry, *next_zip_entry;
-
-	zip = (struct zip *)(a->format->data);
 
 #ifdef HAVE_ZLIB_H
 	if (zip->stream_valid)
@@ -3566,7 +3561,7 @@ archive_read_format_zip_cleanup(struct archive_read *a)
 	free(zip->v_data);
 	archive_string_free(&zip->format_name);
 	free(zip);
-	(a->format->data) = NULL;
+	a->format->data = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -3574,7 +3569,7 @@ static int
 archive_read_format_zip_has_encrypted_entries(struct archive_read *_a)
 {
 	if (_a && _a->format) {
-		struct zip * zip = (struct zip *)_a->format->data;
+		struct zip *zip = _a->format->data;
 		if (zip) {
 			return zip->has_encrypted_entries;
 		}
@@ -3586,10 +3581,9 @@ static int
 archive_read_format_zip_options(struct archive_read *a,
     const char *key, const char *val)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 	int ret = ARCHIVE_FAILED;
 
-	zip = (struct zip *)(a->format->data);
 	if (strcmp(key, "compat-2x")  == 0) {
 		/* Handle filenames as libarchive 2.x */
 		zip->init_default_conversion = (val != NULL) ? 1 : 0;
@@ -3696,13 +3690,11 @@ static int
 archive_read_format_zip_streamable_read_header(struct archive_read *a,
     struct archive_entry *entry)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 
 	a->archive.archive_format = ARCHIVE_FORMAT_ZIP;
 	if (a->archive.archive_format_name == NULL)
 		a->archive.archive_format_name = "ZIP";
-
-	zip = (struct zip *)(a->format->data);
 
 	/*
 	 * It should be sufficient to call archive_read_next_header() for
@@ -3789,10 +3781,9 @@ archive_read_format_zip_streamable_read_header(struct archive_read *a,
 static int
 archive_read_format_zip_read_data_skip_streamable(struct archive_read *a)
 {
-	struct zip *zip;
+	struct zip *zip = a->format->data;
 	int64_t bytes_skipped;
 
-	zip = (struct zip *)(a->format->data);
 	bytes_skipped = __archive_read_consume(a, zip->unconsumed);
 	zip->unconsumed = 0;
 	if (bytes_skipped < 0)
@@ -4034,7 +4025,7 @@ read_zip64_eocd(struct archive_read *a, struct zip *zip, const char *p)
 static int
 archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 {
-	struct zip *zip = (struct zip *)a->format->data;
+	struct zip *zip = a->format->data;
 	int64_t file_size, current_offset;
 	const char *p;
 	int i, tail;
@@ -4432,7 +4423,7 @@ static int
 zip_read_mac_metadata(struct archive_read *a, struct archive_entry *entry,
     struct zip_entry *rsrc)
 {
-	struct zip *zip = (struct zip *)a->format->data;
+	struct zip *zip = a->format->data;
 	unsigned char *metadata, *mp;
 	int64_t offset = archive_filter_bytes(&a->archive, 0);
 	size_t remaining_bytes, metadata_bytes;
@@ -4583,7 +4574,7 @@ static int
 archive_read_format_zip_seekable_read_header(struct archive_read *a,
 	struct archive_entry *entry)
 {
-	struct zip *zip = (struct zip *)a->format->data;
+	struct zip *zip = a->format->data;
 	struct zip_entry *rsrc;
 	int64_t offset;
 	int r, ret = ARCHIVE_OK;
@@ -4663,8 +4654,7 @@ archive_read_format_zip_seekable_read_header(struct archive_read *a,
 static int
 archive_read_format_zip_read_data_skip_seekable(struct archive_read *a)
 {
-	struct zip *zip;
-	zip = (struct zip *)(a->format->data);
+	struct zip *zip = a->format->data;
 
 	zip->unconsumed = 0;
 	return (ARCHIVE_OK);

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -69,7 +69,7 @@ static int	_archive_write_header(struct archive *, struct archive_entry *);
 static int	_archive_write_finish_entry(struct archive *);
 static ssize_t	_archive_write_data(struct archive *, const void *, size_t);
 
-struct archive_none {
+struct client {
 	size_t buffer_size;
 	size_t avail;
 	char *buffer;
@@ -359,7 +359,7 @@ static int
 archive_write_client_open(struct archive_write_filter *f)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-	struct archive_none *state;
+	struct client *client;
 	void *buffer;
 	size_t buffer_size;
 
@@ -368,21 +368,21 @@ archive_write_client_open(struct archive_write_filter *f)
 	    archive_write_get_bytes_in_last_block(f->archive);
 	buffer_size = f->bytes_per_block;
 
-	state = calloc(1, sizeof(*state));
+	client = calloc(1, sizeof(*client));
 	buffer = malloc(buffer_size);
-	if (state == NULL || buffer == NULL) {
-		free(state);
+	if (client == NULL || buffer == NULL) {
+		free(client);
 		free(buffer);
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for output buffering");
 		return (ARCHIVE_FATAL);
 	}
 
-	state->buffer_size = buffer_size;
-	state->buffer = buffer;
-	state->next = state->buffer;
-	state->avail = state->buffer_size;
-	f->data = state;
+	client->buffer_size = buffer_size;
+	client->buffer = buffer;
+	client->next = client->buffer;
+	client->avail = client->buffer_size;
+	f->data = client;
 
 	if (a->client_opener == NULL)
 		return (ARCHIVE_OK);
@@ -394,7 +394,7 @@ archive_write_client_write(struct archive_write_filter *f,
     const void *_buff, size_t length)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-        struct archive_none *state = f->data;
+	struct client *client = f->data;
 	const char *buff = (const char *)_buff;
 	ssize_t remaining, to_copy;
 	ssize_t bytes_written;
@@ -407,7 +407,7 @@ archive_write_client_write(struct archive_write_filter *f,
 	 * particular, this supports "no write delay" operation for
 	 * special applications.  Just set the block size to zero.
 	 */
-	if (state->buffer_size == 0) {
+	if (client->buffer_size == 0) {
 		while (remaining > 0) {
 			bytes_written = (a->client_writer)(&a->archive,
 			    a->client_data, buff, remaining);
@@ -420,20 +420,20 @@ archive_write_client_write(struct archive_write_filter *f,
 	}
 
 	/* If the copy buffer isn't empty, try to fill it. */
-	if (state->avail < state->buffer_size) {
+	if (client->avail < client->buffer_size) {
 		/* If buffer is not empty... */
 		/* ... copy data into buffer ... */
-		to_copy = ((size_t)remaining > state->avail) ?
-			state->avail : (size_t)remaining;
-		memcpy(state->next, buff, to_copy);
-		state->next += to_copy;
-		state->avail -= to_copy;
+		to_copy = ((size_t)remaining > client->avail) ?
+			client->avail : (size_t)remaining;
+		memcpy(client->next, buff, to_copy);
+		client->next += to_copy;
+		client->avail -= to_copy;
 		buff += to_copy;
 		remaining -= to_copy;
 		/* ... if it's full, write it out. */
-		if (state->avail == 0) {
-			char *p = state->buffer;
-			size_t to_write = state->buffer_size;
+		if (client->avail == 0) {
+			char *p = client->buffer;
+			size_t to_write = client->buffer_size;
 			while (to_write > 0) {
 				bytes_written = (a->client_writer)(&a->archive,
 				    a->client_data, p, to_write);
@@ -447,15 +447,15 @@ archive_write_client_write(struct archive_write_filter *f,
 				p += bytes_written;
 				to_write -= bytes_written;
 			}
-			state->next = state->buffer;
-			state->avail = state->buffer_size;
+			client->next = client->buffer;
+			client->avail = client->buffer_size;
 		}
 	}
 
-	while ((size_t)remaining >= state->buffer_size) {
+	while ((size_t)remaining >= client->buffer_size) {
 		/* Write out full blocks directly to client. */
 		bytes_written = (a->client_writer)(&a->archive,
-		    a->client_data, buff, state->buffer_size);
+		    a->client_data, buff, client->buffer_size);
 		if (bytes_written <= 0)
 			return (ARCHIVE_FATAL);
 		buff += bytes_written;
@@ -464,9 +464,9 @@ archive_write_client_write(struct archive_write_filter *f,
 
 	if (remaining > 0) {
 		/* Copy last bit into copy buffer. */
-		memcpy(state->next, buff, remaining);
-		state->next += remaining;
-		state->avail -= remaining;
+		memcpy(client->next, buff, remaining);
+		client->next += remaining;
+		client->avail -= remaining;
 	}
 	return (ARCHIVE_OK);
 }
@@ -475,7 +475,7 @@ static int
 archive_write_client_free(struct archive_write_filter *f)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-	struct archive_none *state = f->data;
+	struct client *client = f->data;
 
 	if (a->client_freer)
 		(*a->client_freer)(&a->archive, a->client_data);
@@ -489,9 +489,9 @@ archive_write_client_free(struct archive_write_filter *f)
 	}
 
 	/* Free state. */
-	if (state != NULL) {
-		free(state->buffer);
-		free(state);
+	if (client != NULL) {
+		free(client->buffer);
+		free(client);
 		f->data = NULL;
 	}
 
@@ -502,7 +502,7 @@ static int
 archive_write_client_close(struct archive_write_filter *f)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-	struct archive_none *state = f->data;
+	struct client *client = f->data;
 	ssize_t block_length;
 	ssize_t target_block_length;
 	ssize_t bytes_written;
@@ -511,8 +511,8 @@ archive_write_client_close(struct archive_write_filter *f)
 	int ret = ARCHIVE_OK;
 
 	/* If there's pending data, pad and write the last block */
-	if (state->next != state->buffer) {
-		block_length = state->buffer_size - state->avail;
+	if (client->next != client->buffer) {
+		block_length = client->buffer_size - client->avail;
 
 		/* Tricky calculation to determine size of last block */
 		if (a->bytes_in_last_block <= 0)
@@ -526,11 +526,11 @@ archive_write_client_close(struct archive_write_filter *f)
 		if (target_block_length > a->bytes_per_block)
 			target_block_length = a->bytes_per_block;
 		if (block_length < target_block_length) {
-			memset(state->next, 0,
+			memset(client->next, 0,
 			    target_block_length - block_length);
 			block_length = target_block_length;
 		}
-		p = state->buffer;
+		p = client->buffer;
 		to_write = block_length;
 		while (to_write > 0) {
 			bytes_written = (a->client_writer)(&a->archive,

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -394,7 +394,7 @@ archive_write_client_write(struct archive_write_filter *f,
     const void *_buff, size_t length)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-        struct archive_none *state = (struct archive_none *)f->data;
+        struct archive_none *state = f->data;
 	const char *buff = (const char *)_buff;
 	ssize_t remaining, to_copy;
 	ssize_t bytes_written;
@@ -475,7 +475,7 @@ static int
 archive_write_client_free(struct archive_write_filter *f)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-	struct archive_none *state = (struct archive_none *)f->data;
+	struct archive_none *state = f->data;
 
 	if (a->client_freer)
 		(*a->client_freer)(&a->archive, a->client_data);
@@ -502,7 +502,7 @@ static int
 archive_write_client_close(struct archive_write_filter *f)
 {
 	struct archive_write *a = (struct archive_write *)f->archive;
-	struct archive_none *state = (struct archive_none *)f->data;
+	struct archive_none *state = f->data;
 	ssize_t block_length;
 	ssize_t target_block_length;
 	ssize_t bytes_written;

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -122,7 +122,7 @@ static int
 archive_filter_b64encode_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_b64encode *state = (struct private_b64encode *)f->data;
+	struct private_b64encode *state = f->data;
 
 	if (strcmp(key, "mode") == 0) {
 		int64_t val;
@@ -162,7 +162,7 @@ archive_filter_b64encode_options(struct archive_write_filter *f, const char *key
 static int
 archive_filter_b64encode_open(struct archive_write_filter *f)
 {
-	struct private_b64encode *state = (struct private_b64encode *)f->data;
+	struct private_b64encode *state = f->data;
 	size_t bs = 65536, bpb;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
@@ -229,7 +229,7 @@ static int
 archive_filter_b64encode_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_b64encode *state = (struct private_b64encode *)f->data;
+	struct private_b64encode *state = f->data;
 	const unsigned char *p = buff;
 	int ret = ARCHIVE_OK;
 
@@ -274,7 +274,7 @@ archive_filter_b64encode_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_filter_b64encode_close(struct archive_write_filter *f)
 {
-	struct private_b64encode *state = (struct private_b64encode *)f->data;
+	struct private_b64encode *state = f->data;
 
 	/* Flush remaining bytes. */
 	if (state->hold_len != 0)

--- a/libarchive/archive_write_add_filter_b64encode.c
+++ b/libarchive/archive_write_add_filter_b64encode.c
@@ -46,7 +46,7 @@
 
 #define LBYTES	57
 
-struct private_b64encode {
+struct b64encode {
 	int			mode;
 	struct archive_string	name;
 	struct archive_string	encoded_buff;
@@ -64,7 +64,7 @@ static int archive_filter_b64encode_close(struct archive_write_filter *);
 static int archive_filter_b64encode_free(struct archive_write_filter *);
 static void la_b64_encode(struct archive_string *, const unsigned char *, size_t);
 static int64_t atol8(const char *, size_t);
-static void free_data(struct private_b64encode *);
+static void free_data(struct b64encode *);
 
 static const char base64[] = {
 	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
@@ -84,23 +84,23 @@ int
 archive_write_add_filter_b64encode(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_b64encode *state;
+	struct b64encode *b64encode;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_b64encode");
 
-	state = calloc(1, sizeof(*state));
-	if (state == NULL)
+	b64encode = calloc(1, sizeof(*b64encode));
+	if (b64encode == NULL)
 		goto memerr;
-	archive_strcpy(&state->name, "-");
-	state->mode = 0644;
+	archive_strcpy(&b64encode->name, "-");
+	b64encode->mode = 0644;
 
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
 	f->name = "b64encode";
 	f->code = ARCHIVE_FILTER_UU;
-	f->data = state;
+	f->data = b64encode;
 	f->options = archive_filter_b64encode_options;
 	f->open = archive_filter_b64encode_open;
 	f->write = archive_filter_b64encode_write;
@@ -109,7 +109,7 @@ archive_write_add_filter_b64encode(struct archive *a)
 
 	return (ARCHIVE_OK);
 memerr:
-	free_data(state);
+	free_data(b64encode);
 	archive_set_error(a, ENOMEM,
 	    "Can't allocate data for b64encode filter");
 	return (ARCHIVE_FATAL);
@@ -122,7 +122,7 @@ static int
 archive_filter_b64encode_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_b64encode *state = f->data;
+	struct b64encode *b64encode = f->data;
 
 	if (strcmp(key, "mode") == 0) {
 		int64_t val;
@@ -138,7 +138,7 @@ archive_filter_b64encode_options(struct archive_write_filter *f, const char *key
 			    "invalid mode option");
 			return (ARCHIVE_FAILED);
 		}
-		state->mode = (int)val & 0777;
+		b64encode->mode = (int)val & 0777;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "name") == 0) {
 		if (value == NULL) {
@@ -146,7 +146,7 @@ archive_filter_b64encode_options(struct archive_write_filter *f, const char *key
 			    "name option requires a string");
 			return (ARCHIVE_FAILED);
 		}
-		archive_strcpy(&state->name, value);
+		archive_strcpy(&b64encode->name, value);
 		return (ARCHIVE_OK);
 	}
 
@@ -162,7 +162,7 @@ archive_filter_b64encode_options(struct archive_write_filter *f, const char *key
 static int
 archive_filter_b64encode_open(struct archive_write_filter *f)
 {
-	struct private_b64encode *state = f->data;
+	struct b64encode *b64encode = f->data;
 	size_t bs = 65536, bpb;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
@@ -175,15 +175,15 @@ archive_filter_b64encode_open(struct archive_write_filter *f)
 			bs -= bs % bpb;
 	}
 
-	state->bs = bs;
-	if (archive_string_ensure(&state->encoded_buff, bs + 512) == NULL) {
+	b64encode->bs = bs;
+	if (archive_string_ensure(&b64encode->encoded_buff, bs + 512) == NULL) {
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for b64encode buffer");
 		return (ARCHIVE_FATAL);
 	}
 
-	archive_string_sprintf(&state->encoded_buff, "begin-base64 %o %s\n",
-	    (unsigned int)state->mode, state->name.s);
+	archive_string_sprintf(&b64encode->encoded_buff, "begin-base64 %o %s\n",
+	    (unsigned int)b64encode->mode, b64encode->name.s);
 
 	return (ARCHIVE_OK);
 }
@@ -229,39 +229,39 @@ static int
 archive_filter_b64encode_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_b64encode *state = f->data;
+	struct b64encode *b64encode = f->data;
 	const unsigned char *p = buff;
 	int ret = ARCHIVE_OK;
 
 	if (length == 0)
 		return (ret);
 
-	if (state->hold_len) {
-		while (state->hold_len < LBYTES && length > 0) {
-			state->hold[state->hold_len++] = *p++;
+	if (b64encode->hold_len) {
+		while (b64encode->hold_len < LBYTES && length > 0) {
+			b64encode->hold[b64encode->hold_len++] = *p++;
 			length--;
 		}
-		if (state->hold_len < LBYTES)
+		if (b64encode->hold_len < LBYTES)
 			return (ret);
-		la_b64_encode(&state->encoded_buff, state->hold, LBYTES);
-		state->hold_len = 0;
+		la_b64_encode(&b64encode->encoded_buff, b64encode->hold, LBYTES);
+		b64encode->hold_len = 0;
 	}
 
 	for (; length >= LBYTES; length -= LBYTES, p += LBYTES)
-		la_b64_encode(&state->encoded_buff, p, LBYTES);
+		la_b64_encode(&b64encode->encoded_buff, p, LBYTES);
 
 	/* Save remaining bytes. */
 	if (length > 0) {
-		memcpy(state->hold, p, length);
-		state->hold_len = length;
+		memcpy(b64encode->hold, p, length);
+		b64encode->hold_len = length;
 	}
-	while (archive_strlen(&state->encoded_buff) >= state->bs) {
+	while (archive_strlen(&b64encode->encoded_buff) >= b64encode->bs) {
 		ret = __archive_write_filter(f->next_filter,
-		    state->encoded_buff.s, state->bs);
-		memmove(state->encoded_buff.s,
-		    state->encoded_buff.s + state->bs,
-		    state->encoded_buff.length - state->bs);
-		state->encoded_buff.length -= state->bs;
+		    b64encode->encoded_buff.s, b64encode->bs);
+		memmove(b64encode->encoded_buff.s,
+		    b64encode->encoded_buff.s + b64encode->bs,
+		    b64encode->encoded_buff.length - b64encode->bs);
+		b64encode->encoded_buff.length -= b64encode->bs;
 	}
 
 	return (ret);
@@ -274,16 +274,17 @@ archive_filter_b64encode_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_filter_b64encode_close(struct archive_write_filter *f)
 {
-	struct private_b64encode *state = f->data;
+	struct b64encode *b64encode = f->data;
 
 	/* Flush remaining bytes. */
-	if (state->hold_len != 0)
-		la_b64_encode(&state->encoded_buff, state->hold, state->hold_len);
-	archive_string_sprintf(&state->encoded_buff, "====\n");
+	if (b64encode->hold_len != 0)
+		la_b64_encode(&b64encode->encoded_buff, b64encode->hold,
+		    b64encode->hold_len);
+	archive_string_sprintf(&b64encode->encoded_buff, "====\n");
 	/* Write the last block */
 	archive_write_set_bytes_in_last_block(f->archive, 1);
 	return __archive_write_filter(f->next_filter,
-	    state->encoded_buff.s, archive_strlen(&state->encoded_buff));
+	    b64encode->encoded_buff.s, archive_strlen(&b64encode->encoded_buff));
 }
 
 static int
@@ -318,11 +319,11 @@ atol8(const char *p, size_t char_cnt)
 }
 
 static void
-free_data(struct private_b64encode *data)
+free_data(struct b64encode *b64encode)
 {
-	if (data != NULL) {
-		archive_string_free(&data->name);
-		archive_string_free(&data->encoded_buff);
-		free(data);
+	if (b64encode != NULL) {
+		archive_string_free(&b64encode->name);
+		archive_string_free(&b64encode->encoded_buff);
+		free(b64encode);
 	}
 }

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -138,7 +138,7 @@ static int
 archive_compressor_bzip2_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -180,7 +180,7 @@ static int drive_compressor(struct archive_write_filter *,
 static int
 archive_compressor_bzip2_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	if (data->compressed == NULL) {
@@ -250,7 +250,7 @@ static int
 archive_compressor_bzip2_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	/* Compress input data to output buffer */
 	SET_NEXT_IN(data, buff);
@@ -267,7 +267,7 @@ archive_compressor_bzip2_write(struct archive_write_filter *f,
 static int
 archive_compressor_bzip2_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	/* Finish compression cycle. */
@@ -364,7 +364,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_bzip2_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -386,7 +386,7 @@ static int
 archive_compressor_bzip2_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -394,7 +394,7 @@ archive_compressor_bzip2_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_bzip2_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_bzip2.c
+++ b/libarchive/archive_write_add_filter_bzip2.c
@@ -53,7 +53,7 @@ archive_write_set_compression_bzip2(struct archive *a)
 }
 #endif
 
-struct private_data {
+struct bzip2 {
 	int		 compression_level;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
 	bz_stream	 stream;
@@ -71,7 +71,7 @@ static int archive_compressor_bzip2_options(struct archive_write_filter *,
 		    const char *, const char *);
 static int archive_compressor_bzip2_write(struct archive_write_filter *,
 		    const void *, size_t);
-static void free_data(struct private_data *);
+static void free_data(struct bzip2 *);
 
 /*
  * Add a bzip2 compression filter to this write handle.
@@ -80,24 +80,24 @@ int
 archive_write_add_filter_bzip2(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_data *data;
+	struct bzip2 *bzip2;
 	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_bzip2");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	bzip2 = calloc(1, sizeof(*bzip2));
+	if (bzip2 == NULL)
 		goto memerr;
 #if defined(HAVE_BZLIB_H) && defined(BZ_CONFIG_ERROR)
-	data->compression_level = 9;
+	bzip2->compression_level = 9;
 
 	r = ARCHIVE_OK;
 #else
-	data->pdata = __archive_write_program_allocate("bzip2");
-	if (data->pdata == NULL)
+	bzip2->pdata = __archive_write_program_allocate("bzip2");
+	if (bzip2->pdata == NULL)
 		goto memerr;
-	data->compression_level = 0;
+	bzip2->compression_level = 0;
 
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external bzip2 program");
@@ -109,7 +109,7 @@ archive_write_add_filter_bzip2(struct archive *a)
 		goto memerr;
 	f->name = "bzip2";
 	f->code = ARCHIVE_FILTER_BZIP2;
-	f->data = data;
+	f->data = bzip2;
 	f->options = archive_compressor_bzip2_options;
 	f->open = archive_compressor_bzip2_open;
 	f->write = archive_compressor_bzip2_write;
@@ -118,7 +118,7 @@ archive_write_add_filter_bzip2(struct archive *a)
 
 	return (r);
 memerr:
-	free_data(data);
+	free_data(bzip2);
 	archive_set_error(a, ENOMEM, "Out of memory");
 	return (ARCHIVE_FATAL);
 }
@@ -138,7 +138,7 @@ static int
 archive_compressor_bzip2_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -147,12 +147,12 @@ archive_compressor_bzip2_options(struct archive_write_filter *f,
 			    "compression-level invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = value[0] - '0';
+		bzip2->compression_level = value[0] - '0';
 		/* Make '0' be a synonym for '1'. */
 		/* This way, bzip2 compressor supports the same 0..9
 		 * range of levels as gzip. */
-		if (data->compression_level < 1)
-			data->compression_level = 1;
+		if (bzip2->compression_level < 1)
+			bzip2->compression_level = 1;
 		return (ARCHIVE_OK);
 	}
 
@@ -172,7 +172,7 @@ archive_compressor_bzip2_options(struct archive_write_filter *f,
 #define	SET_NEXT_IN(st,src)					\
 	(st)->stream.next_in = (char *)(uintptr_t)(const void *)(src)
 static int drive_compressor(struct archive_write_filter *,
-		    struct private_data *, int finishing);
+		    struct bzip2 *, int finishing);
 
 /*
  * Setup callback.
@@ -180,10 +180,10 @@ static int drive_compressor(struct archive_write_filter *,
 static int
 archive_compressor_bzip2_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 	int ret;
 
-	if (data->compressed == NULL) {
+	if (bzip2->compressed == NULL) {
 		size_t bs = 65536, bpb;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of the bytes
@@ -194,22 +194,22 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 			else if (bpb != 0)
 				bs -= bs % bpb;
 		}
-		data->compressed_buffer_size = bs;
-		data->compressed = malloc(data->compressed_buffer_size);
-		if (data->compressed == NULL) {
+		bzip2->compressed_buffer_size = bs;
+		bzip2->compressed = malloc(bzip2->compressed_buffer_size);
+		if (bzip2->compressed == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
 	}
 
-	memset(&data->stream, 0, sizeof(data->stream));
-	data->stream.next_out = data->compressed;
-	data->stream.avail_out = (uint32_t)data->compressed_buffer_size;
+	memset(&bzip2->stream, 0, sizeof(bzip2->stream));
+	bzip2->stream.next_out = bzip2->compressed;
+	bzip2->stream.avail_out = (uint32_t)bzip2->compressed_buffer_size;
 
 	/* Initialize compression library */
-	ret = BZ2_bzCompressInit(&(data->stream),
-	    data->compression_level, 0, 30);
+	ret = BZ2_bzCompressInit(&(bzip2->stream),
+	    bzip2->compression_level, 0, 30);
 	if (ret == BZ_OK) {
 		return (ARCHIVE_OK);
 	}
@@ -250,12 +250,12 @@ static int
 archive_compressor_bzip2_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 
 	/* Compress input data to output buffer */
-	SET_NEXT_IN(data, buff);
-	data->stream.avail_in = (uint32_t)length;
-	if (drive_compressor(f, data, 0))
+	SET_NEXT_IN(bzip2, buff);
+	bzip2->stream.avail_in = (uint32_t)length;
+	if (drive_compressor(f, bzip2, 0))
 		return (ARCHIVE_FATAL);
 	return (ARCHIVE_OK);
 }
@@ -267,19 +267,19 @@ archive_compressor_bzip2_write(struct archive_write_filter *f,
 static int
 archive_compressor_bzip2_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 	int ret;
 
 	/* Finish compression cycle. */
-	ret = drive_compressor(f, data, 1);
+	ret = drive_compressor(f, bzip2, 1);
 	if (ret == ARCHIVE_OK) {
 		/* Write the last block */
 		ret = __archive_write_filter(f->next_filter,
-		    data->compressed,
-		    data->compressed_buffer_size - data->stream.avail_out);
+		    bzip2->compressed,
+		    bzip2->compressed_buffer_size - bzip2->stream.avail_out);
 	}
 
-	switch (BZ2_bzCompressEnd(&(data->stream))) {
+	switch (BZ2_bzCompressEnd(&(bzip2->stream))) {
 	case BZ_OK:
 		break;
 	default:
@@ -299,35 +299,35 @@ archive_compressor_bzip2_close(struct archive_write_filter *f)
  */
 static int
 drive_compressor(struct archive_write_filter *f,
-    struct private_data *data, int finishing)
+    struct bzip2 *bzip2, int finishing)
 {
 	int ret;
 
 	for (;;) {
-		if (data->stream.avail_out == 0) {
+		if (bzip2->stream.avail_out == 0) {
 			ret = __archive_write_filter(f->next_filter,
-			    data->compressed,
-			    data->compressed_buffer_size);
+			    bzip2->compressed,
+			    bzip2->compressed_buffer_size);
 			if (ret != ARCHIVE_OK) {
 				/* TODO: Handle this write failure */
 				return (ARCHIVE_FATAL);
 			}
-			data->stream.next_out = data->compressed;
-			data->stream.avail_out = (uint32_t)data->compressed_buffer_size;
+			bzip2->stream.next_out = bzip2->compressed;
+			bzip2->stream.avail_out = (uint32_t)bzip2->compressed_buffer_size;
 		}
 
 		/* If there's nothing to do, we're done. */
-		if (!finishing && data->stream.avail_in == 0)
+		if (!finishing && bzip2->stream.avail_in == 0)
 			return (ARCHIVE_OK);
 
-		ret = BZ2_bzCompress(&(data->stream),
+		ret = BZ2_bzCompress(&(bzip2->stream),
 		    finishing ? BZ_FINISH : BZ_RUN);
 
 		switch (ret) {
 		case BZ_RUN_OK:
 			/* In non-finishing case, did compressor
 			 * consume everything? */
-			if (!finishing && data->stream.avail_in == 0)
+			if (!finishing && bzip2->stream.avail_in == 0)
 				return (ARCHIVE_OK);
 			break;
 		case BZ_FINISH_OK:  /* Finishing: There's more work to do */
@@ -348,14 +348,14 @@ drive_compressor(struct archive_write_filter *f,
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct bzip2 *bzip2)
 {
-	if (data != NULL) {
+	if (bzip2 != NULL) {
 		/* May already have been called, but not necessarily. */
-		(void)BZ2_bzCompressEnd(&(data->stream));
+		(void)BZ2_bzCompressEnd(&(bzip2->stream));
 
-		free(data->compressed);
-		free(data);
+		free(bzip2->compressed);
+		free(bzip2);
 	}
 }
 
@@ -364,7 +364,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_bzip2_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 	struct archive_string as;
 	int r;
 
@@ -372,12 +372,12 @@ archive_compressor_bzip2_open(struct archive_write_filter *f)
 	archive_strcpy(&as, "bzip2");
 
 	/* Specify compression level. */
-	if (data->compression_level > 0) {
+	if (bzip2->compression_level > 0) {
 		archive_strcat(&as, " -");
-		archive_strappend_char(&as, '0' + data->compression_level);
+		archive_strappend_char(&as, '0' + bzip2->compression_level);
 	}
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, bzip2->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -386,25 +386,25 @@ static int
 archive_compressor_bzip2_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, bzip2->pdata, buff, length);
 }
 
 static int
 archive_compressor_bzip2_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct bzip2 *bzip2 = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, bzip2->pdata);
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct bzip2 *bzip2)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (bzip2 != NULL) {
+		__archive_write_program_free(bzip2->pdata);
+		free(bzip2);
 	}
 }
 

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -85,7 +85,7 @@
 #define	FIRST	257		/* First free entry. */
 #define	CLEAR	256		/* Table clear output code. */
 
-struct private_data {
+struct compress {
 	int64_t in_count, out_count, checkpoint;
 
 	int code_len;			/* Number of bits/code. */
@@ -111,7 +111,7 @@ static int archive_compressor_compress_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_compressor_compress_close(struct archive_write_filter *);
 static int archive_compressor_compress_free(struct archive_write_filter *);
-static void free_data(struct private_data *);
+static void free_data(struct compress *);
 
 #if ARCHIVE_VERSION_NUMBER < 4000000
 int
@@ -129,13 +129,13 @@ int
 archive_write_add_filter_compress(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_data *state;
+	struct compress *compress;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_compress");
 
-	state = calloc(1, sizeof(*state));
-	if (state == NULL)
+	compress = calloc(1, sizeof(*compress));
+	if (compress == NULL)
 		goto memerr;
 
 	f = __archive_write_allocate_filter(a);
@@ -143,7 +143,7 @@ archive_write_add_filter_compress(struct archive *a)
 		goto memerr;
 	f->name = "compress";
 	f->code = ARCHIVE_FILTER_COMPRESS;
-	f->data = state;
+	f->data = compress;
 	f->open = archive_compressor_compress_open;
 	f->write = archive_compressor_compress_write;
 	f->close = archive_compressor_compress_close;
@@ -151,7 +151,7 @@ archive_write_add_filter_compress(struct archive *a)
 
 	return (ARCHIVE_OK);
 memerr:
-	free_data(state);
+	free_data(compress);
 	archive_set_error(a, ENOMEM,
 	    "Can't allocate data for compression");
 	return (ARCHIVE_FATAL);
@@ -163,7 +163,7 @@ memerr:
 static int
 archive_compressor_compress_open(struct archive_write_filter *f)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 	size_t bs = 65536, bpb;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
@@ -175,33 +175,36 @@ archive_compressor_compress_open(struct archive_write_filter *f)
 		else if (bpb != 0)
 			bs -= bs % bpb;
 	}
-	state->compressed_buffer_size = bs;
-	state->compressed = malloc(state->compressed_buffer_size);
+	compress->compressed_buffer_size = bs;
+	compress->compressed = malloc(compress->compressed_buffer_size);
 
-	if (state->compressed == NULL) {
+	if (compress->compressed == NULL) {
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for compression buffer");
 		return (ARCHIVE_FATAL);
 	}
 
-	state->max_maxcode = 0x10000;	/* Should NEVER generate this code. */
-	state->in_count = 0;		/* Length of input. */
-	state->bit_buf = 0;
-	state->bit_offset = 0;
-	state->out_count = 3;		/* Includes 3-byte header mojo. */
-	state->compress_ratio = 0;
-	state->checkpoint = CHECK_GAP;
-	state->code_len = 9;
-	state->cur_maxcode = MAXCODE(state->code_len);
-	state->first_free = FIRST;
+	/* Should NEVER generate this code. */
+	compress->max_maxcode = 0x10000;
+	/* Length of input. */
+	compress->in_count = 0;
+	compress->bit_buf = 0;
+	compress->bit_offset = 0;
+	/* Includes 3-byte header mojo. */
+	compress->out_count = 3;
+	compress->compress_ratio = 0;
+	compress->checkpoint = CHECK_GAP;
+	compress->code_len = 9;
+	compress->cur_maxcode = MAXCODE(compress->code_len);
+	compress->first_free = FIRST;
 
-	memset(state->hashtab, 0xff, sizeof(state->hashtab));
+	memset(compress->hashtab, 0xff, sizeof(compress->hashtab));
 
 	/* Prime output buffer with a gzip header. */
-	state->compressed[0] = 0x1f; /* Compress */
-	state->compressed[1] = 0x9d;
-	state->compressed[2] = 0x90; /* Block mode, 16bit max */
-	state->compressed_offset = 3;
+	compress->compressed[0] = 0x1f; /* Compress */
+	compress->compressed[1] = 0x9d;
+	compress->compressed[2] = 0x90; /* Block mode, 16bit max */
+	compress->compressed_offset = 3;
 
 	return (ARCHIVE_OK);
 }
@@ -227,17 +230,17 @@ static const unsigned char rmask[9] =
 static int
 output_byte(struct archive_write_filter *f, unsigned char c)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 
-	state->compressed[state->compressed_offset++] = c;
-	++state->out_count;
+	compress->compressed[compress->compressed_offset++] = c;
+	++compress->out_count;
 
-	if (state->compressed_buffer_size == state->compressed_offset) {
+	if (compress->compressed_buffer_size == compress->compressed_offset) {
 		int ret = __archive_write_filter(f->next_filter,
-		    state->compressed, state->compressed_buffer_size);
+		    compress->compressed, compress->compressed_buffer_size);
 		if (ret != ARCHIVE_OK)
 			return ARCHIVE_FATAL;
-		state->compressed_offset = 0;
+		compress->compressed_offset = 0;
 	}
 
 	return ARCHIVE_OK;
@@ -246,7 +249,7 @@ output_byte(struct archive_write_filter *f, unsigned char c)
 static int
 output_code(struct archive_write_filter *f, int ocode)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 	int bits, ret, clear_flg, bit_offset;
 
 	clear_flg = ocode == CLEAR;
@@ -255,11 +258,11 @@ output_code(struct archive_write_filter *f, int ocode)
 	 * Since ocode is always >= 8 bits, only need to mask the first
 	 * hunk on the left.
 	 */
-	bit_offset = state->bit_offset % 8;
-	state->bit_buf |= (ocode << bit_offset) & 0xff;
-	output_byte(f, state->bit_buf);
+	bit_offset = compress->bit_offset % 8;
+	compress->bit_buf |= (ocode << bit_offset) & 0xff;
+	output_byte(f, compress->bit_buf);
 
-	bits = state->code_len - (8 - bit_offset);
+	bits = compress->code_len - (8 - bit_offset);
 	ocode >>= 8 - bit_offset;
 	/* Get any 8 bit parts in the middle (<=1 for up to 16 bits). */
 	if (bits >= 8) {
@@ -268,41 +271,41 @@ output_code(struct archive_write_filter *f, int ocode)
 		bits -= 8;
 	}
 	/* Last bits. */
-	state->bit_offset += state->code_len;
-	state->bit_buf = ocode & rmask[bits];
-	if (state->bit_offset == state->code_len * 8)
-		state->bit_offset = 0;
+	compress->bit_offset += compress->code_len;
+	compress->bit_buf = ocode & rmask[bits];
+	if (compress->bit_offset == compress->code_len * 8)
+		compress->bit_offset = 0;
 
 	/*
 	 * If the next entry is going to be too big for the ocode size,
 	 * then increase it, if possible.
 	 */
-	if (clear_flg || state->first_free > state->cur_maxcode) {
+	if (clear_flg || compress->first_free > compress->cur_maxcode) {
 	       /*
 		* Write the whole buffer, because the input side won't
 		* discover the size increase until after it has read it.
 		*/
-		if (state->bit_offset > 0) {
-			while (state->bit_offset < state->code_len * 8) {
-				ret = output_byte(f, state->bit_buf);
+		if (compress->bit_offset > 0) {
+			while (compress->bit_offset < compress->code_len * 8) {
+				ret = output_byte(f, compress->bit_buf);
 				if (ret != ARCHIVE_OK)
 					return ret;
-				state->bit_offset += 8;
-				state->bit_buf = 0;
+				compress->bit_offset += 8;
+				compress->bit_buf = 0;
 			}
 		}
-		state->bit_buf = 0;
-		state->bit_offset = 0;
+		compress->bit_buf = 0;
+		compress->bit_offset = 0;
 
 		if (clear_flg) {
-			state->code_len = 9;
-			state->cur_maxcode = MAXCODE(state->code_len);
+			compress->code_len = 9;
+			compress->cur_maxcode = MAXCODE(compress->code_len);
 		} else {
-			state->code_len++;
-			if (state->code_len == 16)
-				state->cur_maxcode = state->max_maxcode;
+			compress->code_len++;
+			if (compress->code_len == 16)
+				compress->cur_maxcode = compress->max_maxcode;
 			else
-				state->cur_maxcode = MAXCODE(state->code_len);
+				compress->cur_maxcode = MAXCODE(compress->code_len);
 		}
 	}
 
@@ -312,13 +315,13 @@ output_code(struct archive_write_filter *f, int ocode)
 static int
 output_flush(struct archive_write_filter *f)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 	int ret;
 
 	/* At EOF, write the rest of the buffer. */
-	if (state->bit_offset % 8) {
-		state->code_len = (state->bit_offset % 8 + 7) / 8;
-		ret = output_byte(f, state->bit_buf);
+	if (compress->bit_offset % 8) {
+		compress->code_len = (compress->bit_offset % 8 + 7) / 8;
+		ret = output_byte(f, compress->bit_buf);
 		if (ret != ARCHIVE_OK)
 			return ret;
 	}
@@ -333,7 +336,7 @@ static int
 archive_compressor_compress_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 	int i;
 	int ratio;
 	int c, disp, ret;
@@ -344,23 +347,24 @@ archive_compressor_compress_write(struct archive_write_filter *f,
 
 	bp = buff;
 
-	if (state->in_count == 0) {
-		state->cur_code = *bp++;
-		++state->in_count;
+	if (compress->in_count == 0) {
+		compress->cur_code = *bp++;
+		++compress->in_count;
 		--length;
 	}
 
 	while (length--) {
 		c = *bp++;
-		state->in_count++;
-		state->cur_fcode = (c << 16) | state->cur_code;
-		i = ((c << HSHIFT) ^ state->cur_code);	/* Xor hashing. */
+		compress->in_count++;
+		compress->cur_fcode = (c << 16) | compress->cur_code;
+		/* Xor hashing. */
+		i = ((c << HSHIFT) ^ compress->cur_code);
 
-		if (state->hashtab[i] == state->cur_fcode) {
-			state->cur_code = state->codetab[i];
+		if (compress->hashtab[i] == compress->cur_fcode) {
+			compress->cur_code = compress->codetab[i];
 			continue;
 		}
-		if (state->hashtab[i] < 0)	/* Empty slot. */
+		if (compress->hashtab[i] < 0)	/* Empty slot. */
 			goto nomatch;
 		/* Secondary hash (after G. Knott). */
 		if (i == 0)
@@ -371,40 +375,40 @@ archive_compressor_compress_write(struct archive_write_filter *f,
 		if ((i -= disp) < 0)
 			i += HSIZE;
 
-		if (state->hashtab[i] == state->cur_fcode) {
-			state->cur_code = state->codetab[i];
+		if (compress->hashtab[i] == compress->cur_fcode) {
+			compress->cur_code = compress->codetab[i];
 			continue;
 		}
-		if (state->hashtab[i] >= 0)
+		if (compress->hashtab[i] >= 0)
 			goto probe;
  nomatch:
-		ret = output_code(f, state->cur_code);
+		ret = output_code(f, compress->cur_code);
 		if (ret != ARCHIVE_OK)
 			return ret;
-		state->cur_code = c;
-		if (state->first_free < state->max_maxcode) {
-			state->codetab[i] = state->first_free++;	/* code -> hashtable */
-			state->hashtab[i] = state->cur_fcode;
+		compress->cur_code = c;
+		if (compress->first_free < compress->max_maxcode) {
+			compress->codetab[i] = compress->first_free++;	/* code -> hashtable */
+			compress->hashtab[i] = compress->cur_fcode;
 			continue;
 		}
-		if (state->in_count < state->checkpoint)
+		if (compress->in_count < compress->checkpoint)
 			continue;
 
-		state->checkpoint = state->in_count + CHECK_GAP;
+		compress->checkpoint = compress->in_count + CHECK_GAP;
 
-		if (state->in_count <= 0x007fffff && state->out_count != 0)
-			ratio = (int)(state->in_count * 256 / state->out_count);
-		else if ((ratio = (int)(state->out_count / 256)) == 0)
+		if (compress->in_count <= 0x007fffff && compress->out_count != 0)
+			ratio = (int)(compress->in_count * 256 / compress->out_count);
+		else if ((ratio = (int)(compress->out_count / 256)) == 0)
 			ratio = 0x7fffffff;
 		else
-			ratio = (int)(state->in_count / ratio);
+			ratio = (int)(compress->in_count / ratio);
 
-		if (ratio > state->compress_ratio)
-			state->compress_ratio = ratio;
+		if (ratio > compress->compress_ratio)
+			compress->compress_ratio = ratio;
 		else {
-			state->compress_ratio = 0;
-			memset(state->hashtab, 0xff, sizeof(state->hashtab));
-			state->first_free = FIRST;
+			compress->compress_ratio = 0;
+			memset(compress->hashtab, 0xff, sizeof(compress->hashtab));
+			compress->first_free = FIRST;
 			ret = output_code(f, CLEAR);
 			if (ret != ARCHIVE_OK)
 				return ret;
@@ -421,10 +425,10 @@ archive_compressor_compress_write(struct archive_write_filter *f,
 static int
 archive_compressor_compress_close(struct archive_write_filter *f)
 {
-	struct private_data *state = f->data;
+	struct compress *compress = f->data;
 	int ret;
 
-	ret = output_code(f, state->cur_code);
+	ret = output_code(f, compress->cur_code);
 	if (ret != ARCHIVE_OK)
 		return ret;
 	ret = output_flush(f);
@@ -433,7 +437,7 @@ archive_compressor_compress_close(struct archive_write_filter *f)
 
 	/* Write the last block */
 	ret = __archive_write_filter(f->next_filter,
-	    state->compressed, state->compressed_offset);
+	    compress->compressed, compress->compressed_offset);
 	return (ret);
 }
 
@@ -446,10 +450,10 @@ archive_compressor_compress_free(struct archive_write_filter *f)
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct compress *compress)
 {
-	if (data != NULL) {
-		free(data->compressed);
-		free(data);
+	if (compress != NULL) {
+		free(compress->compressed);
+		free(compress);
 	}
 }

--- a/libarchive/archive_write_add_filter_compress.c
+++ b/libarchive/archive_write_add_filter_compress.c
@@ -333,7 +333,7 @@ static int
 archive_compressor_compress_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *state = (struct private_data *)f->data;
+	struct private_data *state = f->data;
 	int i;
 	int ratio;
 	int c, disp, ret;
@@ -421,7 +421,7 @@ archive_compressor_compress_write(struct archive_write_filter *f,
 static int
 archive_compressor_compress_close(struct archive_write_filter *f)
 {
-	struct private_data *state = (struct private_data *)f->data;
+	struct private_data *state = f->data;
 	int ret;
 
 	ret = output_code(f, state->cur_code);

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -35,7 +35,7 @@
 #include "archive.h"
 #include "archive_write_private.h"
 
-struct write_grzip {
+struct grzip {
 	struct archive_write_program_data *pdata;
 };
 
@@ -46,22 +46,22 @@ static int archive_write_grzip_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_grzip_close(struct archive_write_filter *);
 static int archive_write_grzip_free(struct archive_write_filter *);
-static void free_data(struct write_grzip *);
+static void free_data(struct grzip *);
 
 int
 archive_write_add_filter_grzip(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct write_grzip *data;
+	struct grzip *grzip;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_grzip");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	grzip = calloc(1, sizeof(*grzip));
+	if (grzip == NULL)
 		goto memerr;
-	data->pdata = __archive_write_program_allocate("grzip");
-	if (data->pdata == NULL)
+	grzip->pdata = __archive_write_program_allocate("grzip");
+	if (grzip->pdata == NULL)
 		goto memerr;
 
 	f = __archive_write_allocate_filter(a);
@@ -69,7 +69,7 @@ archive_write_add_filter_grzip(struct archive *a)
 		goto memerr;
 	f->name = "grzip";
 	f->code = ARCHIVE_FILTER_GRZIP;
-	f->data = data;
+	f->data = grzip;
 	f->options = archive_write_grzip_options;
 	f->open = archive_write_grzip_open;
 	f->write = archive_write_grzip_write;
@@ -82,7 +82,7 @@ archive_write_add_filter_grzip(struct archive *a)
 	    "Using external grzip program for grzip compression");
 	return (ARCHIVE_WARN);
 memerr:
-	free_data(data);
+	free_data(grzip);
 	archive_set_error(a, ENOMEM, "Can't allocate memory");
 	return (ARCHIVE_FATAL);
 }
@@ -103,26 +103,26 @@ archive_write_grzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_grzip_open(struct archive_write_filter *f)
 {
-	struct write_grzip *data = f->data;
+	struct grzip *grzip = f->data;
 
-	return __archive_write_program_open(f, data->pdata, "grzip");
+	return __archive_write_program_open(f, grzip->pdata, "grzip");
 }
 
 static int
 archive_write_grzip_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_grzip *data = f->data;
+	struct grzip *grzip = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, grzip->pdata, buff, length);
 }
 
 static int
 archive_write_grzip_close(struct archive_write_filter *f)
 {
-	struct write_grzip *data = f->data;
+	struct grzip *grzip = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, grzip->pdata);
 }
 
 static int
@@ -134,10 +134,10 @@ archive_write_grzip_free(struct archive_write_filter *f)
 }
 
 static void
-free_data(struct write_grzip *data)
+free_data(struct grzip *grzip)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (grzip != NULL) {
+		__archive_write_program_free(grzip->pdata);
+		free(grzip);
 	}
 }

--- a/libarchive/archive_write_add_filter_grzip.c
+++ b/libarchive/archive_write_add_filter_grzip.c
@@ -103,7 +103,7 @@ archive_write_grzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_grzip_open(struct archive_write_filter *f)
 {
-	struct write_grzip *data = (struct write_grzip *)f->data;
+	struct write_grzip *data = f->data;
 
 	return __archive_write_program_open(f, data->pdata, "grzip");
 }
@@ -112,7 +112,7 @@ static int
 archive_write_grzip_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_grzip *data = (struct write_grzip *)f->data;
+	struct write_grzip *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -120,7 +120,7 @@ archive_write_grzip_write(struct archive_write_filter *f,
 static int
 archive_write_grzip_close(struct archive_write_filter *f)
 {
-	struct write_grzip *data = (struct write_grzip *)f->data;
+	struct write_grzip *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -158,7 +158,7 @@ static int
 archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -198,7 +198,7 @@ archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_compressor_gzip_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret = ARCHIVE_OK;
 	int init_success;
 
@@ -318,7 +318,7 @@ static int
 archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	/* Update statistics */
@@ -340,8 +340,8 @@ archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_gzip_close(struct archive_write_filter *f)
 {
+	struct private_data *data = f->data;
 	unsigned char trailer[8];
-	struct private_data *data = (struct private_data *)f->data;
 	int ret;
 
 	/* Finish compression cycle */
@@ -440,7 +440,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_gzip_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -468,7 +468,7 @@ static int
 archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -476,7 +476,7 @@ archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_gzip_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_gzip.c
+++ b/libarchive/archive_write_add_filter_gzip.c
@@ -56,7 +56,7 @@ archive_write_set_compression_gzip(struct archive *a)
 
 /* Don't compile this if we don't have zlib. */
 
-struct private_data {
+struct gzip {
 	int		 compression_level;
 	int		 timestamp;
 	char	*original_filename;
@@ -87,9 +87,9 @@ static int archive_compressor_gzip_close(struct archive_write_filter *);
 static int archive_compressor_gzip_free(struct archive_write_filter *);
 #ifdef HAVE_ZLIB_H
 static int drive_compressor(struct archive_write_filter *,
-		    struct private_data *, int finishing);
+		    struct gzip *, int finishing);
 #endif
-static void free_data(struct private_data *);
+static void free_data(struct gzip *);
 
 
 /*
@@ -99,25 +99,25 @@ int
 archive_write_add_filter_gzip(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_data *data;
+	struct gzip *gzip;
 	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_gzip");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	gzip = calloc(1, sizeof(*gzip));
+	if (gzip == NULL)
 		goto memerr;
-	data->original_filename = NULL;
+	gzip->original_filename = NULL;
 #ifdef HAVE_ZLIB_H
-	data->compression_level = Z_DEFAULT_COMPRESSION;
+	gzip->compression_level = Z_DEFAULT_COMPRESSION;
 
 	r = ARCHIVE_OK;
 #else
-	data->pdata = __archive_write_program_allocate("gzip");
-	if (data->pdata == NULL)
+	gzip->pdata = __archive_write_program_allocate("gzip");
+	if (gzip->pdata == NULL)
 		goto memerr;
-	data->compression_level = 0;
+	gzip->compression_level = 0;
 
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external gzip program");
@@ -129,7 +129,7 @@ archive_write_add_filter_gzip(struct archive *a)
 		goto memerr;
 	f->name = "gzip";
 	f->code = ARCHIVE_FILTER_GZIP;
-	f->data = data;
+	f->data = gzip;
 	f->options = archive_compressor_gzip_options;
 	f->open = archive_compressor_gzip_open;
 	f->write = archive_compressor_gzip_write;
@@ -138,7 +138,7 @@ archive_write_add_filter_gzip(struct archive *a)
 
 	return (r);
 memerr:
-	free_data(data);
+	free_data(gzip);
 	archive_set_error(a, ENOMEM, "Out of memory");
 	return (ARCHIVE_FATAL);
 }
@@ -158,7 +158,7 @@ static int
 archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -167,19 +167,19 @@ archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
 			    "compression-level invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = value[0] - '0';
+		gzip->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "timestamp") == 0) {
-		data->timestamp = (value == NULL)?-1:1;
+		gzip->timestamp = (value == NULL)?-1:1;
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "original-filename") == 0) {
-		free((void*)data->original_filename);
-		data->original_filename = NULL;
+		free((void*)gzip->original_filename);
+		gzip->original_filename = NULL;
 		if (value) {
-			data->original_filename = strdup(value);
-			if (data->original_filename == NULL)
+			gzip->original_filename = strdup(value);
+			if (gzip->original_filename == NULL)
 				return (ARCHIVE_FAILED);
 		}
 		return (ARCHIVE_OK);
@@ -198,11 +198,11 @@ archive_compressor_gzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_compressor_gzip_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 	int ret = ARCHIVE_OK;
 	int init_success;
 
-	if (data->compressed == NULL) {
+	if (gzip->compressed == NULL) {
 		size_t bs = 65536, bpb;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
@@ -213,60 +213,60 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 			else if (bpb != 0)
 				bs -= bs % bpb;
 		}
-		data->compressed_buffer_size = bs;
-		data->compressed = malloc(data->compressed_buffer_size);
-		if (data->compressed == NULL) {
+		gzip->compressed_buffer_size = bs;
+		gzip->compressed = malloc(gzip->compressed_buffer_size);
+		if (gzip->compressed == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
 	}
 
-	data->crc = crc32(0L, NULL, 0);
-	data->stream.next_out = data->compressed;
-	data->stream.avail_out = (uInt)data->compressed_buffer_size;
+	gzip->crc = crc32(0L, NULL, 0);
+	gzip->stream.next_out = gzip->compressed;
+	gzip->stream.avail_out = (uInt)gzip->compressed_buffer_size;
 
 	/* Prime output buffer with a gzip header. */
-	data->compressed[0] = 0x1f; /* GZip signature bytes */
-	data->compressed[1] = 0x8b;
-	data->compressed[2] = 0x08; /* "Deflate" compression */
-	data->compressed[3] = 0x00; /* Flags */
-	if (data->timestamp >= 0) {
+	gzip->compressed[0] = 0x1f; /* GZip signature bytes */
+	gzip->compressed[1] = 0x8b;
+	gzip->compressed[2] = 0x08; /* "Deflate" compression */
+	gzip->compressed[3] = 0x00; /* Flags */
+	if (gzip->timestamp >= 0) {
 		uint32_t t = (uint32_t)time(NULL);
-		archive_le32enc(data->compressed + 4, t); /* Timestamp */
+		archive_le32enc(gzip->compressed + 4, t); /* Timestamp */
 	} else {
-		memset(&data->compressed[4], 0, 4);
+		memset(&gzip->compressed[4], 0, 4);
 	}
-	if (data->compression_level == 9) {
-		data->compressed[8] = 2;
-	} else if(data->compression_level == 1) {
-		data->compressed[8] = 4;
+	if (gzip->compression_level == 9) {
+		gzip->compressed[8] = 2;
+	} else if(gzip->compression_level == 1) {
+		gzip->compressed[8] = 4;
 	} else {
-		data->compressed[8] = 0;
+		gzip->compressed[8] = 0;
 	}
-	data->compressed[9] = 3; /* OS=Unix */
-	data->stream.next_out += 10;
-	data->stream.avail_out -= 10;
+	gzip->compressed[9] = 3; /* OS=Unix */
+	gzip->stream.next_out += 10;
+	gzip->stream.avail_out -= 10;
 
-	if (data->original_filename != NULL) {
+	if (gzip->original_filename != NULL) {
 		/* Limit "original filename" to 32k or the
 		 * remaining space in the buffer, whichever is smaller.
 		 */
-		size_t ofn_length = strlen(data->original_filename);
+		size_t ofn_length = strlen(gzip->original_filename);
 		size_t ofn_max_length = 32768;
-		size_t ofn_space_available = data->compressed
-			+ data->compressed_buffer_size
-			- data->stream.next_out
+		size_t ofn_space_available = gzip->compressed
+			+ gzip->compressed_buffer_size
+			- gzip->stream.next_out
 			- 1;
 		if (ofn_max_length > ofn_space_available) {
 			ofn_max_length = ofn_space_available;
 		}
 		if (ofn_length < ofn_max_length) {
-			data->compressed[3] |= 0x8;
-			strcpy((char*)data->compressed + 10,
-			       data->original_filename);
-			data->stream.next_out += ofn_length + 1;
-			data->stream.avail_out -= ofn_length + 1;
+			gzip->compressed[3] |= 0x8;
+			strcpy((char*)gzip->compressed + 10,
+			       gzip->original_filename);
+			gzip->stream.next_out += ofn_length + 1;
+			gzip->stream.avail_out -= ofn_length + 1;
 		} else {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 					  "Gzip 'Original Filename' ignored because it is too long");
@@ -275,8 +275,8 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	}
 
 	/* Initialize compression library. */
-	init_success = deflateInit2(&(data->stream),
-	    data->compression_level,
+	init_success = deflateInit2(&(gzip->stream),
+	    gzip->compression_level,
 	    Z_DEFLATED,
 	    -15 /* < 0 to suppress zlib header */,
 	    8,
@@ -318,17 +318,17 @@ static int
 archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 	int ret;
 
 	/* Update statistics */
-	data->crc = crc32(data->crc, (const Bytef *)buff, (uInt)length);
-	data->total_in += length;
+	gzip->crc = crc32(gzip->crc, (const Bytef *)buff, (uInt)length);
+	gzip->total_in += length;
 
 	/* Compress input data to output buffer */
-	SET_NEXT_IN(data, buff);
-	data->stream.avail_in = (uInt)length;
-	if ((ret = drive_compressor(f, data, 0)) != ARCHIVE_OK)
+	SET_NEXT_IN(gzip, buff);
+	gzip->stream.avail_in = (uInt)length;
+	if ((ret = drive_compressor(f, gzip, 0)) != ARCHIVE_OK)
 		return (ret);
 
 	return (ARCHIVE_OK);
@@ -340,26 +340,26 @@ archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_gzip_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 	unsigned char trailer[8];
 	int ret;
 
 	/* Finish compression cycle */
-	ret = drive_compressor(f, data, 1);
+	ret = drive_compressor(f, gzip, 1);
 	if (ret == ARCHIVE_OK) {
 		/* Write the last compressed data. */
 		ret = __archive_write_filter(f->next_filter,
-		    data->compressed,
-		    data->compressed_buffer_size - data->stream.avail_out);
+		    gzip->compressed,
+		    gzip->compressed_buffer_size - gzip->stream.avail_out);
 	}
 	if (ret == ARCHIVE_OK) {
 		/* Build and write out 8-byte trailer. */
-		archive_le32enc(trailer, data->crc);
-		archive_le32enc(trailer + 4, data->total_in);
+		archive_le32enc(trailer, gzip->crc);
+		archive_le32enc(trailer + 4, gzip->total_in);
 		ret = __archive_write_filter(f->next_filter, trailer, 8);
 	}
 
-	switch (deflateEnd(&(data->stream))) {
+	switch (deflateEnd(&(gzip->stream))) {
 	case Z_OK:
 		break;
 	default:
@@ -379,34 +379,34 @@ archive_compressor_gzip_close(struct archive_write_filter *f)
  */
 static int
 drive_compressor(struct archive_write_filter *f,
-    struct private_data *data, int finishing)
+    struct gzip *gzip, int finishing)
 {
 	int ret;
 
 	for (;;) {
-		if (data->stream.avail_out == 0) {
+		if (gzip->stream.avail_out == 0) {
 			ret = __archive_write_filter(f->next_filter,
-			    data->compressed,
-			    data->compressed_buffer_size);
+			    gzip->compressed,
+			    gzip->compressed_buffer_size);
 			if (ret != ARCHIVE_OK)
 				return (ARCHIVE_FATAL);
-			data->stream.next_out = data->compressed;
-			data->stream.avail_out =
-			    (uInt)data->compressed_buffer_size;
+			gzip->stream.next_out = gzip->compressed;
+			gzip->stream.avail_out =
+			    (uInt)gzip->compressed_buffer_size;
 		}
 
 		/* If there's nothing to do, we're done. */
-		if (!finishing && data->stream.avail_in == 0)
+		if (!finishing && gzip->stream.avail_in == 0)
 			return (ARCHIVE_OK);
 
-		ret = deflate(&(data->stream),
+		ret = deflate(&(gzip->stream),
 		    finishing ? Z_FINISH : Z_NO_FLUSH );
 
 		switch (ret) {
 		case Z_OK:
 			/* In non-finishing case, check if compressor
 			 * consumed everything */
-			if (!finishing && data->stream.avail_in == 0)
+			if (!finishing && gzip->stream.avail_in == 0)
 				return (ARCHIVE_OK);
 			/* In finishing case, this return always means
 			 * there's more work */
@@ -426,12 +426,12 @@ drive_compressor(struct archive_write_filter *f,
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct gzip *gzip)
 {
-	if (data != NULL) {
-		free(data->compressed);
-		free(data->original_filename);
-		free(data);
+	if (gzip != NULL) {
+		free(gzip->compressed);
+		free(gzip->original_filename);
+		free(gzip);
 	}
 }
 
@@ -440,7 +440,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_gzip_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 	struct archive_string as;
 	int r;
 
@@ -448,18 +448,18 @@ archive_compressor_gzip_open(struct archive_write_filter *f)
 	archive_strcpy(&as, "gzip");
 
 	/* Specify compression level. */
-	if (data->compression_level > 0) {
+	if (gzip->compression_level > 0) {
 		archive_strcat(&as, " -");
-		archive_strappend_char(&as, '0' + data->compression_level);
+		archive_strappend_char(&as, '0' + gzip->compression_level);
 	}
-	if (data->timestamp < 0)
+	if (gzip->timestamp < 0)
 		/* Do not save timestamp. */
 		archive_strcat(&as, " -n");
-	else if (data->timestamp > 0)
+	else if (gzip->timestamp > 0)
 		/* Save timestamp. */
 		archive_strcat(&as, " -N");
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, gzip->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -468,26 +468,26 @@ static int
 archive_compressor_gzip_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, gzip->pdata, buff, length);
 }
 
 static int
 archive_compressor_gzip_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct gzip *gzip = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, gzip->pdata);
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct gzip *gzip)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data->original_filename);
-		free(data);
+	if (gzip != NULL) {
+		__archive_write_program_free(gzip->pdata);
+		free(gzip->original_filename);
+		free(gzip);
 	}
 }
 #endif /* HAVE_ZLIB_H */

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -39,7 +39,7 @@
 #include "archive_string.h"
 #include "archive_write_private.h"
 
-struct write_lrzip {
+struct lrzip {
 	struct archive_write_program_data *pdata;
 	int	compression_level;
 	enum { lzma = 0, bzip2, gzip, lzo, none, zpaq } compression;
@@ -52,22 +52,22 @@ static int archive_write_lrzip_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_lrzip_close(struct archive_write_filter *);
 static int archive_write_lrzip_free(struct archive_write_filter *);
-static void free_data(struct write_lrzip *);
+static void free_data(struct lrzip *);
 
 int
 archive_write_add_filter_lrzip(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct write_lrzip *data;
+	struct lrzip *lrzip;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lrzip");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	lrzip = calloc(1, sizeof(*lrzip));
+	if (lrzip == NULL)
 		goto memerr;
-	data->pdata = __archive_write_program_allocate("lrzip");
-	if (data->pdata == NULL)
+	lrzip->pdata = __archive_write_program_allocate("lrzip");
+	if (lrzip->pdata == NULL)
 		goto memerr;
 
 	f = __archive_write_allocate_filter(a);
@@ -75,7 +75,7 @@ archive_write_add_filter_lrzip(struct archive *a)
 		goto memerr;
 	f->name = "lrzip";
 	f->code = ARCHIVE_FILTER_LRZIP;
-	f->data = data;
+	f->data = lrzip;
 	f->options = archive_write_lrzip_options;
 	f->open = archive_write_lrzip_open;
 	f->write = archive_write_lrzip_write;
@@ -88,7 +88,7 @@ archive_write_add_filter_lrzip(struct archive *a)
 	    "Using external lrzip program for lrzip compression");
 	return (ARCHIVE_WARN);
 memerr:
-	free_data(data);
+	free_data(lrzip);
 	archive_set_error(a, ENOMEM, "Can't allocate memory");
 	return (ARCHIVE_FATAL);
 }
@@ -97,7 +97,7 @@ static int
 archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct write_lrzip *data = f->data;
+	struct lrzip *lrzip = f->data;
 
 	if (strcmp(key, "compression") == 0) {
 		if (value == NULL) {
@@ -106,15 +106,15 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 			return (ARCHIVE_FAILED);
 		}
 		else if (strcmp(value, "bzip2") == 0)
-			data->compression = bzip2;
+			lrzip->compression = bzip2;
 		else if (strcmp(value, "gzip") == 0)
-			data->compression = gzip;
+			lrzip->compression = gzip;
 		else if (strcmp(value, "lzo") == 0)
-			data->compression = lzo;
+			lrzip->compression = lzo;
 		else if (strcmp(value, "none") == 0)
-			data->compression = none;
+			lrzip->compression = none;
 		else if (strcmp(value, "zpaq") == 0)
-			data->compression = zpaq;
+			lrzip->compression = zpaq;
 		else {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "compression invalid");
@@ -128,7 +128,7 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 			    "compression-level invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = value[0] - '0';
+		lrzip->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}
 	/* Note: The "warn" return is just to inform the options
@@ -140,7 +140,7 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_lrzip_open(struct archive_write_filter *f)
 {
-	struct write_lrzip *data = f->data;
+	struct lrzip *lrzip = f->data;
 	struct archive_string as;
 	int r;
 
@@ -148,7 +148,7 @@ archive_write_lrzip_open(struct archive_write_filter *f)
 	archive_strcpy(&as, "lrzip -q");
 
 	/* Specify compression type. */
-	switch (data->compression) {
+	switch (lrzip->compression) {
 	case lzma:/* default compression */
 		break;
 	case bzip2:
@@ -169,12 +169,12 @@ archive_write_lrzip_open(struct archive_write_filter *f)
 	}
 
 	/* Specify compression level. */
-	if (data->compression_level > 0) {
+	if (lrzip->compression_level > 0) {
 		archive_strcat(&as, " -L ");
-		archive_strappend_char(&as, '0' + data->compression_level);
+		archive_strappend_char(&as, '0' + lrzip->compression_level);
 	}
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, lrzip->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -183,17 +183,17 @@ static int
 archive_write_lrzip_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lrzip *data = f->data;
+	struct lrzip *lrzip = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, lrzip->pdata, buff, length);
 }
 
 static int
 archive_write_lrzip_close(struct archive_write_filter *f)
 {
-	struct write_lrzip *data = f->data;
+	struct lrzip *lrzip = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, lrzip->pdata);
 }
 
 static int
@@ -205,10 +205,10 @@ archive_write_lrzip_free(struct archive_write_filter *f)
 }
 
 static void
-free_data(struct write_lrzip *data)
+free_data(struct lrzip *lrzip)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (lrzip != NULL) {
+		__archive_write_program_free(lrzip->pdata);
+		free(lrzip);
 	}
 }

--- a/libarchive/archive_write_add_filter_lrzip.c
+++ b/libarchive/archive_write_add_filter_lrzip.c
@@ -97,7 +97,7 @@ static int
 archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct write_lrzip *data = (struct write_lrzip *)f->data;
+	struct write_lrzip *data = f->data;
 
 	if (strcmp(key, "compression") == 0) {
 		if (value == NULL) {
@@ -140,7 +140,7 @@ archive_write_lrzip_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_lrzip_open(struct archive_write_filter *f)
 {
-	struct write_lrzip *data = (struct write_lrzip *)f->data;
+	struct write_lrzip *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -183,7 +183,7 @@ static int
 archive_write_lrzip_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lrzip *data = (struct write_lrzip *)f->data;
+	struct write_lrzip *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -191,7 +191,7 @@ archive_write_lrzip_write(struct archive_write_filter *f,
 static int
 archive_write_lrzip_close(struct archive_write_filter *f)
 {
-	struct write_lrzip *data = (struct write_lrzip *)f->data;
+	struct write_lrzip *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -50,7 +50,7 @@
 
 #define LZ4_MAGICNUMBER	0x184d2204
 
-struct private_data {
+struct lz4 {
 	int		 compression_level;
 	unsigned	 header_written:1;
 	unsigned	 version_number:1;
@@ -85,7 +85,7 @@ static int archive_filter_lz4_options(struct archive_write_filter *,
 		    const char *, const char *);
 static int archive_filter_lz4_write(struct archive_write_filter *,
 		    const void *, size_t);
-static void free_data(struct private_data *);
+static void free_data(struct lz4 *);
 
 /*
  * Add an lz4 compression filter to this write handle.
@@ -94,27 +94,27 @@ int
 archive_write_add_filter_lz4(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_data *data;
+	struct lz4 *lz4;
 	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lz4");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	lz4 = calloc(1, sizeof(*lz4));
+	if (lz4 == NULL)
 		goto memerr;
 	/*
 	 * Setup default settings.
 	 */
-	data->version_number = 0x01;
-	data->block_independence = 1;
-	data->block_checksum = 0;
-	data->stream_size = 0;
-	data->stream_checksum = 1;
-	data->preset_dictionary = 0;
-	data->block_maximum_size = 7;
+	lz4->version_number = 0x01;
+	lz4->block_independence = 1;
+	lz4->block_checksum = 0;
+	lz4->stream_size = 0;
+	lz4->stream_checksum = 1;
+	lz4->preset_dictionary = 0;
+	lz4->block_maximum_size = 7;
 #if defined(HAVE_LIBLZ4) && LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 2
-	data->compression_level = 1;
+	lz4->compression_level = 1;
 
 	r = ARCHIVE_OK;
 #else
@@ -122,10 +122,10 @@ archive_write_add_filter_lz4(struct archive *a)
 	 * We don't have lz4 library, and execute external lz4 program
 	 * instead.
 	 */
-	data->pdata = __archive_write_program_allocate("lz4");
-	if (data->pdata == NULL)
+	lz4->pdata = __archive_write_program_allocate("lz4");
+	if (lz4->pdata == NULL)
 		goto memerr;
-	data->compression_level = 0;
+	lz4->compression_level = 0;
 
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
 	    "Using external lz4 program");
@@ -140,7 +140,7 @@ archive_write_add_filter_lz4(struct archive *a)
 		goto memerr;
 	f->name = "lz4";
 	f->code = ARCHIVE_FILTER_LZ4;
-	f->data = data;
+	f->data = lz4;
 	f->options = archive_filter_lz4_options;
 	f->open = archive_filter_lz4_open;
 	f->write = archive_filter_lz4_write;
@@ -149,7 +149,7 @@ archive_write_add_filter_lz4(struct archive *a)
 
 	return (r);
 memerr:
-	free_data(data);
+	free_data(lz4);
 	archive_set_error(a, ENOMEM, "Out of memory");
 	return (ARCHIVE_FATAL);
 }
@@ -169,7 +169,7 @@ static int
 archive_filter_lz4_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		int val;
@@ -188,15 +188,15 @@ archive_filter_lz4_options(struct archive_write_filter *f,
 			return (ARCHIVE_FATAL);
 		}
 #endif
-		data->compression_level = val;
+		lz4->compression_level = val;
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "stream-checksum") == 0) {
-		data->stream_checksum = value != NULL;
+		lz4->stream_checksum = value != NULL;
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "block-checksum") == 0) {
-		data->block_checksum = value != NULL;
+		lz4->block_checksum = value != NULL;
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "block-size") == 0) {
@@ -206,11 +206,11 @@ archive_filter_lz4_options(struct archive_write_filter *f,
 			    "block-size invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->block_maximum_size = value[0] - '0';
+		lz4->block_maximum_size = value[0] - '0';
 		return (ARCHIVE_OK);
 	}
 	if (strcmp(key, "block-dependence") == 0) {
-		data->block_independence = value == NULL;
+		lz4->block_independence = value == NULL;
 		return (ARCHIVE_OK);
 	}
 
@@ -240,21 +240,21 @@ static ssize_t lz4_write_one_block(struct archive_write_filter *, const char *,
 static int
 archive_filter_lz4_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	size_t required_size;
 	static const size_t bkmap[] = { 64 * 1024, 256 * 1024, 1 * 1024 * 1024,
 			   4 * 1024 * 1024 };
 	size_t pre_block_size;
 
-	if (data->block_maximum_size < 4)
-		data->block_size = bkmap[0];
+	if (lz4->block_maximum_size < 4)
+		lz4->block_size = bkmap[0];
 	else
-		data->block_size = bkmap[data->block_maximum_size - 4];
+		lz4->block_size = bkmap[lz4->block_maximum_size - 4];
 
-	required_size = 4 + 15 + 4 + data->block_size + 4 + 4;
-	if (data->out_buffer_size < required_size) {
+	required_size = 4 + 15 + 4 + lz4->block_size + 4 + 4;
+	if (lz4->out_buffer_size < required_size) {
 		size_t bs = required_size, bpb;
-		free(data->out_buffer);
+		free(lz4->out_buffer);
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
 			 * the bytes per block for performance. */
@@ -266,27 +266,27 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 				bs -= bs % bpb;
 			}
 		}
-		data->out_block_size = bs;
+		lz4->out_block_size = bs;
 		bs += required_size;
-		data->out_buffer = malloc(bs);
-		data->out = data->out_buffer;
-		data->out_buffer_size = bs;
+		lz4->out_buffer = malloc(bs);
+		lz4->out = lz4->out_buffer;
+		lz4->out_buffer_size = bs;
 	}
 
-	pre_block_size = (data->block_independence)? 0: 64 * 1024;
-	if (data->in_buffer_size < data->block_size + pre_block_size) {
-		free(data->in_buffer_allocated);
-		data->in_buffer_size = data->block_size;
-		data->in_buffer_allocated =
-		    malloc(data->in_buffer_size + pre_block_size);
-		data->in_buffer = data->in_buffer_allocated + pre_block_size;
-		if (!data->block_independence && data->compression_level >= 3)
-		    data->in_buffer = data->in_buffer_allocated;
-		data->in = data->in_buffer;
-		data->in_buffer_size = data->block_size;
+	pre_block_size = (lz4->block_independence)? 0: 64 * 1024;
+	if (lz4->in_buffer_size < lz4->block_size + pre_block_size) {
+		free(lz4->in_buffer_allocated);
+		lz4->in_buffer_size = lz4->block_size;
+		lz4->in_buffer_allocated =
+		    malloc(lz4->in_buffer_size + pre_block_size);
+		lz4->in_buffer = lz4->in_buffer_allocated + pre_block_size;
+		if (!lz4->block_independence && lz4->compression_level >= 3)
+		    lz4->in_buffer = lz4->in_buffer_allocated;
+		lz4->in = lz4->in_buffer;
+		lz4->in_buffer_size = lz4->block_size;
 	}
 
-	if (data->out_buffer == NULL || data->in_buffer_allocated == NULL) {
+	if (lz4->out_buffer == NULL || lz4->in_buffer_allocated == NULL) {
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for compression buffer");
 		return (ARCHIVE_FATAL);
@@ -304,18 +304,18 @@ static int
 archive_filter_lz4_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	int ret = ARCHIVE_OK;
 	const char *p;
 	size_t remaining;
 	ssize_t size;
 
 	/* If we haven't written a stream descriptor, we have to do it first. */
-	if (!data->header_written) {
+	if (!lz4->header_written) {
 		ret = lz4_write_stream_descriptor(f);
 		if (ret != ARCHIVE_OK)
 			return (ret);
-		data->header_written = 1;
+		lz4->header_written = 1;
 	}
 
 	p = (const char *)buff;
@@ -326,14 +326,14 @@ archive_filter_lz4_write(struct archive_write_filter *f,
 		size = lz4_write_one_block(f, p, remaining);
 		if (size < ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
-		l = data->out - data->out_buffer;
-		if (l >= data->out_block_size) {
+		l = lz4->out - lz4->out_buffer;
+		if (l >= lz4->out_block_size) {
 			ret = __archive_write_filter(f->next_filter,
-			    data->out_buffer, data->out_block_size);
-			l -= data->out_block_size;
-			memcpy(data->out_buffer,
-			    data->out_buffer + data->out_block_size, l);
-			data->out = data->out_buffer + l;
+			    lz4->out_buffer, lz4->out_block_size);
+			l -= lz4->out_block_size;
+			memcpy(lz4->out_buffer,
+			    lz4->out_buffer + lz4->out_block_size, l);
+			lz4->out = lz4->out_buffer + l;
 			if (ret < ARCHIVE_WARN)
 				break;
 		}
@@ -350,7 +350,7 @@ archive_filter_lz4_write(struct archive_write_filter *f,
 static int
 archive_filter_lz4_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	int ret;
 
 	/* Finish compression cycle. */
@@ -361,18 +361,18 @@ archive_filter_lz4_close(struct archive_write_filter *f)
 		 */
 
 		/* Write End Of Stream. */
-		memset(data->out, 0, 4); data->out += 4;
+		memset(lz4->out, 0, 4); lz4->out += 4;
 		/* Write Stream checksum if needed. */
-		if (data->stream_checksum) {
+		if (lz4->stream_checksum) {
 			unsigned int checksum;
 			checksum = __archive_xxhash.XXH32_digest(
-					data->xxh32_state);
-			data->xxh32_state = NULL;
-			archive_le32enc(data->out, checksum);
-			data->out += 4;
+					lz4->xxh32_state);
+			lz4->xxh32_state = NULL;
+			archive_le32enc(lz4->out, checksum);
+			lz4->out += 4;
 		}
 		ret = __archive_write_filter(f->next_filter,
-			    data->out_buffer, data->out - data->out_buffer);
+			    lz4->out_buffer, lz4->out - lz4->out_buffer);
 	}
 	return ret;
 }
@@ -380,29 +380,29 @@ archive_filter_lz4_close(struct archive_write_filter *f)
 static int
 lz4_write_stream_descriptor(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	uint8_t *sd;
 
-	sd = (uint8_t *)data->out;
+	sd = (uint8_t *)lz4->out;
 	/* Write Magic Number. */
 	archive_le32enc(&sd[0], LZ4_MAGICNUMBER);
 	/* FLG */
-	sd[4] = (data->version_number << 6)
-	      | (data->block_independence << 5)
-	      | (data->block_checksum << 4)
-	      | (data->stream_size << 3)
-	      | (data->stream_checksum << 2)
-	      | (data->preset_dictionary << 0);
+	sd[4] = (lz4->version_number << 6)
+	      | (lz4->block_independence << 5)
+	      | (lz4->block_checksum << 4)
+	      | (lz4->stream_size << 3)
+	      | (lz4->stream_checksum << 2)
+	      | (lz4->preset_dictionary << 0);
 	/* BD */
-	sd[5] = (data->block_maximum_size << 4);
+	sd[5] = (lz4->block_maximum_size << 4);
 	sd[6] = (__archive_xxhash.XXH32(&sd[4], 2, 0) >> 8) & 0xff;
-	data->out += 7;
-	if (data->stream_checksum) {
-		data->xxh32_state = __archive_xxhash.XXH32_init(0);
-		if (data->xxh32_state == NULL)
+	lz4->out += 7;
+	if (lz4->stream_checksum) {
+		lz4->xxh32_state = __archive_xxhash.XXH32_init(0);
+		if (lz4->xxh32_state == NULL)
 			return (ARCHIVE_FATAL);
 	} else
-		data->xxh32_state = NULL;
+		lz4->xxh32_state = NULL;
 	return (ARCHIVE_OK);
 }
 
@@ -410,36 +410,36 @@ static ssize_t
 lz4_write_one_block(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	ssize_t r;
 
 	if (p == NULL) {
 		/* Compress remaining uncompressed data. */
-		if (data->in_buffer == data->in)
+		if (lz4->in_buffer == lz4->in)
 			return 0;
 		else {
-			size_t l = data->in - data->in_buffer;
-			r = drive_compressor(f, data->in_buffer, l);
+			size_t l = lz4->in - lz4->in_buffer;
+			r = drive_compressor(f, lz4->in_buffer, l);
 			if (r == ARCHIVE_OK)
 				r = (ssize_t)l;
 		}
-	} else if ((data->block_independence || data->compression_level < 3) &&
-	    data->in_buffer == data->in && length >= data->block_size) {
-		r = drive_compressor(f, p, data->block_size);
+	} else if ((lz4->block_independence || lz4->compression_level < 3) &&
+	    lz4->in_buffer == lz4->in && length >= lz4->block_size) {
+		r = drive_compressor(f, p, lz4->block_size);
 		if (r == ARCHIVE_OK)
-			r = (ssize_t)data->block_size;
+			r = (ssize_t)lz4->block_size;
 	} else {
-		size_t remaining_size = data->in_buffer_size -
-			(data->in - data->in_buffer);
+		size_t remaining_size = lz4->in_buffer_size -
+			(lz4->in - lz4->in_buffer);
 		size_t l = (remaining_size > length)? length: remaining_size;
-		memcpy(data->in, p, l);
-		data->in += l;
+		memcpy(lz4->in, p, l);
+		lz4->in += l;
 		if (l == remaining_size) {
-			r = drive_compressor(f, data->in_buffer,
-			    data->block_size);
+			r = drive_compressor(f, lz4->in_buffer,
+			    lz4->block_size);
 			if (r == ARCHIVE_OK)
 				r = (ssize_t)l;
-			data->in = data->in_buffer;
+			lz4->in = lz4->in_buffer;
 		} else
 			r = (ssize_t)l;
 	}
@@ -458,12 +458,12 @@ lz4_write_one_block(struct archive_write_filter *f, const char *p,
 static int
 drive_compressor(struct archive_write_filter *f, const char *p, size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 
-	if (data->stream_checksum)
-		__archive_xxhash.XXH32_update(data->xxh32_state,
+	if (lz4->stream_checksum)
+		__archive_xxhash.XXH32_update(lz4->xxh32_state,
 			p, (int)length);
-	if (data->block_independence)
+	if (lz4->block_independence)
 		return drive_compressor_independence(f, p, length);
 	else
 		return drive_compressor_dependence(f, p, length);
@@ -473,48 +473,48 @@ static int
 drive_compressor_independence(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	unsigned int outsize;
 
 #ifdef HAVE_LZ4HC_H
-	if (data->compression_level >= 3)
+	if (lz4->compression_level >= 3)
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-		outsize = LZ4_compress_HC(p, data->out + 4,
-		     (int)length, (int)data->block_size,
-		    data->compression_level);
+		outsize = LZ4_compress_HC(p, lz4->out + 4,
+		     (int)length, (int)lz4->block_size,
+		    lz4->compression_level);
 #else
-		outsize = LZ4_compressHC2_limitedOutput(p, data->out + 4,
-		    (int)length, (int)data->block_size,
-		    data->compression_level);
+		outsize = LZ4_compressHC2_limitedOutput(p, lz4->out + 4,
+		    (int)length, (int)lz4->block_size,
+		    lz4->compression_level);
 #endif
 	else
 #endif
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-		outsize = LZ4_compress_default(p, data->out + 4,
-		    (int)length, (int)data->block_size);
+		outsize = LZ4_compress_default(p, lz4->out + 4,
+		    (int)length, (int)lz4->block_size);
 #else
-		outsize = LZ4_compress_limitedOutput(p, data->out + 4,
-		    (int)length, (int)data->block_size);
+		outsize = LZ4_compress_limitedOutput(p, lz4->out + 4,
+		    (int)length, (int)lz4->block_size);
 #endif
 
 	if (outsize) {
 		/* The buffer is compressed. */
-		archive_le32enc(data->out, outsize);
-		data->out += 4;
+		archive_le32enc(lz4->out, outsize);
+		lz4->out += 4;
 	} else {
 		/* The buffer is not compressed. The compressed size was
 		 * bigger than its uncompressed size. */
-		archive_le32enc(data->out, (uint32_t)(length | 0x80000000));
-		data->out += 4;
-		memcpy(data->out, p, length);
+		archive_le32enc(lz4->out, (uint32_t)(length | 0x80000000));
+		lz4->out += 4;
+		memcpy(lz4->out, p, length);
 		outsize = (uint32_t)length;
 	}
-	data->out += outsize;
-	if (data->block_checksum) {
+	lz4->out += outsize;
+	if (lz4->block_checksum) {
 		unsigned int checksum =
-		    __archive_xxhash.XXH32(data->out - outsize, outsize, 0);
-		archive_le32enc(data->out, checksum);
-		data->out += 4;
+		    __archive_xxhash.XXH32(lz4->out - outsize, outsize, 0);
+		archive_le32enc(lz4->out, checksum);
+		lz4->out += 4;
 	}
 	return (ARCHIVE_OK);
 }
@@ -523,21 +523,21 @@ static int
 drive_compressor_dependence(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	int outsize;
 
 #define DICT_SIZE	(64 * 1024)
 #ifdef HAVE_LZ4HC_H
-	if (data->compression_level >= 3) {
-		if (data->lz4_stream == NULL) {
+	if (lz4->compression_level >= 3) {
+		if (lz4->lz4_stream == NULL) {
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-			data->lz4_stream = LZ4_createStreamHC();
-			LZ4_resetStreamHC(data->lz4_stream, data->compression_level);
+			lz4->lz4_stream = LZ4_createStreamHC();
+			LZ4_resetStreamHC(lz4->lz4_stream, lz4->compression_level);
 #else
-			data->lz4_stream =
-			    LZ4_createHC(data->in_buffer_allocated);
+			lz4->lz4_stream =
+			    LZ4_createHC(lz4->in_buffer_allocated);
 #endif
-			if (data->lz4_stream == NULL) {
+			if (lz4->lz4_stream == NULL) {
 				archive_set_error(f->archive, ENOMEM,
 				    "Can't allocate data for compression"
 				    " buffer");
@@ -545,23 +545,23 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 			}
 		}
 		else
-			LZ4_loadDictHC(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
+			LZ4_loadDictHC(lz4->lz4_stream, lz4->in_buffer_allocated, DICT_SIZE);
 
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		outsize = LZ4_compress_HC_continue(
-		    data->lz4_stream, p, data->out + 4, (int)length,
-		    (int)data->block_size);
+		    lz4->lz4_stream, p, lz4->out + 4, (int)length,
+		    (int)lz4->block_size);
 #else
 		outsize = LZ4_compressHC2_limitedOutput_continue(
-		    data->lz4_stream, p, data->out + 4, (int)length,
-		    (int)data->block_size, data->compression_level);
+		    lz4->lz4_stream, p, lz4->out + 4, (int)length,
+		    (int)lz4->block_size, lz4->compression_level);
 #endif
 	} else
 #endif
 	{
-		if (data->lz4_stream == NULL) {
-			data->lz4_stream = LZ4_createStream();
-			if (data->lz4_stream == NULL) {
+		if (lz4->lz4_stream == NULL) {
+			lz4->lz4_stream = LZ4_createStream();
+			if (lz4->lz4_stream == NULL) {
 				archive_set_error(f->archive, ENOMEM,
 				    "Can't allocate data for compression"
 				    " buffer");
@@ -569,82 +569,82 @@ drive_compressor_dependence(struct archive_write_filter *f, const char *p,
 			}
 		}
 		else
-			LZ4_loadDict(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
+			LZ4_loadDict(lz4->lz4_stream, lz4->in_buffer_allocated, DICT_SIZE);
 
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
 		outsize = LZ4_compress_fast_continue(
-		    data->lz4_stream, p, data->out + 4, (int)length,
-		    (int)data->block_size, 1);
+		    lz4->lz4_stream, p, lz4->out + 4, (int)length,
+		    (int)lz4->block_size, 1);
 #else
 		outsize = LZ4_compress_limitedOutput_continue(
-		    data->lz4_stream, p, data->out + 4, (int)length,
-		    (int)data->block_size);
+		    lz4->lz4_stream, p, lz4->out + 4, (int)length,
+		    (int)lz4->block_size);
 #endif
 	}
 
 	if (outsize) {
 		/* The buffer is compressed. */
-		archive_le32enc(data->out, outsize);
-		data->out += 4;
+		archive_le32enc(lz4->out, outsize);
+		lz4->out += 4;
 	} else {
 		/* The buffer is not compressed. The compressed size was
 		 * bigger than its uncompressed size. */
-		archive_le32enc(data->out, (uint32_t)(length | 0x80000000));
-		data->out += 4;
-		memcpy(data->out, p, length);
+		archive_le32enc(lz4->out, (uint32_t)(length | 0x80000000));
+		lz4->out += 4;
+		memcpy(lz4->out, p, length);
 		outsize = (uint32_t)length;
 	}
-	data->out += outsize;
-	if (data->block_checksum) {
+	lz4->out += outsize;
+	if (lz4->block_checksum) {
 		unsigned int checksum =
-		    __archive_xxhash.XXH32(data->out - outsize, outsize, 0);
-		archive_le32enc(data->out, checksum);
-		data->out += 4;
+		    __archive_xxhash.XXH32(lz4->out - outsize, outsize, 0);
+		archive_le32enc(lz4->out, checksum);
+		lz4->out += 4;
 	}
 
-	if (length == data->block_size) {
+	if (length == lz4->block_size) {
 #ifdef HAVE_LZ4HC_H
-		if (data->compression_level >= 3) {
+		if (lz4->compression_level >= 3) {
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-			LZ4_saveDictHC(data->lz4_stream, data->in_buffer_allocated, DICT_SIZE);
+			LZ4_saveDictHC(lz4->lz4_stream, lz4->in_buffer_allocated, DICT_SIZE);
 #else
-			LZ4_slideInputBufferHC(data->lz4_stream);
+			LZ4_slideInputBufferHC(lz4->lz4_stream);
 #endif
-			data->in_buffer = data->in_buffer_allocated + DICT_SIZE;
+			lz4->in_buffer = lz4->in_buffer_allocated + DICT_SIZE;
 		}
 		else
 #endif
-			LZ4_saveDict(data->lz4_stream,
-			    data->in_buffer_allocated, DICT_SIZE);
+			LZ4_saveDict(lz4->lz4_stream,
+			    lz4->in_buffer_allocated, DICT_SIZE);
 #undef DICT_SIZE
 	}
 	return (ARCHIVE_OK);
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct lz4 *lz4)
 {
-	if (data != NULL) {
-		if (data->lz4_stream != NULL) {
+	if (lz4 != NULL) {
+		if (lz4->lz4_stream != NULL) {
 #ifdef HAVE_LZ4HC_H
-			if (data->compression_level >= 3)
+			if (lz4->compression_level >= 3)
 #if LZ4_VERSION_MAJOR >= 1 && LZ4_VERSION_MINOR >= 7
-				LZ4_freeStreamHC(data->lz4_stream);
+				LZ4_freeStreamHC(lz4->lz4_stream);
 #else
-				LZ4_freeHC(data->lz4_stream);
+				LZ4_freeHC(lz4->lz4_stream);
 #endif
 			else
 #endif
 #if LZ4_VERSION_MINOR >= 3
-				LZ4_freeStream(data->lz4_stream);
+				LZ4_freeStream(lz4->lz4_stream);
 #else
-				LZ4_free(data->lz4_stream);
+				LZ4_free(lz4->lz4_stream);
 #endif
 		}
-		free(data->out_buffer);
-		free(data->in_buffer_allocated);
-		free(data->xxh32_state);
-		free(data);
+		free(lz4->out_buffer);
+		free(lz4->in_buffer_allocated);
+		free(lz4->xxh32_state);
+		free(lz4);
 	}
 }
 
@@ -653,7 +653,7 @@ free_data(struct private_data *data)
 static int
 archive_filter_lz4_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 	struct archive_string as;
 	int r;
 
@@ -661,22 +661,22 @@ archive_filter_lz4_open(struct archive_write_filter *f)
 	archive_strcpy(&as, "lz4 -z -q -q");
 
 	/* Specify a compression level. */
-	if (data->compression_level > 0) {
+	if (lz4->compression_level > 0) {
 		archive_strcat(&as, " -");
-		archive_strappend_char(&as, '0' + data->compression_level);
+		archive_strappend_char(&as, '0' + lz4->compression_level);
 	}
 	/* Specify a block size. */
 	archive_strcat(&as, " -B");
-	archive_strappend_char(&as, '0' + data->block_maximum_size);
+	archive_strappend_char(&as, '0' + lz4->block_maximum_size);
 
-	if (data->block_checksum)
+	if (lz4->block_checksum)
 		archive_strcat(&as, " -BX");
-	if (data->stream_checksum == 0)
+	if (lz4->stream_checksum == 0)
 		archive_strcat(&as, " --no-frame-crc");
-	if (data->block_independence == 0)
+	if (lz4->block_independence == 0)
 		archive_strcat(&as, " -BD");
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, lz4->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -685,25 +685,25 @@ static int
 archive_filter_lz4_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, lz4->pdata, buff, length);
 }
 
 static int
 archive_filter_lz4_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct lz4 *lz4 = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, lz4->pdata);
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct lz4 *lz4)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (lz4 != NULL) {
+		__archive_write_program_free(lz4->pdata);
+		free(lz4);
 	}
 }
 

--- a/libarchive/archive_write_add_filter_lz4.c
+++ b/libarchive/archive_write_add_filter_lz4.c
@@ -169,7 +169,7 @@ static int
 archive_filter_lz4_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		int val;
@@ -240,7 +240,7 @@ static ssize_t lz4_write_one_block(struct archive_write_filter *, const char *,
 static int
 archive_filter_lz4_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	size_t required_size;
 	static const size_t bkmap[] = { 64 * 1024, 256 * 1024, 1 * 1024 * 1024,
 			   4 * 1024 * 1024 };
@@ -304,7 +304,7 @@ static int
 archive_filter_lz4_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret = ARCHIVE_OK;
 	const char *p;
 	size_t remaining;
@@ -350,7 +350,7 @@ archive_filter_lz4_write(struct archive_write_filter *f,
 static int
 archive_filter_lz4_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	/* Finish compression cycle. */
@@ -380,7 +380,7 @@ archive_filter_lz4_close(struct archive_write_filter *f)
 static int
 lz4_write_stream_descriptor(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	uint8_t *sd;
 
 	sd = (uint8_t *)data->out;
@@ -410,7 +410,7 @@ static ssize_t
 lz4_write_one_block(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	ssize_t r;
 
 	if (p == NULL) {
@@ -458,7 +458,7 @@ lz4_write_one_block(struct archive_write_filter *f, const char *p,
 static int
 drive_compressor(struct archive_write_filter *f, const char *p, size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (data->stream_checksum)
 		__archive_xxhash.XXH32_update(data->xxh32_state,
@@ -473,7 +473,7 @@ static int
 drive_compressor_independence(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	unsigned int outsize;
 
 #ifdef HAVE_LZ4HC_H
@@ -523,7 +523,7 @@ static int
 drive_compressor_dependence(struct archive_write_filter *f, const char *p,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int outsize;
 
 #define DICT_SIZE	(64 * 1024)
@@ -653,7 +653,7 @@ free_data(struct private_data *data)
 static int
 archive_filter_lz4_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -685,7 +685,7 @@ static int
 archive_filter_lz4_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -693,7 +693,7 @@ archive_filter_lz4_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_filter_lz4_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -207,7 +207,7 @@ static int
 archive_write_lzop_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '1' && value[0] <= '9') ||
@@ -229,7 +229,7 @@ archive_write_lzop_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_lzop_open(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 
 	switch (data->compression_level) {
 	case 1:
@@ -288,7 +288,7 @@ archive_write_lzop_open(struct archive_write_filter *f)
 static int
 make_header(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 	int64_t t;
 	uint32_t checksum;
 
@@ -317,7 +317,7 @@ make_header(struct archive_write_filter *f)
 static int
 drive_compressor(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 	unsigned char *p;
 	const int block_info_bytes = 12;
 	int header_bytes, r;
@@ -392,7 +392,7 @@ static int
 archive_write_lzop_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 	const char *p = buff;
 	int r;
 
@@ -424,7 +424,7 @@ archive_write_lzop_write(struct archive_write_filter *f,
 static int
 archive_write_lzop_close(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 	const uint32_t endmark = 0;
 	int r;
 
@@ -454,7 +454,7 @@ free_data(struct write_lzop *data)
 static int
 archive_write_lzop_open(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -476,7 +476,7 @@ static int
 archive_write_lzop_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -484,7 +484,7 @@ archive_write_lzop_write(struct archive_write_filter *f,
 static int
 archive_write_lzop_close(struct archive_write_filter *f)
 {
-	struct write_lzop *data = (struct write_lzop *)f->data;
+	struct write_lzop *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_lzop.c
+++ b/libarchive/archive_write_add_filter_lzop.c
@@ -55,7 +55,7 @@ enum lzo_method {
 	METHOD_LZO1X_1_15 = 2,
 	METHOD_LZO1X_999 = 3
 };
-struct write_lzop {
+struct lzop {
 	int compression_level;
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	unsigned char	*uncompressed;
@@ -80,7 +80,7 @@ static int archive_write_lzop_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_write_lzop_close(struct archive_write_filter *);
 static int archive_write_lzop_free(struct archive_write_filter *);
-static void free_data(struct write_lzop *);
+static void free_data(struct lzop *);
 
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 /* Maximum block size. */
@@ -137,37 +137,37 @@ int
 archive_write_add_filter_lzop(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct write_lzop *data;
+	struct lzop *lzop;
 	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_lzop");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	lzop = calloc(1, sizeof(*lzop));
+	if (lzop == NULL)
 		goto memerr;
 #if defined(HAVE_LZO_LZOCONF_H) && defined(HAVE_LZO_LZO1X_H)
 	if (lzo_init() != LZO_E_OK) {
-		free_data(data);
+		free_data(lzop);
 		archive_set_error(a, ARCHIVE_ERRNO_MISC,
 		    "lzo_init(type check) failed");
 		return (ARCHIVE_FATAL);
 	}
 	if (lzo_version() < 0x940) {
-		free_data(data);
+		free_data(lzop);
 		archive_set_error(a, ARCHIVE_ERRNO_MISC,
 		    "liblzo library is too old(%s < 0.940)",
 		    lzo_version_string());
 		return (ARCHIVE_FATAL);
 	}
-	data->compression_level = 5;
+	lzop->compression_level = 5;
 
 	r = ARCHIVE_OK;
 #else
-	data->pdata = __archive_write_program_allocate("lzop");
-	if (data->pdata == NULL)
+	lzop->pdata = __archive_write_program_allocate("lzop");
+	if (lzop->pdata == NULL)
 		goto memerr;
-	data->compression_level = 0;
+	lzop->compression_level = 0;
 
 	/* Note: We return "warn" to inform of using an external lzop
 	 * program. */
@@ -181,7 +181,7 @@ archive_write_add_filter_lzop(struct archive *a)
 		goto memerr;
 	f->name = "lzop";
 	f->code = ARCHIVE_FILTER_LZOP;
-	f->data = data;
+	f->data = lzop;
 	f->options = archive_write_lzop_options;
 	f->open = archive_write_lzop_open;
 	f->write = archive_write_lzop_write;
@@ -190,7 +190,7 @@ archive_write_add_filter_lzop(struct archive *a)
 
 	return (r);
 memerr:
-	free_data(data);
+	free_data(lzop);
 	archive_set_error(a, ENOMEM, "Can't allocate memory");
 	return (ARCHIVE_FATAL);
 }
@@ -207,7 +207,7 @@ static int
 archive_write_lzop_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '1' && value[0] <= '9') ||
@@ -216,7 +216,7 @@ archive_write_lzop_options(struct archive_write_filter *f, const char *key,
 			    "compression-level invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = value[0] - '0';
+		lzop->compression_level = value[0] - '0';
 		return (ARCHIVE_OK);
 	}
 	/* Note: The "warn" return is just to inform the options
@@ -229,58 +229,58 @@ archive_write_lzop_options(struct archive_write_filter *f, const char *key,
 static int
 archive_write_lzop_open(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 
-	switch (data->compression_level) {
+	switch (lzop->compression_level) {
 	case 1:
-		data->method = METHOD_LZO1X_1_15; data->level = 1; break;
+		lzop->method = METHOD_LZO1X_1_15; lzop->level = 1; break;
 	default:
 	case 2: case 3: case 4: case 5: case 6:
-		data->method = METHOD_LZO1X_1; data->level = 5; break;
+		lzop->method = METHOD_LZO1X_1; lzop->level = 5; break;
 	case 7:
-		data->method = METHOD_LZO1X_999; data->level = 7; break;
+		lzop->method = METHOD_LZO1X_999; lzop->level = 7; break;
 	case 8:
-		data->method = METHOD_LZO1X_999; data->level = 8; break;
+		lzop->method = METHOD_LZO1X_999; lzop->level = 8; break;
 	case 9:
-		data->method = METHOD_LZO1X_999; data->level = 9; break;
+		lzop->method = METHOD_LZO1X_999; lzop->level = 9; break;
 	}
-	switch (data->method) {
+	switch (lzop->method) {
 	case METHOD_LZO1X_1:
-		data->work_buffer_size = LZO1X_1_MEM_COMPRESS; break;
+		lzop->work_buffer_size = LZO1X_1_MEM_COMPRESS; break;
 	case METHOD_LZO1X_1_15:
-		data->work_buffer_size = LZO1X_1_15_MEM_COMPRESS; break;
+		lzop->work_buffer_size = LZO1X_1_15_MEM_COMPRESS; break;
 	case METHOD_LZO1X_999:
-		data->work_buffer_size = LZO1X_999_MEM_COMPRESS; break;
+		lzop->work_buffer_size = LZO1X_999_MEM_COMPRESS; break;
 	}
-	if (data->work_buffer == NULL) {
-		data->work_buffer = (lzo_voidp)malloc(data->work_buffer_size);
-		if (data->work_buffer == NULL) {
+	if (lzop->work_buffer == NULL) {
+		lzop->work_buffer = (lzo_voidp)malloc(lzop->work_buffer_size);
+		if (lzop->work_buffer == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
 	}
-	if (data->compressed == NULL) {
-		data->compressed_buffer_size = sizeof(header) +
+	if (lzop->compressed == NULL) {
+		lzop->compressed_buffer_size = sizeof(header) +
 		    BLOCK_SIZE + (BLOCK_SIZE >> 4) + 64 + 3;
-		data->compressed = (unsigned char *)
-		    malloc(data->compressed_buffer_size);
-		if (data->compressed == NULL) {
+		lzop->compressed = (unsigned char *)
+		    malloc(lzop->compressed_buffer_size);
+		if (lzop->compressed == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
 	}
-	if (data->uncompressed == NULL) {
-		data->uncompressed_buffer_size = BLOCK_SIZE;
-		data->uncompressed = (unsigned char *)
-		    malloc(data->uncompressed_buffer_size);
-		if (data->uncompressed == NULL) {
+	if (lzop->uncompressed == NULL) {
+		lzop->uncompressed_buffer_size = BLOCK_SIZE;
+		lzop->uncompressed = (unsigned char *)
+		    malloc(lzop->uncompressed_buffer_size);
+		if (lzop->uncompressed == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
-		data->uncompressed_avail_bytes = BLOCK_SIZE;
+		lzop->uncompressed_avail_bytes = BLOCK_SIZE;
 	}
 	return (ARCHIVE_OK);
 }
@@ -288,68 +288,68 @@ archive_write_lzop_open(struct archive_write_filter *f)
 static int
 make_header(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 	int64_t t;
 	uint32_t checksum;
 
-	memcpy(data->compressed, header, sizeof(header));
+	memcpy(lzop->compressed, header, sizeof(header));
 	/* Overwrite library version. */
-	data->compressed[HEADER_LIBVERSION] = (unsigned char )
+	lzop->compressed[HEADER_LIBVERSION] = (unsigned char )
 	    (lzo_version() >> 8) & 0xff;
-	data->compressed[HEADER_LIBVERSION + 1] = (unsigned char )
+	lzop->compressed[HEADER_LIBVERSION + 1] = (unsigned char )
 	    lzo_version() & 0xff;
 	/* Overwrite method and level. */
-	data->compressed[HEADER_METHOD] = (unsigned char)data->method;
-	data->compressed[HEADER_LEVEL] = data->level;
+	lzop->compressed[HEADER_METHOD] = (unsigned char)lzop->method;
+	lzop->compressed[HEADER_LEVEL] = lzop->level;
 	/* Overwrite mtime with current time. */
 	t = (int64_t)time(NULL);
-	archive_be32enc(&data->compressed[HEADER_MTIME_LOW],
+	archive_be32enc(&lzop->compressed[HEADER_MTIME_LOW],
 	    (uint32_t)(t & 0xffffffff));
-	archive_be32enc(&data->compressed[HEADER_MTIME_HIGH],
+	archive_be32enc(&lzop->compressed[HEADER_MTIME_HIGH],
 	    (uint32_t)((t >> 32) & 0xffffffff));
 	/* Overwrite header checksum with calculated value. */
-	checksum = lzo_adler32(1, data->compressed + HEADER_VERSION,
+	checksum = lzo_adler32(1, lzop->compressed + HEADER_VERSION,
 			(lzo_uint)(HEADER_H_CHECKSUM - HEADER_VERSION));
-	archive_be32enc(&data->compressed[HEADER_H_CHECKSUM], checksum);
+	archive_be32enc(&lzop->compressed[HEADER_H_CHECKSUM], checksum);
 	return (sizeof(header));
 }
 
 static int
 drive_compressor(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 	unsigned char *p;
 	const int block_info_bytes = 12;
 	int header_bytes, r;
 	lzo_uint usize, csize;
 	uint32_t checksum;
 
-	if (!data->header_written) {
+	if (!lzop->header_written) {
 		header_bytes = make_header(f);
-		data->header_written = 1;
+		lzop->header_written = 1;
 	} else
 		header_bytes = 0;
-	p = data->compressed;
+	p = lzop->compressed;
 
 	usize = (lzo_uint)
-	    (data->uncompressed_buffer_size - data->uncompressed_avail_bytes);
+	    (lzop->uncompressed_buffer_size - lzop->uncompressed_avail_bytes);
 	csize = 0;
-	switch (data->method) {
+	switch (lzop->method) {
 	default:
 	case METHOD_LZO1X_1:
-		r = lzo1x_1_compress(data->uncompressed, usize,
+		r = lzo1x_1_compress(lzop->uncompressed, usize,
 			p + header_bytes + block_info_bytes, &csize,
-			data->work_buffer);
+			lzop->work_buffer);
 		break;
 	case METHOD_LZO1X_1_15:
-		r = lzo1x_1_15_compress(data->uncompressed, usize,
+		r = lzo1x_1_15_compress(lzop->uncompressed, usize,
 			p + header_bytes + block_info_bytes, &csize,
-			data->work_buffer);
+			lzop->work_buffer);
 		break;
 	case METHOD_LZO1X_999:
-		r = lzo1x_999_compress_level(data->uncompressed, usize,
+		r = lzo1x_999_compress_level(lzop->uncompressed, usize,
 			p + header_bytes + block_info_bytes, &csize,
-			data->work_buffer, NULL, 0, 0, data->level);
+			lzop->work_buffer, NULL, 0, 0, lzop->level);
 		break;
 	}
 	if (r != LZO_E_OK) {
@@ -361,13 +361,13 @@ drive_compressor(struct archive_write_filter *f)
 	/* Store uncompressed size. */
 	archive_be32enc(p + header_bytes, (uint32_t)usize);
 	/* Store the checksum of the uncompressed data. */
-	checksum = lzo_adler32(1, data->uncompressed, usize);
+	checksum = lzo_adler32(1, lzop->uncompressed, usize);
 	archive_be32enc(p + header_bytes + 8, checksum);
 
 	if (csize < usize) {
 		/* Store compressed size. */
 		archive_be32enc(p + header_bytes + 4, (uint32_t)csize);
-		r = __archive_write_filter(f->next_filter, data->compressed,
+		r = __archive_write_filter(f->next_filter, lzop->compressed,
 			header_bytes + block_info_bytes + csize);
 	} else {
 		/*
@@ -375,11 +375,11 @@ drive_compressor(struct archive_write_filter *f)
 		 */
 		/* Store uncompressed size as compressed size. */
 		archive_be32enc(p + header_bytes + 4, (uint32_t)usize);
-		r = __archive_write_filter(f->next_filter, data->compressed,
+		r = __archive_write_filter(f->next_filter, lzop->compressed,
 			header_bytes + block_info_bytes);
 		if (r != ARCHIVE_OK)
 			return (ARCHIVE_FATAL);
-		r = __archive_write_filter(f->next_filter, data->uncompressed,
+		r = __archive_write_filter(f->next_filter, lzop->uncompressed,
 			usize);
 	}
 
@@ -392,30 +392,30 @@ static int
 archive_write_lzop_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 	const char *p = buff;
 	int r;
 
 	do {
-		if (data->uncompressed_avail_bytes > length) {
-			memcpy(data->uncompressed
-				+ data->uncompressed_buffer_size
-				- data->uncompressed_avail_bytes,
+		if (lzop->uncompressed_avail_bytes > length) {
+			memcpy(lzop->uncompressed
+				+ lzop->uncompressed_buffer_size
+				- lzop->uncompressed_avail_bytes,
 			    p, length);
-			data->uncompressed_avail_bytes -= length;
+			lzop->uncompressed_avail_bytes -= length;
 			return (ARCHIVE_OK);
 		}
 
-		memcpy(data->uncompressed + data->uncompressed_buffer_size
-			- data->uncompressed_avail_bytes,
-		    p, data->uncompressed_avail_bytes);
-		length -= data->uncompressed_avail_bytes;
-		p += data->uncompressed_avail_bytes;
-		data->uncompressed_avail_bytes = 0;
+		memcpy(lzop->uncompressed + lzop->uncompressed_buffer_size
+			- lzop->uncompressed_avail_bytes,
+		    p, lzop->uncompressed_avail_bytes);
+		length -= lzop->uncompressed_avail_bytes;
+		p += lzop->uncompressed_avail_bytes;
+		lzop->uncompressed_avail_bytes = 0;
 
 		r = drive_compressor(f);
 		if (r != ARCHIVE_OK) return (r);
-		data->uncompressed_avail_bytes = BLOCK_SIZE;
+		lzop->uncompressed_avail_bytes = BLOCK_SIZE;
 	} while (length);
 
 	return (ARCHIVE_OK);
@@ -424,11 +424,11 @@ archive_write_lzop_write(struct archive_write_filter *f,
 static int
 archive_write_lzop_close(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 	const uint32_t endmark = 0;
 	int r;
 
-	if (data->uncompressed_avail_bytes < BLOCK_SIZE) {
+	if (lzop->uncompressed_avail_bytes < BLOCK_SIZE) {
 		/* Compress and output remaining data. */
 		r = drive_compressor(f);
 		if (r != ARCHIVE_OK)
@@ -440,13 +440,13 @@ archive_write_lzop_close(struct archive_write_filter *f)
 }
 
 static void
-free_data(struct write_lzop *data)
+free_data(struct lzop *lzop)
 {
-	if (data != NULL) {
-		free(data->uncompressed);
-		free(data->compressed);
-		free(data->work_buffer);
-		free(data);
+	if (lzop != NULL) {
+		free(lzop->uncompressed);
+		free(lzop->compressed);
+		free(lzop->work_buffer);
+		free(lzop);
 	}
 }
 
@@ -454,20 +454,20 @@ free_data(struct write_lzop *data)
 static int
 archive_write_lzop_open(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 	struct archive_string as;
 	int r;
 
 	archive_string_init(&as);
 	archive_strcpy(&as, "lzop");
 	/* Specify compression level. */
-	if (data->compression_level > 0) {
+	if (lzop->compression_level > 0) {
 		archive_strappend_char(&as, ' ');
 		archive_strappend_char(&as, '-');
-		archive_strappend_char(&as, '0' + data->compression_level);
+		archive_strappend_char(&as, '0' + lzop->compression_level);
 	}
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, lzop->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -476,25 +476,25 @@ static int
 archive_write_lzop_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, lzop->pdata, buff, length);
 }
 
 static int
 archive_write_lzop_close(struct archive_write_filter *f)
 {
-	struct write_lzop *data = f->data;
+	struct lzop *lzop = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, lzop->pdata);
 }
 
 static void
-free_data(struct write_lzop *data)
+free_data(struct lzop *lzop)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (lzop != NULL) {
+		__archive_write_program_free(lzop->pdata);
+		free(lzop);
 	}
 }
 #endif

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -70,7 +70,7 @@ struct archive_write_program_data {
 	char		*program_name;
 };
 
-struct private_data {
+struct program {
 	struct archive_write_program_data *pdata;
 	struct archive_string description;
 	char		*cmd;
@@ -81,7 +81,7 @@ static int archive_compressor_program_write(struct archive_write_filter *,
 		    const void *, size_t);
 static int archive_compressor_program_close(struct archive_write_filter *);
 static int archive_compressor_program_free(struct archive_write_filter *);
-static void free_data(struct private_data *);
+static void free_data(struct program *);
 
 /*
  * Add a filter to this write handle that passes all data through an
@@ -91,34 +91,34 @@ int
 archive_write_add_filter_program(struct archive *a, const char *cmd)
 {
 	struct archive_write_filter *f;
-	struct private_data *data;
+	struct program *program;
 	static const char prefix[] = "Program: ";
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_program");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	program = calloc(1, sizeof(*program));
+	if (program == NULL)
 		goto memerr;
-	data->cmd = strdup(cmd);
-	if (data->cmd == NULL)
+	program->cmd = strdup(cmd);
+	if (program->cmd == NULL)
 		goto memerr;
-	data->pdata = __archive_write_program_allocate(cmd);
-	if (data->pdata == NULL)
+	program->pdata = __archive_write_program_allocate(cmd);
+	if (program->pdata == NULL)
 		goto memerr;
 	/* Make up a description string. */
-	if (archive_string_ensure(&data->description,
+	if (archive_string_ensure(&program->description,
 	    strlen(prefix) + strlen(cmd) + 1) == NULL)
 		goto memerr;
-	archive_strcpy(&data->description, prefix);
-	archive_strcat(&data->description, cmd);
+	archive_strcpy(&program->description, prefix);
+	archive_strcat(&program->description, cmd);
 
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
-	f->name = data->description.s;
+	f->name = program->description.s;
 	f->code = ARCHIVE_FILTER_PROGRAM;
-	f->data = data;
+	f->data = program;
 	f->open = archive_compressor_program_open;
 	f->write = archive_compressor_program_write;
 	f->close = archive_compressor_program_close;
@@ -126,7 +126,7 @@ archive_write_add_filter_program(struct archive *a, const char *cmd)
 
 	return (ARCHIVE_OK);
 memerr:
-	free_data(data);
+	free_data(program);
 	archive_set_error(a, ENOMEM,
 	    "Can't allocate memory for filter program");
 	return (ARCHIVE_FATAL);
@@ -135,26 +135,26 @@ memerr:
 static int
 archive_compressor_program_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct program *program = f->data;
 
-	return __archive_write_program_open(f, data->pdata, data->cmd);
+	return __archive_write_program_open(f, program->pdata, program->cmd);
 }
 
 static int
 archive_compressor_program_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = f->data;
+	struct program *program = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, program->pdata, buff, length);
 }
 
 static int
 archive_compressor_program_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct program *program = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, program->pdata);
 }
 
 static int
@@ -387,12 +387,12 @@ cleanup:
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct program *program)
 {
-	if (data) {
-		free(data->cmd);
-		archive_string_free(&data->description);
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (program) {
+		free(program->cmd);
+		archive_string_free(&program->description);
+		__archive_write_program_free(program->pdata);
+		free(program);
 	}
 }

--- a/libarchive/archive_write_add_filter_program.c
+++ b/libarchive/archive_write_add_filter_program.c
@@ -135,7 +135,7 @@ memerr:
 static int
 archive_compressor_program_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_open(f, data->pdata, data->cmd);
 }
@@ -144,7 +144,7 @@ static int
 archive_compressor_program_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -152,7 +152,7 @@ archive_compressor_program_write(struct archive_write_filter *f,
 static int
 archive_compressor_program_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -111,7 +111,7 @@ static int
 archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_uuencode *state = (struct private_uuencode *)f->data;
+	struct private_uuencode *state = f->data;
 
 	if (strcmp(key, "mode") == 0) {
 		int64_t val;
@@ -151,7 +151,7 @@ archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
 static int
 archive_filter_uuencode_open(struct archive_write_filter *f)
 {
-	struct private_uuencode *state = (struct private_uuencode *)f->data;
+	struct private_uuencode *state = f->data;
 	size_t bs = 65536, bpb;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
@@ -220,7 +220,7 @@ static int
 archive_filter_uuencode_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_uuencode *state = (struct private_uuencode *)f->data;
+	struct private_uuencode *state = f->data;
 	const unsigned char *p = buff;
 	int ret = ARCHIVE_OK;
 
@@ -265,7 +265,7 @@ archive_filter_uuencode_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_filter_uuencode_close(struct archive_write_filter *f)
 {
-	struct private_uuencode *state = (struct private_uuencode *)f->data;
+	struct private_uuencode *state = f->data;
 
 	/* Flush remaining bytes. */
 	if (state->hold_len != 0)

--- a/libarchive/archive_write_add_filter_uuencode.c
+++ b/libarchive/archive_write_add_filter_uuencode.c
@@ -46,7 +46,7 @@
 
 #define LBYTES 45
 
-struct private_uuencode {
+struct uuencode {
 	int			mode;
 	struct archive_string	name;
 	struct archive_string	encoded_buff;
@@ -64,7 +64,7 @@ static int archive_filter_uuencode_close(struct archive_write_filter *);
 static int archive_filter_uuencode_free(struct archive_write_filter *);
 static void uu_encode(struct archive_string *, const unsigned char *, size_t);
 static int64_t atol8(const char *, size_t);
-static void free_data(struct private_uuencode *);
+static void free_data(struct uuencode *);
 
 /*
  * Add a compress filter to this write handle.
@@ -73,23 +73,23 @@ int
 archive_write_add_filter_uuencode(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_uuencode *state;
+	struct uuencode *uuencode;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_uuencode");
 
-	state = calloc(1, sizeof(*state));
-	if (state == NULL)
+	uuencode = calloc(1, sizeof(*uuencode));
+	if (uuencode == NULL)
 		goto memerr;
-	archive_strcpy(&state->name, "-");
-	state->mode = 0644;
+	archive_strcpy(&uuencode->name, "-");
+	uuencode->mode = 0644;
 
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
 	f->name = "uuencode";
 	f->code = ARCHIVE_FILTER_UU;
-	f->data = state;
+	f->data = uuencode;
 	f->options = archive_filter_uuencode_options;
 	f->open = archive_filter_uuencode_open;
 	f->write = archive_filter_uuencode_write;
@@ -98,7 +98,7 @@ archive_write_add_filter_uuencode(struct archive *a)
 
 	return (ARCHIVE_OK);
 memerr:
-	free_data(state);
+	free_data(uuencode);
 	archive_set_error(a, ENOMEM,
 	    "Can't allocate data for uuencode filter");
 	return (ARCHIVE_FATAL);
@@ -111,7 +111,7 @@ static int
 archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_uuencode *state = f->data;
+	struct uuencode *uuencode = f->data;
 
 	if (strcmp(key, "mode") == 0) {
 		int64_t val;
@@ -127,7 +127,7 @@ archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
 			    "invalid mode option");
 			return (ARCHIVE_FAILED);
 		}
-		state->mode = (int)val & 0777;
+		uuencode->mode = (int)val & 0777;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "name") == 0) {
 		if (value == NULL) {
@@ -135,7 +135,7 @@ archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
 			    "name option requires a string");
 			return (ARCHIVE_FAILED);
 		}
-		archive_strcpy(&state->name, value);
+		archive_strcpy(&uuencode->name, value);
 		return (ARCHIVE_OK);
 	}
 
@@ -151,7 +151,7 @@ archive_filter_uuencode_options(struct archive_write_filter *f, const char *key,
 static int
 archive_filter_uuencode_open(struct archive_write_filter *f)
 {
-	struct private_uuencode *state = f->data;
+	struct uuencode *uuencode = f->data;
 	size_t bs = 65536, bpb;
 
 	if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
@@ -164,15 +164,15 @@ archive_filter_uuencode_open(struct archive_write_filter *f)
 			bs -= bs % bpb;
 	}
 
-	state->bs = bs;
-	if (archive_string_ensure(&state->encoded_buff, bs + 512) == NULL) {
+	uuencode->bs = bs;
+	if (archive_string_ensure(&uuencode->encoded_buff, bs + 512) == NULL) {
 		archive_set_error(f->archive, ENOMEM,
 		    "Can't allocate data for uuencode buffer");
 		return (ARCHIVE_FATAL);
 	}
 
-	archive_string_sprintf(&state->encoded_buff, "begin %o %s\n",
-	    (unsigned int)state->mode, state->name.s);
+	archive_string_sprintf(&uuencode->encoded_buff, "begin %o %s\n",
+	    (unsigned int)uuencode->mode, uuencode->name.s);
 
 	return (ARCHIVE_OK);
 }
@@ -220,39 +220,39 @@ static int
 archive_filter_uuencode_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_uuencode *state = f->data;
+	struct uuencode *uuencode = f->data;
 	const unsigned char *p = buff;
 	int ret = ARCHIVE_OK;
 
 	if (length == 0)
 		return (ret);
 
-	if (state->hold_len) {
-		while (state->hold_len < LBYTES && length > 0) {
-			state->hold[state->hold_len++] = *p++;
+	if (uuencode->hold_len) {
+		while (uuencode->hold_len < LBYTES && length > 0) {
+			uuencode->hold[uuencode->hold_len++] = *p++;
 			length--;
 		}
-		if (state->hold_len < LBYTES)
+		if (uuencode->hold_len < LBYTES)
 			return (ret);
-		uu_encode(&state->encoded_buff, state->hold, LBYTES);
-		state->hold_len = 0;
+		uu_encode(&uuencode->encoded_buff, uuencode->hold, LBYTES);
+		uuencode->hold_len = 0;
 	}
 
 	for (; length >= LBYTES; length -= LBYTES, p += LBYTES)
-		uu_encode(&state->encoded_buff, p, LBYTES);
+		uu_encode(&uuencode->encoded_buff, p, LBYTES);
 
 	/* Save remaining bytes. */
 	if (length > 0) {
-		memcpy(state->hold, p, length);
-		state->hold_len = length;
+		memcpy(uuencode->hold, p, length);
+		uuencode->hold_len = length;
 	}
-	while (archive_strlen(&state->encoded_buff) >= state->bs) {
+	while (archive_strlen(&uuencode->encoded_buff) >= uuencode->bs) {
 		ret = __archive_write_filter(f->next_filter,
-		    state->encoded_buff.s, state->bs);
-		memmove(state->encoded_buff.s,
-		    state->encoded_buff.s + state->bs,
-		    state->encoded_buff.length - state->bs);
-		state->encoded_buff.length -= state->bs;
+		    uuencode->encoded_buff.s, uuencode->bs);
+		memmove(uuencode->encoded_buff.s,
+		    uuencode->encoded_buff.s + uuencode->bs,
+		    uuencode->encoded_buff.length - uuencode->bs);
+		uuencode->encoded_buff.length -= uuencode->bs;
 	}
 
 	return (ret);
@@ -265,16 +265,17 @@ archive_filter_uuencode_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_filter_uuencode_close(struct archive_write_filter *f)
 {
-	struct private_uuencode *state = f->data;
+	struct uuencode *uuencode = f->data;
 
 	/* Flush remaining bytes. */
-	if (state->hold_len != 0)
-		uu_encode(&state->encoded_buff, state->hold, state->hold_len);
-	archive_string_sprintf(&state->encoded_buff, "`\nend\n");
+	if (uuencode->hold_len != 0)
+		uu_encode(&uuencode->encoded_buff, uuencode->hold,
+		    uuencode->hold_len);
+	archive_string_sprintf(&uuencode->encoded_buff, "`\nend\n");
 	/* Write the last block */
 	archive_write_set_bytes_in_last_block(f->archive, 1);
 	return __archive_write_filter(f->next_filter,
-	    state->encoded_buff.s, archive_strlen(&state->encoded_buff));
+	    uuencode->encoded_buff.s, archive_strlen(&uuencode->encoded_buff));
 }
 
 static int
@@ -309,11 +310,11 @@ atol8(const char *p, size_t char_cnt)
 }
 
 static void
-free_data(struct private_uuencode *data)
+free_data(struct uuencode *uuencode)
 {
-	if (data != NULL) {
-		archive_string_free(&data->name);
-		archive_string_free(&data->encoded_buff);
-		free(data);
+	if (uuencode != NULL) {
+		archive_string_free(&uuencode->name);
+		archive_string_free(&uuencode->encoded_buff);
+		free(uuencode);
 	}
 }

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -360,7 +360,7 @@ static int
 archive_compressor_xz_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -414,7 +414,7 @@ static int
 archive_compressor_xz_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	/* Update statistics */
@@ -438,7 +438,7 @@ archive_compressor_xz_write(struct archive_write_filter *f,
 static int
 archive_compressor_xz_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	int ret;
 
 	ret = drive_compressor(f, data, 1);

--- a/libarchive/archive_write_add_filter_xz.c
+++ b/libarchive/archive_write_add_filter_xz.c
@@ -99,7 +99,7 @@ archive_write_add_filter_lzip(struct archive *a)
 #else
 /* Don't compile this if we don't have liblzma. */
 
-struct private_data {
+struct xz {
 	int		 compression_level;
 	uint32_t	 threads;
 	lzma_stream	 stream;
@@ -121,8 +121,8 @@ static int	archive_compressor_xz_write(struct archive_write_filter *,
 static int	archive_compressor_xz_close(struct archive_write_filter *);
 static int	archive_compressor_xz_free(struct archive_write_filter *);
 static int	drive_compressor(struct archive_write_filter *,
-		    struct private_data *, int finishing);
-static void	free_data(struct private_data *);
+		    struct xz *, int finishing);
+static void	free_data(struct xz *);
 
 struct option_value {
 	uint32_t dict_size;
@@ -145,21 +145,21 @@ static const struct option_value option_values[] = {
 static int
 common_setup(struct archive *a, const char *name, int code)
 {
-	struct private_data *data;
+	struct xz *xz;
 	struct archive_write_filter *f;
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	xz = calloc(1, sizeof(*xz));
+	if (xz == NULL)
 		goto memerr;
-	data->compression_level = LZMA_PRESET_DEFAULT;
-	data->threads = 1;
+	xz->compression_level = LZMA_PRESET_DEFAULT;
+	xz->threads = 1;
 
 	f = __archive_write_allocate_filter(a);
 	if (f == NULL)
 		goto memerr;
 	f->name = name;
 	f->code = code;
-	f->data = data;
+	f->data = xz;
 	f->options = archive_compressor_xz_options;
 	f->open = archive_compressor_xz_open;
 	f->write = archive_compressor_xz_write;
@@ -168,7 +168,7 @@ common_setup(struct archive *a, const char *name, int code)
 
 	return (ARCHIVE_OK);
 memerr:
-	free_data(data);
+	free_data(xz);
 	archive_set_error(a, ENOMEM, "Out of memory");
 	return (ARCHIVE_FATAL);
 }
@@ -208,7 +208,7 @@ archive_write_add_filter_lzip(struct archive *a)
 
 static int
 archive_compressor_xz_init_stream(struct archive_write_filter *f,
-    struct private_data *data)
+    struct xz *xz)
 {
 	static const lzma_stream lzma_stream_init_data = LZMA_STREAM_INIT;
 	int ret;
@@ -216,27 +216,27 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 	lzma_mt mt_options;
 #endif
 
-	data->stream = lzma_stream_init_data;
-	data->stream.next_out = data->compressed;
-	data->stream.avail_out = data->compressed_buffer_size;
+	xz->stream = lzma_stream_init_data;
+	xz->stream.next_out = xz->compressed;
+	xz->stream.avail_out = xz->compressed_buffer_size;
 	if (f->code == ARCHIVE_FILTER_XZ) {
 #ifdef HAVE_LZMA_STREAM_ENCODER_MT
-		if (data->threads != 1) {
+		if (xz->threads != 1) {
 			memset(&mt_options, 0, sizeof(mt_options));
-			mt_options.threads = data->threads;
+			mt_options.threads = xz->threads;
 			mt_options.timeout = 300;
-			mt_options.filters = data->lzmafilters;
+			mt_options.filters = xz->lzmafilters;
 			mt_options.check = LZMA_CHECK_CRC64;
-			ret = lzma_stream_encoder_mt(&(data->stream),
+			ret = lzma_stream_encoder_mt(&(xz->stream),
 			    &mt_options);
 		} else
 #endif
-			ret = lzma_stream_encoder(&(data->stream),
-			    data->lzmafilters, LZMA_CHECK_CRC64);
+			ret = lzma_stream_encoder(&(xz->stream),
+			    xz->lzmafilters, LZMA_CHECK_CRC64);
 	} else if (f->code == ARCHIVE_FILTER_LZMA) {
-		ret = lzma_alone_encoder(&(data->stream), &data->lzma_opt);
+		ret = lzma_alone_encoder(&(xz->stream), &xz->lzma_opt);
 	} else {	/* ARCHIVE_FILTER_LZIP */
-		int dict_size = data->lzma_opt.dict_size;
+		int dict_size = xz->lzma_opt.dict_size;
 		int ds, log2dic, wedges;
 
 		/* Calculate a coded dictionary size */
@@ -258,18 +258,18 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 			wedges = 0;
 		ds = ((wedges << 5) & 0xe0) | (log2dic & 0x1f);
 
-		data->crc32 = 0;
+		xz->crc32 = 0;
 		/* Make a header */
-		data->compressed[0] = 0x4C;
-		data->compressed[1] = 0x5A;
-		data->compressed[2] = 0x49;
-		data->compressed[3] = 0x50;
-		data->compressed[4] = 1;/* Version */
-		data->compressed[5] = (unsigned char)ds;
-		data->stream.next_out += 6;
-		data->stream.avail_out -= 6;
+		xz->compressed[0] = 0x4C;
+		xz->compressed[1] = 0x5A;
+		xz->compressed[2] = 0x49;
+		xz->compressed[3] = 0x50;
+		xz->compressed[4] = 1;/* Version */
+		xz->compressed[5] = (unsigned char)ds;
+		xz->stream.next_out += 6;
+		xz->stream.avail_out -= 6;
 
-		ret = lzma_raw_encoder(&(data->stream), data->lzmafilters);
+		ret = lzma_raw_encoder(&(xz->stream), xz->lzmafilters);
 	}
 	if (ret == LZMA_OK)
 		return (ARCHIVE_OK);
@@ -295,10 +295,10 @@ archive_compressor_xz_init_stream(struct archive_write_filter *f,
 static int
 archive_compressor_xz_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct xz *xz = f->data;
 	int ret;
 
-	if (data->compressed == NULL) {
+	if (xz->compressed == NULL) {
 		size_t bs = 65536, bpb;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of the bytes
@@ -309,9 +309,9 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 			else if (bpb != 0)
 				bs -= bs % bpb;
 		}
-		data->compressed_buffer_size = bs;
-		data->compressed = malloc(data->compressed_buffer_size);
-		if (data->compressed == NULL) {
+		xz->compressed_buffer_size = bs;
+		xz->compressed = malloc(xz->compressed_buffer_size);
+		if (xz->compressed == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
@@ -321,32 +321,32 @@ archive_compressor_xz_open(struct archive_write_filter *f)
 	/* Initialize compression library. */
 	if (f->code == ARCHIVE_FILTER_LZIP) {
 		const struct option_value *val =
-		    &option_values[data->compression_level];
+		    &option_values[xz->compression_level];
 
-		data->lzma_opt.dict_size = val->dict_size;
-		data->lzma_opt.preset_dict = NULL;
-		data->lzma_opt.preset_dict_size = 0;
-		data->lzma_opt.lc = LZMA_LC_DEFAULT;
-		data->lzma_opt.lp = LZMA_LP_DEFAULT;
-		data->lzma_opt.pb = LZMA_PB_DEFAULT;
-		data->lzma_opt.mode =
-		    data->compression_level<= 2? LZMA_MODE_FAST:LZMA_MODE_NORMAL;
-		data->lzma_opt.nice_len = val->nice_len;
-		data->lzma_opt.mf = val->mf;
-		data->lzma_opt.depth = 0;
-		data->lzmafilters[0].id = LZMA_FILTER_LZMA1;
-		data->lzmafilters[0].options = &data->lzma_opt;
-		data->lzmafilters[1].id = LZMA_VLI_UNKNOWN;/* Terminate */
+		xz->lzma_opt.dict_size = val->dict_size;
+		xz->lzma_opt.preset_dict = NULL;
+		xz->lzma_opt.preset_dict_size = 0;
+		xz->lzma_opt.lc = LZMA_LC_DEFAULT;
+		xz->lzma_opt.lp = LZMA_LP_DEFAULT;
+		xz->lzma_opt.pb = LZMA_PB_DEFAULT;
+		xz->lzma_opt.mode =
+		    xz->compression_level<= 2? LZMA_MODE_FAST:LZMA_MODE_NORMAL;
+		xz->lzma_opt.nice_len = val->nice_len;
+		xz->lzma_opt.mf = val->mf;
+		xz->lzma_opt.depth = 0;
+		xz->lzmafilters[0].id = LZMA_FILTER_LZMA1;
+		xz->lzmafilters[0].options = &xz->lzma_opt;
+		xz->lzmafilters[1].id = LZMA_VLI_UNKNOWN;/* Terminate */
 	} else {
-		if (lzma_lzma_preset(&data->lzma_opt, data->compression_level)) {
+		if (lzma_lzma_preset(&xz->lzma_opt, xz->compression_level)) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "Internal error initializing compression library");
 		}
-		data->lzmafilters[0].id = LZMA_FILTER_LZMA2;
-		data->lzmafilters[0].options = &data->lzma_opt;
-		data->lzmafilters[1].id = LZMA_VLI_UNKNOWN;/* Terminate */
+		xz->lzmafilters[0].id = LZMA_FILTER_LZMA2;
+		xz->lzmafilters[0].options = &xz->lzma_opt;
+		xz->lzmafilters[1].id = LZMA_VLI_UNKNOWN;/* Terminate */
 	}
-	ret = archive_compressor_xz_init_stream(f, data);
+	ret = archive_compressor_xz_init_stream(f, xz);
 	if (ret == LZMA_OK) {
 		return (ARCHIVE_OK);
 	}
@@ -360,7 +360,7 @@ static int
 archive_compressor_xz_options(struct archive_write_filter *f,
     const char *key, const char *value)
 {
-	struct private_data *data = f->data;
+	struct xz *xz = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		if (value == NULL || !(value[0] >= '0' && value[0] <= '9') ||
@@ -369,9 +369,9 @@ archive_compressor_xz_options(struct archive_write_filter *f,
 			    "compression-level invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = value[0] - '0';
-		if (data->compression_level > 9)
-			data->compression_level = 9;
+		xz->compression_level = value[0] - '0';
+		if (xz->compression_level > 9)
+			xz->compression_level = 9;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "threads") == 0) {
 		char *endptr;
@@ -385,17 +385,17 @@ archive_compressor_xz_options(struct archive_write_filter *f,
 		errno = 0;
 		val = strtoul(value, &endptr, 10);
 		if (errno != 0 || *endptr != '\0' || val > (unsigned)INT_MAX) {
-			data->threads = 1;
+			xz->threads = 1;
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "threads invalid");
 			return (ARCHIVE_FAILED);
 		}
-		data->threads = (int)val;
-		if (data->threads == 0) {
+		xz->threads = (int)val;
+		if (xz->threads == 0) {
 #ifdef HAVE_LZMA_STREAM_ENCODER_MT
-			data->threads = lzma_cputhreads();
+			xz->threads = lzma_cputhreads();
 #else
-			data->threads = 1;
+			xz->threads = 1;
 #endif
 		}
 		return (ARCHIVE_OK);
@@ -414,18 +414,18 @@ static int
 archive_compressor_xz_write(struct archive_write_filter *f,
     const void *buff, size_t length)
 {
-	struct private_data *data = f->data;
+	struct xz *xz = f->data;
 	int ret;
 
 	/* Update statistics */
-	data->total_in += length;
+	xz->total_in += length;
 	if (f->code == ARCHIVE_FILTER_LZIP)
-		data->crc32 = lzma_crc32(buff, length, data->crc32);
+		xz->crc32 = lzma_crc32(buff, length, xz->crc32);
 
 	/* Compress input data to output buffer */
-	data->stream.next_in = buff;
-	data->stream.avail_in = length;
-	if ((ret = drive_compressor(f, data, 0)) != ARCHIVE_OK)
+	xz->stream.next_in = buff;
+	xz->stream.avail_in = length;
+	if ((ret = drive_compressor(f, xz, 0)) != ARCHIVE_OK)
 		return (ret);
 
 	return (ARCHIVE_OK);
@@ -438,25 +438,25 @@ archive_compressor_xz_write(struct archive_write_filter *f,
 static int
 archive_compressor_xz_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct xz *xz = f->data;
 	int ret;
 
-	ret = drive_compressor(f, data, 1);
+	ret = drive_compressor(f, xz, 1);
 	if (ret == ARCHIVE_OK) {
-		data->total_out +=
-		    data->compressed_buffer_size - data->stream.avail_out;
+		xz->total_out +=
+		    xz->compressed_buffer_size - xz->stream.avail_out;
 		ret = __archive_write_filter(f->next_filter,
-		    data->compressed,
-		    data->compressed_buffer_size - data->stream.avail_out);
+		    xz->compressed,
+		    xz->compressed_buffer_size - xz->stream.avail_out);
 		if (f->code == ARCHIVE_FILTER_LZIP && ret == ARCHIVE_OK) {
-			archive_le32enc(data->compressed, data->crc32);
-			archive_le64enc(data->compressed+4, data->total_in);
-			archive_le64enc(data->compressed+12, data->total_out + 20);
+			archive_le32enc(xz->compressed, xz->crc32);
+			archive_le64enc(xz->compressed+4, xz->total_in);
+			archive_le64enc(xz->compressed+12, xz->total_out + 20);
 			ret = __archive_write_filter(f->next_filter,
-			    data->compressed, 20);
+			    xz->compressed, 20);
 		}
 	}
-	lzma_end(&(data->stream));
+	lzma_end(&(xz->stream));
 	return ret;
 }
 
@@ -477,34 +477,34 @@ archive_compressor_xz_free(struct archive_write_filter *f)
  */
 static int
 drive_compressor(struct archive_write_filter *f,
-    struct private_data *data, int finishing)
+    struct xz *xz, int finishing)
 {
 	int ret;
 
 	for (;;) {
-		if (data->stream.avail_out == 0) {
-			data->total_out += data->compressed_buffer_size;
+		if (xz->stream.avail_out == 0) {
+			xz->total_out += xz->compressed_buffer_size;
 			ret = __archive_write_filter(f->next_filter,
-			    data->compressed,
-			    data->compressed_buffer_size);
+			    xz->compressed,
+			    xz->compressed_buffer_size);
 			if (ret != ARCHIVE_OK)
 				return (ARCHIVE_FATAL);
-			data->stream.next_out = data->compressed;
-			data->stream.avail_out = data->compressed_buffer_size;
+			xz->stream.next_out = xz->compressed;
+			xz->stream.avail_out = xz->compressed_buffer_size;
 		}
 
 		/* If there's nothing to do, we're done. */
-		if (!finishing && data->stream.avail_in == 0)
+		if (!finishing && xz->stream.avail_in == 0)
 			return (ARCHIVE_OK);
 
-		ret = lzma_code(&(data->stream),
+		ret = lzma_code(&(xz->stream),
 		    finishing ? LZMA_FINISH : LZMA_RUN );
 
 		switch (ret) {
 		case LZMA_OK:
 			/* In non-finishing case, check if compressor
 			 * consumed everything */
-			if (!finishing && data->stream.avail_in == 0)
+			if (!finishing && xz->stream.avail_in == 0)
 				return (ARCHIVE_OK);
 			/* In finishing case, this return always means
 			 * there's more work */
@@ -520,7 +520,7 @@ drive_compressor(struct archive_write_filter *f,
 			archive_set_error(f->archive, ENOMEM,
 			    "lzma compression error: "
 			    "%ju MiB would have been needed",
-			    (uintmax_t)((lzma_memusage(&(data->stream))
+			    (uintmax_t)((lzma_memusage(&(xz->stream))
 				    + 1024 * 1024 -1)
 				/ (1024 * 1024)));
 			return (ARCHIVE_FATAL);
@@ -536,11 +536,11 @@ drive_compressor(struct archive_write_filter *f,
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct xz *xz)
 {
-	if (data != NULL) {
-		free(data->compressed);
-		free(data);
+	if (xz != NULL) {
+		free(xz->compressed);
+		free(xz);
 	}
 }
 

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -55,7 +55,7 @@
 
 /* Don't compile this if we don't have zstd.h */
 
-struct private_data {
+struct zstd {
 	int		 compression_level;
 	int		 threads;
 	int		 long_distance;
@@ -103,9 +103,9 @@ static int archive_compressor_zstd_close(struct archive_write_filter *);
 static int archive_compressor_zstd_free(struct archive_write_filter *);
 #if HAVE_ZSTD_H && HAVE_ZSTD_compressStream
 static int drive_compressor(struct archive_write_filter *,
-		    struct private_data *, int, const void *, size_t);
+		    struct zstd *, int, const void *, size_t);
 #endif
-static void free_data(struct private_data *);
+static void free_data(struct zstd *);
 
 
 /*
@@ -115,34 +115,34 @@ int
 archive_write_add_filter_zstd(struct archive *a)
 {
 	struct archive_write_filter *f;
-	struct private_data *data;
+	struct zstd *zstd;
 	int r;
 
 	archive_check_magic(a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_add_filter_zstd");
 
-	data = calloc(1, sizeof(*data));
-	if (data == NULL)
+	zstd = calloc(1, sizeof(*zstd));
+	if (zstd == NULL)
 		goto memerr;
-	data->compression_level = CLEVEL_DEFAULT;
-	data->threads = 0;
-	data->long_distance = 0;
+	zstd->compression_level = CLEVEL_DEFAULT;
+	zstd->threads = 0;
+	zstd->long_distance = 0;
 #if HAVE_ZSTD_H && HAVE_ZSTD_compressStream
-	data->frame_per_file = 0;
-	data->min_frame_in = 0;
-	data->max_frame_in = SIZE_MAX;
-	data->min_frame_out = 0;
-	data->max_frame_out = SIZE_MAX;
-	data->cur_frame_in = 0;
-	data->cur_frame_out = 0;
-	data->cstream = ZSTD_createCStream();
-	if (data->cstream == NULL)
+	zstd->frame_per_file = 0;
+	zstd->min_frame_in = 0;
+	zstd->max_frame_in = SIZE_MAX;
+	zstd->min_frame_out = 0;
+	zstd->max_frame_out = SIZE_MAX;
+	zstd->cur_frame_in = 0;
+	zstd->cur_frame_out = 0;
+	zstd->cstream = ZSTD_createCStream();
+	if (zstd->cstream == NULL)
 		goto memerr;
 
 	r = ARCHIVE_OK;
 #else
-	data->pdata = __archive_write_program_allocate("zstd");
-	if (data->pdata == NULL)
+	zstd->pdata = __archive_write_program_allocate("zstd");
+	if (zstd->pdata == NULL)
 		goto memerr;
 
 	archive_set_error(a, ARCHIVE_ERRNO_MISC,
@@ -155,7 +155,7 @@ archive_write_add_filter_zstd(struct archive *a)
 		goto memerr;
 	f->name = "zstd";
 	f->code = ARCHIVE_FILTER_ZSTD;
-	f->data = data;
+	f->data = zstd;
 	f->options = archive_compressor_zstd_options;
 	f->open = archive_compressor_zstd_open;
 	f->write = archive_compressor_zstd_write;
@@ -165,7 +165,7 @@ archive_write_add_filter_zstd(struct archive *a)
 
 	return (r);
 memerr:
-	free_data(data);
+	free_data(zstd);
 	archive_set_error(a, ENOMEM, "Out of memory");
 	return (ARCHIVE_FATAL);
 }
@@ -237,7 +237,7 @@ static int
 archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		intmax_t level;
@@ -266,7 +266,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 			    "compression-level out of range");
 			return (ARCHIVE_FAILED);
 		}
-		data->compression_level = (int)level;
+		zstd->compression_level = (int)level;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "threads") == 0) {
 		intmax_t threads;
@@ -293,14 +293,14 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 			    "threads out of rnage");
 			return (ARCHIVE_FAILED);
 		}
-		data->threads = (int)threads;
+		zstd->threads = (int)threads;
 		return (ARCHIVE_OK);
 #if HAVE_ZSTD_H && HAVE_ZSTD_compressStream
 	} else if (strcmp(key, "frame-per-file") == 0) {
-		data->frame_per_file = 1;
+		zstd->frame_per_file = 1;
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "min-frame-in") == 0) {
-		if (string_to_size(value, &data->min_frame_in) != ARCHIVE_OK) {
+		if (string_to_size(value, &zstd->min_frame_in) != ARCHIVE_OK) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "min-frame-in invalid");
 			return (ARCHIVE_FAILED);
@@ -308,7 +308,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "min-frame-out") == 0 ||
 	    strcmp(key, "min-frame-size") == 0) {
-		if (string_to_size(value, &data->min_frame_out) != ARCHIVE_OK) {
+		if (string_to_size(value, &zstd->min_frame_out) != ARCHIVE_OK) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "min-frame-out invalid");
 			return (ARCHIVE_FAILED);
@@ -316,16 +316,16 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "max-frame-in") == 0 ||
 	    strcmp(key, "max-frame-size") == 0) {
-		if (string_to_size(value, &data->max_frame_in) != ARCHIVE_OK ||
-		    data->max_frame_in < 1024) {
+		if (string_to_size(value, &zstd->max_frame_in) != ARCHIVE_OK ||
+		    zstd->max_frame_in < 1024) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "max-frame-size invalid");
 			return (ARCHIVE_FAILED);
 		}
 		return (ARCHIVE_OK);
 	} else if (strcmp(key, "max-frame-out") == 0) {
-		if (string_to_size(value, &data->max_frame_out) != ARCHIVE_OK ||
-		    data->max_frame_out < 1024) {
+		if (string_to_size(value, &zstd->max_frame_out) != ARCHIVE_OK ||
+		    zstd->max_frame_out < 1024) {
 			archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 			    "max-frame-out invalid");
 			return (ARCHIVE_FAILED);
@@ -361,7 +361,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 		if (((int)long_distance) < 10 || (int)long_distance > max_distance)
 		    return (ARCHIVE_FAILED);
 #endif
-		data->long_distance = (int)long_distance;
+		zstd->long_distance = (int)long_distance;
 		return (ARCHIVE_OK);
 	}
 
@@ -378,9 +378,9 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 static int
 archive_compressor_zstd_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	if (data->out.dst == NULL) {
+	if (zstd->out.dst == NULL) {
 		size_t bs = ZSTD_CStreamOutSize(), bpb;
 		if (f->archive->magic == ARCHIVE_WRITE_MAGIC) {
 			/* Buffer size should be a multiple number of
@@ -391,29 +391,29 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 			else if (bpb != 0)
 				bs -= bs % bpb;
 		}
-		data->out.size = bs;
-		data->out.pos = 0;
-		data->out.dst = malloc(data->out.size);
-		if (data->out.dst == NULL) {
+		zstd->out.size = bs;
+		zstd->out.pos = 0;
+		zstd->out.dst = malloc(zstd->out.size);
+		if (zstd->out.dst == NULL) {
 			archive_set_error(f->archive, ENOMEM,
 			    "Can't allocate data for compression buffer");
 			return (ARCHIVE_FATAL);
 		}
 	}
 
-	if (ZSTD_isError(ZSTD_initCStream(data->cstream,
-	    data->compression_level))) {
+	if (ZSTD_isError(ZSTD_initCStream(zstd->cstream,
+	    zstd->compression_level))) {
 		archive_set_error(f->archive, ARCHIVE_ERRNO_MISC,
 		    "Internal error initializing zstd compressor object");
 		return (ARCHIVE_FATAL);
 	}
 
-	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_nbWorkers, data->threads);
+	ZSTD_CCtx_setParameter(zstd->cstream, ZSTD_c_nbWorkers, zstd->threads);
 
-	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_checksumFlag, 1);
+	ZSTD_CCtx_setParameter(zstd->cstream, ZSTD_c_checksumFlag, 1);
 
 #if ZSTD_VERSION_NUMBER >= MINVER_LONG
-	ZSTD_CCtx_setParameter(data->cstream, ZSTD_c_windowLog, data->long_distance);
+	ZSTD_CCtx_setParameter(zstd->cstream, ZSTD_c_windowLog, zstd->long_distance);
 #endif
 
 	return (ARCHIVE_OK);
@@ -426,9 +426,9 @@ static int
 archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	return (drive_compressor(f, data, 0, buff, length));
+	return (drive_compressor(f, zstd, 0, buff, length));
 }
 
 /*
@@ -437,15 +437,15 @@ archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_zstd_flush(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	if (data->frame_per_file && data->state == running) {
-		if (data->cur_frame_in > data->min_frame_in &&
-		    data->cur_frame_out > data->min_frame_out) {
-			data->state = finishing;
+	if (zstd->frame_per_file && zstd->state == running) {
+		if (zstd->cur_frame_in > zstd->min_frame_in &&
+		    zstd->cur_frame_out > zstd->min_frame_out) {
+			zstd->state = finishing;
 		}
 	}
-	return (drive_compressor(f, data, 1, NULL, 0));
+	return (drive_compressor(f, zstd, 1, NULL, 0));
 }
 
 /*
@@ -454,11 +454,11 @@ archive_compressor_zstd_flush(struct archive_write_filter *f)
 static int
 archive_compressor_zstd_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	if (data->state == running)
-		data->state = finishing;
-	return (drive_compressor(f, data, 1, NULL, 0));
+	if (zstd->state == running)
+		zstd->state = finishing;
+	return (drive_compressor(f, zstd, 1, NULL, 0));
 }
 
 /*
@@ -467,7 +467,7 @@ archive_compressor_zstd_close(struct archive_write_filter *f)
  */
 static int
 drive_compressor(struct archive_write_filter *f,
-    struct private_data *data, int flush, const void *src, size_t length)
+    struct zstd *zstd, int flush, const void *src, size_t length)
 {
 	ZSTD_inBuffer in = { .src = src, .size = length, .pos = 0 };
 	size_t ipos, opos, zstdret = 0;
@@ -475,46 +475,46 @@ drive_compressor(struct archive_write_filter *f,
 
 	for (;;) {
 		ipos = in.pos;
-		opos = data->out.pos;
-		switch (data->state) {
+		opos = zstd->out.pos;
+		switch (zstd->state) {
 		case running:
 			if (in.pos == in.size)
 				return (ARCHIVE_OK);
-			zstdret = ZSTD_compressStream(data->cstream,
-			    &data->out, &in);
+			zstdret = ZSTD_compressStream(zstd->cstream,
+			    &zstd->out, &in);
 			if (ZSTD_isError(zstdret))
 				goto zstd_fatal;
 			break;
 		case finishing:
-			zstdret = ZSTD_endStream(data->cstream, &data->out);
+			zstdret = ZSTD_endStream(zstd->cstream, &zstd->out);
 			if (ZSTD_isError(zstdret))
 				goto zstd_fatal;
 			if (zstdret == 0)
-				data->state = resetting;
+				zstd->state = resetting;
 			break;
 		case resetting:
-			ZSTD_CCtx_reset(data->cstream, ZSTD_reset_session_only);
-			data->cur_frame++;
-			data->cur_frame_in = 0;
-			data->cur_frame_out = 0;
-			data->state = running;
+			ZSTD_CCtx_reset(zstd->cstream, ZSTD_reset_session_only);
+			zstd->cur_frame++;
+			zstd->cur_frame_in = 0;
+			zstd->cur_frame_out = 0;
+			zstd->state = running;
 			break;
 		}
-		data->cur_frame_in += in.pos - ipos;
-		data->cur_frame_out += data->out.pos - opos;
-		if (data->state == running) {
-			if (data->cur_frame_in >= data->max_frame_in ||
-			    data->cur_frame_out >= data->max_frame_out) {
-				data->state = finishing;
+		zstd->cur_frame_in += in.pos - ipos;
+		zstd->cur_frame_out += zstd->out.pos - opos;
+		if (zstd->state == running) {
+			if (zstd->cur_frame_in >= zstd->max_frame_in ||
+			    zstd->cur_frame_out >= zstd->max_frame_out) {
+				zstd->state = finishing;
 			}
 		}
-		if (data->out.pos == data->out.size ||
-		    (flush && data->out.pos > 0)) {
+		if (zstd->out.pos == zstd->out.size ||
+		    (flush && zstd->out.pos > 0)) {
 			ret = __archive_write_filter(f->next_filter,
-			    data->out.dst, data->out.pos);
+			    zstd->out.dst, zstd->out.pos);
 			if (ret != ARCHIVE_OK)
 				goto fatal;
-			data->out.pos = 0;
+			zstd->out.pos = 0;
 		}
 	}
 zstd_fatal:
@@ -526,12 +526,12 @@ fatal:
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct zstd *zstd)
 {
-	if (data != NULL) {
-		ZSTD_freeCStream(data->cstream);
-		free(data->out.dst);
-		free(data);
+	if (zstd != NULL) {
+		ZSTD_freeCStream(zstd->cstream);
+		free(zstd->out.dst);
+		free(zstd);
 	}
 }
 
@@ -540,7 +540,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_zstd_open(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 	struct archive_string as;
 	int r;
 
@@ -548,25 +548,25 @@ archive_compressor_zstd_open(struct archive_write_filter *f)
 	/* --no-check matches library default */
 	archive_strcpy(&as, "zstd --no-check");
 
-	if (data->compression_level < CLEVEL_STD_MIN) {
-		archive_string_sprintf(&as, " --fast=%d", -data->compression_level);
+	if (zstd->compression_level < CLEVEL_STD_MIN) {
+		archive_string_sprintf(&as, " --fast=%d", -zstd->compression_level);
 	} else {
-		archive_string_sprintf(&as, " -%d", data->compression_level);
+		archive_string_sprintf(&as, " -%d", zstd->compression_level);
 	}
 
-	if (data->compression_level > CLEVEL_STD_MAX) {
+	if (zstd->compression_level > CLEVEL_STD_MAX) {
 		archive_strcat(&as, " --ultra");
 	}
 
-	if (data->threads != 0) {
-		archive_string_sprintf(&as, " --threads=%d", data->threads);
+	if (zstd->threads != 0) {
+		archive_string_sprintf(&as, " --threads=%d", zstd->threads);
 	}
 
-	if (data->long_distance != 0) {
-		archive_string_sprintf(&as, " --long=%d", data->long_distance);
+	if (zstd->long_distance != 0) {
+		archive_string_sprintf(&as, " --long=%d", zstd->long_distance);
 	}
 
-	r = __archive_write_program_open(f, data->pdata, as.s);
+	r = __archive_write_program_open(f, zstd->pdata, as.s);
 	archive_string_free(&as);
 	return (r);
 }
@@ -575,9 +575,9 @@ static int
 archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	return __archive_write_program_write(f, data->pdata, buff, length);
+	return __archive_write_program_write(f, zstd->pdata, buff, length);
 }
 
 static int
@@ -591,17 +591,17 @@ archive_compressor_zstd_flush(struct archive_write_filter *f)
 static int
 archive_compressor_zstd_close(struct archive_write_filter *f)
 {
-	struct private_data *data = f->data;
+	struct zstd *zstd = f->data;
 
-	return __archive_write_program_close(f, data->pdata);
+	return __archive_write_program_close(f, zstd->pdata);
 }
 
 static void
-free_data(struct private_data *data)
+free_data(struct zstd *zstd)
 {
-	if (data != NULL) {
-		__archive_write_program_free(data->pdata);
-		free(data);
+	if (zstd != NULL) {
+		__archive_write_program_free(zstd->pdata);
+		free(zstd);
 	}
 }
 

--- a/libarchive/archive_write_add_filter_zstd.c
+++ b/libarchive/archive_write_add_filter_zstd.c
@@ -237,7 +237,7 @@ static int
 archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
     const char *value)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (strcmp(key, "compression-level") == 0) {
 		intmax_t level;
@@ -378,7 +378,7 @@ archive_compressor_zstd_options(struct archive_write_filter *f, const char *key,
 static int
 archive_compressor_zstd_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (data->out.dst == NULL) {
 		size_t bs = ZSTD_CStreamOutSize(), bpb;
@@ -426,7 +426,7 @@ static int
 archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return (drive_compressor(f, data, 0, buff, length));
 }
@@ -437,7 +437,7 @@ archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
 static int
 archive_compressor_zstd_flush(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (data->frame_per_file && data->state == running) {
 		if (data->cur_frame_in > data->min_frame_in &&
@@ -454,7 +454,7 @@ archive_compressor_zstd_flush(struct archive_write_filter *f)
 static int
 archive_compressor_zstd_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	if (data->state == running)
 		data->state = finishing;
@@ -540,7 +540,7 @@ free_data(struct private_data *data)
 static int
 archive_compressor_zstd_open(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 	struct archive_string as;
 	int r;
 
@@ -575,7 +575,7 @@ static int
 archive_compressor_zstd_write(struct archive_write_filter *f, const void *buff,
     size_t length)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_write(f, data->pdata, buff, length);
 }
@@ -591,7 +591,7 @@ archive_compressor_zstd_flush(struct archive_write_filter *f)
 static int
 archive_compressor_zstd_close(struct archive_write_filter *f)
 {
-	struct private_data *data = (struct private_data *)f->data;
+	struct private_data *data = f->data;
 
 	return __archive_write_program_close(f, data->pdata);
 }

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -412,9 +412,7 @@ archive_write_set_format_7zip(struct archive *_a)
 static int
 _7z_options(struct archive_write *a, const char *key, const char *value)
 {
-	struct _7zip *zip;
-
-	zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 
 	if (strcmp(key, "compression") == 0) {
 		const char *name = NULL;
@@ -556,11 +554,10 @@ _7z_options(struct archive_write *a, const char *key, const char *value)
 static int
 _7z_write_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	struct file *file;
 	int r;
 
-	zip = (struct _7zip *)a->format_data;
 	zip->cur_file = NULL;
 	zip->entry_bytes_remaining = 0;
 
@@ -664,11 +661,9 @@ _7z_write_header(struct archive_write *a, struct archive_entry *entry)
 static int
 write_to_temp(struct archive_write *a, const void *buff, size_t s)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	const unsigned char *p;
 	ssize_t ws;
-
-	zip = (struct _7zip *)a->format_data;
 
 	/*
 	 * Open a temporary file.
@@ -702,7 +697,7 @@ static ssize_t
 compress_out(struct archive_write *a, const void *buff, size_t s,
     enum la_zaction run)
 {
-	struct _7zip *zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 	int r;
 
 	if (run == ARCHIVE_Z_FINISH && zip->stream.total_in == 0 && s == 0)
@@ -748,10 +743,8 @@ compress_out(struct archive_write *a, const void *buff, size_t s,
 static ssize_t
 _7z_write_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	ssize_t bytes;
-
-	zip = (struct _7zip *)a->format_data;
 
 	if (s > zip->entry_bytes_remaining)
 		s = (size_t)zip->entry_bytes_remaining;
@@ -768,11 +761,10 @@ _7z_write_data(struct archive_write *a, const void *buff, size_t s)
 static int
 _7z_finish_entry(struct archive_write *a)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	size_t s;
 	ssize_t r;
 
-	zip = (struct _7zip *)a->format_data;
 	if (zip->cur_file == NULL)
 		return (ARCHIVE_OK);
 
@@ -793,11 +785,10 @@ _7z_finish_entry(struct archive_write *a)
 static int
 flush_wbuff(struct archive_write *a)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	int r;
 	size_t s;
 
-	zip = (struct _7zip *)a->format_data;
 	s = sizeof(zip->wbuff) - zip->wbuff_remaining;
 	r = __archive_write_output(a, zip->wbuff, s);
 	if (r != ARCHIVE_OK)
@@ -809,10 +800,9 @@ flush_wbuff(struct archive_write *a)
 static int
 copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	int r;
 
-	zip = (struct _7zip *)a->format_data;
 	if (zip->temp_offset > 0 &&
 	    lseek(zip->temp_fd, offset, SEEK_SET) < 0) {
 		archive_set_error(&(a->archive), errno, "lseek failed");
@@ -855,14 +845,12 @@ copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 static int
 _7z_close(struct archive_write *a)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	unsigned char *wb;
 	uint64_t header_offset, header_size, header_unpacksize;
 	uint64_t length;
 	uint32_t header_crc32;
 	int r;
-
-	zip = (struct _7zip *)a->format_data;
 
 	if (zip->total_number_entry > 0) {
 		struct archive_rb_node *n;
@@ -1028,7 +1016,7 @@ enc_uint64(struct archive_write *a, uint64_t val)
 static int
 make_substreamsInfo(struct archive_write *a, struct coder *coders)
 {
-	struct _7zip *zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 	struct file *file;
 	int r;
 
@@ -1104,7 +1092,7 @@ make_streamsInfo(struct archive_write *a, uint64_t offset, uint64_t pack_size,
     uint64_t unpack_size, int num_coder, struct coder *coders, int substrm,
     uint32_t header_crc)
 {
-	struct _7zip *zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 	uint8_t codec_buff[8];
 	int numFolders, fi;
 	int codec_size;
@@ -1296,8 +1284,8 @@ make_streamsInfo(struct archive_write *a, uint64_t offset, uint64_t pack_size,
 static int
 make_time(struct archive_write *a, uint8_t type, unsigned flg, int ti)
 {
+	struct _7zip *zip = a->format_data;
 	uint8_t filetime[8];
-	struct _7zip *zip = (struct _7zip *)a->format_data;
 	struct file *file;
 	int r;
 	uint8_t b, mask;
@@ -1385,7 +1373,7 @@ static int
 make_header(struct archive_write *a, uint64_t offset, uint64_t pack_size,
     uint64_t unpack_size, int codernum, struct coder *coders)
 {
-	struct _7zip *zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 	struct file *file;
 	int r;
 	uint8_t b, mask;
@@ -1593,7 +1581,7 @@ make_header(struct archive_write *a, uint64_t offset, uint64_t pack_size,
 static int
 _7z_free(struct archive_write *a)
 {
-	struct _7zip *zip = (struct _7zip *)a->format_data;
+	struct _7zip *zip = a->format_data;
 
 	/* Close the temporary file. */
 	if (zip->temp_fd >= 0)
@@ -1631,13 +1619,12 @@ static int
 file_new(struct archive_write *a, struct archive_entry *entry,
     struct file **newfile)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	struct file *file;
 	const char *u16;
 	size_t u16len;
 	int ret = ARCHIVE_OK;
 
-	zip = (struct _7zip *)a->format_data;
 	*newfile = NULL;
 
 	file = calloc(1, sizeof(*file));
@@ -2255,7 +2242,7 @@ static void
 ppmd_write(void *p, Byte b)
 {
 	struct archive_write *a = ((IByteOut *)p)->a;
-	struct _7zip *zip = (struct _7zip *)(a->format_data);
+	struct _7zip *zip = a->format_data;
 	struct la_zstream *lastrm = &(zip->stream);
 	struct ppmd_stream *strm;
 
@@ -2512,10 +2499,9 @@ static int
 _7z_compression_init_encoder(struct archive_write *a, unsigned compression,
     int compression_level)
 {
-	struct _7zip *zip;
+	struct _7zip *zip = a->format_data;
 	int r;
 
-	zip = (struct _7zip *)a->format_data;
 	switch (compression) {
 	case _7Z_DEFLATE:
 		r = compression_init_encoder_deflate(

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -147,7 +147,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	int ret, append_fn;
 	char buff[60];
 	char *ss;
-	struct ar_w *ar;
+	struct ar_w *ar = a->format_data;
 	struct archive_string se;
 	const char *pathname;
 	const char *filename;
@@ -155,7 +155,6 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	int64_t size;
 
 	append_fn = 0;
-	ar = (struct ar_w *)a->format_data;
 	ar->is_strtab = 0;
 	filename = NULL;
 	filename_length = 0;
@@ -364,10 +363,9 @@ size:
 static ssize_t
 archive_write_ar_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct ar_w *ar;
+	struct ar_w *ar = a->format_data;
 	int ret;
 
-	ar = (struct ar_w *)a->format_data;
 	if (s > ar->entry_bytes_remaining)
 		s = (size_t)ar->entry_bytes_remaining;
 
@@ -400,9 +398,7 @@ archive_write_ar_data(struct archive_write *a, const void *buff, size_t s)
 static int
 archive_write_ar_free(struct archive_write *a)
 {
-	struct ar_w *ar;
-
-	ar = (struct ar_w *)a->format_data;
+	struct ar_w *ar = a->format_data;
 
 	if (ar == NULL)
 		return (ARCHIVE_OK);
@@ -420,14 +416,13 @@ archive_write_ar_free(struct archive_write *a)
 static int
 archive_write_ar_close(struct archive_write *a)
 {
-	struct ar_w *ar;
+	struct ar_w *ar = a->format_data;
 	int ret;
 
 	/*
 	 * If we haven't written anything yet, we need to write
 	 * the ar global header now to make it a valid ar archive.
 	 */
-	ar = (struct ar_w *)a->format_data;
 	if (!ar->wrote_global_header) {
 		ar->wrote_global_header = 1;
 		ret = __archive_write_output(a, "!<arch>\n", 8);
@@ -440,10 +435,8 @@ archive_write_ar_close(struct archive_write *a)
 static int
 archive_write_ar_finish_entry(struct archive_write *a)
 {
-	struct ar_w *ar;
+	struct ar_w *ar = a->format_data;
 	int ret;
-
-	ar = (struct ar_w *)a->format_data;
 
 	if (ar->entry_bytes_remaining != 0) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,

--- a/libarchive/archive_write_set_format_ar.c
+++ b/libarchive/archive_write_set_format_ar.c
@@ -44,7 +44,7 @@
 #include "archive_write_private.h"
 #include "archive_write_set_format_private.h"
 
-struct ar_w {
+struct ar {
 	uint64_t	 entry_bytes_remaining;
 	uint64_t	 entry_padding;
 	int		 is_strtab;
@@ -120,7 +120,7 @@ archive_write_set_format_ar_svr4(struct archive *_a)
 static int
 archive_write_set_format_ar(struct archive_write *a)
 {
-	struct ar_w *ar;
+	struct ar *ar;
 
 	/* If someone else was already registered, unregister them. */
 	(void)__archive_write_unregister_format(a);
@@ -147,7 +147,7 @@ archive_write_ar_header(struct archive_write *a, struct archive_entry *entry)
 	int ret, append_fn;
 	char buff[60];
 	char *ss;
-	struct ar_w *ar = a->format_data;
+	struct ar *ar = a->format_data;
 	struct archive_string se;
 	const char *pathname;
 	const char *filename;
@@ -363,7 +363,7 @@ size:
 static ssize_t
 archive_write_ar_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct ar_w *ar = a->format_data;
+	struct ar *ar = a->format_data;
 	int ret;
 
 	if (s > ar->entry_bytes_remaining)
@@ -398,7 +398,7 @@ archive_write_ar_data(struct archive_write *a, const void *buff, size_t s)
 static int
 archive_write_ar_free(struct archive_write *a)
 {
-	struct ar_w *ar = a->format_data;
+	struct ar *ar = a->format_data;
 
 	if (ar == NULL)
 		return (ARCHIVE_OK);
@@ -416,7 +416,7 @@ archive_write_ar_free(struct archive_write *a)
 static int
 archive_write_ar_close(struct archive_write *a)
 {
-	struct ar_w *ar = a->format_data;
+	struct ar *ar = a->format_data;
 	int ret;
 
 	/*
@@ -435,7 +435,7 @@ archive_write_ar_close(struct archive_write *a)
 static int
 archive_write_ar_finish_entry(struct archive_write *a)
 {
-	struct ar_w *ar = a->format_data;
+	struct ar *ar = a->format_data;
 	int ret;
 
 	if (ar->entry_bytes_remaining != 0) {

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -235,7 +235,7 @@ static int
 archive_write_binary_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct cpio *cpio = (struct cpio *)a->format_data;
+	struct cpio *cpio = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -335,10 +335,9 @@ synthesize_ino_value(struct cpio *cpio, struct archive_entry *entry)
 static struct archive_string_conv *
 get_sconv(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	struct archive_string_conv *sconv;
 
-	cpio = (struct cpio *)a->format_data;
 	sconv = cpio->opt_sconv;
 	if (sconv == NULL) {
 		if (!cpio->init_default_conversion) {
@@ -384,7 +383,7 @@ archive_write_binary_header(struct archive_write *a, struct archive_entry *entry
 static int
 write_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	const char *p, *path;
 	int ret, ret_final;
 	int64_t	ino;
@@ -393,7 +392,6 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	struct archive_entry *entry_main;
 	size_t len, pathlength;
 
-	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
 	sconv = get_sconv(a);
 
@@ -567,10 +565,9 @@ exit_write_header:
 static ssize_t
 archive_write_binary_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	int ret;
 
-	cpio = (struct cpio *)a->format_data;
 	if (s > cpio->entry_bytes_remaining)
 		s = (size_t)cpio->entry_bytes_remaining;
 
@@ -604,9 +601,8 @@ archive_write_binary_close(struct archive_write *a)
 static int
 archive_write_binary_free(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	free(cpio->ino_list);
 	free(cpio);
 	a->format_data = NULL;
@@ -616,8 +612,7 @@ archive_write_binary_free(struct archive_write *a)
 static int
 archive_write_binary_finish_entry(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	return (__archive_write_nulls(a, cpio->entry_bytes_remaining));
 }

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -137,7 +137,7 @@ static int
 archive_write_newc_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct cpio *cpio = (struct cpio *)a->format_data;
+	struct cpio *cpio = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -165,10 +165,9 @@ archive_write_newc_options(struct archive_write *a, const char *key,
 static struct archive_string_conv *
 get_sconv(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	struct archive_string_conv *sconv;
 
-	cpio = (struct cpio *)a->format_data;
 	sconv = cpio->opt_sconv;
 	if (sconv == NULL) {
 		if (!cpio->init_default_conversion) {
@@ -215,8 +214,8 @@ archive_write_newc_header(struct archive_write *a, struct archive_entry *entry)
 static int
 write_header(struct archive_write *a, struct archive_entry *entry)
 {
+	struct cpio *cpio = a->format_data;
 	int64_t ino;
-	struct cpio *cpio;
 	const char *p, *path;
 	int ret, ret_final;
 	char h[c_header_size];
@@ -225,7 +224,6 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	size_t len, pathlength;
 	int pad;
 
-	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
 	sconv = get_sconv(a);
 
@@ -377,10 +375,9 @@ exit_write_header:
 static ssize_t
 archive_write_newc_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	int ret;
 
-	cpio = (struct cpio *)a->format_data;
 	if (s > cpio->entry_bytes_remaining)
 		s = (size_t)cpio->entry_bytes_remaining;
 
@@ -443,9 +440,8 @@ archive_write_newc_close(struct archive_write *a)
 static int
 archive_write_newc_free(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	free(cpio);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);
@@ -454,9 +450,8 @@ archive_write_newc_free(struct archive_write *a)
 static int
 archive_write_newc_finish_entry(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	return (__archive_write_nulls(a,
 	    cpio->entry_bytes_remaining + cpio->padding));
 }

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -132,7 +132,7 @@ static int
 archive_write_odc_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct cpio *cpio = (struct cpio *)a->format_data;
+	struct cpio *cpio = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -232,10 +232,9 @@ synthesize_ino_value(struct cpio *cpio, struct archive_entry *entry)
 static struct archive_string_conv *
 get_sconv(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	struct archive_string_conv *sconv;
 
-	cpio = (struct cpio *)a->format_data;
 	sconv = cpio->opt_sconv;
 	if (sconv == NULL) {
 		if (!cpio->init_default_conversion) {
@@ -281,7 +280,7 @@ archive_write_odc_header(struct archive_write *a, struct archive_entry *entry)
 static int
 write_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	const char *p, *path;
 	int ret, ret_final;
 	int64_t	ino;
@@ -290,7 +289,6 @@ write_header(struct archive_write *a, struct archive_entry *entry)
 	struct archive_entry *entry_main;
 	size_t len, pathlength;
 
-	cpio = (struct cpio *)a->format_data;
 	ret_final = ARCHIVE_OK;
 	sconv = get_sconv(a);
 
@@ -426,10 +424,9 @@ exit_write_header:
 static ssize_t
 archive_write_odc_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 	int ret;
 
-	cpio = (struct cpio *)a->format_data;
 	if (s > cpio->entry_bytes_remaining)
 		s = (size_t)cpio->entry_bytes_remaining;
 
@@ -493,9 +490,8 @@ archive_write_odc_close(struct archive_write *a)
 static int
 archive_write_odc_free(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	free(cpio->ino_list);
 	free(cpio);
 	a->format_data = NULL;
@@ -505,9 +501,8 @@ archive_write_odc_free(struct archive_write *a)
 static int
 archive_write_odc_finish_entry(struct archive_write *a)
 {
-	struct cpio *cpio;
+	struct cpio *cpio = a->format_data;
 
-	cpio = (struct cpio *)a->format_data;
 	return (__archive_write_nulls(a, 
 	    cpio->entry_bytes_remaining));
 }

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -202,7 +202,7 @@ static int
 archive_write_gnutar_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct gnutar *gnutar = (struct gnutar *)a->format_data;
+	struct gnutar *gnutar = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -236,9 +236,8 @@ archive_write_gnutar_close(struct archive_write *a)
 static int
 archive_write_gnutar_free(struct archive_write *a)
 {
-	struct gnutar *gnutar;
+	struct gnutar *gnutar = a->format_data;
 
-	gnutar = (struct gnutar *)a->format_data;
 	free(gnutar);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);
@@ -247,10 +246,9 @@ archive_write_gnutar_free(struct archive_write *a)
 static int
 archive_write_gnutar_finish_entry(struct archive_write *a)
 {
-	struct gnutar *gnutar;
+	struct gnutar *gnutar = a->format_data;
 	int ret;
 
-	gnutar = (struct gnutar *)a->format_data;
 	ret = __archive_write_nulls(a,
 	    gnutar->entry_bytes_remaining + gnutar->entry_padding);
 	gnutar->entry_bytes_remaining = gnutar->entry_padding = 0;
@@ -260,10 +258,9 @@ archive_write_gnutar_finish_entry(struct archive_write *a)
 static ssize_t
 archive_write_gnutar_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct gnutar *gnutar;
+	struct gnutar *gnutar = a->format_data;
 	int ret;
 
-	gnutar = (struct gnutar *)a->format_data;
 	if (s > gnutar->entry_bytes_remaining)
 		s = (size_t)gnutar->entry_bytes_remaining;
 	ret = __archive_write_output(a, buff, s);
@@ -277,14 +274,12 @@ static int
 archive_write_gnutar_header(struct archive_write *a,
      struct archive_entry *entry)
 {
+	struct gnutar *gnutar = a->format_data;
 	char buff[512];
 	int r, ret, ret2 = ARCHIVE_OK;
 	char tartype;
-	struct gnutar *gnutar;
 	struct archive_string_conv *sconv;
 	struct archive_entry *entry_main;
-
-	gnutar = (struct gnutar *)a->format_data;
 
 	/* Setup default string conversion. */
 	if (gnutar->opt_sconv == NULL) {
@@ -608,13 +603,11 @@ static int
 archive_format_gnutar_header(struct archive_write *a, char h[512],
     struct archive_entry *entry, char tartype)
 {
+	struct gnutar *gnutar = a->format_data;
 	unsigned int checksum;
 	int i, ret;
 	size_t copy_length;
 	const char *p;
-	struct gnutar *gnutar;
-
-	gnutar = (struct gnutar *)a->format_data;
 
 	ret = 0;
 

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -1528,12 +1528,10 @@ invalid_value:
 static int
 iso9660_write_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	struct isofile *file;
 	struct isoent *isoent;
 	int r, ret = ARCHIVE_OK;
-
-	iso9660 = a->format_data;
 
 	iso9660->cur_file = NULL;
 	iso9660->bytes_remaining = 0;
@@ -1676,7 +1674,7 @@ wb_write_to_temp(struct archive_write *a, const void *buff, size_t s)
 	 * order to reduce a extra memory copy.
 	 */
 	if (wb_remaining(a) == wb_buffmax() && s > (1024 * 16)) {
-		struct iso9660 *iso9660 = (struct iso9660 *)a->format_data;
+		struct iso9660 *iso9660 = a->format_data;
 		xs = s % LOGICAL_BLOCK_SIZE;
 		iso9660->wbuff_offset += s - xs;
 		if (write_to_temp(a, buff, s - xs) != ARCHIVE_OK)
@@ -1858,10 +1856,8 @@ iso9660_finish_entry(struct archive_write *a)
 static int
 iso9660_close(struct archive_write *a)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	int ret, blocks;
-
-	iso9660 = a->format_data;
 
 	/*
 	 * Write remaining data out to the temporary file.
@@ -2120,10 +2116,8 @@ iso9660_close(struct archive_write *a)
 static int
 iso9660_free(struct archive_write *a)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	int i, ret;
-
-	iso9660 = a->format_data;
 
 	/* Close the temporary file. */
 	if (iso9660->temp_fd >= 0)
@@ -3618,7 +3612,7 @@ get_dir_rec_size(struct iso9660 *iso9660, struct isoent *isoent,
 static inline unsigned char *
 wb_buffptr(struct archive_write *a)
 {
-	struct iso9660 *iso9660 = (struct iso9660 *)a->format_data;
+	struct iso9660 *iso9660 = a->format_data;
 
 	return (&(iso9660->wbuff[sizeof(iso9660->wbuff)
 		- iso9660->wbuff_remaining]));
@@ -3627,7 +3621,7 @@ wb_buffptr(struct archive_write *a)
 static int
 wb_write_out(struct archive_write *a)
 {
-	struct iso9660 *iso9660 = (struct iso9660 *)a->format_data;
+	struct iso9660 *iso9660 = a->format_data;
 	size_t wsize, nw;
 	int r;
 
@@ -3652,7 +3646,7 @@ wb_write_out(struct archive_write *a)
 static int
 wb_consume(struct archive_write *a, size_t size)
 {
-	struct iso9660 *iso9660 = (struct iso9660 *)a->format_data;
+	struct iso9660 *iso9660 = a->format_data;
 
 	if (size > iso9660->wbuff_remaining ||
 	    iso9660->wbuff_remaining == 0) {
@@ -3673,7 +3667,7 @@ wb_consume(struct archive_write *a, size_t size)
 static int
 wb_set_offset(struct archive_write *a, int64_t off)
 {
-	struct iso9660 *iso9660 = (struct iso9660 *)a->format_data;
+	struct iso9660 *iso9660 = a->format_data;
 	int64_t used, ext_bytes;
 
 	if (iso9660->wbuff_type != WB_TO_TEMP) {
@@ -3840,7 +3834,7 @@ set_file_identifier(unsigned char *bp, int from, int to, enum vdc vdc,
 static int
 write_VD(struct archive_write *a, struct vdd *vdd)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	unsigned char *bp;
 	uint16_t volume_set_size = 1;
 	char identifier[256];
@@ -3849,7 +3843,6 @@ write_VD(struct archive_write *a, struct vdd *vdd)
 	unsigned char vd_ver, fst_ver;
 	int r;
 
-	iso9660 = a->format_data;
 	switch (vdd->vdd_type) {
 	case VDD_JOLIET:
 		vdt = VDT_SUPPLEMENTARY;
@@ -3987,10 +3980,9 @@ write_VD(struct archive_write *a, struct vdd *vdd)
 static int
 write_VD_boot_record(struct archive_write *a)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	unsigned char *bp;
 
-	iso9660 = a->format_data;
 	bp = wb_buffptr(a) -1;
 	/* Volume Descriptor Type */
 	set_VD_bp(bp, VDT_BOOT_RECORD, 1);
@@ -4058,7 +4050,7 @@ set_option_info(struct archive_string *info, int *opt, const char *key,
 static int
 write_information_block(struct archive_write *a)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	char buf[128];
 	const char *v;
 	int opt, r;
@@ -4066,7 +4058,6 @@ write_information_block(struct archive_write *a)
 	size_t info_size = LOGICAL_BLOCK_SIZE *
 			       NON_ISO_FILE_SYSTEM_INFORMATION_BLOCK;
 
-	iso9660 = (struct iso9660 *)a->format_data;
 	if (info_size > wb_remaining(a)) {
 		r = wb_write_out(a);
 		if (r != ARCHIVE_OK)
@@ -4716,13 +4707,11 @@ cleanup_backslash_2(wchar_t *p)
 static int
 isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	const char *pathname;
 	char *p, *dirname, *slash;
 	size_t len;
 	int ret = ARCHIVE_OK;
-
-	iso9660 = a->format_data;
 
 	archive_string_empty(&(file->parentdir));
 	archive_string_empty(&(file->basename));
@@ -5562,6 +5551,7 @@ get_path_component(char *name, size_t n, const char *fn)
 static int
 isoent_tree(struct archive_write *a, struct isoent **isoentpp)
 {
+	struct iso9660 *iso9660 = a->format_data;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	char name[_MAX_FNAME];/* Included null terminator size. */
 #elif defined(NAME_MAX) && NAME_MAX >= 255
@@ -5569,7 +5559,6 @@ isoent_tree(struct archive_write *a, struct isoent **isoentpp)
 #else
 	char name[256];
 #endif
-	struct iso9660 *iso9660 = a->format_data;
 	struct isoent *dent, *isoent, *np;
 	struct isofile *f1, *f2;
 	const char *fn, *p;
@@ -5997,7 +5986,7 @@ static int
 isoent_gen_iso9660_identifier(struct archive_write *a, struct isoent *isoent,
     struct idr *idr)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	struct isoent *np;
 	char *p;
 	int l, r;
@@ -6015,7 +6004,6 @@ isoent_gen_iso9660_identifier(struct archive_write *a, struct isoent *isoent,
 	if (isoent->children.cnt == 0)
 		return (ARCHIVE_OK);
 
-	iso9660 = a->format_data;
 	char_map = idr->char_map;
 	if (iso9660->opt.iso_level <= 3) {
 		allow_ldots = 0;
@@ -6257,7 +6245,7 @@ static int
 isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
     struct idr *idr)
 {
-	struct iso9660 *iso9660;
+	struct iso9660 *iso9660 = a->format_data;
 	struct isoent *np;
 	unsigned char *p;
 	size_t l;
@@ -6272,7 +6260,6 @@ isoent_gen_joliet_identifier(struct archive_write *a, struct isoent *isoent,
 	if (isoent->children.cnt == 0)
 		return (ARCHIVE_OK);
 
-	iso9660 = a->format_data;
 	if (iso9660->opt.joliet == OPT_JOLIET_LONGNAME)
 		ffmax = 206;
 	else

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -913,7 +913,7 @@ static int
 archive_write_mtree_header(struct archive_write *a,
     struct archive_entry *entry)
 {
-	struct mtree_writer *mtree= a->format_data;
+	struct mtree_writer *mtree = a->format_data;
 	struct mtree_entry *mtree_entry;
 	int r, r2;
 
@@ -1261,7 +1261,7 @@ archive_write_mtree_finish_entry(struct archive_write *a)
 static int
 archive_write_mtree_close(struct archive_write *a)
 {
-	struct mtree_writer *mtree= a->format_data;
+	struct mtree_writer *mtree = a->format_data;
 	int ret;
 
 	if (mtree->root != NULL) {
@@ -1278,7 +1278,7 @@ archive_write_mtree_close(struct archive_write *a)
 static ssize_t
 archive_write_mtree_data(struct archive_write *a, const void *buff, size_t n)
 {
-	struct mtree_writer *mtree= a->format_data;
+	struct mtree_writer *mtree = a->format_data;
 
 	if (n > mtree->entry_bytes_remaining)
 		n = (size_t)mtree->entry_bytes_remaining;
@@ -1297,7 +1297,7 @@ archive_write_mtree_data(struct archive_write *a, const void *buff, size_t n)
 static int
 archive_write_mtree_free(struct archive_write *a)
 {
-	struct mtree_writer *mtree= a->format_data;
+	struct mtree_writer *mtree = a->format_data;
 
 	if (mtree == NULL)
 		return (ARCHIVE_OK);
@@ -1317,7 +1317,7 @@ static int
 archive_write_mtree_options(struct archive_write *a, const char *key,
     const char *value)
 {
-	struct mtree_writer *mtree= a->format_data;
+	struct mtree_writer *mtree = a->format_data;
 	int keybit = 0;
 
 	switch (key[0]) {
@@ -1480,9 +1480,7 @@ archive_write_set_format_mtree_classic(struct archive *_a)
 		"archive_write_set_format_mtree_classic");
 	if (r == ARCHIVE_OK) {
 		struct archive_write *a = (struct archive_write *)_a;
-		struct mtree_writer *mtree;
-
-		mtree = (struct mtree_writer *)a->format_data;
+		struct mtree_writer *mtree = a->format_data;
 
 		/* Set to output a mtree archive in classic format. */
 		mtree->classic = 1;
@@ -2072,6 +2070,7 @@ get_path_component(char *name, size_t n, const char *fn)
 static int
 mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 {
+	struct mtree_writer *mtree = a->format_data;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	char name[_MAX_FNAME];/* Included null terminator size. */
 #elif defined(NAME_MAX) && NAME_MAX >= 255
@@ -2079,7 +2078,6 @@ mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 #else
 	char name[256];
 #endif
-	struct mtree_writer *mtree = (struct mtree_writer *)a->format_data;
 	struct mtree_entry *dent, *file, *np;
 	const char *fn, *p;
 	int l, r;

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -117,7 +117,7 @@ struct mtree_entry {
 	int64_t ino;
 };
 
-struct mtree_writer {
+struct mtree {
 	struct mtree_entry *mtree_entry;
 	struct mtree_entry *root;
 	struct mtree_entry *cur_dirent;
@@ -220,10 +220,10 @@ static int attr_counter_inc(struct attr_counter **, struct attr_counter *,
 	struct attr_counter *, struct mtree_entry *);
 static struct attr_counter * attr_counter_new(struct mtree_entry *,
 	struct attr_counter *);
-static int attr_counter_set_collect(struct mtree_writer *,
+static int attr_counter_set_collect(struct mtree *,
 	struct mtree_entry *);
-static void attr_counter_set_free(struct mtree_writer *);
-static int get_global_set_keys(struct mtree_writer *, struct mtree_entry *);
+static void attr_counter_set_free(struct mtree *);
+static int get_global_set_keys(struct mtree *, struct mtree_entry *);
 static int mtree_entry_add_child_tail(struct mtree_entry *,
 	struct mtree_entry *);
 static int mtree_entry_create_virtual_dir(struct archive_write *, const char *,
@@ -236,14 +236,14 @@ static int mtree_entry_exchange_same_entry(struct archive_write *,
 static void mtree_entry_free(struct mtree_entry *);
 static int mtree_entry_new(struct archive_write *, struct archive_entry *,
 	struct mtree_entry **);
-static void mtree_entry_register_free(struct mtree_writer *);
-static void mtree_entry_register_init(struct mtree_writer *);
+static void mtree_entry_register_free(struct mtree *);
+static void mtree_entry_register_init(struct mtree *);
 static int mtree_entry_setup_filenames(struct archive_write *,
 	struct mtree_entry *, struct archive_entry *);
 static int mtree_entry_tree_add(struct archive_write *, struct mtree_entry **);
-static void sum_init(struct mtree_writer *);
-static void sum_update(struct mtree_writer *, const void *, size_t);
-static void sum_final(struct mtree_writer *, struct reg_info *);
+static void sum_init(struct mtree *);
+static void sum_update(struct mtree *, const void *, size_t);
+static void sum_final(struct mtree *, struct reg_info *);
 static void sum_write(struct archive_string *, struct reg_info *);
 static int write_mtree_entry(struct archive_write *, struct mtree_entry *);
 static int write_dot_dot_entry(struct archive_write *, struct mtree_entry *);
@@ -358,7 +358,7 @@ mtree_quote(struct archive_string *s, const char *str)
  * Indent a line as the mtree utility does so it is readable for people.
  */
 static void
-mtree_indent(struct mtree_writer *mtree)
+mtree_indent(struct mtree *mtree)
 {
 	int i, fn, nd, pd;
 	const char *r, *s, *x;
@@ -434,7 +434,7 @@ mtree_indent(struct mtree_writer *mtree)
  * collected by the attr_counter_set_collect() function.
  */
 static void
-write_global(struct mtree_writer *mtree)
+write_global(struct mtree *mtree)
 {
 	struct archive_string setstr;
 	struct archive_string unsetstr;
@@ -636,7 +636,7 @@ attr_counter_inc(struct attr_counter **top, struct attr_counter *ac,
  * Tabulate uid, gid, mode and fflags of a entry in order to be used for /set.
  */
 static int
-attr_counter_set_collect(struct mtree_writer *mtree, struct mtree_entry *me)
+attr_counter_set_collect(struct mtree *mtree, struct mtree_entry *me)
 {
 	struct attr_counter *ac, *last;
 	struct attr_counter_set *acs = &mtree->acs;
@@ -713,7 +713,7 @@ attr_counter_set_collect(struct mtree_writer *mtree, struct mtree_entry *me)
 }
 
 static void
-attr_counter_set_free(struct mtree_writer *mtree)
+attr_counter_set_free(struct mtree *mtree)
 {
 	struct attr_counter_set *acs = &mtree->acs;
 
@@ -724,7 +724,7 @@ attr_counter_set_free(struct mtree_writer *mtree)
 }
 
 static int
-get_global_set_keys(struct mtree_writer *mtree, struct mtree_entry *me)
+get_global_set_keys(struct mtree *mtree, struct mtree_entry *me)
 {
 	int keys;
 
@@ -913,7 +913,7 @@ static int
 archive_write_mtree_header(struct archive_write *a,
     struct archive_entry *entry)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	struct mtree_entry *mtree_entry;
 	int r, r2;
 
@@ -956,7 +956,7 @@ archive_write_mtree_header(struct archive_write *a,
 static int
 write_mtree_entry(struct archive_write *a, struct mtree_entry *me)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	struct archive_string *str;
 	int keys, ret;
 
@@ -1107,7 +1107,7 @@ write_mtree_entry(struct archive_write *a, struct mtree_entry *me)
 static int
 write_dot_dot_entry(struct archive_write *a, struct mtree_entry *n)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	int ret;
 
 	if (n->parentdir.s) {
@@ -1142,7 +1142,7 @@ write_dot_dot_entry(struct archive_write *a, struct mtree_entry *n)
 static int
 write_mtree_entry_tree(struct archive_write *a)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	struct mtree_entry *np = mtree->root;
 	struct archive_rb_node *n;
 	int ret;
@@ -1245,7 +1245,7 @@ write_mtree_entry_tree(struct archive_write *a)
 static int
 archive_write_mtree_finish_entry(struct archive_write *a)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	struct mtree_entry *me;
 
 	if ((me = mtree->mtree_entry) == NULL)
@@ -1261,7 +1261,7 @@ archive_write_mtree_finish_entry(struct archive_write *a)
 static int
 archive_write_mtree_close(struct archive_write *a)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	int ret;
 
 	if (mtree->root != NULL) {
@@ -1278,7 +1278,7 @@ archive_write_mtree_close(struct archive_write *a)
 static ssize_t
 archive_write_mtree_data(struct archive_write *a, const void *buff, size_t n)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 
 	if (n > mtree->entry_bytes_remaining)
 		n = (size_t)mtree->entry_bytes_remaining;
@@ -1297,7 +1297,7 @@ archive_write_mtree_data(struct archive_write *a, const void *buff, size_t n)
 static int
 archive_write_mtree_free(struct archive_write *a)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 
 	if (mtree == NULL)
 		return (ARCHIVE_OK);
@@ -1317,7 +1317,7 @@ static int
 archive_write_mtree_options(struct archive_write *a, const char *key,
     const char *value)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 	int keybit = 0;
 
 	switch (key[0]) {
@@ -1429,7 +1429,7 @@ static int
 archive_write_set_format_mtree_default(struct archive *_a, const char *fn)
 {
 	struct archive_write *a = (struct archive_write *)_a;
-	struct mtree_writer *mtree;
+	struct mtree *mtree;
 
 	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC, ARCHIVE_STATE_NEW, fn);
 
@@ -1480,7 +1480,7 @@ archive_write_set_format_mtree_classic(struct archive *_a)
 		"archive_write_set_format_mtree_classic");
 	if (r == ARCHIVE_OK) {
 		struct archive_write *a = (struct archive_write *)_a;
-		struct mtree_writer *mtree = a->format_data;
+		struct mtree *mtree = a->format_data;
 
 		/* Set to output a mtree archive in classic format. */
 		mtree->classic = 1;
@@ -1492,7 +1492,7 @@ archive_write_set_format_mtree_classic(struct archive *_a)
 }
 
 static void
-sum_init(struct mtree_writer *mtree)
+sum_init(struct mtree *mtree)
 {
 
 	mtree->compute_sum = 0;
@@ -1553,7 +1553,7 @@ sum_init(struct mtree_writer *mtree)
 }
 
 static void
-sum_update(struct mtree_writer *mtree, const void *buff, size_t n)
+sum_update(struct mtree *mtree, const void *buff, size_t n)
 {
 	if (mtree->compute_sum & F_CKSUM) {
 		/*
@@ -1611,7 +1611,7 @@ sum_update(struct mtree_writer *mtree, const void *buff, size_t n)
 }
 
 static void
-sum_final(struct mtree_writer *mtree, struct reg_info *reg)
+sum_final(struct mtree *mtree, struct reg_info *reg)
 {
 	struct ae_digest digest;
 
@@ -1992,7 +1992,7 @@ mtree_entry_create_virtual_dir(struct archive_write *a, const char *pathname,
 }
 
 static void
-mtree_entry_register_add(struct mtree_writer *mtree, struct mtree_entry *file)
+mtree_entry_register_add(struct mtree *mtree, struct mtree_entry *file)
 {
         file->next = NULL;
         *mtree->file_list.last = file;
@@ -2000,14 +2000,14 @@ mtree_entry_register_add(struct mtree_writer *mtree, struct mtree_entry *file)
 }
 
 static void
-mtree_entry_register_init(struct mtree_writer *mtree)
+mtree_entry_register_init(struct mtree *mtree)
 {
 	mtree->file_list.first = NULL;
 	mtree->file_list.last = &(mtree->file_list.first);
 }
 
 static void
-mtree_entry_register_free(struct mtree_writer *mtree)
+mtree_entry_register_free(struct mtree *mtree)
 {
 	struct mtree_entry *file, *file_next;
 
@@ -2070,7 +2070,7 @@ get_path_component(char *name, size_t n, const char *fn)
 static int
 mtree_entry_tree_add(struct archive_write *a, struct mtree_entry **filep)
 {
-	struct mtree_writer *mtree = a->format_data;
+	struct mtree *mtree = a->format_data;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	char name[_MAX_FNAME];/* Included null terminator size. */
 #elif defined(NAME_MAX) && NAME_MAX >= 255

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -172,7 +172,7 @@ static int
 archive_write_pax_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct pax *pax = (struct pax *)a->format_data;
+	struct pax *pax = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -680,6 +680,7 @@ static int
 archive_write_pax_header(struct archive_write *a,
     struct archive_entry *entry_original)
 {
+	struct pax *pax = a->format_data;
 	struct archive_entry *entry_main;
 	const char *p;
 	const char *suffix;
@@ -687,7 +688,6 @@ archive_write_pax_header(struct archive_write *a,
 	int acl_types;
 	int sparse_count;
 	uint64_t sparse_total, real_size;
-	struct pax *pax;
 	const char *hardlink;
 	const char *path = NULL, *linkpath = NULL;
 	const char *uname = NULL, *gname = NULL;
@@ -707,7 +707,6 @@ archive_write_pax_header(struct archive_write *a,
 
 	ret = ARCHIVE_OK;
 	need_extension = 0;
-	pax = (struct pax *)a->format_data;
 
 	const time_t ustar_max_mtime = get_ustar_max_mtime();
 
@@ -1962,9 +1961,8 @@ archive_write_pax_close(struct archive_write *a)
 static int
 archive_write_pax_free(struct archive_write *a)
 {
-	struct pax *pax;
+	struct pax *pax = a->format_data;
 
-	pax = (struct pax *)a->format_data;
 	if (pax == NULL)
 		return (ARCHIVE_OK);
 
@@ -1980,11 +1978,10 @@ archive_write_pax_free(struct archive_write *a)
 static int
 archive_write_pax_finish_entry(struct archive_write *a)
 {
-	struct pax *pax;
+	struct pax *pax = a->format_data;
 	uint64_t remaining;
 	int ret;
 
-	pax = (struct pax *)a->format_data;
 	remaining = pax->entry_bytes_remaining;
 	if (remaining == 0) {
 		while (pax->sparse_list) {
@@ -2004,12 +2001,10 @@ archive_write_pax_finish_entry(struct archive_write *a)
 static ssize_t
 archive_write_pax_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct pax *pax;
+	struct pax *pax = a->format_data;
 	size_t ws;
 	size_t total;
 	int ret;
-
-	pax = (struct pax *)a->format_data;
 
 	/*
 	 * According to GNU PAX format 1.0, write a sparse map

--- a/libarchive/archive_write_set_format_raw.c
+++ b/libarchive/archive_write_set_format_raw.c
@@ -81,7 +81,7 @@ archive_write_set_format_raw(struct archive *_a)
 static int
 archive_write_raw_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct raw *raw = (struct raw *)a->format_data;
+	struct raw *raw = a->format_data;
 
 	if (archive_entry_filetype(entry) != AE_IFREG) {
 		archive_set_error(&a->archive, ERANGE,
@@ -115,9 +115,8 @@ archive_write_raw_data(struct archive_write *a, const void *buff, size_t s)
 static int
 archive_write_raw_free(struct archive_write *a)
 {
-	struct raw *raw;
+	struct raw *raw = a->format_data;
 
-	raw = (struct raw *)a->format_data;
 	free(raw);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -98,11 +98,8 @@ shar_quote(struct archive_string *buf, const char *str, int in_shell)
 	}
 }
 
-/*
- * Set output format to 'shar' format.
- */
-int
-archive_write_set_format_shar(struct archive *_a)
+static int
+shar_set_format(struct archive *_a, int dump)
 {
 	struct archive_write *a = (struct archive_write *)_a;
 	struct shar *shar;
@@ -120,16 +117,32 @@ archive_write_set_format_shar(struct archive *_a)
 	}
 	archive_string_init(&shar->work);
 	archive_string_init(&shar->quoted_name);
+	if (dump) {
+		shar->dump = 1;
+		a->format_write_data = archive_write_shar_data_uuencode;
+		a->archive.archive_format = ARCHIVE_FORMAT_SHAR_DUMP;
+		a->archive.archive_format_name = "shar dump";
+	} else {
+		a->format_write_data = archive_write_shar_data_sed;
+		a->archive.archive_format = ARCHIVE_FORMAT_SHAR_BASE;
+		a->archive.archive_format_name = "shar";
+	}
 	a->format_data = shar;
 	a->format_name = "shar";
 	a->format_write_header = archive_write_shar_header;
 	a->format_close = archive_write_shar_close;
 	a->format_free = archive_write_shar_free;
-	a->format_write_data = archive_write_shar_data_sed;
 	a->format_finish_entry = archive_write_shar_finish_entry;
-	a->archive.archive_format = ARCHIVE_FORMAT_SHAR_BASE;
-	a->archive.archive_format_name = "shar";
 	return (ARCHIVE_OK);
+}
+
+/*
+ * Set output format to 'shar' format.
+ */
+int
+archive_write_set_format_shar(struct archive *a)
+{
+	return shar_set_format(a, 0);
 }
 
 /*
@@ -139,22 +152,9 @@ archive_write_set_format_shar(struct archive *_a)
  * and other extended file information.
  */
 int
-archive_write_set_format_shar_dump(struct archive *_a)
+archive_write_set_format_shar_dump(struct archive *a)
 {
-	struct archive_write *a = (struct archive_write *)_a;
-	struct shar *shar;
-	int ret;
-
-	ret = archive_write_set_format_shar(&a->archive);
-	if (ret != ARCHIVE_OK)
-		return ret;
-
-	shar = a->format_data;
-	shar->dump = 1;
-	a->format_write_data = archive_write_shar_data_uuencode;
-	a->archive.archive_format = ARCHIVE_FORMAT_SHAR_DUMP;
-	a->archive.archive_format_name = "shar dump";
-	return (ARCHIVE_OK);
+	return shar_set_format(a, 1);
 }
 
 static int

--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -143,11 +143,13 @@ archive_write_set_format_shar_dump(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
 	struct shar *shar;
+	int ret;
 
-	int ret = archive_write_set_format_shar(&a->archive);
+	ret = archive_write_set_format_shar(&a->archive);
 	if (ret != ARCHIVE_OK)
 		return ret;
-	shar = (struct shar *)a->format_data;
+
+	shar = a->format_data;
 	shar->dump = 1;
 	a->format_write_data = archive_write_shar_data_uuencode;
 	a->archive.archive_format = ARCHIVE_FORMAT_SHAR_DUMP;
@@ -158,12 +160,11 @@ archive_write_set_format_shar_dump(struct archive *_a)
 static int
 archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 {
+	struct shar *shar = a->format_data;
 	const char *linkname;
 	const char *name;
 	char *p, *pp;
-	struct shar *shar;
 
-	shar = (struct shar *)a->format_data;
 	if (!shar->wrote_header) {
 		archive_strcat(&shar->work, "#!/bin/sh\n");
 		archive_strcat(&shar->work, "# This is a shell archive\n");
@@ -342,14 +343,13 @@ archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 static ssize_t
 archive_write_shar_data_sed(struct archive_write *a, const void *buff, size_t n)
 {
+	struct shar *shar = a->format_data;
 	static const size_t ensured = 65533;
-	struct shar *shar;
 	const char *src;
 	char *buf, *buf_end;
 	int ret;
 	size_t written = n;
 
-	shar = (struct shar *)a->format_data;
 	if (!shar->has_data || n == 0)
 		return (0);
 
@@ -474,12 +474,11 @@ static ssize_t
 archive_write_shar_data_uuencode(struct archive_write *a, const void *buff,
     size_t length)
 {
-	struct shar *shar;
+	struct shar *shar = a->format_data;
 	const char *src;
 	size_t n;
 	int ret;
 
-	shar = (struct shar *)a->format_data;
 	if (!shar->has_data)
 		return (ARCHIVE_OK);
 	src = (const char *)buff;
@@ -523,11 +522,10 @@ archive_write_shar_data_uuencode(struct archive_write *a, const void *buff,
 static int
 archive_write_shar_finish_entry(struct archive_write *a)
 {
+	struct shar *shar = a->format_data;
 	const char *g, *p, *u;
-	struct shar *shar;
 	int ret;
 
-	shar = (struct shar *)a->format_data;
 	if (shar->entry == NULL)
 		return (ARCHIVE_OK);
 
@@ -601,15 +599,13 @@ archive_write_shar_finish_entry(struct archive_write *a)
 static int
 archive_write_shar_close(struct archive_write *a)
 {
-	struct shar *shar;
+	struct shar *shar = a->format_data;
 	int ret;
 
 	/*
 	 * TODO: Accumulate list of directory names/modes and
 	 * fix them all up at end-of-archive.
 	 */
-
-	shar = (struct shar *)a->format_data;
 
 	/*
 	 * Only write the end-of-archive markers if the archive was
@@ -639,9 +635,8 @@ archive_write_shar_close(struct archive_write *a)
 static int
 archive_write_shar_free(struct archive_write *a)
 {
-	struct shar *shar;
+	struct shar *shar = a->format_data;
 
-	shar = (struct shar *)a->format_data;
 	if (shar == NULL)
 		return (ARCHIVE_OK);
 

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -205,7 +205,7 @@ static int
 archive_write_ustar_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct ustar *ustar = (struct ustar *)a->format_data;
+	struct ustar *ustar = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -233,13 +233,11 @@ archive_write_ustar_options(struct archive_write *a, const char *key,
 static int
 archive_write_ustar_header(struct archive_write *a, struct archive_entry *entry)
 {
+	struct ustar *ustar = a->format_data;
 	char buff[512];
 	int ret, ret2;
-	struct ustar *ustar;
 	struct archive_entry *entry_main;
 	struct archive_string_conv *sconv;
-
-	ustar = (struct ustar *)a->format_data;
 
 	/* Setup default string conversion. */
 	if (ustar->opt_sconv == NULL) {
@@ -735,9 +733,8 @@ archive_write_ustar_close(struct archive_write *a)
 static int
 archive_write_ustar_free(struct archive_write *a)
 {
-	struct ustar *ustar;
+	struct ustar *ustar = a->format_data;
 
-	ustar = (struct ustar *)a->format_data;
 	free(ustar);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);
@@ -746,10 +743,9 @@ archive_write_ustar_free(struct archive_write *a)
 static int
 archive_write_ustar_finish_entry(struct archive_write *a)
 {
-	struct ustar *ustar;
+	struct ustar *ustar = a->format_data;
 	int ret;
 
-	ustar = (struct ustar *)a->format_data;
 	ret = __archive_write_nulls(a,
 	    ustar->entry_bytes_remaining + ustar->entry_padding);
 	ustar->entry_bytes_remaining = ustar->entry_padding = 0;
@@ -759,10 +755,9 @@ archive_write_ustar_finish_entry(struct archive_write *a)
 static ssize_t
 archive_write_ustar_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct ustar *ustar;
+	struct ustar *ustar = a->format_data;
 	int ret;
 
-	ustar = (struct ustar *)a->format_data;
 	if (s > ustar->entry_bytes_remaining)
 		s = (size_t)ustar->entry_bytes_remaining;
 	ret = __archive_write_output(a, buff, s);

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -182,7 +182,7 @@ static int
 archive_write_v7tar_options(struct archive_write *a, const char *key,
     const char *val)
 {
-	struct v7tar *v7tar = (struct v7tar *)a->format_data;
+	struct v7tar *v7tar = a->format_data;
 	int ret = ARCHIVE_FAILED;
 
 	if (strcmp(key, "hdrcharset")  == 0) {
@@ -210,13 +210,11 @@ archive_write_v7tar_options(struct archive_write *a, const char *key,
 static int
 archive_write_v7tar_header(struct archive_write *a, struct archive_entry *entry)
 {
+	struct v7tar *v7tar = a->format_data;
 	char buff[512];
 	int ret, ret2;
-	struct v7tar *v7tar;
 	struct archive_entry *entry_main;
 	struct archive_string_conv *sconv;
-
-	v7tar = (struct v7tar *)a->format_data;
 
 	/* Setup default string conversion. */
 	if (v7tar->opt_sconv == NULL) {
@@ -615,9 +613,8 @@ archive_write_v7tar_close(struct archive_write *a)
 static int
 archive_write_v7tar_free(struct archive_write *a)
 {
-	struct v7tar *v7tar;
+	struct v7tar *v7tar = a->format_data;
 
-	v7tar = (struct v7tar *)a->format_data;
 	free(v7tar);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);
@@ -626,10 +623,9 @@ archive_write_v7tar_free(struct archive_write *a)
 static int
 archive_write_v7tar_finish_entry(struct archive_write *a)
 {
-	struct v7tar *v7tar;
+	struct v7tar *v7tar = a->format_data;
 	int ret;
 
-	v7tar = (struct v7tar *)a->format_data;
 	ret = __archive_write_nulls(a,
 	    v7tar->entry_bytes_remaining + v7tar->entry_padding);
 	v7tar->entry_bytes_remaining = v7tar->entry_padding = 0;
@@ -639,10 +635,9 @@ archive_write_v7tar_finish_entry(struct archive_write *a)
 static ssize_t
 archive_write_v7tar_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct v7tar *v7tar;
+	struct v7tar *v7tar = a->format_data;
 	int ret;
 
-	v7tar = (struct v7tar *)a->format_data;
 	if (s > v7tar->entry_bytes_remaining)
 		s = (size_t)v7tar->entry_bytes_remaining;
 	ret = __archive_write_output(a, buff, s);

--- a/libarchive/archive_write_set_format_warc.c
+++ b/libarchive/archive_write_set_format_warc.c
@@ -59,7 +59,7 @@
  * Content-Length header.
  */
 
-struct warc_s {
+struct warc {
 	unsigned int omit_warcinfo:1;
 
 	time_t now;
@@ -127,7 +127,7 @@ int
 archive_write_set_format_warc(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
-	struct warc_s *w;
+	struct warc *warc;
 
 	archive_check_magic(_a, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_NEW, "archive_write_set_format_warc");
@@ -135,20 +135,20 @@ archive_write_set_format_warc(struct archive *_a)
 	/* If another format was already registered, unregister it. */
 	(void)__archive_write_unregister_format(a);
 
-	w = malloc(sizeof(*w));
-	if (w == NULL) {
+	warc = malloc(sizeof(*warc));
+	if (warc == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate warc data");
 		return (ARCHIVE_FATAL);
 	}
 	/* Emit a warcinfo record by default. */
-	w->omit_warcinfo = 0U;
+	warc->omit_warcinfo = 0U;
 	/* Use the current time for WARC-Date values. */
-	w->now = time(NULL);
+	warc->now = time(NULL);
 	/* Reset file type information. */
-	w->typ = 0;
+	warc->typ = 0;
 
-	a->format_data = w;
+	a->format_data = warc;
 	a->format_name = "WARC/1.0";
 	a->format_options = _warc_options;
 	a->format_write_header = _warc_header;
@@ -166,12 +166,12 @@ archive_write_set_format_warc(struct archive *_a)
 static int
 _warc_options(struct archive_write *a, const char *key, const char *val)
 {
-	struct warc_s *w = a->format_data;
+	struct warc *warc = a->format_data;
 
 	if (strcmp(key, "omit-warcinfo") == 0) {
 		if (val == NULL || strcmp(val, "true") == 0) {
 			/* Option accepted. */
-			w->omit_warcinfo = 1U;
+			warc->omit_warcinfo = 1U;
 			return (ARCHIVE_OK);
 		}
 	}
@@ -184,12 +184,12 @@ _warc_options(struct archive_write *a, const char *key, const char *val)
 static int
 _warc_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct warc_s *w = a->format_data;
+	struct warc *warc = a->format_data;
 	struct archive_string hdr;
 #define MAX_HDR_SIZE 512
 
 	/* Emit the warcinfo record if needed. */
-	if (!w->omit_warcinfo) {
+	if (!warc->omit_warcinfo) {
 		ssize_t r;
 		int rc;
 		warc_essential_hdr_t wi = {
@@ -201,8 +201,8 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			/* Content type */"application/warc-fields",
 			/* Content length */sizeof(warcinfo) - 1U,
 		};
-		wi.rtime = w->now;
-		wi.mtime = w->now;
+		wi.rtime = warc->now;
+		wi.mtime = warc->now;
 
 		archive_string_init(&hdr);
 		r = _popul_ehdr(&hdr, MAX_HDR_SIZE, wi);
@@ -228,7 +228,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 		}
 
 		/* Mark the file header as written. */
-		w->omit_warcinfo = 1U;
+		warc->omit_warcinfo = 1U;
 		archive_string_free(&hdr);
 	}
 
@@ -238,9 +238,9 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 		return (ARCHIVE_WARN);
 	}
 
-	w->typ = archive_entry_filetype(entry);
-	w->entry_bytes_remaining = 0U;
-	if (w->typ == AE_IFREG) {
+	warc->typ = archive_entry_filetype(entry);
+	warc->entry_bytes_remaining = 0U;
+	if (warc->typ == AE_IFREG) {
 		warc_essential_hdr_t rh = {
 			WT_RSRC,
 			/* URI */NULL,
@@ -254,7 +254,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 		int rc;
 		int64_t size;
 		rh.tgturi = archive_entry_pathname(entry);
-		rh.rtime = w->now;
+		rh.rtime = warc->now;
 		rh.mtime = archive_entry_mtime(entry);
 		if (!archive_entry_size_is_set(entry)) {
 			archive_set_error(&a->archive, -1,
@@ -287,7 +287,7 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 			return (rc);
 		}
 		/* Save the remaining size for subsequent _data() calls. */
-		w->entry_bytes_remaining = rh.cntlen;
+		warc->entry_bytes_remaining = rh.cntlen;
 		archive_string_free(&hdr);
 		return (ARCHIVE_OK);
 	}
@@ -300,14 +300,14 @@ _warc_header(struct archive_write *a, struct archive_entry *entry)
 static ssize_t
 _warc_data(struct archive_write *a, const void *buf, size_t len)
 {
-	struct warc_s *w = a->format_data;
+	struct warc *warc = a->format_data;
 
-	if (w->typ == AE_IFREG) {
+	if (warc->typ == AE_IFREG) {
 		int rc;
 
 		/* Never write more bytes than announced. */
-		if ((uint64_t)len > w->entry_bytes_remaining) {
-			len = (size_t)w->entry_bytes_remaining;
+		if ((uint64_t)len > warc->entry_bytes_remaining) {
+			len = (size_t)warc->entry_bytes_remaining;
 		}
 
 		/* Write the entry data. */
@@ -315,7 +315,7 @@ _warc_data(struct archive_write *a, const void *buf, size_t len)
 		if (rc != ARCHIVE_OK) {
 			return rc;
 		}
-		w->entry_bytes_remaining -= len;
+		warc->entry_bytes_remaining -= len;
 	}
 	return len;
 }
@@ -324,12 +324,12 @@ static int
 _warc_finish_entry(struct archive_write *a)
 {
 	static const char _eor[] = "\r\n\r\n";
-	struct warc_s *w = a->format_data;
+	struct warc *warc = a->format_data;
 
-	if (w->typ == AE_IFREG) {
+	if (warc->typ == AE_IFREG) {
 		int rc;
 
-		if (w->entry_bytes_remaining != 0U) {
+		if (warc->entry_bytes_remaining != 0U) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "WARC entry is shorter than Content-Length");
 			return (ARCHIVE_FATAL);
@@ -341,7 +341,7 @@ _warc_finish_entry(struct archive_write *a)
 		}
 	}
 	/* reset type info */
-	w->typ = 0;
+	warc->typ = 0;
 	return (ARCHIVE_OK);
 }
 
@@ -355,9 +355,9 @@ _warc_close(struct archive_write *a)
 static int
 _warc_free(struct archive_write *a)
 {
-	struct warc_s *w = a->format_data;
+	struct warc *warc = a->format_data;
 
-	free(w);
+	free(warc);
 	a->format_data = NULL;
 	return (ARCHIVE_OK);
 }

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -434,9 +434,7 @@ memerr:
 static int
 xar_options(struct archive_write *a, const char *key, const char *value)
 {
-	struct xar *xar;
-
-	xar = (struct xar *)a->format_data;
+	struct xar *xar = a->format_data;
 
 	if (strcmp(key, "checksum") == 0) {
 		if (value == NULL)
@@ -566,12 +564,11 @@ xar_options(struct archive_write *a, const char *key, const char *value)
 static int
 xar_write_header(struct archive_write *a, struct archive_entry *entry)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	struct file *file;
 	struct archive_entry *file_entry;
 	int r, r2;
 
-	xar = (struct xar *)a->format_data;
 	xar->cur_file = NULL;
 	xar->bytes_remaining = 0;
 
@@ -696,11 +693,10 @@ xar_write_header(struct archive_write *a, struct archive_entry *entry)
 static int
 write_to_temp(struct archive_write *a, const void *buff, size_t s)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	const unsigned char *p;
 	ssize_t ws;
 
-	xar = (struct xar *)a->format_data;
 	p = (const unsigned char *)buff;
 	while (s) {
 		ws = write(xar->temp_fd, p, s);
@@ -719,13 +715,11 @@ write_to_temp(struct archive_write *a, const void *buff, size_t s)
 static ssize_t
 xar_write_data(struct archive_write *a, const void *buff, size_t s)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	enum la_zaction run;
 	size_t size = 0;
 	size_t rsize;
 	int r;
-
-	xar = (struct xar *)a->format_data;
 
 	if (s > xar->bytes_remaining)
 		s = (size_t)xar->bytes_remaining;
@@ -820,12 +814,11 @@ xar_write_data(struct archive_write *a, const void *buff, size_t s)
 static int
 xar_finish_entry(struct archive_write *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	struct file *file;
 	size_t s;
 	ssize_t w;
 
-	xar = (struct xar *)a->format_data;
 	if (xar->cur_file == NULL)
 		return (ARCHIVE_OK);
 
@@ -926,10 +919,9 @@ static int __LA_PRINTF(4, 5)
 xmlwrite_fstring(struct archive_write *a, struct xml_writer *writer,
 	const char *key, const char *fmt, ...)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	va_list ap;
 
-	xar = (struct xar *)a->format_data;
 	va_start(ap, fmt);
 	archive_string_empty(&xar->vstr);
 	archive_string_vsprintf(&xar->vstr, fmt, ap);
@@ -1217,7 +1209,7 @@ static int
 make_file_entry(struct archive_write *a, struct xml_writer *writer,
     struct file *file)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	const char *filetype, *filelink, *fflags;
 	struct archive_string linkto;
 	struct heap_data *heap;
@@ -1225,7 +1217,6 @@ make_file_entry(struct archive_write *a, struct xml_writer *writer,
 	size_t len;
 	int r, r2;
 
-	xar = (struct xar *)a->format_data;
 	r2 = ARCHIVE_OK;
 
 	/*
@@ -1587,15 +1578,13 @@ make_file_entry(struct archive_write *a, struct xml_writer *writer,
 static int
 make_toc(struct archive_write *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	struct file *np;
 	struct xml_writer *writer;
 	const char* content;
 	size_t use;
 	int algsize;
 	int r, ret;
-
-	xar = (struct xar *)a->format_data;
 
 	ret = ARCHIVE_FATAL;
 
@@ -1837,11 +1826,10 @@ exit_toc:
 static int
 flush_wbuff(struct archive_write *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	int r;
 	size_t s;
 
-	xar = (struct xar *)a->format_data;
 	s = sizeof(xar->wbuff) - xar->wbuff_remaining;
 	r = __archive_write_output(a, xar->wbuff, s);
 	if (r != ARCHIVE_OK)
@@ -1853,10 +1841,9 @@ flush_wbuff(struct archive_write *a)
 static int
 copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	int r;
 
-	xar = (struct xar *)a->format_data;
 	if (lseek(xar->temp_fd, offset, SEEK_SET) < 0) {
 		archive_set_error(&(a->archive), errno, "lseek failed");
 		return (ARCHIVE_FATAL);
@@ -1898,12 +1885,10 @@ copy_out(struct archive_write *a, uint64_t offset, uint64_t length)
 static int
 xar_close(struct archive_write *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	unsigned char *wb;
 	uint64_t length;
 	int r;
-
-	xar = (struct xar *)a->format_data;
 
 	/* Empty! */
 	if (xar->root->children.first == NULL)
@@ -1964,9 +1949,7 @@ xar_close(struct archive_write *a)
 static int
 xar_free(struct archive_write *a)
 {
-	struct xar *xar;
-
-	xar = (struct xar *)a->format_data;
+	struct xar *xar = a->format_data;
 
 	/* Close the temporary file. */
 	if (xar->temp_fd >= 0)
@@ -2124,13 +2107,12 @@ cleanup_backslash(char *utf8, size_t len)
 static int
 file_gen_utility_names(struct archive_write *a, struct file *file)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	const char *pp;
 	char *p, *dirname, *slash;
 	size_t len;
 	int r = ARCHIVE_OK;
 
-	xar = (struct xar *)a->format_data;
 	archive_string_empty(&(file->parentdir));
 	archive_string_empty(&(file->basename));
 	archive_string_empty(&(file->symlink));
@@ -2318,6 +2300,7 @@ get_path_component(char *name, int n, const char *fn)
 static int
 file_tree(struct archive_write *a, struct file **filepp)
 {
+	struct xar *xar = a->format_data;
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	char name[_MAX_FNAME];/* Included null terminator size. */
 #elif defined(NAME_MAX) && NAME_MAX >= 255
@@ -2325,7 +2308,6 @@ file_tree(struct archive_write *a, struct file **filepp)
 #else
 	char name[256];
 #endif
-	struct xar *xar = (struct xar *)a->format_data;
 	struct file *dent, *file, *np;
 	struct archive_entry *ent;
 	const char *fn, *p;
@@ -2545,7 +2527,7 @@ file_free_register(struct xar *xar)
 static int
 file_register_hardlink(struct archive_write *a, struct file *file)
 {
-	struct xar *xar = (struct xar *)a->format_data;
+	struct xar *xar = a->format_data;
 	struct hardlink *hl;
 	const char *pathname;
 
@@ -3151,10 +3133,9 @@ compression_init_encoder_xz(struct archive *a,
 static int
 xar_compression_init_encoder(struct archive_write *a)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	int r;
 
-	xar = (struct xar *)a->format_data;
 	switch (xar->opt_compression) {
 	case GZIP:
 		r = compression_init_encoder_gzip(
@@ -3211,14 +3192,13 @@ compression_end(struct archive *a, struct la_zstream *lastrm)
 static int
 save_xattrs(struct archive_write *a, struct file *file)
 {
-	struct xar *xar;
+	struct xar *xar = a->format_data;
 	const char *name;
 	const void *value;
 	struct heap_data *heap;
 	size_t size;
 	int count, r;
 
-	xar = (struct xar *)a->format_data;
 	count = archive_entry_xattr_reset(file->entry);
 	if (count == 0)
 		return (ARCHIVE_OK);

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -789,9 +789,9 @@ is_all_ascii(const char *p)
 static int
 archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 {
+	struct zip *zip = a->format_data;
 	unsigned char local_header[32];
 	unsigned char local_extra[144];
-	struct zip *zip = a->format_data;
 	unsigned char *e;
 	unsigned char *cd_extra;
 	size_t filename_length;
@@ -1520,8 +1520,8 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 static ssize_t
 archive_write_zip_data(struct archive_write *a, const void *buff, size_t s)
 {
-	int ret;
 	struct zip *zip = a->format_data;
+	int ret;
 
 	if ((int64_t)s > zip->entry_uncompressed_limit)
 		s = (size_t)zip->entry_uncompressed_limit;
@@ -2189,9 +2189,9 @@ archive_write_zip_finish_entry(struct archive_write *a)
 static int
 archive_write_zip_close(struct archive_write *a)
 {
+	struct zip *zip = a->format_data;
 	uint8_t buff[64];
 	int64_t offset_start, offset_end;
-	struct zip *zip = a->format_data;
 	struct cd_segment *segment;
 	int ret;
 
@@ -2261,10 +2261,9 @@ archive_write_zip_close(struct archive_write *a)
 static int
 archive_write_zip_free(struct archive_write *a)
 {
-	struct zip *zip;
+	struct zip *zip = a->format_data;
 	struct cd_segment *segment;
 
-	zip = a->format_data;
 	while (zip->central_directory != NULL) {
 		segment = zip->central_directory;
 		zip->central_directory = segment->next;


### PR DESCRIPTION
Another huge PR which is only reasonably reviewed by going through it commit by commit (and most likely with resting breaks for the eyes in between files. At least that's what I did).

The libarchive parsers and writers for filters and formats have very common structures, which should be unified to clarify that these really have identical meanings. Over the years, it seems that some styles diverged into these 4 blocks (formater parsers, filter writers etc.):

- Each parser/writer has its own data/state. Most times, the struct has the name of the filter/format itself.
- Accessing its own data happens through its own variable, which most of the times is assigned at the top of a function. This is actually really helpful to shift this "boilerplate code" away from the function block, which makes reading a lot easier. Format parsers use their format as variable name, while filters often call it "data" or "state". Let's follow the format parsers
- Filter writers use `f` as variable name for the filter, while parsers use `self`. This is even true for `archive_reader` and at first glance, it might make sense. But as soon as the `self` variable is reused as iterator to climb up the `upstream` list, it's not exactly true anymore. Just use `f` as the writers do. Formats do not have such a variable, they use `a->format` instead.

Hint for reviewers: Each commit tries to achieve exactly one thing, focussing either on filters or formats. IDEs are helpful with renaming these structs and variables but there are some preprocessor conditionals which makes it much harder again. Searching as text for the variable name as in `varname->` or `struct structname` helped to find more and hopefully all cases.