### PR TITLE
rar5: reject EX_UOWNER owner names larger than the extra field (fixes #3066)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1065,6 +1065,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_nonempty_dir_stream.rar.uu \
 	libarchive/test/test_read_format_rar5_dirdata.rar.uu \
 	libarchive/test/test_read_format_rar5_owner.rar.uu \
+	libarchive/test/test_read_format_rar5_owner_name_toolong.rar.uu \
 	libarchive/test/test_read_format_rar5_readtables_overflow.rar.uu \
 	libarchive/test/test_read_format_rar5_sfx.exe.uu \
 	libarchive/test/test_read_format_rar5_solid.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1547,7 +1547,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 		 * this field. Rejecting an oversized length here also avoids
 		 * requesting a huge allocation from read_ahead() below. */
 		if(*extra_data_size < 0 ||
-		    name_size > (size_t)*extra_data_size) {
+		    (uint64_t)name_size > (uint64_t)*extra_data_size) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Owner name is too long");
 			return ARCHIVE_FATAL;
@@ -1575,7 +1575,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 			return ARCHIVE_EOF;
 
 		if(*extra_data_size < 0 ||
-		    name_size > (size_t)*extra_data_size) {
+		    (uint64_t)name_size > (uint64_t)*extra_data_size) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Group name is too long");
 			return ARCHIVE_FATAL;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1547,7 +1547,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 		 * this field. Rejecting an oversized length here also avoids
 		 * requesting a huge allocation from read_ahead() below. */
 		if(*extra_data_size < 0 ||
-		    (uint64_t)name_size > (uint64_t)*extra_data_size) {
+		    name_size > (uint64_t)*extra_data_size) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Owner name is too long");
 			return ARCHIVE_FATAL;
@@ -1575,7 +1575,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 			return ARCHIVE_EOF;
 
 		if(*extra_data_size < 0 ||
-		    (uint64_t)name_size > (uint64_t)*extra_data_size) {
+		    name_size > (uint64_t)*extra_data_size) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Group name is too long");
 			return ARCHIVE_FATAL;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1542,6 +1542,16 @@ static int parse_file_extra_owner(struct archive_read* a,
 	if ((flags & OWNER_USER_NAME) != 0) {
 		if(!read_var_sized(a, &name_size, NULL))
 			return ARCHIVE_EOF;
+
+		/* The name cannot be larger than the remaining extra data of
+		 * this field. Rejecting an oversized length here also avoids
+		 * requesting a huge allocation from read_ahead() below. */
+		if(*extra_data_size < 0 ||
+		    name_size > (size_t)*extra_data_size) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT, "Owner name is too long");
+			return ARCHIVE_FATAL;
+		}
 		*extra_data_size -= name_size + 1;
 
 		if(!read_ahead(a, name_size, &p))
@@ -1563,6 +1573,13 @@ static int parse_file_extra_owner(struct archive_read* a,
 	if ((flags & OWNER_GROUP_NAME) != 0) {
 		if(!read_var_sized(a, &name_size, NULL))
 			return ARCHIVE_EOF;
+
+		if(*extra_data_size < 0 ||
+		    name_size > (size_t)*extra_data_size) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT, "Group name is too long");
+			return ARCHIVE_FATAL;
+		}
 		*extra_data_size -= name_size + 1;
 
 		if(!read_ahead(a, name_size, &p))

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -912,6 +912,20 @@ DEFINE_TEST(test_read_format_rar5_owner)
 	EPILOGUE();
 }
 
+DEFINE_TEST(test_read_format_rar5_owner_name_toolong)
+{
+	/* GH #3066: a crafted HEAD_FILE declares an EX_UOWNER owner user name
+	 * whose length is far larger than the extra field that contains it.
+	 * The reader used to pass that length straight to read_ahead(), which
+	 * attempted a multi-terabyte allocation. It must reject the header
+	 * instead of trying to satisfy the bogus length. */
+	PROLOGUE("test_read_format_rar5_owner_name_toolong.rar");
+
+	assertA(archive_read_next_header(a, &ae) < 0);
+
+	EPILOGUE();
+}
+
 DEFINE_TEST(test_read_format_rar5_symlink)
 {
 	const int DATA_SIZE = 5;

--- a/libarchive/test/test_read_format_rar5_owner_name_toolong.rar.uu
+++ b/libarchive/test/test_read_format_rar5_owner_name_toolong.rar.uu
@@ -1,0 +1,5 @@
+begin 644 test_read_format_rar5_owner_name_toolong.rar
+M4F%R(1H'`0#%&C,R`P$``)8[*R<5`@$+`0`0``$!80H&`8"`@("`@(`$6@``
+"````
+`
+end


### PR DESCRIPTION
Fixes #3066.

## The defect

`parse_file_extra_owner()` reads a file-supplied owner (and group) name length with `read_var_sized()` and passes it straight to `read_ahead()` before validating it:

```c
if(!read_var_sized(a, &name_size, NULL))
    return ARCHIVE_EOF;
*extra_data_size -= name_size + 1;
if(!read_ahead(a, name_size, &p))     /* name_size is unbounded here */
    return ARCHIVE_EOF;
```

A crafted `EX_UOWNER` field can declare `name_size = 0x8000000000000`, which `read_ahead()` turns into a request to grow the copy buffer to that size — a multi-terabyte `malloc` that ASan reports as `allocation-size-too-big` and that returns `NULL` (then SIGSEGV) in a normal build.

## Note on the original PoC vs. current master

The PoC attached to #3066 no longer reproduces on `master` on its own, but the defect is still live — the PoC is only masked incidentally. In that archive the `name_size` varint is the last 8 bytes of the file, and the varint-handling change in #3317 made `read_var()` require 10 bytes of look-ahead, so the length now fails to decode before the oversized `read_ahead()` is reached. Appending two padding bytes so the varint decodes restores the original crash exactly:

```
==...==ERROR: AddressSanitizer: requested allocation size 0x8000000000000 ...
    #2 read_ahead ... archive_read_support_format_rar5.c:908
    #3 parse_file_extra_owner ... archive_read_support_format_rar5.c:1547
```

The bundled regression archive is that padded variant, so it exercises the real path rather than relying on the incidental varint masking. It carries a valid header CRC.

## The fix

The name of an owner or group is stored inside its extra field, so it can never be larger than the extra data remaining for that field. Reject any length that exceeds it before calling `read_ahead()`, for both the user-name and group-name branches. The comparison is done in `size_t` after a `*extra_data_size < 0` guard, so an enormous length cannot wrap through the signed subtraction.

The link-target path in `parse_file_extra_redir()` already bounds its length with `target_size > (MAX_NAME_IN_CHARS - 1)`, so it is not affected.

## Verification

New test `test_read_format_rar5_owner_name_toolong` feeds the crafted archive and expects `archive_read_next_header()` to fail rather than abort. Built with `-fsanitize=address`:

```
# before this change
test_read_format_rar5_owner_name_toolong -> AddressSanitizer: allocation-size-too-big, ABORTING
# after
60 rar5 tests passed, no failures   (1,375,246 assertions)
```

The existing `test_read_format_rar5_owner` still passes, so well-formed owner fields are unaffected.

## AI tool disclosure

Prepared with AI assistance; I confirmed the root cause, reproduced the crash, and verified the fix and the full rar5 suite locally, and can answer questions during review. The commits carry an `Assisted-by:` trailer.
