### PR TITLE
program: Avoid signature length overflow

### DIFF
--- a/libarchive/archive_read_support_filter_program.c
+++ b/libarchive/archive_read_support_filter_program.c
@@ -149,6 +149,11 @@ archive_read_support_filter_program_signature(struct archive *_a,
 	archive_strcat(&state->description, cmd);
 
 	if (signature != NULL && signature_len > 0) {
+		if (signature_len > (size_t)INT_MAX / 8) {
+			free_state(state);
+			archive_set_error(_a, EINVAL, "Signature too large");
+			return (ARCHIVE_FATAL);
+		}
 		state->signature_len = signature_len;
 		state->signature = malloc(signature_len);
 		if (state->signature == NULL)


### PR DESCRIPTION
If a signature is too large, the bid value could overflow `INT_MAX`. With its current implementation, it could even lead to a signed integer overflow, which is undefined behavior:

https://github.com/libarchive/libarchive/blob/454168772be735b51201b132dc2352ee3a76084a/libarchive/archive_read_support_filter_program.c#L214

Disallow huge signatures, which most likely won't impact anyone.

Proof of Concept (any system with `cat`)
1. Compile libarchive with UBSAN (or `-ftrapv`)
1. Create program
```
cat > poc.c << EOF
#include <archive.h>
#include <err.h>
#include <limits.h>
#include <stdlib.h>

int
main(void)
{
        char *p;
        struct archive *a;
        int i;
        size_t s = INT_MAX / 8 + 1;

        a = archive_read_new();
        if (a == NULL)
                err(1, "archive_read_open_memory");

        p = calloc(s, 1);

        if (archive_read_support_filter_program_signature(a, "cat", p, s) != ARCHIVE_OK)
                errx(1, "archive_read_support_filter_program_signature");

        if (archive_read_open_FILE(a, stdin) != ARCHIVE_OK)
                errx(1, "archive_read_open_FILE");

        archive_read_free(a);

        return 0;
}
EOF
cc -larchive -o poc poc.c
```
2. Trigger signed integer overflow
```
dd if=/dev/zero bs=4096 count=65536 | ./poc
```
```
../libarchive/archive_read_support_filter_program.c:214:37: runtime error: signed integer overflow: 268435456 * 8 cannot be represented in type 'int'
```
