### PR TITLE
disk: add O_NOFOLLOW when creating regular files during extraction

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2433,7 +2433,7 @@ create_filesystem_object(struct archive_write_disk *a)
 	case AE_IFREG:
 		a->tmpname = NULL;
 		a->fd = open(a->name,
-		    O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC, mode);
+		    O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC | O_NOFOLLOW, mode);
 		__archive_ensure_cloexec_flag(a->fd);
 		r = (a->fd < 0);
 		break;


### PR DESCRIPTION
## Summary
The regular-file extraction path in `create_filesystem_object()` still uses a plain pathname-based `open()` call. Two other extraction paths in the same file, hardlink-data (line 2380) and the deferred fflags fixup (line 4090), were hardened with `O_NOFOLLOW` after symlink traversal caused real filesystem misbehavior. The regular-file path never got the same treatment.

This PR brings all three in line.

## Details

### Current state
Three `open()` calls in `archive_write_disk_posix.c`. Two are hardened.

**Hardlink data (line 2380)**, hardened in 2016 (commit `9f0dee22`):
```c
a->fd = open(a->name, O_WRONLY | O_TRUNC |
    O_BINARY | O_CLOEXEC | O_NOFOLLOW);
```
Commit note: *"TODO: Consider using this flag in other situations as well."*

**Deferred fflags fixup (line 4090)**, hardened in 2021 (commit `e2ad1a2c`):
```c
myfd = open(name, O_RDONLY | O_NONBLOCK | O_BINARY |
    O_CLOEXEC | O_NOFOLLOW);
```
Commit message: *"This fixes the case when an archive contains a directory entry followed by a symlink entry with the same path. The fixup code would modify file flags of the symlink target."*

**Regular file creation (line 2435), not hardened:**
```c
a->fd = open(a->name,
    O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC, mode);
```

### Why this matters
`O_NOFOLLOW` is a syscall-level guarantee that doesn't depend on `ARCHIVE_EXTRACT_SECURE_SYMLINKS` being set. In practice, `O_CREAT | O_EXCL` already gives the same rejection on POSIX systems that conform to the documented semantics (`open()` fails on a trailing symlink regardless of target). This mirrors the hardlink-data and fflags-fixup paths, closes the 2016 TODO, and is a no-cost defense-in-depth addition for platforms/filesystems (e.g. older NFS) where `O_EXCL`'s symlink-rejection isn't guaranteed atomic. It brings the three `open()` calls in this file to a consistent, defensive style rather than leaving one as a silent exception.

### Fix
Add `O_NOFOLLOW` to the regular-file `open()` call:
```diff
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -2433,7 +2433,7 @@ create_filesystem_object(struct archive_write_disk *a)
     case AE_IFREG:
         a->tmpname = NULL;
         a->fd = open(a->name,
-            O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC, mode);
+            O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC | O_NOFOLLOW, mode);
         __archive_ensure_cloexec_flag(a->fd);
         r = (a->fd < 0);
         break;
```
