### PR TITLE
formats: simplify parent directory handling

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1067,7 +1067,6 @@ static int
 read_header(struct archive_read *a, struct archive_entry *entry)
 {
 	struct mtree *mtree = a->format->data;
-	char *p;
 	int r, use_next;
 
 	if (mtree->fd >= 0) {
@@ -1096,14 +1095,9 @@ read_header(struct archive_read *a, struct archive_entry *entry)
 			mtree->this_entry->used = 1;
 			if (archive_strlen(&mtree->current_dir) > 0) {
 				/* Roll back current path. */
-				p = mtree->current_dir.s
-				    + mtree->current_dir.length - 1;
-				while (p >= mtree->current_dir.s && *p != '/')
-					--p;
-				if (p >= mtree->current_dir.s)
-					--p;
-				mtree->current_dir.length
-				    = p - mtree->current_dir.s + 1;
+				archive_string_dirname(&mtree->current_dir);
+				if (strcmp(mtree->current_dir.s, ".") == 0)
+					archive_string_empty(&mtree->current_dir);
 			}
 		}
 		if (!mtree->this_entry->used) {

--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -1932,15 +1932,8 @@ mtree_entry_setup_filenames(struct archive_write *a, struct mtree_entry *file,
 		len = archive_strlen(&file->parentdir);
 	}
 
-	/*
-	 * Find out the position which points to the last position of
-	 * path separator('/').
-	 */
-	slash = NULL;
-	for (; *p != '\0'; p++) {
-		if (*p == '/')
-			slash = p;
-	}
+	/* Find the last path separator. */
+	slash = strrchr(p, '/');
 	if (slash == NULL) {
 		/* The pathname doesn't have a parent directory. */
 		file->parentdir.length = len;

--- a/libarchive/archive_write_set_format_xar.c
+++ b/libarchive/archive_write_set_format_xar.c
@@ -2249,15 +2249,8 @@ file_gen_utility_names(struct archive_write *a, struct file *file)
 		archive_strncpy(&(file->symlink), pp, len2);
 		cleanup_backslash(file->symlink.s, file->symlink.length);
 	}
-	/*
-	 * - Count up directory elements.
-	 * - Find out the position which points the last position of
-	 *   path separator('/').
-	 */
-	slash = NULL;
-	for (; *p != '\0'; p++)
-		if (*p == '/')
-			slash = p;
+	/* Find the last path separator. */
+	slash = strrchr(p, '/');
 	if (slash == NULL) {
 		/* The pathname doesn't have a parent directory. */
 		file->parentdir.length = len;


### PR DESCRIPTION
Simplify parent-directory handling:

- mtree reader: Use `archive_string_dirname()` when rolling back paths.
- mtree writer: Use `strrchr()` when locating parent directories.
- XAR writer: Use `strrchr()` when locating parent directories.

*Bonus:* Also fixes UB by avoiding pointer arithmetic before the mtree path buffer. :)