### PR TITLE
Add missing dictionary for RAR (v4) OSS-Fuzz fuzzer

### DIFF
--- a/contrib/oss-fuzz/libarchive_rar_fuzzer.dict
+++ b/contrib/oss-fuzz/libarchive_rar_fuzzer.dict
@@ -1,0 +1,51 @@
+# RAR (v4) format dictionary
+# Magic bytes (RAR4 signature, see RAR_SIGNATURE in archive_read_support_format_rar.c)
+"Rar!\x1a\x07\x00"
+"\x52\x61\x72\x21\x1a\x07\x00"
+
+# Block header types (MARK_HEAD .. ENDARC_HEAD)
+"\x72"
+"\x73"
+"\x74"
+"\x75"
+"\x76"
+"\x77"
+"\x78"
+"\x79"
+"\x7a"
+"\x7b"
+
+# Main archive header flags (MHD_*)
+"\x01\x00"
+"\x02\x00"
+"\x04\x00"
+"\x08\x00"
+"\x10\x00"
+"\x20\x00"
+"\x40\x00"
+"\x80\x00"
+"\x00\x01"
+"\x00\x02"
+
+# File header flags (FHD_*)
+"\x04\x00"
+"\x08\x00"
+"\x10\x00"
+"\x00\x01"
+"\x00\x02"
+"\x00\x04"
+"\x00\x08"
+"\x00\x10"
+"\x00\x20"
+
+# Compression methods (COMPRESS_METHOD_*)
+"\x30"
+"\x31"
+"\x32"
+"\x33"
+"\x34"
+"\x35"
+
+# Password/encryption marker (fuzzer supplies this passphrase)
+"password"
+"Password"


### PR DESCRIPTION
## Summary
- `libarchive_rar5_fuzzer` already ships a `.dict` file, but its RAR v4 sibling (`libarchive_rar_fuzzer.cc`) did not have one.
- Adds `contrib/oss-fuzz/libarchive_rar_fuzzer.dict` with tokens taken directly from `archive_read_support_format_rar.c`: the `RAR_SIGNATURE` marker, the block header type bytes (`MARK_HEAD`..`ENDARC_HEAD`), the `MHD_*`/`FHD_*` flag words, and the `COMPRESS_METHOD_*` bytes, plus the `"password"` token the fuzzer already supplies via `archive_read_add_passphrase`.
- No build script changes needed; `oss-fuzz-build.sh` already globs `*.dict` into `$OUT`.

## Test plan
- [ ] CIFuzz / OSS-Fuzz picks up the new dictionary automatically on next build.