### PR TITLE
warc: fix UB signed overflow in time conversion

### DIFF
--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -552,19 +552,29 @@ time_from_tm(struct tm *t)
         /* Use platform timegm() if available. */
         return (timegm(t));
 #else
+        int64_t days, result;
+
         /* Otherwise, calculate directly using POSIX assumptions. */
         /* First, fix up tm_yday based on the year, month, and day. */
         if (mktime(t) == (time_t)-1)
                 return ((time_t)-1);
         /* Then compute timegm() from first principles. */
-        return (t->tm_sec
-            + t->tm_min * 60
-            + t->tm_hour * 3600
-            + t->tm_yday * 86400
-            + (t->tm_year - 70) * 31536000
-            + ((t->tm_year - 69) / 4) * 86400
-            - ((t->tm_year - 1) / 100) * 86400
-            + ((t->tm_year + 299) / 400) * 86400);
+        days = (int64_t)t->tm_yday
+            + ((int64_t)t->tm_year - 70) * 365
+            + ((int64_t)t->tm_year - 69) / 4
+            - ((int64_t)t->tm_year - 1) / 100
+            + ((int64_t)t->tm_year + 299) / 400;
+        if (archive_ckd_mul_i64(&result, days, 86400) ||
+            archive_ckd_add_i64(&result, result,
+                (int64_t)t->tm_hour * 3600 + t->tm_min * 60
+                + t->tm_sec))
+                return ((time_t)-1);
+        if (result < 0) {
+                if (TIME_MIN == 0 || result < (int64_t)TIME_MIN)
+                        return ((time_t)-1);
+        } else if ((uint64_t)result > (uint64_t)TIME_MAX)
+                return ((time_t)-1);
+        return ((time_t)result);
 #endif
 }
 

--- a/libarchive/test/test_read_format_warc.c
+++ b/libarchive/test/test_read_format_warc.c
@@ -202,3 +202,37 @@ DEFINE_TEST(test_read_format_warc_truncated_body)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
+
+DEFINE_TEST(test_read_format_warc_future_date)
+{
+	static const char warc[] =
+	    "WARC/1.0\r\n"
+	    "WARC-Type: resource\r\n"
+	    "WARC-Date: 2039-01-01T00:00:00Z\r\n"
+	    "WARC-Target-URI: file://test.txt\r\n"
+	    "Content-Length: 0\r\n"
+	    "\r\n"
+	    "\r\n\r\n";
+	struct archive_entry *ae;
+	struct archive *a;
+
+	if (sizeof(time_t) < 8) {
+		skipping("This test requires a 64-bit time_t");
+		return;
+	}
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, warc, sizeof(warc) - 1U));
+
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_next_header(a, &ae));
+	assertEqualInt(2177452800LL, archive_entry_mtime(ae));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
The fallback WARC date conversion can overflow signed integers for dates after 2038 when `timegm()` is unavailable. I found out that the year arithmetic is done as `int` before conversion, so this change uses checked 64-bit math, rejects values outside `time_t`, and adds a test for a 2039 date.