### PR TITLE
iso9660: avoid NULL cur_content deref for relocated directory record

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -3481,6 +3481,16 @@ set_directory_record(unsigned char *p, size_t n, struct isoent *isoent,
 		file = isoent->file;
 		if (file->hardlink_target != NULL)
 			file = file->hardlink_target;
+		/*
+		 * A Rockridge relocated ("CL") directory placeholder shares
+		 * its file object with the real directory that was moved to
+		 * "rr_moved", and an earlier directory traversal can advance
+		 * that shared cur_content to NULL.  Restore it to the first
+		 * content so a non-directory record is written from valid
+		 * data instead of dereferencing a NULL pointer.
+		 */
+		if (file->cur_content == NULL)
+			file->cur_content = &(file->content);
 		/* Make a file flag. */
 		if (xisoent->dir)
 			flag = FILE_FLAG_DIRECTORY;

--- a/libarchive/test/test_write_format_iso9660_bugs.c
+++ b/libarchive/test/test_write_format_iso9660_bugs.c
@@ -247,6 +247,73 @@ DEFINE_TEST(test_write_format_iso9660_duplicate_identifier_truncation)
 	free(buff);
 }
 
+DEFINE_TEST(test_write_format_iso9660_rockridge_deep_relocation)
+{
+	const char *pathname = "A/A/A/A/A/A/A/A/A";
+	struct archive *a;
+	struct archive_entry *entry;
+	unsigned char *buff;
+	size_t buffsize = 4 * 1024 * 1024;
+	size_t used = 0;
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+	if (buff == NULL)
+		return;
+
+	assert((a = archive_write_new()) != NULL);
+	if (a == NULL) {
+		free(buff);
+		return;
+	}
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_format_iso9660(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_bytes_per_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_bytes_in_last_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:joliet"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:rockridge"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:iso-level=4"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:!limit-depth"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+
+	entry = archive_entry_new();
+	if (!assert(entry != NULL)) {
+		archive_write_free(a);
+		free(buff);
+		return;
+	}
+
+	archive_entry_copy_pathname(entry, pathname);
+	archive_entry_set_filetype(entry, AE_IFREG);
+	archive_entry_set_perm(entry, 0644);
+	archive_entry_set_size(entry, 0);
+	archive_entry_set_uid(entry, 1000);
+	archive_entry_set_gid(entry, 1000);
+	archive_entry_set_uname(entry, "user");
+	archive_entry_set_gname(entry, "group");
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_header(a, entry));
+	archive_entry_free(entry);
+
+	/* The relocated CL placeholder must not be traversed as a real
+	 * directory: current HEAD dereferences a NULL file->cur_content
+	 * while writing directory records during close. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	free(buff);
+}
+
 
 DEFINE_TEST(test_write_format_iso9660_symlink)
 {


### PR DESCRIPTION
Fixes #3235.

When Rockridge relocates a deep directory into `rr_moved`, the original entry is turned into a "CL" placeholder and marked as a non-directory, but it keeps sharing its file object (via `isoent_clone`) with the relocated real directory. An earlier directory traversal advances that shared `cur_content` to NULL, so when `set_directory_record()` later writes the placeholder through the non-directory branch it dereferences `file->cur_content`, crashing during `archive_write_close()`.

Restoring `cur_content` to the first content when it is NULL writes the record from valid data instead. Added the reproducer from the issue as `test_write_format_iso9660_rockridge_deep_relocation`; it segfaults on current HEAD and passes with the fix (verified with a standalone build under ASan/UBSan).