### PR TITLE
bsdcpio: fix UB signed overflow in time formatting

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -1160,6 +1160,7 @@ list_item_verbose(struct cpio *cpio, struct archive_entry *entry)
 	const char 		*uname, *gname;
 	FILE			*out = stdout;
 	const char		*fmt;
+	double			 age;
 	time_t			 mtime;
 	static time_t		 now;
 	struct tm		*ltime;
@@ -1199,16 +1200,15 @@ list_item_verbose(struct cpio *cpio, struct archive_entry *entry)
 
 	/* Format the time using 'ls -l' conventions. */
 	mtime = archive_entry_mtime(entry);
+	age = difftime(mtime, now);
 #if defined(_WIN32) && !defined(__CYGWIN__)
 	/* Windows' strftime function does not support %e format. */
-	if (mtime - now > 365*86400/2
-		|| mtime - now < -365*86400/2)
+	if (age > 365.0 * 86400 / 2 || age < -365.0 * 86400 / 2)
 		fmt = cpio->day_first ? "%d %b  %Y" : "%b %d  %Y";
 	else
 		fmt = cpio->day_first ? "%d %b %H:%M" : "%b %d %H:%M";
 #else
-	if (mtime - now > 365*86400/2
-		|| mtime - now < -365*86400/2)
+	if (age > 365.0 * 86400 / 2 || age < -365.0 * 86400 / 2)
 		fmt = cpio->day_first ? "%e %b  %Y" : "%b %e  %Y";
 	else
 		fmt = cpio->day_first ? "%e %b %H:%M" : "%b %e %H:%M";

--- a/tar/util.c
+++ b/tar/util.c
@@ -688,6 +688,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	size_t			 sw;
 	const char		*p;
 	const char		*fmt;
+	double			 age;
 	time_t			 tim;
 	static time_t		 now;
 	struct tm		*ltime;
@@ -756,13 +757,14 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 
 	/* Format the time using 'ls -l' conventions. */
 	tim = archive_entry_mtime(entry);
-#define	HALF_YEAR (time_t)365 * 86400 / 2
+	age = difftime(tim, now);
+#define	HALF_YEAR (365.0 * 86400 / 2)
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define	DAY_FMT  "%d"  /* Windows' strftime function does not support %e format. */
 #else
 #define	DAY_FMT  "%e"  /* Day number without leading zeros */
 #endif
-	if (tim < now - HALF_YEAR || tim > now + HALF_YEAR)
+	if (age < -HALF_YEAR || age > HALF_YEAR)
 		fmt = bsdtar->day_first ? DAY_FMT " %b  %Y" : "%b " DAY_FMT "  %Y";
 	else
 		fmt = bsdtar->day_first ? DAY_FMT " %b %H:%M" : "%b " DAY_FMT " %H:%M";


### PR DESCRIPTION
bsdcpio subtracts an archive timestamp from the current time when choosing its date format. A very small timestamp can overflow signed `time_t`, so use `difftime()` instead.

Apply the same fix to bsdtar, where adding or subtracting the half-year range can overflow near the limits of `time_t`.