### PR TITLE
Return fatal when closing a failed writer

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -641,8 +641,7 @@ _archive_write_close(struct archive *_a)
 	int r = ARCHIVE_OK, r1 = ARCHIVE_OK;
 
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
-	    ARCHIVE_STATE_ANY | ARCHIVE_STATE_FATAL,
-	    "archive_write_close");
+	    ARCHIVE_STATE_ANY, "archive_write_close");
 	if (a->archive.state == ARCHIVE_STATE_NEW
 	    || a->archive.state == ARCHIVE_STATE_CLOSED)
 		return (ARCHIVE_OK); /* Okay to close() when not open. */

--- a/libarchive/test/test_write_format_pax.c
+++ b/libarchive/test/test_write_format_pax.c
@@ -38,6 +38,20 @@ DEFINE_TEST(test_write_format_pax)
 	int64_t offset, length;
 	char long_slashes[300 + 1];
 
+	/* Only archive_write_free() is valid once the archive is fatal. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_pax(a));
+	archive_write_fail(a);
+	assertEqualIntA(a, ARCHIVE_FATAL,
+	    archive_write_open_memory(a, buff2, sizeof(buff2), &used));
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "test");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_header(a, ae));
+	archive_entry_free(ae);
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
 	buff = malloc(buffsize); /* million bytes of work area */
 	assert(buff != NULL);
 

--- a/libarchive/test/test_write_format_raw.c
+++ b/libarchive/test/test_write_format_raw.c
@@ -92,7 +92,7 @@ test_format(int	(*set_format)(struct archive *))
 	assertEqualMem(err, "Raw format only supports one entry per archive", 47);
 	archive_entry_free(ae);
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	/* Create a new archive */
@@ -111,7 +111,7 @@ test_format(int	(*set_format)(struct archive *))
 	assertEqualMem(err, "Raw format only supports filetype AE_IFREG", 43);
 	archive_entry_free(ae);
 
-	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 
 	free(buff);


### PR DESCRIPTION
 Fixes #3353.

  Reject `archive_write_close()` immediately when the writer is already in a fatal state, before invoking format close callbacks.

  Add pax regression coverage for open, header, close, and free behavior after `archive_write_fail()`, and update the existing raw-format expectations.