### PR TITLE
tar: move entry-modifying code into a single function

### DIFF
--- a/tar/bsdtar.1
+++ b/tar/bsdtar.1
@@ -431,8 +431,7 @@ See
 .Xr chmod 1
 for more information and examples of both types.
 .It Fl Fl mtime Ar date
-(c, r, u modes only)
-Set the modification times of added files to the specified date.
+Set the modification times of files to the specified date.
 .It Fl n , Fl Fl norecurse , Fl Fl no-recursion
 Do not operate recursively on the content of directories.
 .It Fl Fl newer Ar date

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -994,6 +994,10 @@ main(int argc, char **argv)
 		lafe_errc(1, 0,
 		    "--clamp-mtime is not valid without --mtime <date>");
 
+	/* Don't warn about files with leading slashes when listing. */
+	if (bsdtar->mode == 't')
+		bsdtar->flags |= OPTFLAG_ABSOLUTE_PATHS;
+
 	/*
 	 * When creating an archive from a directory tree, the directory
 	 * walking code will already avoid entering directories when

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -192,6 +192,7 @@ enum {
 
 int	bsdtar_getopt(struct bsdtar *);
 void	do_chdir(struct bsdtar *);
+int	edit_entry(struct bsdtar *, struct archive_entry *);
 int	edit_pathname(struct bsdtar *, struct archive_entry *);
 void	edit_mtime(struct bsdtar *, struct archive_entry *);
 int	need_report(void);

--- a/tar/read.c
+++ b/tar/read.c
@@ -266,25 +266,6 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 			continue;
 		}
 
-		if (bsdtar->uid >= 0) {
-			archive_entry_set_uid(entry, bsdtar->uid);
-			archive_entry_set_uname(entry, NULL);
-		}
-		if (bsdtar->gid >= 0) {
-			archive_entry_set_gid(entry, bsdtar->gid);
-			archive_entry_set_gname(entry, NULL);
-		}
-		if (bsdtar->uname)
-			archive_entry_set_uname(entry, bsdtar->uname);
-		if (bsdtar->gname)
-			archive_entry_set_gname(entry, bsdtar->gname);
-
-		if (bsdtar->file_mode) {
-			mode_t m = archive_entry_mode(entry);
-			m = lafe_getmode(bsdtar->file_mode, m);
-			archive_entry_set_mode(entry, m);
-		}
-
 		/*
 		 * Note that pattern exclusions are checked before
 		 * pathname rewrites are handled.  This gives more
@@ -300,6 +281,10 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 				    archive_error_string(bsdtar->matching));
 		if (r)
 			continue; /* Excluded by a pattern test. */
+
+		/* Note: some rewrite failures prevent extraction. */
+		if (edit_entry(bsdtar, entry))
+			continue; /* Excluded by a rewrite failure. */
 
 		if (mode == 't') {
 			/* Perversely, gtar uses -O to mean "send to stderr"
@@ -339,10 +324,6 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 			}
 			fprintf(out, "\n");
 		} else {
-			/* Note: some rewrite failures prevent extraction. */
-			if (edit_pathname(bsdtar, entry))
-				continue; /* Excluded by a rewrite failure. */
-
 			if ((bsdtar->flags & OPTFLAG_INTERACTIVE) &&
 			    !yes("extract '%s'", archive_entry_pathname(entry)))
 				continue;

--- a/tar/test/test_list_item.c
+++ b/tar/test/test_list_item.c
@@ -43,6 +43,9 @@ static const char *tvf_out =
 "-rw-r--r--  0 1000            1000            0 Jan  1  1980 f\n";
 #endif
 
+static const char *edit_out =
+"-rwxr-s-w-  0 123    456         0 Jan 11  1970 d/f\n";
+
 DEFINE_TEST(test_list_item)
 {
 	extract_reference_file("test_list_item.tar");
@@ -60,4 +63,16 @@ DEFINE_TEST(test_list_item)
 	failure("'t' mode with 'v' should write more results to stdout");
 	assertTextFileContents(tvf_out, "tvf.out");
 	assertEmptyFile("tvf.err");
+
+	/*
+	 * Run 'tvf' with editing options and check output.  -s is not supported
+	 * on all systems, so that is checked in the test_option_s tests.
+	 */
+	assertEqualInt(0,
+	    systemf("%s tvf test_list_item.tar "
+	    	"--mode 2752 --owner 123 --group 456 "
+	    	"--mtime \"1970-01-11 00:00:01\" "
+	    	"d/f >edit.out 2>edit.err", testprog));
+	assertTextFileContents(edit_out, "edit.out");
+	assertEmptyFile("edit.err");
 }

--- a/tar/test/test_option_gid_gname.c
+++ b/tar/test/test_option_gid_gname.c
@@ -26,7 +26,7 @@ DEFINE_TEST(test_option_gid_gname)
 	/* Again with both --gid and --gname */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive2 --gid=17 --gname=foofoofoo --format=ustar file >stdout2.txt 2>stderr2.txt",
+	    systemf("%s cf archive2 --gid=17 --gname=foofoofoo --format=ustar file @archive1 >stdout2.txt 2>stderr2.txt",
 		testprog));
 	assertEmptyFile("stdout2.txt");
 	assertEmptyFile("stderr2.txt");
