### PR TITLE
archive_read: don't poison archive when format lacks seek_data (fixes #3323)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -411,6 +411,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_read_open2.c \
 	libarchive/test/test_archive_read_set_options.c \
 	libarchive/test/test_archive_read_support.c \
+	libarchive/test/test_archive_seek_data_unsupported.c \
 	libarchive/test/test_archive_set_error.c \
 	libarchive/test/test_archive_string.c \
 	libarchive/test/test_archive_string_conversion.c \

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1003,11 +1003,9 @@ archive_seek_data(struct archive *_a, int64_t offset, int whence)
 	    "archive_seek_data_block");
 
 	if (a->format->seek_data == NULL) {
-		archive_set_error(&a->archive, ARCHIVE_ERRNO_PROGRAMMER,
-		    "Internal error: "
-		    "No format_seek_data_block function registered");
-		a->archive.state = ARCHIVE_STATE_FATAL;
-		return (ARCHIVE_FATAL);
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Cannot seek data with this format");
+		return (ARCHIVE_FAILED);
 	}
 
 	r = (a->format->seek_data)(a, offset, whence);

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -4396,13 +4396,15 @@ static int rar5_read_data_skip(struct archive_read *a) {
 static int64_t rar5_seek_data(struct archive_read *a, int64_t offset,
     int whence)
 {
-	(void) a;
 	(void) offset;
 	(void) whence;
 
-	/* We're a streaming unpacker, and we don't support seeking. */
+	/* We're a streaming unpacker, and we don't support seeking.
+	 * That's a capability gap, not a fatal error. */
+	archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+	    "Seeking of RAR5 files is unsupported");
 
-	return ARCHIVE_FATAL;
+	return (ARCHIVE_FAILED);
 }
 
 static int rar5_cleanup(struct archive_read *a) {

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -40,6 +40,7 @@ IF(ENABLE_TEST)
     test_archive_read_open2.c
     test_archive_read_set_options.c
     test_archive_read_support.c
+    test_archive_seek_data_unsupported.c
     test_archive_set_error.c
     test_archive_string.c
     test_archive_string_conversion.c

--- a/libarchive/test/test_archive_seek_data_unsupported.c
+++ b/libarchive/test/test_archive_seek_data_unsupported.c
@@ -1,0 +1,95 @@
+/*-
+ * Copyright (c) 2026 tbontb-iaq
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * archive_seek_data() returns ARCHIVE_FAILED when the active format
+ * does not implement a seek_data hook.  Such "no seeking for this
+ * format" is a capability gap, not stream corruption, and the archive
+ * must remain usable for subsequent reads.  See #3323.
+ */
+
+DEFINE_TEST(test_archive_seek_data_unsupported)
+{
+	char buff[8192];
+	size_t used = 0;
+	struct archive *a;
+	struct archive_entry *ae;
+	char rbuf[64];
+	la_ssize_t rd;
+	la_int64_t probe;
+
+	/* Build a small ustar archive in memory.  ustar has no seek_data. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_ustar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff), &used));
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_copy_pathname(ae, "hello.txt");
+	archive_entry_set_mode(ae, S_IFREG | 0644);
+	archive_entry_set_size(ae, 11);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+	assertEqualIntA(a, 11, archive_write_data(a, "hello world", 11));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/* Read it back. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("hello.txt", archive_entry_pathname(ae));
+
+	/*
+	 * Capability probe.  Must report the missing capability with
+	 * ARCHIVE_FAILED and set an error string.  3.8.7 and 3.8.8 both
+	 * returned ARCHIVE_FATAL here; ARCHIVE_FAILED is the new
+	 * contract, because a missing hook is recoverable.
+	 */
+	probe = archive_seek_data(a, 0, SEEK_CUR);
+	failure("archive_seek_data() on a format without a seek_data hook "
+	    "must report ARCHIVE_FAILED (return value contract)");
+	assertEqualInt(ARCHIVE_FAILED, probe);
+	failure("archive_seek_data() must set an error string when "
+	    "the format has no seek_data hook");
+	assert(archive_error_string(a) != NULL);
+
+	/*
+	 * The probe must NOT have poisoned the archive.  Subsequent reads
+	 * from the current entry must still succeed and return the real
+	 * entry content.  This is the 3.8.8 regression.
+	 */
+	rd = archive_read_data(a, rbuf, sizeof(rbuf));
+	failure("archive_read_data() after a non-fatal capability probe "
+	    "must still return the entry data (regression in 3.8.8, "
+	    "see GitHub issue #3323)");
+	assertEqualInt(11, rd);
+	assertEqualMem(rbuf, "hello world", 11);
+
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1586,3 +1586,31 @@ DEFINE_TEST(test_read_format_rar5_unpacked_size_exceeds_declared)
 
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+/*
+ * RAR5 is a streaming unpacker and never implements seeking.
+ * archive_seek_data() on a RAR5 entry must report unsupported via
+ * ARCHIVE_FAILED without poisoning the archive state.  See #3323.
+ */
+DEFINE_TEST(test_read_format_rar5_seek_data_unsupported)
+{
+	const int DATA_SIZE = 1200;
+	uint8_t buff[1200];
+
+	PROLOGUE("test_read_format_rar5_compressed.rar");
+
+	assertA(0 == archive_read_next_header(a, &ae));
+	assertEqualString("test.bin", archive_entry_pathname(ae));
+
+	/* Capability probe. */
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_seek_data(a, 0, SEEK_CUR));
+	assertA(archive_error_string(a) != NULL);
+
+	/* Subsequent read must still return the real entry content. */
+	assertA(DATA_SIZE == archive_read_data(a, buff, DATA_SIZE));
+	assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
+	assertA(1 == verify_data(buff, 0, DATA_SIZE));
+
+	EPILOGUE();
+}


### PR DESCRIPTION
> **Note on authorship:** This pull request was prepared with the assistance of an AI coding assistant (GLM 5.2 running in OpenCode). The regression was bisected, isolated, and verified empirically by the human author together with the assistant; the fix, the test cases, the build/verification, and the prose below were drafted by the assistant under human review and direction. The human author has verified the fix on their own system and reviewed the final patch.

## Summary

Fixes the regression reported in #3323: starting with 3.8.8, calling `archive_seek_data()` on a format that does not support seeking permanently poisons the archive state to `ARCHIVE_STATE_FATAL`, so any later `archive_read_data()` / `archive_read_data_block()` returns `ARCHIVE_FATAL` with no way to recover.

This breaks clients that probe seekability before reading. The reporter's case is VLC 3.0.x: `modules/stream_extractor/archive.c` `archive_seek_subentry()` calls

```c
if( p_sys->b_seekable_source )
{
    if( archive_seek_data( p_sys->p_archive, 0, SEEK_CUR ) >= 0 )
        p_sys->b_seekable_archive = true;
}
```

on a non-seekable format (streaming ZIP reader for a `.vlt` skin packed as gzip/zip). The probe killed the archive and VLC could no longer read any entry, so skins2 can no longer load ZIP-packed `.vlt` themes on distributions that shipped libarchive 3.8.8.

## Root cause

Commit `e1f890dc` ("archive_read: make ARCHIVE_FATAL sticky in data-reading entry points") made `archive_seek_data()` set `a->archive.state = ARCHIVE_STATE_FATAL` whenever the call returned `ARCHIVE_FATAL`. That is correct for genuine I/O / parse failures returned by a format's `seek_data()` implementation, but the stickiness also poisoned the archive in two cases where seeking is simply **unsupported** for the current format:

1. The `seek_data == NULL` branch in `archive_seek_data()` itself (no `format_seek_data_block` registered: ustar/tar, the streaming ZIP reader, ...).
2. `rar5_seek_data()` in `archive_read_support_format_rar5.c`, which unconditionally returned `ARCHIVE_FATAL` because RAR5 is a streaming unpacker. This was latent before 3.8.8 because the read core did not make FATAL sticky; the stickiness change exposed it.

Both are capability gaps, not stream corruption.

## The fix

Two minimal changes:

**1. `libarchive/archive_read.c`** - in the `seek_data == NULL` branch, drop `a->archive.state = ARCHIVE_STATE_FATAL;` and return `ARCHIVE_FAILED` instead of `ARCHIVE_FATAL`. `ARCHIVE_FATAL` must always be sticky (it means the archive is irrecoverably damaged), so a capability gap must not use it. The error is also reported more accurately: a format that never registers a seek hook is not illegal use of the library, so it is now `ARCHIVE_ERRNO_MISC` / `"Cannot seek data with this format"` instead of `ARCHIVE_ERRNO_PROGRAMMER` / `"Internal error: No format_seek_data_block function registered"`. The sticky-on-genuine-FATAL part of the 3.8.8 change is preserved:

```c
r = (a->format->seek_data)(a, offset, whence);
if (r == ARCHIVE_FATAL)
    a->archive.state = ARCHIVE_STATE_FATAL;
return (r);
```

so any actual `ARCHIVE_FATAL` returned by a format's `seek_data()` implementation still promotes the archive state, as intended.

**2. `libarchive/archive_read_support_format_rar5.c`** - change `rar5_seek_data()` to return `ARCHIVE_FAILED` with a proper error string instead of `ARCHIVE_FATAL`. This matches how the RAR4 reader reports the same situation (`archive_read_support_format_rar.c:1339` returns `ARCHIVE_FAILED` for compressed RAR files). With this change `rar5_seek_data()` no longer trips the sticky-FATAL path above, and capability probes against RAR5 archives no longer poison them.

## Verification

- The reproducer from issue #3323 now succeeds (probe returns `ARCHIVE_FAILED`, subsequent `archive_read_data()` returns the entry content `"hello world"`):
  ```
  ############ libarchive 3.9.0dev (this PR) ############
  probe archive_seek_data(0,SEEK_CUR): -25
    PROBE ERR: Cannot seek data with this format
  read_data_block after probe: 11
    CONTENT: hello world
  ```
- Two new tests cover both fix sites. Each **fails** on `master` and **passes** with this PR:
  - `test_archive_seek_data_unsupported` - covers the `seek_data == NULL` branch using an in-memory ustar archive (probe returns `ARCHIVE_FAILED`, error string set, archive survives the probe and returns real entry content).
  - `test_read_format_rar5_seek_data_unsupported` - covers the `rar5_seek_data()` branch using the existing `test_read_format_rar5_compressed.rar` fixture (probe returns `ARCHIVE_FAILED`, archive survives, and the entry content is checked with `verify_data()` as in `test_read_format_rar5_compressed`).
- Existing tests that depend on the sticky behaviour of genuine `ARCHIVE_FATAL` returns still pass:
  - `test_read_format_lha_symlink_missing_target` (its `test_illegal_seek_data` case asserts that `archive_seek_data()` refuses a failed entry)
  - `test_read_format_zip_symlink_unsupported_compression`
- Full test suite, no regressions:
  - `libarchive_test`: 849 tests, 0 failures (33,003,967 assertions)
  - `bsdcpio_test`: 49 tests, 0 failures
  - `bsdtar_test`: 77 tests, 0 failures
  - `bsdunzip_test`: 28 tests, 0 failures

## Notes

- This PR intentionally makes the **smallest** change that resolves the regression. The `read_data == NULL` branch in `_archive_read_data_block()` and the `archive_read_data_skip()` change from the same 3.8.8 commit are left intact, because a format with no `read_data` is a genuine internal error and the sticky-FATAL behaviour there is the intended contract enforced by the tests above.

- Both fix sites keep only a one-line comment noting that unsupported seeking is a capability gap rather than a fatal error; the full rationale lives in the commit message.

Closes #3323.


