### PR TITLE
Use calloc for array allocations to prevent integer overflow

### DIFF
--- a/libarchive/archive_disk_acl_sunos.c
+++ b/libarchive/archive_disk_acl_sunos.c
@@ -135,9 +135,9 @@ sunacl_get(int cmd, int *aclcnt, int fd, const char *path)
 
 		if (cnt > 0) {
 			if (aclp == NULL)
-				aclp = malloc(cnt * size);
+				aclp = calloc(cnt, size);
 			else
-				aclp = realloc(NULL, cnt * size);
+				aclp = calloc(cnt, size);
 			if (aclp != NULL) {
 				if (path != NULL)
 					cnt = acl(path, cmd, cnt, aclp);
@@ -470,12 +470,12 @@ set_acl(struct archive *a, int fd, const char *name,
 	switch (ae_requested_type) {
 	case ARCHIVE_ENTRY_ACL_TYPE_POSIX1E:
 		cmd = SETACL;
-		aclp = malloc(entries * sizeof(aclent_t));
+		aclp = calloc(entries, sizeof(aclent_t));
 		break;
 #if ARCHIVE_ACL_SUNOS_NFS4
 	case ARCHIVE_ENTRY_ACL_TYPE_NFS4:
 		cmd = ACE_SETACL;
-		aclp = malloc(entries * sizeof(ace_t));
+		aclp = calloc(entries, sizeof(ace_t));
 
 		break;
 #endif

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -2224,7 +2224,7 @@ lzx_decode_init(struct lzx_stream *strm, int w_bits)
 		if (ds->w_buff == NULL)
 			return (ARCHIVE_FATAL);
 		free(ds->pos_tbl);
-		ds->pos_tbl = malloc(sizeof(ds->pos_tbl[0]) * w_slot);
+		ds->pos_tbl = calloc(w_slot, sizeof(ds->pos_tbl[0]));
 		if (ds->pos_tbl == NULL)
 			return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -2563,7 +2563,7 @@ lzh_huffman_init(struct huffman *hf, size_t len_size, int tbl_bits)
 	int bits;
 
 	if (hf->bitlen == NULL) {
-		hf->bitlen = malloc(len_size * sizeof(hf->bitlen[0]));
+		hf->bitlen = calloc(len_size, sizeof(hf->bitlen[0]));
 		if (hf->bitlen == NULL)
 			return (ARCHIVE_FATAL);
 	}
@@ -2572,13 +2572,13 @@ lzh_huffman_init(struct huffman *hf, size_t len_size, int tbl_bits)
 			bits = tbl_bits;
 		else
 			bits = HTBL_BITS;
-		hf->tbl = malloc(((size_t)1 << bits) * sizeof(hf->tbl[0]));
+		hf->tbl = calloc((size_t)1 << bits, sizeof(hf->tbl[0]));
 		if (hf->tbl == NULL)
 			return (ARCHIVE_FATAL);
 	}
 	if (hf->tree == NULL && tbl_bits > HTBL_BITS) {
 		hf->tree_avail = 1 << (tbl_bits - HTBL_BITS + 4);
-		hf->tree = malloc(hf->tree_avail * sizeof(hf->tree[0]));
+		hf->tree = calloc(hf->tree_avail, sizeof(hf->tree[0]));
 		if (hf->tree == NULL)
 			return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -403,7 +403,7 @@ static int cdeque_init(struct cdeque* d, int max_capacity_power_of_2) {
 		return CDE_PARAM;
 
 	cdeque_clear(d);
-	d->arr = malloc(sizeof(void*) * max_capacity_power_of_2);
+	d->arr = calloc(max_capacity_power_of_2, sizeof(void*));
 
 	return d->arr ? CDE_OK : CDE_ALLOC;
 }

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -6554,7 +6554,7 @@ isoent_make_sorted_files(struct archive_write *a, struct isoent *isoent,
 	struct archive_rb_node *rn;
 	struct isoent **children;
 
-	children = malloc(isoent->children.cnt * sizeof(struct isoent *));
+	children = calloc(isoent->children.cnt, sizeof(struct isoent *));
 	if (children == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory");
@@ -6971,7 +6971,7 @@ isoent_make_path_table_2(struct archive_write *a, struct vdd *vdd,
 		pt->sorted = NULL;
 		return (ARCHIVE_OK);
 	}
-	enttbl = malloc(pt->cnt * sizeof(struct isoent *));
+	enttbl = calloc(pt->cnt, sizeof(struct isoent *));
 	if (enttbl == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory");


### PR DESCRIPTION
Replace `malloc(count * sizeof(T))` with `calloc(count, sizeof(T))` in array allocation sites where count is a runtime variable.

Unlike `malloc`, `calloc` checks for integer overflow in the `count * size` computation and returns `NULL` instead of allocating an undersized buffer when the product would wrap around (CWE-190 → CWE-122).

### Changed files

| File | Sites | Count source |
|------|-------|-------------|
| `archive_read_support_format_lha.c` | 3 | Huffman table sizes from LHA headers |
| `archive_read_support_format_cab.c` | 1 | LZX position table from CAB headers |
| `archive_read_support_format_rar5.c` | 1 | Circular deque capacity |
| `archive_write_set_format_iso9660.c` | 2 | Directory entry counts |
| `archive_disk_acl_sunos.c` | 4 | ACL entry counts |

All 11 sites are mechanical conversions with identical allocation sizes and error handling. The zero-initialization from `calloc` is harmless since all buffers are immediately filled after allocation.