@@ -34,12 +34,14 @@ DEFINE_TEST(test_option_gid_gname)
 	/* Should force gid and gname fields in ustar header. */
 	assertEqualMem(data + 116, "000021 \0", 8);
 	assertEqualMem(data + 297, "foofoofoo\0", 10);
+	assertEqualMem(data + 116 + 1024, "000021 \0", 8);
+	assertEqualMem(data + 297 + 1024, "foofoofoo\0", 10);
 	free(data);
 
 	/* Again with just --gname */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive4 --gname=foofoofoo --format=ustar file >stdout4.txt 2>stderr4.txt",
+	    systemf("%s cf archive4 --gname=foofoofoo --format=ustar file @archive1 >stdout4.txt 2>stderr4.txt",
 		testprog));
 	assertEmptyFile("stdout4.txt");
 	assertEmptyFile("stderr4.txt");
@@ -47,13 +49,15 @@ DEFINE_TEST(test_option_gid_gname)
 	/* Gid should be unchanged from original reference. */
 	assertEqualMem(data + 116, reference + 116, 8);
 	assertEqualMem(data + 297, "foofoofoo\0", 10);
+	assertEqualMem(data + 116 + 1024, reference + 116, 8);
+	assertEqualMem(data + 297 + 1024, "foofoofoo\0", 10);
 	free(data);
 	free(reference);
 
 	/* Again with --gid  and force gname to empty. */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive3 --gid=17 --gname= --format=ustar file >stdout3.txt 2>stderr3.txt",
+	    systemf("%s cf archive3 --gid=17 --gname= --format=ustar file @archive1 >stdout3.txt 2>stderr3.txt",
 		testprog));
 	assertEmptyFile("stdout3.txt");
 	assertEmptyFile("stderr3.txt");
@@ -61,6 +65,9 @@ DEFINE_TEST(test_option_gid_gname)
 	assertEqualMem(data + 116, "000021 \0", 8);
 	/* Gname field in ustar header should be empty. */
 	assertEqualMem(data + 297, "\0", 1);
+	assertEqualMem(data + 116 + 1024, "000021 \0", 8);
+	/* Gname field in ustar header should be empty. */
+	assertEqualMem(data + 297 + 1024, "\0", 1);
 	free(data);
 
 	/* TODO: It would be nice to verify that --gid= by itself

--- a/tar/test/test_option_group.c
+++ b/tar/test/test_option_group.c
@@ -27,7 +27,7 @@ DEFINE_TEST(test_option_group)
 	/* Create archive with --group (numeric) */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive2 --group=17 --format=ustar file >stdout2.txt 2>stderr2.txt",
+	    systemf("%s cf archive2 --group=17 --format=ustar file @archive1 >stdout2.txt 2>stderr2.txt",
 		testprog));
 	assertEmptyFile("stdout2.txt");
 	assertEmptyFile("stderr2.txt");
