### PR TITLE
Fix empty wide string conversion on Windows

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -785,6 +785,10 @@ archive_string_append_from_wcs_in_codepage(struct archive_string *as,
 			r = WideCharToMultiByte(to_cp, 0, ws, (int)wslen,
 			    as->s + as->length,
 			    (int)(as->buffer_length - as->length - 1), NULL, dp);
+			if (r == 0 && wslen == 0) {
+				count = 0;
+				break;
+			}
 			if (r == 0 &&
 			    GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
 				/* Expand the MBS buffer and retry. */

--- a/tar/test/test_option_ignore_zeros.c
+++ b/tar/test/test_option_ignore_zeros.c
@@ -70,13 +70,6 @@ DEFINE_TEST(test_option_ignore_zeros_mode_x)
 
 DEFINE_TEST(test_option_ignore_zeros_mode_c)
 {
-#if defined(_WIN32) && !defined(__CYGWIN__)
-	// The first command run by systemf below prints this to stderr:
-	// bsdtar.exe: a: Can't translate uname '(null)' to UTF-8
-	// bsdtar.exe: b: Can't translate uname '(null)' to UTF-8
-	skipping("TODO: figure out why this test fails on github workflows with MSVC");
-	return;
-#else
 	if (make_files())
 		return;
 
@@ -96,7 +89,6 @@ DEFINE_TEST(test_option_ignore_zeros_mode_c)
 	assertEqualFile("out/a", "in/a");
 	assertEqualFile("out/b", "in/b");
 	assertEqualFile("out/c", "in/c");
-#endif
 }
 
 static void


### PR DESCRIPTION
On Windows, adding an existing archive with `@archive` fails when its entries
  have empty user or group names.

  Reproduction:

  - `tar cvf test1.tar file.txt`
  - `tar cvf test2.tar @test1.tar`

  `WideCharToMultiByte()` rejects a zero source length, so
  `archive_string_append_from_wcs_in_codepage()` reports a conversion failure
  for an otherwise valid empty string.

  Treat a zero-length wide string as a successful empty conversion after
  ensuring destination storage. Re-enable `test_option_ignore_zeros_mode_c` on
  Windows to cover the original bsdtar path.

  ## Testing

  - `test_option_ignore_zeros_mode_c`: 22 assertions, no failures or skips
  - Full bsdtar suite: 77 passed, 24 skipped; the unrelated `test_list_item`
    locale assertion remains failing under MinGW because localized month output
    does not match its English expectation

  Fixes #3358.