### PR TITLE
lz4/zstd: Bidding result must be based on bits

### DIFF
--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -205,13 +205,11 @@ lz4_reader_bid(struct archive_read_filter_bidder *b,
 		 * if this is LZ4 data.
 		 */
 		if (archive_ckd_add_size(&min,
-		    offset_in_buffer, min_lz4_frame_size))
+		    offset_in_buffer, min_lz4_frame_size) ||
+		    min > max_lookahead)
 			return (0);
 		/* TODO: should this be >= ? */
 		if (min > (size_t)avail) {
-			if (min > max_lookahead)
-				return (0); 
-
 			buffer = __archive_read_filter_ahead(f,
 			    min, &avail);
 			if (buffer == NULL)

--- a/libarchive/archive_read_support_filter_lz4.c
+++ b/libarchive/archive_read_support_filter_lz4.c
@@ -180,6 +180,7 @@ lz4_reader_bid(struct archive_read_filter_bidder *b,
 		uint32_t frame_data_size;
 
 		/* Skip over the magic number */
+		bits_checked += 28;
 		offset_in_buffer += 4;
 
 		/* Ensure that we can read another 4 bytes. */
@@ -224,7 +225,6 @@ lz4_reader_bid(struct archive_read_filter_bidder *b,
 	 * follows, or this isn't LZ4 data.
 	 */
 
-	bits_checked = offset_in_buffer;
 	buffer = buffer + offset_in_buffer;
 
 	if (magic_number == LZ4_MAGICNUMBER) {

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -28,10 +28,6 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
-
-#ifdef HAVE_ERRNO_H
-#include <errno.h>
-#endif
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -105,6 +105,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *b,
 {
 	const unsigned char *buffer;
 	ssize_t avail;
+	int bits_checked = 0;
 	/*
 	 * Zstandard skippable frames contain a 4 byte magic number followed
 	 * by a 4 byte frame data size, then that number of bytes of data.
@@ -143,6 +144,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *b,
 		uint32_t frame_data_size;
 
 		/* Skip over the magic number */
+		bits_checked += 28;
 		offset_in_buffer += 4;
 
 		/* Ensure that we can read another 4 bytes. */
@@ -187,7 +189,7 @@ zstd_bidder_bid(struct archive_read_filter_bidder *b,
 	 */
 
 	if (magic_number == zstd_magic)
-		return (offset_in_buffer + 4);
+		return (bits_checked + 32);
 
 	return (0);
 }

--- a/libarchive/archive_read_support_filter_zstd.c
+++ b/libarchive/archive_read_support_filter_zstd.c
@@ -168,12 +168,10 @@ zstd_bidder_bid(struct archive_read_filter_bidder *b,
 		 * if this is zstd data.
 		 */
 		if (archive_ckd_add_size(&min,
-		    offset_in_buffer, min_zstd_frame_size))
+		    offset_in_buffer, min_zstd_frame_size) ||
+		    min > max_lookahead)
 			return (0);
 		if (min > (size_t)avail) {
-			if (min > max_lookahead)
-				return (0);
-
 			buffer = __archive_read_filter_ahead(f,
 			    min, &avail);
 			if (buffer == NULL)


### PR DESCRIPTION
The lz4 and zstd filters create bidding results based on bytes instead of bits.

They also can read far beyond the expected upper byte limit for bidding if the upstream filter has enough bytes, e.g. if an archive is completely stored in memory. Just calculating `* 8` could make it much easier to trigger a signed integer overflow.

Also, only consider the actually checked bits. Skipping bytes shouldn't be added to the bidding result to stay in sync with other filters and format parsers.

I know that adjusting these values could trigger funny/weird behavior if multiple filter bidders match the stream. Hopefully this doesn't lead to side effects. Another review will definitely help here.