@@ -35,12 +35,15 @@ DEFINE_TEST(test_option_group)
 	assertEqualMem(data + 116, "000021 \0", 8);
 	/* Gname field in ustar header should be empty. */
 	assertEqualMem(data + 297, "\0", 1);
+	assertEqualMem(data + 116 + 1024, "000021 \0", 8);
+	/* Gname field in ustar header should be empty. */
+	assertEqualMem(data + 297 + 1024, "\0", 1);
 	free(data);
 
 	/* Again with --group (name) */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive3 --group=foofoofoo --format=ustar file >stdout3.txt 2>stderr3.txt",
+	    systemf("%s cf archive3 --group=foofoofoo --format=ustar file @archive1 >stdout3.txt 2>stderr3.txt",
 		testprog));
 	assertEmptyFile("stdout3.txt");
 	assertEmptyFile("stderr3.txt");
@@ -48,18 +51,22 @@ DEFINE_TEST(test_option_group)
 	/* Gid should be unchanged from original reference. */
 	assertEqualMem(data + 116, reference + 116, 8);
 	assertEqualMem(data + 297, "foofoofoo\0", 10);
+	assertEqualMem(data + 116 + 1024, reference + 116, 8);
+	assertEqualMem(data + 297 + 1024, "foofoofoo\0", 10);
 	free(data);
 
 	/* Again with --group (name:id) */
 	failure("Error invoking %s c", testprog);
 	assertEqualInt(0,
-	    systemf("%s cf archive4 --group=foofoofoo:17 --format=ustar file >stdout4.txt 2>stderr4.txt",
+	    systemf("%s cf archive4 --group=foofoofoo:17 --format=ustar file @archive1 >stdout4.txt 2>stderr4.txt",
 		testprog));
 	assertEmptyFile("stdout4.txt");
 	assertEmptyFile("stderr4.txt");
 	data = slurpfile(&s, "archive4");
 	assertEqualMem(data + 116, "000021 \0", 8);
 	assertEqualMem(data + 297, "foofoofoo\0", 10);
+	assertEqualMem(data + 116 + 1024, "000021 \0", 8);
+	assertEqualMem(data + 297 + 1024, "foofoofoo\0", 10);
 	free(data);
 
 	free(reference);

--- a/tar/test/test_option_mode.c
+++ b/tar/test/test_option_mode.c
@@ -35,6 +35,11 @@ DEFINE_TEST(test_option_mode)
 	int rv;
 	char *p;
 
+	const char *includedmtree =
+		"#mtree\n"
+		"in/included-all mode=777 type=file\n"
+		"in/included-minimal mode=500 type=file\n";
+
 	const char *test3mtree =
 		"#mtree\n"
 		"in/all mode=777 type=file\n"
@@ -66,16 +71,19 @@ DEFINE_TEST(test_option_mode)
 	/* Create some files with different modes */
 	assertMakeFile("in/all", 0777, "");
 	assertMakeFile("in/minimal", 0500, "");
+	assertMakeFile("included.mtree", 0644, includedmtree);
 
 	/* Archive and override using an absolute mode */
 	assertEqualInt(0,
 		systemf("%s --mode 644 -cf archive1.tar "
-			"in/all in/minimal", testprog));
+			"in/all in/minimal @included.mtree", testprog));
 
 	/* Verify the modes */
 	p = slurpfile(NULL, "archive1.tar");
-	assertEqualString(p + 100,"000644 ");
-	assertEqualString(p + 612,"000644 ");
+	assertEqualString(p + 512*0 + 100,"000644 ");
+	assertEqualString(p + 512*1 + 100,"000644 ");
+	assertEqualString(p + 512*2 + 100,"000644 ");
+	assertEqualString(p + 512*3 + 100,"000644 ");
 	free(p);
 
 /* Skip relative symbolic mode checks on Windows; on-disk files always have
@@ -85,12 +93,14 @@ DEFINE_TEST(test_option_mode)
 	/* Archive and override using a symbolic mode */
 	assertEqualInt(0,
 		systemf("%s --mode u+rw-x,g+X,o-w -cf archive2.tar "
-			"in/all in/minimal", testprog));
+			"in/all in/minimal @included.mtree", testprog));
 
 	/* Verify the modes */
 	p = slurpfile(NULL, "archive2.tar");
