### PR TITLE
write: Correctly handle huge write requests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -673,6 +673,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_write_format_cpio_odc.c \
 	libarchive/test/test_write_format_gnutar.c \
 	libarchive/test/test_write_format_gnutar_filenames.c \
+	libarchive/test/test_write_format_gnutar_huge.c \
 	libarchive/test/test_write_format_iso9660.c \
 	libarchive/test/test_write_format_iso9660_boot.c \
 	libarchive/test/test_write_format_iso9660_bugs.c \

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -340,7 +340,7 @@ __archive_write_filters_flush(struct archive_write *a)
 }
 
 int
-__archive_write_nulls(struct archive_write *a, size_t length)
+__archive_write_nulls(struct archive_write *a, uint64_t length)
 {
 	if (length == 0)
 		return (ARCHIVE_OK);

--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -240,8 +240,10 @@ __archive_write_filter(struct archive_write_filter *f,
 		/* If unset, a fatal error has already occurred, so this filter
 		 * didn't open. We cannot write anything. */
 		return(ARCHIVE_FATAL);
+	if (length > (uint64_t)(INT64_MAX - f->bytes_written))
+		return(ARCHIVE_FATAL);
 	r = (f->write)(f, buff, length);
-	f->bytes_written += length;
+	f->bytes_written += (int64_t)length;
 	return (r);
 }
 

--- a/libarchive/archive_write_private.h
+++ b/libarchive/archive_write_private.h
@@ -69,7 +69,7 @@ void __archive_write_filters_free(struct archive *);
 struct archive_write_filter *__archive_write_allocate_filter(struct archive *);
 
 int __archive_write_output(struct archive_write *, const void *, size_t);
-int __archive_write_nulls(struct archive_write *, size_t);
+int __archive_write_nulls(struct archive_write *, uint64_t);
 int __archive_write_filter(struct archive_write_filter *, const void *, size_t);
 
 struct archive_write {

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -619,6 +619,5 @@ archive_write_binary_finish_entry(struct archive_write *a)
 	struct cpio *cpio;
 
 	cpio = (struct cpio *)a->format_data;
-	return (__archive_write_nulls(a,
-		(size_t)cpio->entry_bytes_remaining));
+	return (__archive_write_nulls(a, cpio->entry_bytes_remaining));
 }

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -458,5 +458,5 @@ archive_write_newc_finish_entry(struct archive_write *a)
 
 	cpio = (struct cpio *)a->format_data;
 	return (__archive_write_nulls(a,
-		(size_t)cpio->entry_bytes_remaining + cpio->padding));
+	    cpio->entry_bytes_remaining + cpio->padding));
 }

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -508,6 +508,6 @@ archive_write_odc_finish_entry(struct archive_write *a)
 	struct cpio *cpio;
 
 	cpio = (struct cpio *)a->format_data;
-	return (__archive_write_nulls(a,
-		(size_t)cpio->entry_bytes_remaining));
+	return (__archive_write_nulls(a, 
+	    cpio->entry_bytes_remaining));
 }

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -251,8 +251,8 @@ archive_write_gnutar_finish_entry(struct archive_write *a)
 	int ret;
 
 	gnutar = (struct gnutar *)a->format_data;
-	ret = __archive_write_nulls(a, (size_t)
-	    (gnutar->entry_bytes_remaining + gnutar->entry_padding));
+	ret = __archive_write_nulls(a,
+	    gnutar->entry_bytes_remaining + gnutar->entry_padding);
 	gnutar->entry_bytes_remaining = gnutar->entry_padding = 0;
 	return (ret);
 }

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -1628,7 +1628,7 @@ archive_write_pax_header(struct archive_write *a,
 			return (ARCHIVE_FATAL);
 		}
 		/* Pad out the end of the entry. */
-		r = __archive_write_nulls(a, (size_t)pax->entry_padding);
+		r = __archive_write_nulls(a, pax->entry_padding);
 		if (r != ARCHIVE_OK) {
 			/* If a write fails, we're pretty much toast. */
 			archive_entry_free(entry_main);
@@ -1996,7 +1996,7 @@ archive_write_pax_finish_entry(struct archive_write *a)
 			pax->sparse_list = sb;
 		}
 	}
-	ret = __archive_write_nulls(a, (size_t)(remaining + pax->entry_padding));
+	ret = __archive_write_nulls(a, remaining + pax->entry_padding);
 	pax->entry_bytes_remaining = pax->entry_padding = 0;
 	return (ret);
 }

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -751,7 +751,7 @@ archive_write_ustar_finish_entry(struct archive_write *a)
 
 	ustar = (struct ustar *)a->format_data;
 	ret = __archive_write_nulls(a,
-	    (size_t)(ustar->entry_bytes_remaining + ustar->entry_padding));
+	    ustar->entry_bytes_remaining + ustar->entry_padding);
 	ustar->entry_bytes_remaining = ustar->entry_padding = 0;
 	return (ret);
 }

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -631,7 +631,7 @@ archive_write_v7tar_finish_entry(struct archive_write *a)
 
 	v7tar = (struct v7tar *)a->format_data;
 	ret = __archive_write_nulls(a,
-	    (size_t)(v7tar->entry_bytes_remaining + v7tar->entry_padding));
+	    v7tar->entry_bytes_remaining + v7tar->entry_padding);
 	v7tar->entry_bytes_remaining = v7tar->entry_padding = 0;
 	return (ret);
 }

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -302,6 +302,7 @@ IF(ENABLE_TEST)
     test_write_format_cpio_odc.c
     test_write_format_gnutar.c
     test_write_format_gnutar_filenames.c
+    test_write_format_gnutar_huge.c
     test_write_format_iso9660.c
     test_write_format_iso9660_boot.c
     test_write_format_iso9660_empty.c

--- a/libarchive/test/test_write_format_gnutar_huge.c
+++ b/libarchive/test/test_write_format_gnutar_huge.c
@@ -1,0 +1,57 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "archive.h"
+#include "test.h"
+
+DEFINE_TEST(test_write_format_gnutar_huge)
+{
+	struct archive_entry *ae;
+	struct archive *a;
+	size_t buffsize = 8192;
+	size_t used;
+	char *buff;
+
+	/* Create a new archive in memory. */
+	assert((buff = malloc(buffsize)) != NULL);
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_gnutar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+
+	/* Create an entry with INT64_MAX bytes. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "file");
+	archive_entry_set_size(ae, INT64_MAX);
+	archive_entry_set_filetype(ae, AE_IFREG);
+
+	/* Try to write entry into archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_finish_entry(a));
+
+	archive_entry_free(ae);
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	free(buff);
+}


### PR DESCRIPTION
Correctly handle write requests which cannot be fulfilled:

- Never write more than `INT64_MAX` bytes
- Avoid integer truncation through `__archive_write_nulls`

The latter can be properly tested on 32 bit systems, since `size_t` casts easily truncate values larger than 4 GB. A unit test for this is added, which tries to write `INT64_MAX` bytes into an entry by an early finish request. Without the fix, the operation erroneously succeeds on 32 bit systems.