### PR TITLE
windows: avoid signed DWORD shifts

### DIFF
--- a/libarchive/archive_entry_copy_bhfi.c
+++ b/libarchive/archive_entry_copy_bhfi.c
@@ -36,6 +36,7 @@ archive_entry_copy_bhfi(struct archive_entry *entry,
 {
 	int64_t secs;
 	uint32_t nsecs;
+	uint64_t file_index, file_size;
 
 	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
 	archive_entry_set_atime(entry, secs, nsecs);
@@ -45,11 +46,18 @@ archive_entry_copy_bhfi(struct archive_entry *entry,
 	archive_entry_set_birthtime(entry, secs, nsecs);
 	archive_entry_set_ctime(entry, secs, nsecs);
 	archive_entry_set_dev(entry, bhfi->dwVolumeSerialNumber);
-	archive_entry_set_ino64(entry, (((int64_t)bhfi->nFileIndexHigh) << 32)
-		+ bhfi->nFileIndexLow);
+	file_index = bhfi_ino(bhfi);
+#if ARCHIVE_VERSION_NUMBER < 4000000
+	if (file_index > (uint64_t)INT64_MAX)
+		archive_entry_set_ino64(entry, -1);
+	else
+#endif
+		archive_entry_set_ino64(entry, (__LA_INO_T)file_index);
 	archive_entry_set_nlink(entry, bhfi->nNumberOfLinks);
-	archive_entry_set_size(entry, (((int64_t)bhfi->nFileSizeHigh) << 32)
-		+ bhfi->nFileSizeLow);
+	file_size = ((uint64_t)bhfi->nFileSizeHigh << 32) |
+	    bhfi->nFileSizeLow;
+	archive_entry_set_size(entry, file_size > INT64_MAX ? INT64_MAX :
+	    (int64_t)file_size);
 	/* archive_entry_set_mode(entry, st->st_mode); */
 }
 #endif

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -92,7 +92,7 @@ struct tree_entry {
 	struct archive_wstring	 full_path;
 	size_t			 dirname_length;
 	int64_t			 dev;
-	int64_t			 ino;
+	uint64_t			 ino;
 	int			 flags;
 	int			 filesystem_id;
 	/* How to restore time of a directory. */
@@ -202,12 +202,6 @@ struct tree {
 };
 
 #define bhfi_dev(bhfi)	((bhfi)->dwVolumeSerialNumber)
-/* Treat FileIndex as i-node. We should remove a sequence number
- * which is high-16-bits of nFileIndexHigh. */
-#define bhfi_ino(bhfi)	\
-	((((int64_t)((bhfi)->nFileIndexHigh & 0x0000FFFFUL)) << 32) \
-    + (bhfi)->nFileIndexLow)
-
 /* Definitions for tree.flags bitmap. */
 #define	hasStat		16 /* The st entry is valid. */
 #define	hasLstat	32 /* The lst entry is valid. */
@@ -222,7 +216,7 @@ static struct tree *tree_reopen(struct tree *, const wchar_t *, int);
 static void tree_close(struct tree *);
 static void tree_free(struct tree *);
 static void tree_push(struct tree *, const wchar_t *, const wchar_t *,
-		int, int64_t, int64_t, struct restore_time *);
+		int, int64_t, uint64_t, struct restore_time *);
 
 /*
  * tree_next() returns Zero if there is no next entry, non-zero if
@@ -1664,7 +1658,7 @@ close_and_restore_time(HANDLE h, struct tree *t, struct restore_time *rt)
  */
 static void
 tree_push(struct tree *t, const wchar_t *path, const wchar_t *full_path,
-    int filesystem_id, int64_t dev, int64_t ino, struct restore_time *rt)
+    int filesystem_id, int64_t dev, uint64_t ino, struct restore_time *rt)
 {
 	struct tree_entry *te;
 
@@ -2054,6 +2048,7 @@ entry_copy_bhfi(struct archive_entry *entry, const wchar_t *path,
 {
 	int64_t secs;
 	uint32_t nsecs;
+	uint64_t file_index, file_size;
 	mode_t mode;
 
 	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
@@ -2064,14 +2059,23 @@ entry_copy_bhfi(struct archive_entry *entry, const wchar_t *path,
 	archive_entry_set_birthtime(entry, secs, nsecs);
 	archive_entry_set_ctime(entry, secs, nsecs);
 	archive_entry_set_dev(entry, bhfi_dev(bhfi));
-	archive_entry_set_ino64(entry, bhfi_ino(bhfi));
+	file_index =
+	    ((uint64_t)(bhfi->nFileIndexHigh & 0x0000FFFFUL) << 32) |
+	    bhfi->nFileIndexLow;
+#if ARCHIVE_VERSION_NUMBER < 4000000
+	if (file_index > (uint64_t)INT64_MAX)
+		archive_entry_set_ino64(entry, -1);
+	else
+#endif
+		archive_entry_set_ino64(entry, (__LA_INO_T)file_index);
 	if (bhfi->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		archive_entry_set_nlink(entry, bhfi->nNumberOfLinks + 1);
 	else
 		archive_entry_set_nlink(entry, bhfi->nNumberOfLinks);
-	archive_entry_set_size(entry,
-	    (((int64_t)bhfi->nFileSizeHigh) << 32)
-	    + bhfi->nFileSizeLow);
+	file_size = ((uint64_t)bhfi->nFileSizeHigh << 32) |
+	    bhfi->nFileSizeLow;
+	archive_entry_set_size(entry, file_size > INT64_MAX ? INT64_MAX :
+	    (int64_t)file_size);
 	archive_entry_set_uid(entry, 0);
 	archive_entry_set_gid(entry, 0);
 	archive_entry_set_rdev(entry, 0);
@@ -2234,7 +2238,7 @@ tree_target_is_same_as_parent(struct tree *t,
 {
 	struct tree_entry *te;
 	int64_t dev = bhfi_dev(st);
-	int64_t ino = bhfi_ino(st);
+	uint64_t ino = bhfi_ino(st);
 
 	for (te = t->current->parent; te != NULL; te = te->parent) {
 		if (te->dev == dev && te->ino == ino)

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -71,8 +71,8 @@ struct ustat {
 	int64_t		st_mtime;
 	uint32_t	st_mtime_nsec;
 	gid_t		st_gid;
-	/* 64bits ino */
-	int64_t		st_ino;
+	/* 64-bit file ID. */
+	uint64_t		st_ino;
 	mode_t		st_mode;
 	uint32_t	st_nlink;
 	uint64_t	st_size;
@@ -540,7 +540,7 @@ static int
 __hstat(HANDLE handle, struct ustat *st)
 {
 	BY_HANDLE_FILE_INFORMATION info;
-	ULARGE_INTEGER ino64;
+	ULARGE_INTEGER ino64, size64;
 	DWORD ftype;
 	mode_t mode;
 
@@ -601,17 +601,20 @@ __hstat(HANDLE handle, struct ustat *st)
 	ntfs_to_unix(FILETIME_to_ntfs(&info.ftLastAccessTime), &st->st_atime, &st->st_atime_nsec);
 	ntfs_to_unix(FILETIME_to_ntfs(&info.ftLastWriteTime), &st->st_mtime, &st->st_mtime_nsec);
 	ntfs_to_unix(FILETIME_to_ntfs(&info.ftCreationTime), &st->st_ctime, &st->st_ctime_nsec);
-	st->st_size =
-	    ((int64_t)(info.nFileSizeHigh) * ((int64_t)MAXDWORD + 1))
-		+ (int64_t)(info.nFileSizeLow);
+	size64.HighPart = info.nFileSizeHigh;
+	size64.LowPart = info.nFileSizeLow;
+	st->st_size = size64.QuadPart;
+	if (st->st_size > (uint64_t)INT64_MAX) {
+		errno = EOVERFLOW;
+		return (-1);
+	}
 #ifdef SIMULATE_WIN_STAT
 	st->st_ino = 0;
 	st->st_nlink = 1;
 	st->st_dev = 0;
 #else
-	/* Getting FileIndex as i-node. We should remove a sequence which
-	 * is high-16-bits of nFileIndexHigh. */
-	ino64.HighPart = info.nFileIndexHigh & 0x0000FFFFUL;
+	/* Preserve the complete opaque file ID. */
+	ino64.HighPart = info.nFileIndexHigh;
 	ino64.LowPart  = info.nFileIndexLow;
 	st->st_ino = ino64.QuadPart;
 	st->st_nlink = info.nNumberOfLinks;

--- a/libarchive/archive_windows.h
+++ b/libarchive/archive_windows.h
@@ -70,6 +70,12 @@
 #endif
 #define NOCRYPT
 #include <windows.h>
+
+/* Treat the complete Windows file index as an opaque 64-bit value. */
+#define bhfi_ino(bhfi) \
+	((((ULONGLONG)(bhfi)->nFileIndexHigh) << 32) | \
+	    (bhfi)->nFileIndexLow)
+
 //#define	EFTYPE 7
 
 #include "archive_platform_stat.h"

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -123,7 +123,7 @@ struct archive_write_disk {
 	int64_t			 user_uid;
 	int			 skip_file_set;
 	int64_t			 skip_file_dev;
-	int64_t			 skip_file_ino;
+	uint64_t			 skip_file_ino;
 	time_t			 start_time;
 
 	int64_t (*lookup_gid)(void *private, const char *gname, int64_t gid);
@@ -237,14 +237,6 @@ static ssize_t	_archive_write_disk_data_block(struct archive *, const void *,
 		    size_t, int64_t);
 
 #define bhfi_dev(bhfi)	((bhfi)->dwVolumeSerialNumber)
-/* Treat FileIndex as i-node. We should remove a sequence number
- * which is high-16-bits of nFileIndexHigh. */
-#define bhfi_ino(bhfi)	\
-	((((int64_t)((bhfi)->nFileIndexHigh & 0x0000FFFFUL)) << 32) \
-    | (bhfi)->nFileIndexLow)
-#define bhfi_size(bhfi)	\
-    ((((int64_t)(bhfi)->nFileSizeHigh) << 32) | (bhfi)->nFileSizeLow)
-
 static int
 file_information(wchar_t *path, BY_HANDLE_FILE_INFORMATION *st,
     mode_t *mode, int sim_lstat)
@@ -1040,7 +1032,7 @@ archive_write_disk_set_skip_file(struct archive *_a, la_int64_t d, la_int64_t i)
 	    ARCHIVE_STATE_ANY, "archive_write_disk_set_skip_file");
 	a->skip_file_set = 1;
 	a->skip_file_dev = d;
-	a->skip_file_ino = i;
+	a->skip_file_ino = (uint64_t)i;
 	return (ARCHIVE_OK);
 }
 

--- a/libarchive/test/test_entry.c
+++ b/libarchive/test/test_entry.c
@@ -1016,3 +1016,54 @@ DEFINE_TEST(test_entry_mac_metadata_self_copy)
 
 	archive_entry_free(entry);
 }
+
+DEFINE_TEST(test_entry_copy_bhfi)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	BY_HANDLE_FILE_INFORMATION bhfi;
+	struct archive_entry *e;
+
+	memset(&bhfi, 0, sizeof(bhfi));
+	assert((e = archive_entry_new()) != NULL);
+
+	bhfi.nFileIndexHigh = 0x7fffffffUL;
+	bhfi.nFileIndexLow = 0xffffffffUL;
+	bhfi.nFileSizeHigh = 0x7fffffffUL;
+	bhfi.nFileSizeLow = 0xffffffffUL;
+	archive_entry_copy_bhfi(e, &bhfi);
+	assertEqualInt(INT64_MAX, archive_entry_ino64(e));
+	assertEqualInt(INT64_MAX, archive_entry_size(e));
+
+	/* Values outside libarchive 3.x's signed API must not wrap negative. */
+	bhfi.nFileIndexHigh = 0x80000000UL;
+	bhfi.nFileIndexLow = 0;
+	bhfi.nFileSizeHigh = 0x80000000UL;
+	bhfi.nFileSizeLow = 0;
+	archive_entry_copy_bhfi(e, &bhfi);
+#if ARCHIVE_VERSION_NUMBER < 4000000
+	assert(!archive_entry_ino_is_set(e));
+#else
+	assert(archive_entry_ino_is_set(e));
+	assert(archive_entry_ino64(e) == ((la_uint64_t)1 << 63));
+#endif
+	assertEqualInt(INT64_MAX, archive_entry_size(e));
+
+	/* Cover the complete unsigned range. */
+	bhfi.nFileIndexHigh = 0xffffffffUL;
+	bhfi.nFileIndexLow = 0xffffffffUL;
+	bhfi.nFileSizeHigh = 0xffffffffUL;
+	bhfi.nFileSizeLow = 0xffffffffUL;
+	archive_entry_copy_bhfi(e, &bhfi);
+#if ARCHIVE_VERSION_NUMBER < 4000000
+	assert(!archive_entry_ino_is_set(e));
+#else
+	assert(archive_entry_ino_is_set(e));
+	assert(archive_entry_ino64(e) == UINT64_MAX);
+#endif
+	assertEqualInt(INT64_MAX, archive_entry_size(e));
+
+	archive_entry_free(e);
+#else
+	skipping("Windows-specific test");
+#endif
+}

--- a/test_utils/test_main.c
+++ b/test_utils/test_main.c
@@ -1727,8 +1727,16 @@ assertion_file_size(const char *file, int line, const char *pathname, long size)
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	{
 		BY_HANDLE_FILE_INFORMATION bhfi;
+		uint64_t size64;
+
 		r = !my_GetFileInformationByName(pathname, &bhfi);
-		filesize = ((int64_t)bhfi.nFileSizeHigh << 32) + bhfi.nFileSizeLow;
+		if (r == 0) {
+			size64 = ((uint64_t)bhfi.nFileSizeHigh << 32) |
+			    bhfi.nFileSizeLow;
+			filesize = size64 > INT64_MAX ? INT64_MAX :
+			    (int64_t)size64;
+		} else
+			filesize = 0;
 	}
 #else
 	{

--- a/unzip/bsdunzip_windows.c
+++ b/unzip/bsdunzip_windows.c
@@ -262,7 +262,7 @@ unzip_stat_w(const wchar_t *path, int stat_link, struct stat *st)
 	int is_link, r;
 	DWORD ftype;
 	BY_HANDLE_FILE_INFORMATION info;
-	ULARGE_INTEGER ino64;
+	ULARGE_INTEGER ino64, size64;
 
 	h = unzip_get_handle(path, 0, stat_link, &is_link);
 	if (h == INVALID_HANDLE_VALUE) {
@@ -352,9 +352,14 @@ unzip_stat_w(const wchar_t *path, int stat_link, struct stat *st)
 	st->st_atime = unzip_FILETIME_to_unix(&info.ftLastAccessTime);
 	st->st_mtime = unzip_FILETIME_to_unix(&info.ftLastWriteTime);
 	st->st_ctime = unzip_FILETIME_to_unix(&info.ftCreationTime);
-	st->st_size =
-	    ((int64_t)(info.nFileSizeHigh) * ((int64_t)MAXDWORD + 1))
-		+ (int64_t)(info.nFileSizeLow);
+	size64.HighPart = info.nFileSizeHigh;
+	size64.LowPart = info.nFileSizeLow;
+	st->st_size = (off_t)size64.QuadPart;
+	if (st->st_size < 0 ||
+	    (uint64_t)st->st_size != size64.QuadPart) {
+		errno = EOVERFLOW;
+		return (-1);
+	}
 #ifdef SIMULATE_WIN_STAT
 	st->st_ino = 0;
 	st->st_nlink = 1;


### PR DESCRIPTION
Windows file sizes and indexes are stored as high and low DWORDs. Several paths combined them with signed arithmetic, which can trigger UB when the high bit is set.

Combine them with unsigned 64-bit arithmetic, clamp or reject values that do not fit their destiantion types, and add boundary tests.

* Add tests for `INT64_MAX`, `2^63`, and `UINT64_MAX`, and avoid reading file information after a failed test lookup.
* Fix archive entry BHFI conversion while preserving the libarchive 3.x and 4.0 inode behavior.
* Fix read-disk BHFI conversion while preserving the existing masked file-index behavior.
* Fix write-disk BHFI conversion and remove the unused signed file-size macro.
* Fix internal stat size conversion while preserving the full unsigned value.
* Fix bsdunzip stat size conversion and return `EOVERFLOW` when the destination type cannot represent the value.

Fixes #3283. Note: the issue is a part of this PR. This is a wider cleanup.