### PR TITLE
Fix NULL pointer dereference and integer overflow in ISO9660 writer

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -4358,6 +4358,8 @@ calculate_directory_descriptors(struct iso9660 *iso9660, struct vdd *vdd,
 				bs += dr_l;
 			file->cur_content = file->cur_content->next;
 		} while (file->cur_content != NULL);
+		/* Reset cur_content for later set_directory_record() calls. */
+		file->cur_content = &(file->content);
 	}
 	return (block);
 }
@@ -5464,8 +5466,8 @@ isoent_setup_file_location(struct iso9660 *iso9660, int location)
 		size = fd_boot_image_size(iso9660->el_torito.media_type);
 		if (size == 0)
 			size = (size_t)archive_entry_size(isoent->file->entry);
-		block = ((int)size + LOGICAL_BLOCK_SIZE -1)
-		    >> LOGICAL_BLOCK_BITS;
+		block = (int)((size + (size_t)LOGICAL_BLOCK_SIZE -1)
+		    >> LOGICAL_BLOCK_BITS);
 		location += block;
 		iso9660->total_file_block += block;
 		isoent->file->content.blocks = block;

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -314,6 +314,7 @@ IF(ENABLE_TEST)
     test_write_format_iso9660_zisofs.c
     test_write_format_iso9660_zisofs_overflow.c
     test_write_format_iso9660_bugs.c
+    test_write_format_iso9660_rr_crash.c
     test_write_format_mtree.c
     test_write_format_mtree_absolute.c
     test_write_format_mtree_absolute_path.c

--- a/libarchive/test/test_write_format_iso9660_rr_crash.c
+++ b/libarchive/test/test_write_format_iso9660_rr_crash.c
@@ -1,0 +1,79 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * Regression test for NULL pointer dereference in ISO9660 writer (Issue #3235).
+ *
+ * When Rockridge deep-directory relocation moves a deep directory into
+ * rr_moved, calculate_directory_descriptors() advances file->cur_content
+ * to NULL.  Later, set_directory_record() dereferences file->cur_content
+ * without a NULL check, causing a crash.
+ *
+ * The fix resets file->cur_content after the calculation loop.
+ */
+DEFINE_TEST(test_write_format_iso9660_rr_crash)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	unsigned char *buff;
+	size_t buffsize = 128 * 2048;
+	size_t used;
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+	if (buff == NULL)
+		return;
+
+	/* ISO9660 format with Rockridge and ISO level 4. */
+	assert((a = archive_write_new()) != NULL);
+	assertA(0 == archive_write_set_format_iso9660(a));
+	assertA(0 == archive_write_add_filter_none(a));
+	assertA(0 == archive_write_set_options(a, "iso9660:iso-level=4"));
+	assertA(0 == archive_write_set_bytes_per_block(a, 1));
+	assertA(0 == archive_write_set_bytes_in_last_block(a, 1));
+	assertA(0 == archive_write_open_memory(a, buff, buffsize, &used));
+
+	/* Add a deep directory to trigger Rockridge relocation. */
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_atime(ae, 2, 0);
+	archive_entry_set_ctime(ae, 4, 0);
+	archive_entry_set_mtime(ae, 5, 0);
+	archive_entry_copy_pathname(ae,
+	    "d1/d2/d3/d4/d5/d6/d7/d8/d9/d10/d11/d12/d13/d14/d15/d16");
+	archive_entry_set_mode(ae, S_IFDIR | 0755);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	/*
+	 * Close must not crash with NULL pointer dereference.
+	 * It may return an error, but must not segfault.
+	 */
+	archive_write_close(a);
+	archive_write_free(a);
+
+	free(buff);
+}


### PR DESCRIPTION
## Description

This PR fixes two security issues in the ISO9660 writer found via manual code audit of issues #3235 and #3269.

### Issue #3235: NULL Pointer Dereference (CWE-476)

`calculate_directory_descriptors()` iterates over each child entry content chain and advances `file->cur_content` to `NULL` via the do-while loop. When Rockridge deep-directory relocation marks an entry as non-directory, `set_directory_record()` later dereferences `file->cur_content->next` without checking for NULL, causing a crash (SIGSEGV).

**Fix**: Reset `file->cur_content = &(file->content)` after the calculation loop, matching the existing pattern in `_write_directory_descriptors()` (line 4395).

### Issue #3269: Integer Overflow (CWE-190)

In `isoent_setup_file_location()`, the boot image block count is computed as:
```c
block = ((int)size + LOGICAL_BLOCK_SIZE -1) >> LOGICAL_BLOCK_BITS;
```
When `size` is near `INT_MAX` (e.g., 2147481600), `(int)size + LOGICAL_BLOCK_SIZE` overflows signed int.

**Fix**: Use `size_t` arithmetic before casting to `int`, matching the pattern used for the catalog block calculation (line 5457):
```c
block = (int)((size + (size_t)LOGICAL_BLOCK_SIZE -1) >> LOGICAL_BLOCK_BITS);
```

## Files Changed

- `libarchive/archive_write_set_format_iso9660.c`: 2 fixes (+4/-2 lines)
- `libarchive/test/test_write_format_iso9660_rr_crash.c`: New regression test
- `libarchive/test/CMakeLists.txt`: Register new test

## Testing

1. **Build**: `cmake .. -DCMAKE_BUILD_TYPE=Debug && make -j$(nproc)` — succeeds
2. **New test**: `libarchive_test test_write_format_iso9660_rr_crash` — PASS
3. **Existing tests**: All ISO9660 tests pass (test_write_format_iso9660, test_write_format_iso9660_boot, test_write_format_iso9660_rockridge)
4. **PoC**: Standalone PoC confirms no crash after fix (returns graceful error instead of SIGSEGV)

## References

- Fixes #3235
- Fixes #3269