-	assertEqualString(p + 100,"000675 ");
-	assertEqualString(p + 612,"000610 ");
+	assertEqualString(p + 512*0 + 100,"000675 ");
+	assertEqualString(p + 512*1 + 100,"000610 ");
+	assertEqualString(p + 512*2 + 100,"000675 ");
+	assertEqualString(p + 512*3 + 100,"000610 ");
 	free(p);
 #endif
 

--- a/tar/test/test_option_mtime.c
+++ b/tar/test/test_option_mtime.c
@@ -62,4 +62,21 @@ DEFINE_TEST(test_option_mtime)
 	assertFileMtime("mid_mtime", 0, 0);
 	assertFileMtime("old_mtime", 0, 0);
 	assertChdir("..");
+
+	/* Create plain archive */
+	assertEqualInt(0,
+		systemf("%s --format pax -C in -cf plain.tar .",
+			testprog));
+
+	/* Extract plain archive with --mtime 0 */
+	assertMakeDir("out.extract", 0755);
+	assertChdir("out.extract");
+	assertEqualInt(0,
+		systemf("%s -xf ../plain.tar "
+			"--mtime \"1970/1/1 0:0:0 UTC\" ",
+			testprog));
+	assertFileMtime("new_mtime", 0, 0);
+	assertFileMtime("mid_mtime", 0, 0);
+	assertFileMtime("old_mtime", 0, 0);
+	assertChdir("..");
 }

--- a/tar/test/test_option_s.c
+++ b/tar/test/test_option_s.c
@@ -285,4 +285,16 @@ DEFINE_TEST(test_option_s)
 	    testprog);
 	assertFileContents("foo", 3, "test14/in/d1/fzo");
 	assertFileContents("bar", 3, "test14/in/d1/baz");
+
+	/*
+	 * Test 15: Basic substitution when listing archive.
+	 */
+	assertMakeDir("test15", 0755);
+	systemf("%s -cf test15.tar in/d1/foo in/d1/bar",
+	    testprog);
+	systemf("%s -tf test15.tar -s /o/z/g -s :in/d1/bar:: "
+	    ">test15/out 2>test15/err",
+	    testprog);
+	assertTextFileContents("in/d1/fzz\n", "test15/out");
+	assertEmptyFile("test15/err");
 }

--- a/tar/util.c
+++ b/tar/util.c
@@ -42,6 +42,7 @@
 
 #include "bsdtar.h"
 #include "lafe_err.h"
+#include "lafe_setmode.h"
 #include "passphrase.h"
 
 static size_t	bsdtar_expand_char(char *, size_t, size_t, char);
@@ -588,6 +589,47 @@ edit_mtime(struct bsdtar *bsdtar, struct archive_entry *entry)
 	if (!bsdtar->clamp_mtime || entry_mtime > bsdtar->mtime)
 		archive_entry_set_mtime(entry, bsdtar->mtime, 0);
 }
