### PR TITLE
archive_string: require localcharset.h

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -445,7 +445,7 @@ static const char *
 default_iconv_charset(const char *charset) {
 	if (charset != NULL && charset[0] != '\0')
 		return charset;
-#if HAVE_LOCALE_CHARSET && !defined(__APPLE__)
+#if HAVE_LOCALE_CHARSET && HAVE_LOCALCHARSET_H && !defined(__APPLE__)
 	/* locale_charset() is broken on Mac OS */
 	return locale_charset();
 #elif HAVE_NL_LANGINFO


### PR DESCRIPTION
Only call `locale_charset()` when `localcharset.h` provides its declaration.

Resolves #3338