### PR TITLE
archive_entry: handle aliased Mac metadata copies

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1562,17 +1562,21 @@ void
 archive_entry_copy_mac_metadata(struct archive_entry *entry,
     const void *p, size_t s)
 {
-  free(entry->mac_metadata);
-  if (p == NULL || s == 0) {
-    entry->mac_metadata = NULL;
-    entry->mac_metadata_size = 0;
-  } else {
-    entry->mac_metadata_size = s;
-    entry->mac_metadata = malloc(s);
-    if (entry->mac_metadata == NULL)
-      abort();
-    memcpy(entry->mac_metadata, p, s);
-  }
+	void *metadata;
+
+	if (p == NULL || s == 0) {
+		free(entry->mac_metadata);
+		entry->mac_metadata = NULL;
+		entry->mac_metadata_size = 0;
+	} else {
+		metadata = malloc(s);
+		if (metadata == NULL)
+			abort();
+		memcpy(metadata, p, s);
+		free(entry->mac_metadata);
+		entry->mac_metadata = metadata;
+		entry->mac_metadata_size = s;
+	}
 }
 
 /* Digest handling */

--- a/libarchive/test/test_entry.c
+++ b/libarchive/test/test_entry.c
@@ -988,3 +988,31 @@ DEFINE_TEST(test_entry)
 	/* Release the experimental entry. */
 	archive_entry_free(e);
 }
+
+DEFINE_TEST(test_entry_mac_metadata_self_copy)
+{
+	static const unsigned char metadata[64] = {
+		0x41, 0x42, 0x43, 0x44
+	};
+	struct archive_entry *entry;
+	const void *copy;
+	size_t copy_size;
+
+	assert((entry = archive_entry_new()) != NULL);
+	archive_entry_copy_mac_metadata(entry, metadata, sizeof(metadata));
+	copy = archive_entry_mac_metadata(entry, &copy_size);
+	assertEqualInt(sizeof(metadata), copy_size);
+
+	archive_entry_copy_mac_metadata(entry, copy, copy_size);
+	copy = archive_entry_mac_metadata(entry, &copy_size);
+	assertEqualInt(sizeof(metadata), copy_size);
+	assertEqualMem(metadata, copy, sizeof(metadata));
+
+	archive_entry_copy_mac_metadata(entry,
+	    (const unsigned char *)copy + 1, copy_size - 1);
+	copy = archive_entry_mac_metadata(entry, &copy_size);
+	assertEqualInt(sizeof(metadata) - 1, copy_size);
+	assertEqualMem(metadata + 1, copy, sizeof(metadata) - 1);
+
+	archive_entry_free(entry);
+}


### PR DESCRIPTION
The current implementation releases the entry-owned Mac metadata buffer before copying the replacement. When callers pass a pointer returned by `archive_entry_mac_metadata()` back to the same entry, the subsequent `memcpy()` reads freed memory.

This change prepares the replacement allocation while the aliased source is still alive, then releases the old buffer. The regression test covers both an exact self-copy and an interior slice of the entry-owned allocation.

Fixes #3313.

## Testing

- `cmake --build build-hunt --parallel 4`
- `ctest --test-dir build-hunt --output-on-failure --parallel 4` (1,017/1,017 passed; platform/tool-specific tests skipped)
- Focused regression test under macOS Guard Malloc
- Standalone reproducer: untouched build exits 139 under Guard Malloc; patched build exits 0 and preserves metadata