+
+/*
+ * Apply entry-modifying options.  Return non-zero on error.
+ */
+int
+edit_entry(struct bsdtar *bsdtar, struct archive_entry *entry)
+{
+	if (bsdtar->uid >= 0) {
+		archive_entry_set_uid(entry, bsdtar->uid);
+		if (bsdtar->diskreader)
+			archive_entry_set_uname(entry,
+			    archive_read_disk_uname(bsdtar->diskreader,
+				bsdtar->uid));
+		else
+			archive_entry_set_uname(entry, NULL);
+	}
+	if (bsdtar->gid >= 0) {
+		archive_entry_set_gid(entry, bsdtar->gid);
+		if (bsdtar->diskreader)
+			archive_entry_set_gname(entry,
+			    archive_read_disk_gname(bsdtar->diskreader,
+				bsdtar->gid));
+		else
+			archive_entry_set_gname(entry, NULL);
+	}
+	if (bsdtar->uname)
+		archive_entry_set_uname(entry, bsdtar->uname);
+	if (bsdtar->gname)
+		archive_entry_set_gname(entry, bsdtar->gname);
+
+	if (bsdtar->file_mode) {
+		mode_t m = archive_entry_mode(entry);
+		m = lafe_getmode(bsdtar->file_mode, m);
+		archive_entry_set_mode(entry, m);
+	}
+
+	edit_mtime(bsdtar, entry);
+
+	return edit_pathname(bsdtar, entry);
+}
+
 
 /*
  * Like strcmp(), but try to be a little more aware of the fact that

--- a/tar/write.c
+++ b/tar/write.c
@@ -718,12 +718,11 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina)
 		}
 		if (e)
 			continue;
-		if(edit_pathname(bsdtar, in_entry))
+		if(edit_entry(bsdtar, in_entry))
 			continue;
 		if ((bsdtar->flags & OPTFLAG_INTERACTIVE) &&
 		    !yes("copy '%s'", archive_entry_pathname(in_entry)))
 			continue;
-		edit_mtime(bsdtar, in_entry);
 		if (bsdtar->verbose > 1) {
 			safe_fprintf(stderr, "a ");
 			list_item_verbose(bsdtar, stderr, in_entry);
@@ -925,40 +924,11 @@ write_hierarchy(struct bsdtar *bsdtar, struct archive *a, const char *path)
 				continue;
 		}
 
-		if (bsdtar->uid >= 0) {
-			archive_entry_set_uid(entry, bsdtar->uid);
-			if (!bsdtar->uname)
-				archive_entry_set_uname(entry,
-				    archive_read_disk_uname(bsdtar->diskreader,
-					bsdtar->uid));
-		}
-		if (bsdtar->gid >= 0) {
-			archive_entry_set_gid(entry, bsdtar->gid);
-			if (!bsdtar->gname)
-				archive_entry_set_gname(entry,
-				    archive_read_disk_gname(bsdtar->diskreader,
-					bsdtar->gid));
-		}
-		if (bsdtar->uname)
-			archive_entry_set_uname(entry, bsdtar->uname);
-		if (bsdtar->gname)
-			archive_entry_set_gname(entry, bsdtar->gname);
-
-		if (bsdtar->file_mode) {
-			mode_t m = archive_entry_mode(entry);
-			m = lafe_getmode(bsdtar->file_mode, m);
-			archive_entry_set_mode(entry, m);
-		}
-
 		/*
-		 * Rewrite the pathname to be archived.  If rewrite
-		 * fails, skip the entry.
+		 * Rewrite entry attributes.  If rewrite fails, skip the entry.
 		 */
-		if (edit_pathname(bsdtar, entry))
+		if (edit_entry(bsdtar, entry))
 			continue;
-
-		/* Rewrite the mtime. */
-		edit_mtime(bsdtar, entry);
 
 		/* Display entry as we process it. */
 		if (bsdtar->verbose > 1) {


### PR DESCRIPTION
Options like `--mtime`, `--owner`, `--group`, `--mode`, and `-s` currently get processed individually, but not consistently, depending on what tar operation is being done or whether the file was listed on the commandline or included via `@` :

|Action |mtime  |owner  |group  |mode   |sed  |
|-------|-------|-------|-------|-------|-----|
|create |Y      |Y      |Y      |Y      |Y    |
|create@|Y      |N      |N      |N      |Y    |
|extract|N      |Y      |Y      |Y      |Y    |
|list   |N      |Y      |Y      |Y      |N    |

Call the new `edit_entry()` function from `read_archive()`, `write_hierarchy()` and `append_archive()`.  Ensures that all files passing through tar get modified the same way.

The refactoring was straightforward except for the `edit_pathname()` function.  By default, if it sees a file with a leading "/", it prints a warning and strips the slash.  That shouldn't happen when listing, so I set the `OPTFLAG_ABSOLUTE_PATHS` flag ( `-P` ) in `main()` during option processing.
