### PR TITLE
Fix a number of Windows/clang(-cl) issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1463,6 +1463,17 @@ IF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
   SET(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-builtin")
 ENDIF (CMAKE_C_COMPILER_ID MATCHES "^GNU$" OR
        CMAKE_C_COMPILER_ID MATCHES "^Clang$")
+IF (MSVC)
+  #
+  # The Windows CRT marks a number of standard functions (e.g. wcscpy) as
+  # deprecated. All source files in this project are compiled with those
+  # deprecations suppressed, so suppress these warnings for the following
+  # symbol checks as well. Otherwise, the deprecation warnings get turned into
+  # errors by ENABLE_WERROR's /WX flag and the check fails even when the
+  # function exists.
+  #
+  LIST(APPEND CMAKE_REQUIRED_DEFINITIONS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS)
+ENDIF (MSVC)
 CHECK_SYMBOL_EXISTS(_CrtSetReportMode "crtdbg.h" HAVE__CrtSetReportMode)
 CHECK_FUNCTION_EXISTS_GLIBC(arc4random_buf HAVE_ARC4RANDOM_BUF)
 CHECK_FUNCTION_EXISTS_GLIBC(chflags HAVE_CHFLAGS)
@@ -2219,7 +2230,10 @@ ENDIF(WIN32 AND NOT CYGWIN AND ENABLE_INSTALL)
 INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/libarchive)
 #
 IF(MSVC)
-  ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE)
+  ADD_DEFINITIONS(
+    -D_CRT_NONSTDC_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
+  )
 ENDIF(MSVC)
 
 OPTION(DONT_FAIL_ON_CRC_ERROR "Ignore CRC errors during parsing (For fuzzing)" OFF)

--- a/libarchive/filter_fork_windows.c
+++ b/libarchive/filter_fork_windows.c
@@ -77,7 +77,7 @@ load_WaitForInputIdle(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
 	(void)Parameter; /* UNUSED */
 
 	*Context = (user32 != NULL) ?
-	    (PVOID)GetProcAddress(user32, "WaitForInputIdle") : failing_wait;
+	    (PVOID)GetProcAddress(user32, "WaitForInputIdle") : (PVOID)failing_wait;
 
 	return TRUE;
 }

--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -45,6 +45,12 @@
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#elif defined(HAVE_IO_H)
+/*
+ * Windows has no <unistd.h>; close(), isatty(), open() and write() are
+ * made available by including io.h instead.
+ */
+#include <io.h>
 #endif
 #if ((!defined(HAVE_UTIMENSAT) && defined(HAVE_LUTIMES)) || \
     (!defined(HAVE_FUTIMENS) && defined(HAVE_FUTIMES)))


### PR DESCRIPTION
I hit a very similar but distinct issue to #2715 - similar enough that I'm pretty confident this change will resolve that issue - with `HAVE_WCSCPY` going undefined in Debug builds. There's also a couple other issues sprinkled around either introduced by various changes or Clang updates that I've fixed here.