### PR TITLE
archive_write: share hdrcharset option handling

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -58,6 +58,7 @@
 #include "archive_entry.h"
 #include "archive_private.h"
 #include "archive_write_private.h"
+#include "archive_write_set_format_private.h"
 
 static int	_archive_filter_code(struct archive *, int);
 static const char *_archive_filter_name(struct archive *, int);
@@ -88,6 +89,25 @@ archive_write_vtable = {
 	.archive_write_finish_entry = _archive_write_finish_entry,
 	.archive_write_data = _archive_write_data,
 };
+
+int
+__archive_write_option_header_charset(struct archive_write *a,
+    const char *key, const char *val,
+    struct archive_string_conv **opt_sconv)
+{
+	if (strcmp(key, "hdrcharset") != 0)
+		return (ARCHIVE_WARN);
+	if (val == NULL || val[0] == '\0') {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "%s: hdrcharset option needs a character-set name",
+		    a->format_name);
+		return (ARCHIVE_FAILED);
+	}
+
+	*opt_sconv = archive_string_conversion_to_charset(
+	    &a->archive, val, 0);
+	return (*opt_sconv != NULL ? ARCHIVE_OK : ARCHIVE_FATAL);
+}
 
 /*
  * Allocate, initialize and return an archive object.

--- a/libarchive/archive_write_set_format_cpio_binary.c
+++ b/libarchive/archive_write_set_format_cpio_binary.c
@@ -236,28 +236,8 @@ archive_write_binary_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct cpio *cpio = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			cpio->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (cpio->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &cpio->opt_sconv));
 }
 
 /*

--- a/libarchive/archive_write_set_format_cpio_newc.c
+++ b/libarchive/archive_write_set_format_cpio_newc.c
@@ -138,28 +138,8 @@ archive_write_newc_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct cpio *cpio = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			cpio->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (cpio->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &cpio->opt_sconv));
 }
 
 static struct archive_string_conv *

--- a/libarchive/archive_write_set_format_cpio_odc.c
+++ b/libarchive/archive_write_set_format_cpio_odc.c
@@ -133,28 +133,8 @@ archive_write_odc_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct cpio *cpio = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			cpio->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (cpio->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &cpio->opt_sconv));
 }
 
 /*

--- a/libarchive/archive_write_set_format_gnutar.c
+++ b/libarchive/archive_write_set_format_gnutar.c
@@ -203,28 +203,8 @@ archive_write_gnutar_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct gnutar *gnutar = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			gnutar->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (gnutar->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &gnutar->opt_sconv));
 }
 
 static int

--- a/libarchive/archive_write_set_format_private.h
+++ b/libarchive/archive_write_set_format_private.h
@@ -34,6 +34,11 @@
 
 #include "archive.h"
 #include "archive_entry.h"
+#include "archive_string.h"
+#include "archive_write_private.h"
+
+int __archive_write_option_header_charset(struct archive_write *,
+    const char *, const char *, struct archive_string_conv **);
 
 void __archive_write_entry_filetype_unsupported(struct archive *a,
     struct archive_entry *entry, const char *format);

--- a/libarchive/archive_write_set_format_ustar.c
+++ b/libarchive/archive_write_set_format_ustar.c
@@ -206,28 +206,8 @@ archive_write_ustar_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct ustar *ustar = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			ustar->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (ustar->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &ustar->opt_sconv));
 }
 
 static int

--- a/libarchive/archive_write_set_format_v7tar.c
+++ b/libarchive/archive_write_set_format_v7tar.c
@@ -183,28 +183,8 @@ archive_write_v7tar_options(struct archive_write *a, const char *key,
     const char *val)
 {
 	struct v7tar *v7tar = a->format_data;
-	int ret = ARCHIVE_FAILED;
-
-	if (strcmp(key, "hdrcharset")  == 0) {
-		if (val == NULL || val[0] == 0)
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		else {
-			v7tar->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (v7tar->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
-	}
-
-	/* Note: The "warn" return is just to inform the options
-	 * supervisor that we didn't handle it.  It will generate
-	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &v7tar->opt_sconv));
 }
 
 static int

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -517,23 +517,6 @@ archive_write_zip_options(struct archive_write *a, const char *key,
 			zip->crc32func = fake_crc32;
 		}
 		return (ARCHIVE_OK);
-	} else if (strcmp(key, "hdrcharset")  == 0) {
-		/*
-		 * Set the character set used in translating filenames.
-		 */
-		if (val == NULL || val[0] == 0) {
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "%s: hdrcharset option needs a character-set name",
-			    a->format_name);
-		} else {
-			zip->opt_sconv = archive_string_conversion_to_charset(
-			    &a->archive, val, 0);
-			if (zip->opt_sconv != NULL)
-				ret = ARCHIVE_OK;
-			else
-				ret = ARCHIVE_FATAL;
-		}
-		return (ret);
 	} else if (strcmp(key, "zip64") == 0) {
 		/*
 		 * Bias decisions about Zip64: force them to be
@@ -554,7 +537,8 @@ archive_write_zip_options(struct archive_write *a, const char *key,
 	/* Note: The "warn" return is just to inform the options
 	 * supervisor that we didn't handle it.  It will generate
 	 * a suitable error if no one used this option. */
-	return (ARCHIVE_WARN);
+	return (__archive_write_option_header_charset(a, key, val,
+	    &zip->opt_sconv));
 }
 
 int


### PR DESCRIPTION
Several archive writers duplicate identical handling for the `hdrcharset` option.

Add `__archive_write_option_header_charset()` and use it across the cpio, tar, and zip writers. The format callbacks remain small adapters for their respective `opt_sconv` fields.

This reduces duplication without changing behavior.

Local GCC build reduced `libarchive.so` code and unwind data by 984 bytes.