### PR TITLE
format: Improve format registration error handling

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -478,8 +478,7 @@ archive_read_support_format_7zip(struct archive *_a)
 
 	zip = calloc(1, sizeof(*zip));
 	if (zip == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate 7zip data");
+		archive_set_error(_a, ENOMEM, "Can't allocate 7zip data");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -488,7 +487,6 @@ archive_read_support_format_7zip(struct archive *_a)
 	 * any encrypted entries yet.
 	 */
 	zip->has_encrypted_entries = ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW;
-
 
 	r = __archive_read_register_format(a,
 	    zip,

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -505,7 +505,7 @@ archive_read_support_format_7zip(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(zip);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -125,11 +125,9 @@ archive_read_support_format_ar(struct archive *_a)
 	    NULL,
 	    NULL);
 
-	if (r != ARCHIVE_OK) {
+	if (r != ARCHIVE_OK)
 		free(ar);
-		return (r);
-	}
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -106,8 +106,7 @@ archive_read_support_format_ar(struct archive *_a)
 
 	ar = calloc(1, sizeof(*ar));
 	if (ar == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate ar data");
+		archive_set_error(_a, ENOMEM, "Can't allocate ar data");
 		return (ARCHIVE_FATAL);
 	}
 	ar->strtab = NULL;

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -488,7 +488,7 @@ archive_read_support_format_cab(struct archive *_a)
 		archive_wstring_free(&cab->ws);
 		free(cab);
 	}
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -459,14 +459,13 @@ archive_read_support_format_cab(struct archive *_a)
 
 	cab = calloc(1, sizeof(*cab));
 	if (cab == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
+		archive_set_error(_a, ENOMEM,
 		    "Can't allocate CAB data");
 		return (ARCHIVE_FATAL);
 	}
 	archive_string_init(&cab->ws);
 	if (archive_wstring_ensure(&cab->ws, 256) == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate memory");
+		archive_set_error(_a, ENOMEM, "Can't allocate memory");
 		free(cab);
 		return (ARCHIVE_FATAL);
 	}

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -254,7 +254,7 @@ archive_read_support_format_cpio(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(cpio);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -234,7 +234,7 @@ archive_read_support_format_cpio(struct archive *_a)
 
 	cpio = calloc(1, sizeof(*cpio));
 	if (cpio == NULL) {
-		archive_set_error(&a->archive, ENOMEM, "Can't allocate cpio data");
+		archive_set_error(_a, ENOMEM, "Can't allocate cpio data");
 		return (ARCHIVE_FATAL);
 	}
 	cpio->magic = CPIO_MAGIC;

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -464,8 +464,7 @@ archive_read_support_format_iso9660(struct archive *_a)
 
 	iso9660 = calloc(1, sizeof(*iso9660));
 	if (iso9660 == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate iso9660 data");
+		archive_set_error(_a, ENOMEM, "Can't allocate iso9660 data");
 		return (ARCHIVE_FATAL);
 	}
 	iso9660->magic = ISO9660_MAGIC;

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -491,11 +491,9 @@ archive_read_support_format_iso9660(struct archive *_a)
 	    NULL,
 	    NULL);
 
-	if (r != ARCHIVE_OK) {
+	if (r != ARCHIVE_OK)
 		free(iso9660);
-		return (r);
-	}
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -264,8 +264,7 @@ archive_read_support_format_lha(struct archive *_a)
 
 	lha = calloc(1, sizeof(*lha));
 	if (lha == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate lha data");
+		archive_set_error(_a, ENOMEM, "Can't allocate lha data");
 		return (ARCHIVE_FATAL);
 	}
 	archive_string_init(&lha->ws);

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -285,7 +285,7 @@ archive_read_support_format_lha(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(lha);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static size_t

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -238,7 +238,7 @@ archive_read_support_format_mtree(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(mtree);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -224,8 +224,7 @@ archive_read_support_format_mtree(struct archive *_a)
 
 	mtree = calloc(1, sizeof(*mtree));
 	if (mtree == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate mtree data");
+		archive_set_error(_a, ENOMEM, "Can't allocate mtree data");
 		return (ARCHIVE_FATAL);
 	}
 	mtree->checkfs = 0;
@@ -233,8 +232,18 @@ archive_read_support_format_mtree(struct archive *_a)
 
 	__archive_rb_tree_init(&mtree->rbtree, &rb_ops);
 
-	r = __archive_read_register_format(a, mtree, "mtree",
-           mtree_bid, archive_read_format_mtree_options, read_header, read_data, skip, NULL, cleanup, NULL, NULL);
+	r = __archive_read_register_format(a,
+	    mtree,
+	    "mtree",
+	    mtree_bid,
+	    archive_read_format_mtree_options,
+	    read_header,
+	    read_data,
+	    skip,
+	    NULL,
+	    cleanup,
+	    NULL,
+	    NULL);
 
 	if (r != ARCHIVE_OK)
 		free(mtree);

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -736,7 +736,7 @@ archive_read_support_format_rar(struct archive *_a)
   rar = calloc(1, sizeof(*rar));
   if (rar == NULL)
   {
-    archive_set_error(&a->archive, ENOMEM, "Can't allocate rar data");
+    archive_set_error(_a, ENOMEM, "Can't allocate rar data");
     return (ARCHIVE_FATAL);
   }
 
@@ -747,17 +747,17 @@ archive_read_support_format_rar(struct archive *_a)
   rar->has_encrypted_entries = ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW;
 
   r = __archive_read_register_format(a,
-                                     rar,
-                                     "rar",
-                                     archive_read_format_rar_bid,
-                                     archive_read_format_rar_options,
-                                     archive_read_format_rar_read_header,
-                                     archive_read_format_rar_read_data,
-                                     archive_read_format_rar_read_data_skip,
-                                     archive_read_format_rar_seek_data,
-                                     archive_read_format_rar_cleanup,
-                                     archive_read_support_format_rar_capabilities,
-                                     archive_read_format_rar_has_encrypted_entries);
+      rar,
+      "rar",
+      archive_read_format_rar_bid,
+      archive_read_format_rar_options,
+      archive_read_format_rar_read_header,
+      archive_read_format_rar_read_data,
+      archive_read_format_rar_read_data_skip,
+      archive_read_format_rar_seek_data,
+      archive_read_format_rar_cleanup,
+      archive_read_support_format_rar_capabilities,
+      archive_read_format_rar_has_encrypted_entries);
 
   if (r != ARCHIVE_OK)
     free(rar);

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -4497,5 +4497,5 @@ int archive_read_support_format_rar5(struct archive *_a) {
 		free(rar5);
 	}
 
-	return ARCHIVE_OK;
+	return ret;
 }

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -889,16 +889,6 @@ static void reset_file_context(struct rar5 *rar5) {
 	free_filters(rar5);
 }
 
-static inline int get_archive_read(struct archive* a,
-    struct archive_read** ar)
-{
-	*ar = (struct archive_read*) a;
-	archive_check_magic(a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_NEW,
-	    "archive_read_support_format_rar5");
-
-	return ARCHIVE_OK;
-}
-
 static int read_ahead(struct archive_read* a, size_t how_many,
     const uint8_t** ptr)
 {
@@ -4458,12 +4448,12 @@ static void rar5_deinit(struct rar5 *rar5) {
 }
 
 int archive_read_support_format_rar5(struct archive *_a) {
-	struct archive_read* ar;
-	int ret;
+	struct archive_read* ar = (struct archive_read*)_a;
 	struct rar5 *rar5;
+	int r;
 
-	if(ARCHIVE_OK != (ret = get_archive_read(_a, &ar)))
-		return ret;
+	archive_check_magic(_a, ARCHIVE_READ_MAGIC, ARCHIVE_STATE_NEW,
+	    "archive_read_support_format_rar5");
 
 	rar5 = malloc(sizeof(*rar5));
 	if(rar5 == NULL) {
@@ -4479,7 +4469,7 @@ int archive_read_support_format_rar5(struct archive *_a) {
 		return ARCHIVE_FATAL;
 	}
 
-	ret = __archive_read_register_format(ar,
+	r = __archive_read_register_format(ar,
 	    rar5,
 	    "rar5",
 	    rar5_bid,
@@ -4492,10 +4482,9 @@ int archive_read_support_format_rar5(struct archive *_a) {
 	    rar5_capabilities,
 	    rar5_has_encrypted_entries);
 
-	if(ret != ARCHIVE_OK) {
+	if(r != ARCHIVE_OK) {
 		rar5_deinit(rar5);
 		free(rar5);
 	}
-
-	return ret;
+	return r;
 }

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -64,8 +64,7 @@ archive_read_support_format_raw(struct archive *_a)
 
 	raw = calloc(1, sizeof(*raw));
 	if (raw == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate raw data");
+		archive_set_error(_a, ENOMEM, "Can't allocate raw data");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -81,6 +80,7 @@ archive_read_support_format_raw(struct archive *_a)
 	    archive_read_format_raw_cleanup,
 	    NULL,
 	    NULL);
+
 	if (r != ARCHIVE_OK)
 		free(raw);
 	return (r);

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -294,7 +294,7 @@ archive_read_support_format_tar(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(tar);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -272,8 +272,7 @@ archive_read_support_format_tar(struct archive *_a)
 
 	tar = calloc(1, sizeof(*tar));
 	if (tar == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate tar data");
+		archive_set_error(_a, ENOMEM, "Can't allocate tar data");
 		return (ARCHIVE_FATAL);
 	}
 #ifdef HAVE_COPYFILE_H
@@ -281,7 +280,9 @@ archive_read_support_format_tar(struct archive *_a)
 	tar->process_mac_extensions = 1;
 #endif
 
-	r = __archive_read_register_format(a, tar, "tar",
+	r = __archive_read_register_format(a,
+	    tar,
+	    "tar",
 	    archive_read_format_tar_bid,
 	    archive_read_format_tar_options,
 	    archive_read_format_tar_read_header,

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -150,8 +150,7 @@ archive_read_support_format_warc(struct archive *_a)
 	    ARCHIVE_STATE_NEW, "archive_read_support_format_warc");
 
 	if ((warc = calloc(1, sizeof(*warc))) == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate warc data");
+		archive_set_error(_a, ENOMEM, "Can't allocate warc data");
 		return (ARCHIVE_FATAL);
 	}
 

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -168,11 +168,9 @@ archive_read_support_format_warc(struct archive *_a)
 	    NULL,
 	    NULL);
 
-	if (r != ARCHIVE_OK) {
+	if (r != ARCHIVE_OK)
 		free(warc);
-		return (r);
-	}
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 static int

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -460,8 +460,8 @@ static int	xmllite_read_toc(struct archive_read *);
 int
 archive_read_support_format_xar(struct archive *_a)
 {
-	struct xar *xar;
 	struct archive_read *a = (struct archive_read *)_a;
+	struct xar *xar;
 	int r;
 
 	archive_check_magic(_a, ARCHIVE_READ_MAGIC,
@@ -469,8 +469,7 @@ archive_read_support_format_xar(struct archive *_a)
 
 	xar = calloc(1, sizeof(*xar));
 	if (xar == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate xar data");
+		archive_set_error(_a, ENOMEM, "Can't allocate xar data");
 		return (ARCHIVE_FATAL);
 	}
 
@@ -491,6 +490,7 @@ archive_read_support_format_xar(struct archive *_a)
 	    xar_cleanup,
 	    NULL,
 	    NULL);
+
 	if (r != ARCHIVE_OK)
 		free(xar);
 	return (r);

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3911,7 +3911,7 @@ archive_read_support_format_zip_streamable(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(zip);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -4704,7 +4704,7 @@ archive_read_support_format_zip_seekable(struct archive *_a)
 
 	if (r != ARCHIVE_OK)
 		free(zip);
-	return (ARCHIVE_OK);
+	return (r);
 }
 
 /*# vim:set noet:*/

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3881,8 +3881,7 @@ archive_read_support_format_zip_streamable(struct archive *_a)
 
 	zip = calloc(1, sizeof(*zip));
 	if (zip == NULL) {
-		archive_set_error(&a->archive, ENOMEM,
-		    "Can't allocate zip data");
+		archive_set_error(_a, ENOMEM, "Can't allocate zip data");
 		return (ARCHIVE_FATAL);
 	}
 

--- a/libarchive/test/test_archive_read_support.c
+++ b/libarchive/test/test_archive_read_support.c
@@ -144,3 +144,39 @@ DEFINE_TEST(test_archive_read_support)
 	test_filter_or_format(archive_read_support_filter_uu);
 	test_filter_or_format(archive_read_support_filter_xz);
 }
+
+DEFINE_TEST(test_archive_read_support_twice)
+{
+	struct archive *a;
+
+	a = archive_read_new();
+	assert(a != NULL);
+
+	/* Adding format bidders once should work. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_7zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_ar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_cab(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_cpio(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_empty(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_iso9660(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_lha(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
+
+	/* Adding format bidders twice should lead to warnings. */
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_7zip(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_ar(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_cab(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_cpio(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_empty(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_iso9660(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_lha(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_tar(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_WARN, archive_read_support_format_zip(a));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
Some `support_format` functions, i.e. the format bidding registrations, return `ARCHIVE_WARN` if multiple registration attempts were performed. Others do not.

I've created a unit test which highlights this.

Make all registration functions behave the same and look the same. Split into 4 commits in total (unit test, fix, unify return value handling, unify style).