### PR TITLE
formats: Unify SFX window handling while bidding

### DIFF
--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -529,11 +529,11 @@ archive_read_format_7zip_has_encrypted_entries(struct archive_read *a)
 static int
 get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 {
-	const unsigned char *p;
+	const unsigned char *h;
 	int64_t offset, sfx_offset;
 	int r, window;
 
-	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL) {
+	if ((h = __archive_read_ahead(a, 6, NULL)) == NULL) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Truncated 7-Zip file body");
 		return (ARCHIVE_FATAL);
@@ -541,7 +541,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 
 	/* If first six bytes are the 7-Zip signature,
 	 * return the offset right now. */
-	if (memcmp(p, _7ZIP_SIGNATURE, 6) == 0) {
+	if (memcmp(h, _7ZIP_SIGNATURE, 6) == 0) {
 		*data_offset = 0;
 		return (ARCHIVE_OK);
 	}
@@ -554,9 +554,9 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 	 * performing a seek, get_elf_sfx_offset requires one,
 	 * thus a performance difference between the two is expected. 
 	 */
-	if ((p[0] == 'M' && p[1] == 'Z'))
+	if ((h[0] == 'M' && h[1] == 'Z'))
 		r = get_pe_sfx_offset(a, &sfx_offset);
-	else if (memcmp(p, "\x7F\x45LF", 4) == 0)
+	else if (memcmp(h, "\x7F\x45LF", 4) == 0)
 		r = get_elf_sfx_offset(a, &sfx_offset, compat);
 	else
 		r = ARCHIVE_FATAL;
@@ -567,25 +567,26 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 	window = 4096;
 	while (offset + window <= (sfx_offset + SFX_MAX_OFFSET)) {
 		ssize_t bytes_avail;
-		const unsigned char *buff = __archive_read_ahead(a,
-				offset + window, &bytes_avail);
-		if (buff == NULL) {
+		const unsigned char *p;
+
+		h = __archive_read_ahead(a, offset + window, &bytes_avail);
+		if (h == NULL) {
 			/* Remaining bytes are less than window. */
 			window >>= 1;
 			if (window < 0x40)
 				goto fail;
 			continue;
 		}
-		p = buff + offset;
-		while (buff + bytes_avail - p >= 32) {
+		p = h + offset;
+		while (h + bytes_avail - p >= 32) {
 			size_t step = check_7zip_header_in_sfx(p);
 			if (step == 0) {
-				*data_offset = p - buff;
+				*data_offset = p - h;
 				return (ARCHIVE_OK);
 			}
 			p += step;
 		}
-		offset = p - buff;
+		offset = p - h;
 	}
 fail:
 	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -565,7 +565,8 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 
 	offset = sfx_offset;
 	window = 4096;
-	while (offset + window <= sfx_offset + SFX_MAX_OFFSET) {
+#define SFX_MAX_READAHEAD	(sfx_offset + SFX_MAX_OFFSET)
+	while (offset + window <= SFX_MAX_READAHEAD) {
 		ssize_t bytes_avail;
 
 		h = __archive_read_ahead(a, offset + window, &bytes_avail);
@@ -577,8 +578,8 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 			}
 			goto fail;
 		}
-		if (bytes_avail > sfx_offset + SFX_MAX_OFFSET)
-			bytes_avail = sfx_offset + SFX_MAX_OFFSET;
+		if (bytes_avail > SFX_MAX_READAHEAD)
+			bytes_avail = SFX_MAX_READAHEAD;
 		while (offset <= bytes_avail - 32) {
 			size_t step = check_7zip_header_in_sfx(h + offset);
 			if (step == 0) {

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -567,7 +567,6 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 	window = 4096;
 	while (offset + window <= (sfx_offset + SFX_MAX_OFFSET)) {
 		ssize_t bytes_avail;
-		const unsigned char *p;
 
 		h = __archive_read_ahead(a, offset + window, &bytes_avail);
 		if (h == NULL) {
@@ -577,16 +576,14 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 				goto fail;
 			continue;
 		}
-		p = h + offset;
-		while (h + bytes_avail - p >= 32) {
-			size_t step = check_7zip_header_in_sfx(p);
+		while (offset <= bytes_avail - 32) {
+			size_t step = check_7zip_header_in_sfx(h + offset);
 			if (step == 0) {
-				*data_offset = p - h;
+				*data_offset = offset;
 				return (ARCHIVE_OK);
 			}
-			p += step;
+			offset += step;
 		}
-		offset = p - h;
 	}
 fail:
 	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -570,11 +570,12 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 
 		h = __archive_read_ahead(a, offset + window, &bytes_avail);
 		if (h == NULL) {
-			/* Remaining bytes are less than window. */
-			window >>= 1;
-			if (window < 0x40)
-				goto fail;
-			continue;
+			if (bytes_avail >= offset + 32) {
+				/* Remaining bytes are less than window. */
+				window = bytes_avail - offset;
+				continue;
+			}
+			goto fail;
 		}
 		if (bytes_avail > sfx_offset + SFX_MAX_OFFSET)
 			bytes_avail = sfx_offset + SFX_MAX_OFFSET;

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -576,6 +576,8 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 				goto fail;
 			continue;
 		}
+		if (bytes_avail > sfx_offset + SFX_MAX_OFFSET)
+			bytes_avail = sfx_offset + SFX_MAX_OFFSET;
 		while (offset <= bytes_avail - 32) {
 			size_t step = check_7zip_header_in_sfx(h + offset);
 			if (step == 0) {

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -565,7 +565,7 @@ get_data_offset(struct archive_read *a, int64_t *data_offset, int compat)
 
 	offset = sfx_offset;
 	window = 4096;
-	while (offset + window <= (sfx_offset + SFX_MAX_OFFSET)) {
+	while (offset + window <= sfx_offset + SFX_MAX_OFFSET) {
 		ssize_t bytes_avail;
 
 		h = __archive_read_ahead(a, offset + window, &bytes_avail);

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -284,6 +284,7 @@ struct lzx_stream {
 #define MAX_UNCOMPRESS_SIZE	0x8000
 #define MAX_FILE_SIZE		(UINT16_MAX * MAX_UNCOMPRESS_SIZE)
 #define MAX_E8_TRANSLATION	(0x8000 * MAX_UNCOMPRESS_SIZE)
+#define SFX_MAX_READAHEAD	(1024 * 128)
 
 static const char * const compression_name[] = {
 	"NONE",
@@ -540,7 +541,7 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 
 		offset = 0;
 		window = 4096;
-		while (offset + window <= 1024 * 128) {
+		while (offset + window <= SFX_MAX_READAHEAD) {
 			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
 			if (h == NULL) {
@@ -551,8 +552,8 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 				}
 				return (0);
 			}
-			if (bytes_avail > 1024 * 128)
-				bytes_avail = 1024 * 128;
+			if (bytes_avail > SFX_MAX_READAHEAD)
+				bytes_avail = SFX_MAX_READAHEAD;
 			while (offset <= bytes_avail - 8) {
 				size_t next = find_cab_magic(h + offset);
 				if (next == 0)

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -540,7 +540,7 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 
 		offset = 0;
 		window = 4096;
-		while (offset < (1024 * 128)) {
+		while (offset + window <= 1024 * 128) {
 			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
 			if (h == NULL) {

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -544,11 +544,12 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
 			if (h == NULL) {
-				/* Remaining bytes are less than window. */
-				window >>= 1;
-				if (window < 128)
-					return (0);
-				continue;
+				if (bytes_avail >= offset + 8) {
+					/* Remaining bytes are less than window. */
+					window = bytes_avail - offset;
+					continue;
+				}
+				return (0);
 			}
 			if (bytes_avail > 1024 * 128)
 				bytes_avail = 1024 * 128;

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -490,7 +490,7 @@ archive_read_support_format_cab(struct archive *_a)
 	return (r);
 }
 
-static int
+static size_t
 find_cab_magic(const char *p)
 {
 	switch (p[4]) {
@@ -550,8 +550,8 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 			}
 			p = h + offset;
 			while (p + 8 < h + bytes_avail) {
-				int next;
-				if ((next = find_cab_magic(p)) == 0)
+				size_t next = find_cab_magic(p);
+				if (next == 0)
 					return (64);
 				p += next;
 			}
@@ -618,8 +618,8 @@ cab_skip_sfx(struct archive_read *a)
 		 * like the cab header.
 		 */
 		while (p + 8 < q) {
-			int next;
-			if ((next = find_cab_magic(p)) == 0) {
+			size_t next = find_cab_magic(p);
+			if (next == 0) {
 				skip = p - h;
 				__archive_read_consume(a, skip);
 				return (ARCHIVE_OK);

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -535,7 +535,6 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 	 * up to 128k for an 'MSCF' marker.
 	 */
 	if (h[0] == 'M' && h[1] == 'Z') {
-		const char *p;
 		ssize_t bytes_avail;
 		ssize_t offset, window;
 
@@ -551,14 +550,12 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 					return (0);
 				continue;
 			}
-			p = h + offset;
-			while (p + 8 < h + bytes_avail) {
-				size_t next = find_cab_magic(p);
+			while (offset <= bytes_avail - 8) {
+				size_t next = find_cab_magic(h + offset);
 				if (next == 0)
 					return (64);
-				p += next;
+				offset += next;
 			}
-			offset = p - h;
 		}
 	}
 	return (0);

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -550,6 +550,8 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 					return (0);
 				continue;
 			}
+			if (bytes_avail > 1024 * 128)
+				bytes_avail = 1024 * 128;
 			while (offset <= bytes_avail - 8) {
 				size_t next = find_cab_magic(h + offset);
 				if (next == 0)

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -516,18 +516,17 @@ find_cab_magic(const char *p)
 static int
 archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 {
-	const char *p;
-	ssize_t bytes_avail, offset, window;
+	const char *h;
 
 	/* If there's already a better bid than we can ever
 	   make, don't bother testing. */
 	if (best_bid > 64)
 		return (-1);
 
-	if ((p = __archive_read_ahead(a, 8, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, 8, NULL)) == NULL)
 		return (-1);
 
-	if (memcmp(p, "MSCF\0\0\0\0", 8) == 0)
+	if (memcmp(h, "MSCF\0\0\0\0", 8) == 0)
 		return (64);
 
 	/*
@@ -535,11 +534,15 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 	 * by noting a PE header and searching forward
 	 * up to 128k for an 'MSCF' marker.
 	 */
-	if (p[0] == 'M' && p[1] == 'Z') {
+	if (h[0] == 'M' && h[1] == 'Z') {
+		const char *p;
+		ssize_t bytes_avail;
+		ssize_t offset, window;
+
 		offset = 0;
 		window = 4096;
 		while (offset < (1024 * 128)) {
-			const char *h = __archive_read_ahead(a, offset + window,
+			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
 			if (h == NULL) {
 				/* Remaining bytes are less than window. */

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -262,16 +262,16 @@ static int
 archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 {
 	struct cpio *cpio = a->format->data;
-	const unsigned char *p;
+	const void *h;
 	int bid;
 
 	(void)best_bid; /* UNUSED */
 
-	if ((p = __archive_read_ahead(a, 6, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, 6, NULL)) == NULL)
 		return (-1);
 
 	bid = 0;
-	if (memcmp(p, "070707", 6) == 0) {
+	if (memcmp(h, "070707", 6) == 0) {
 		/* ASCII cpio archive (odc, POSIX.1) */
 		cpio->read_header = header_odc;
 		bid += 48;
@@ -279,7 +279,7 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		 * XXX TODO:  More verification; Could check that only octal
 		 * digits appear in appropriate header locations. XXX
 		 */
-	} else if (memcmp(p, "070727", 6) == 0) {
+	} else if (memcmp(h, "070727", 6) == 0) {
 		/* afio large ASCII cpio archive */
 		cpio->read_header = header_odc;
 		bid += 48;
@@ -287,7 +287,7 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		 * XXX TODO:  More verification; Could check that almost hex
 		 * digits appear in appropriate header locations. XXX
 		 */
-	} else if (memcmp(p, "070701", 6) == 0) {
+	} else if (memcmp(h, "070701", 6) == 0) {
 		/* ASCII cpio archive (SVR4 without CRC) */
 		cpio->read_header = header_newc;
 		bid += 48;
@@ -295,7 +295,7 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		 * XXX TODO:  More verification; Could check that only hex
 		 * digits appear in appropriate header locations. XXX
 		 */
-	} else if (memcmp(p, "070702", 6) == 0) {
+	} else if (memcmp(h, "070702", 6) == 0) {
 		/* ASCII cpio archive (SVR4 with CRC) */
 		/* XXX TODO: Flag that we should check the CRC. XXX */
 		cpio->read_header = header_newc;
@@ -304,12 +304,12 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		 * XXX TODO:  More verification; Could check that only hex
 		 * digits appear in appropriate header locations. XXX
 		 */
-	} else if (archive_be16dec(p) == 070707) {
+	} else if (archive_be16dec(h) == 070707) {
 		/* big-endian binary cpio archives */
 		cpio->read_header = header_bin_be;
 		bid += 16;
 		/* Is more verification possible here? */
-	} else if (archive_le16dec(p) == 070707) {
+	} else if (archive_le16dec(h) == 070707) {
 		/* little-endian binary cpio archives */
 		cpio->read_header = header_bin_le;
 		bid += 16;

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -501,7 +501,7 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 {
 	struct iso9660 *iso9660 = a->format->data;
 	ssize_t bytes_read;
-	const unsigned char *p;
+	const unsigned char *h;
 	int seenTerminator;
 
 	/* If there's already a better bid than we can ever
@@ -515,41 +515,41 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	 * if the I/O layer gives us more, we'll take it.
 	 */
 #define RESERVED_AREA	(SYSTEM_AREA_BLOCK * LOGICAL_BLOCK_SIZE)
-	p = __archive_read_ahead(a,
+	h = __archive_read_ahead(a,
 	    RESERVED_AREA + 8 * LOGICAL_BLOCK_SIZE,
 	    &bytes_read);
-	if (p == NULL)
+	if (h == NULL)
 	    return (-1);
 
 	/* Skip the reserved area. */
 	bytes_read -= RESERVED_AREA;
-	p += RESERVED_AREA;
+	h += RESERVED_AREA;
 
 	/* Check each volume descriptor. */
 	seenTerminator = 0;
 	for (; bytes_read > LOGICAL_BLOCK_SIZE;
-	    bytes_read -= LOGICAL_BLOCK_SIZE, p += LOGICAL_BLOCK_SIZE) {
+	    bytes_read -= LOGICAL_BLOCK_SIZE, h += LOGICAL_BLOCK_SIZE) {
 		/* Do not handle undefined Volume Descriptor Type. */
-		if (p[0] >= 4 && p[0] <= 254)
+		if (h[0] >= 4 && h[0] <= 254)
 			return (0);
 		/* Standard Identifier must be "CD001" */
-		if (memcmp(p + 1, "CD001", 5) != 0)
+		if (memcmp(h + 1, "CD001", 5) != 0)
 			return (0);
-		if (isPVD(iso9660, p))
+		if (isPVD(iso9660, h))
 			continue;
 		if (!iso9660->joliet.location) {
-			if (isJolietSVD(iso9660, p))
+			if (isJolietSVD(iso9660, h))
 				continue;
 		}
-		if (isBootRecord(p))
+		if (isBootRecord(h))
 			continue;
-		if (isEVD(p))
+		if (isEVD(h))
 			continue;
-		if (isSVD(p))
+		if (isSVD(h))
 			continue;
-		if (isVolumePartition(iso9660, p))
+		if (isVolumePartition(iso9660, h))
 			continue;
-		if (isVDSetTerminator(p)) {
+		if (isVDSetTerminator(h)) {
 			seenTerminator = 1;
 			break;
 		}

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -361,7 +361,7 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 		/* PE file */
 		offset = 0;
 		window = 4096;
-		while (offset < (1024 * 20)) {
+		while (offset + window <= 1024 * 24) {
 			ssize_t bytes_avail;
 
 			h = __archive_read_ahead(a, offset + window,

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -228,7 +228,7 @@ static int	lha_read_file_header_2(struct archive_read *, struct lha *);
 static int	lha_read_file_header_3(struct archive_read *, struct lha *);
 static int	lha_read_file_extended_header(struct archive_read *,
 		    struct lha *, uint16_t *, int, uint64_t, size_t *);
-static size_t	lha_check_header_format(const void *);
+static size_t	lha_check_header_format(const char *);
 static int	lha_skip_sfx(struct archive_read *);
 static unsigned char	lha_calcsum(unsigned char, const void *,
 		    int, size_t);
@@ -288,12 +288,11 @@ archive_read_support_format_lha(struct archive *_a)
 }
 
 static size_t
-lha_check_header_format(const void *h)
+lha_check_header_format(const char *h)
 {
-	const unsigned char *p = h;
 	size_t next_skip_bytes;
 
-	switch (p[H_METHOD_OFFSET+3]) {
+	switch (h[H_METHOD_OFFSET + 3]) {
 	/*
 	 * "-lh0-" ... "-lh7-" "-lhd-"
 	 * "-lzs-" "-lz5-"
@@ -304,29 +303,29 @@ lha_check_header_format(const void *h)
 	case 's':
 		next_skip_bytes = 4;
 
-		/* b0 == 0 means the end of an LHa archive file.	*/
-		if (p[0] == 0)
+		/* 0 means the end of an LHa archive file. */
+		if (h[0] == 0)
 			break;
-		if (p[H_METHOD_OFFSET] != '-' || p[H_METHOD_OFFSET+1] != 'l'
-		    ||  p[H_METHOD_OFFSET+4] != '-')
+		if (h[H_METHOD_OFFSET] != '-' || h[H_METHOD_OFFSET + 1] != 'l'
+		    ||  h[H_METHOD_OFFSET + 4] != '-')
 			break;
 
-		if (p[H_METHOD_OFFSET+2] == 'h') {
+		if (h[H_METHOD_OFFSET + 2] == 'h') {
 			/* "-lh?-" */
-			if (p[H_METHOD_OFFSET+3] == 's')
+			if (h[H_METHOD_OFFSET + 3] == 's')
 				break;
-			if (p[H_LEVEL_OFFSET] == 0)
+			if (h[H_LEVEL_OFFSET] == 0)
 				return (0);
-			if (p[H_LEVEL_OFFSET] <= 3 && p[H_ATTR_OFFSET] == 0x20)
+			if (h[H_LEVEL_OFFSET] <= 3 && h[H_ATTR_OFFSET] == 0x20)
 				return (0);
 		}
-		if (p[H_METHOD_OFFSET+2] == 'z') {
+		if (h[H_METHOD_OFFSET + 2] == 'z') {
 			/* LArc extensions: -lzs-,-lz4- and -lz5- */
-			if (p[H_LEVEL_OFFSET] != 0)
+			if (h[H_LEVEL_OFFSET] != 0)
 				break;
-			if (p[H_METHOD_OFFSET+3] == 's'
-			    || p[H_METHOD_OFFSET+3] == '4'
-			    || p[H_METHOD_OFFSET+3] == '5')
+			if (h[H_METHOD_OFFSET + 3] == 's'
+			    || h[H_METHOD_OFFSET + 3] == '4'
+			    || h[H_METHOD_OFFSET + 3] == '5')
 				return (0);
 		}
 		break;
@@ -473,7 +472,7 @@ archive_read_format_lha_read_header(struct archive_read *a,
 	struct lha *lha = a->format->data;
 	struct archive_wstring linkname;
 	struct archive_wstring pathname;
-	const unsigned char *p;
+	const char *p;
 	const char *signature;
 	int err;
 	struct archive_mstring conv_buffer;
@@ -499,7 +498,7 @@ archive_read_format_lha_read_header(struct archive_read *a,
 		return (truncated_error(a));
 	}
 
-	signature = (const char *)p;
+	signature = p;
 	if (lha->found_first_header == 0 &&
 	    signature[0] == 'M' && signature[1] == 'Z') {
                 /* This is an executable?  Must be self-extracting... 	*/
@@ -509,7 +508,7 @@ archive_read_format_lha_read_header(struct archive_read *a,
 
 		if ((p = __archive_read_ahead(a, sizeof(*p), NULL)) == NULL)
 			return (truncated_error(a));
-		signature = (const char *)p;
+		signature = p;
 	}
 	/* signature[0] == 0 means the end of an LHa archive file. */
 	if (signature[0] == 0)

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -367,11 +367,12 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
 			if (h == NULL) {
-				/* Remaining bytes are less than window. */
-				window >>= 1;
-				if (window < (H_SIZE + 3))
-					return (0);
-				continue;
+				if (bytes_avail >= offset + H_SIZE) {
+					/* Remaining bytes are less than window. */
+					window = bytes_avail - offset;
+					continue;
+				}
+				return (0);
 			}
 			if (bytes_avail > 1024 * 24)
 				bytes_avail = 1024 * 24;

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -342,43 +342,46 @@ lha_check_header_format(const char *h)
 static int
 archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 {
-	const char *p;
-	const void *buff;
-	ssize_t bytes_avail, offset, window;
-	size_t next;
+	const char *h;
 
 	/* If there's already a better bid than we can ever
 	   make, don't bother testing. */
 	if (best_bid > 30)
 		return (-1);
 
-	if ((p = __archive_read_ahead(a, H_SIZE, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, H_SIZE, NULL)) == NULL)
 		return (-1);
 
-	if (lha_check_header_format(p) == 0)
+	if (lha_check_header_format(h) == 0)
 		return (30);
 
-	if (p[0] == 'M' && p[1] == 'Z') {
+	if (h[0] == 'M' && h[1] == 'Z') {
+		ssize_t offset, window;
+
 		/* PE file */
 		offset = 0;
 		window = 4096;
 		while (offset < (1024 * 20)) {
-			buff = __archive_read_ahead(a, offset + window,
+			const char *p;
+			ssize_t bytes_avail;
+
+			h = __archive_read_ahead(a, offset + window,
 			    &bytes_avail);
-			if (buff == NULL) {
+			if (h == NULL) {
 				/* Remaining bytes are less than window. */
 				window >>= 1;
 				if (window < (H_SIZE + 3))
 					return (0);
 				continue;
 			}
-			p = (const char *)buff + offset;
-			while (p + H_SIZE < (const char *)buff + bytes_avail) {
-				if ((next = lha_check_header_format(p)) == 0)
+			p = h + offset;
+			while (p + H_SIZE < h + bytes_avail) {
+				size_t next = lha_check_header_format(p);
+				if (next == 0)
 					return (30);
 				p += next;
 			}
-			offset = p - (const char *)buff;
+			offset = p - h;
 		}
 	}
 	return (0);

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -210,6 +210,8 @@ struct lha {
 #define H_LEVEL_OFFSET	20	/* Header Level.  */
 #define H_SIZE		22	/* Minimum header size. */
 
+#define SFX_MAX_READAHEAD	(1024 * 24)
+
 static int      archive_read_format_lha_bid(struct archive_read *, int);
 static int      archive_read_format_lha_options(struct archive_read *,
 		    const char *, const char *);
@@ -361,7 +363,7 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 		/* PE file */
 		offset = 0;
 		window = 4096;
-		while (offset + window <= 1024 * 24) {
+		while (offset + window <= SFX_MAX_READAHEAD) {
 			ssize_t bytes_avail;
 
 			h = __archive_read_ahead(a, offset + window,
@@ -374,8 +376,8 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 				}
 				return (0);
 			}
-			if (bytes_avail > 1024 * 24)
-				bytes_avail = 1024 * 24;
+			if (bytes_avail > SFX_MAX_READAHEAD)
+				bytes_avail = SFX_MAX_READAHEAD;
 			while (offset <= bytes_avail - H_SIZE) {
 				size_t next = lha_check_header_format(h + offset);
 				if (next == 0)

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -362,7 +362,6 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 		offset = 0;
 		window = 4096;
 		while (offset < (1024 * 20)) {
-			const char *p;
 			ssize_t bytes_avail;
 
 			h = __archive_read_ahead(a, offset + window,
@@ -374,14 +373,12 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 					return (0);
 				continue;
 			}
-			p = h + offset;
-			while (p + H_SIZE < h + bytes_avail) {
-				size_t next = lha_check_header_format(p);
+			while (offset <= bytes_avail - H_SIZE) {
+				size_t next = lha_check_header_format(h + offset);
 				if (next == 0)
 					return (30);
-				p += next;
+				offset += next;
 			}
-			offset = p - h;
 		}
 	}
 	return (0);

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -373,6 +373,8 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 					return (0);
 				continue;
 			}
+			if (bytes_avail > 1024 * 24)
+				bytes_avail = 1024 * 24;
 			while (offset <= bytes_avail - H_SIZE) {
 				size_t next = lha_check_header_format(h + offset);
 				if (next == 0)

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -629,16 +629,16 @@ static int
 mtree_bid(struct archive_read *a, int best_bid)
 {
 	const char *signature = "#mtree";
-	const char *p;
+	const void *h;
 
 	(void)best_bid; /* UNUSED */
 
 	/* Now let's look at the actual header and see if it matches. */
-	p = __archive_read_ahead(a, strlen(signature), NULL);
-	if (p == NULL)
+	h = __archive_read_ahead(a, strlen(signature), NULL);
+	if (h == NULL)
 		return (-1);
 
-	if (memcmp(p, signature, strlen(signature)) == 0)
+	if (memcmp(h, signature, strlen(signature)) == 0)
 		return (8 * (int)strlen(signature));
 
 	/*

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -809,11 +809,12 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
     while (offset + window <= 1024 * 128) {
       h = __archive_read_ahead(a, offset + window, &bytes_avail);
       if (h == NULL) {
-        /* Remaining bytes are less than window. */
-        window >>= 1;
-        if (window < 0x40)
-          return (0);
-        continue;
+        if (bytes_avail >= offset + 0x10) {
+          /* Remaining bytes are less than window. */
+          window = bytes_avail - offset;
+          continue;
+        }
+        return (0);
       }
       if (bytes_avail > 1024 * 128)
         bytes_avail = 1024 * 128;

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -805,7 +805,6 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
     ssize_t offset = 0x10000;
     ssize_t window = 4096;
     ssize_t bytes_avail;
-    const char *p;
 
     while (offset + window <= (1024 * 128)) {
       h = __archive_read_ahead(a, offset + window, &bytes_avail);
@@ -816,13 +815,11 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
           return (0);
         continue;
       }
-      p = h + offset;
-      while (p + 7 < h + bytes_avail) {
-        if (memcmp(p, RAR_SIGNATURE, 7) == 0)
+      while (offset <= bytes_avail - 7) {
+        if (memcmp(h + offset, RAR_SIGNATURE, 7) == 0)
           return (30);
-        p += 0x10;
+        offset += 0x10;
       }
-      offset = p - h;
     }
   }
   return (0);

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -806,7 +806,7 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
     ssize_t window = 4096;
     ssize_t bytes_avail;
 
-    while (offset + window <= (1024 * 128)) {
+    while (offset + window <= 1024 * 128) {
       h = __archive_read_ahead(a, offset + window, &bytes_avail);
       if (h == NULL) {
         /* Remaining bytes are less than window. */

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -788,39 +788,41 @@ archive_read_format_rar_has_encrypted_entries(struct archive_read *_a)
 static int
 archive_read_format_rar_bid(struct archive_read *a, int best_bid)
 {
-  const char *p;
+  const char *h;
 
   /* If there's already a bid > 30, we'll never win. */
   if (best_bid > 30)
     return (-1);
 
-  if ((p = __archive_read_ahead(a, 7, NULL)) == NULL)
+  if ((h = __archive_read_ahead(a, 7, NULL)) == NULL)
     return (-1);
 
-  if (memcmp(p, RAR_SIGNATURE, 7) == 0)
+  if (memcmp(h, RAR_SIGNATURE, 7) == 0)
     return (30);
 
-  if ((p[0] == 'M' && p[1] == 'Z') || memcmp(p, "\x7F\x45LF", 4) == 0) {
+  if ((h[0] == 'M' && h[1] == 'Z') || memcmp(h, "\x7F\x45LF", 4) == 0) {
     /* This is a PE file */
     ssize_t offset = 0x10000;
     ssize_t window = 4096;
     ssize_t bytes_avail;
+    const char *p;
+
     while (offset + window <= (1024 * 128)) {
-      const char *buff = __archive_read_ahead(a, offset + window, &bytes_avail);
-      if (buff == NULL) {
+      h = __archive_read_ahead(a, offset + window, &bytes_avail);
+      if (h == NULL) {
         /* Remaining bytes are less than window. */
         window >>= 1;
         if (window < 0x40)
           return (0);
         continue;
       }
-      p = buff + offset;
-      while (p + 7 < buff + bytes_avail) {
+      p = h + offset;
+      while (p + 7 < h + bytes_avail) {
         if (memcmp(p, RAR_SIGNATURE, 7) == 0)
           return (30);
         p += 0x10;
       }
-      offset = p - buff;
+      offset = p - h;
     }
   }
   return (0);

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -815,6 +815,8 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
           return (0);
         continue;
       }
+      if (bytes_avail > 1024 * 128)
+        bytes_avail = 1024 * 128;
       while (offset <= bytes_avail - 7) {
         if (memcmp(h + offset, RAR_SIGNATURE, 7) == 0)
           return (30);

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -136,6 +136,8 @@
 #define MAX_SYMBOL_LENGTH 0xF
 #define MAX_SYMBOLS       20
 
+#define SFX_MAX_READAHEAD (1024 * 128)
+
 /* Virtual Machine Properties */
 #define VM_MEMORY_SIZE 0x40000
 #define VM_MEMORY_MASK (VM_MEMORY_SIZE - 1)
@@ -806,7 +808,7 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
     ssize_t window = 4096;
     ssize_t bytes_avail;
 
-    while (offset + window <= 1024 * 128) {
+    while (offset + window <= SFX_MAX_READAHEAD) {
       h = __archive_read_ahead(a, offset + window, &bytes_avail);
       if (h == NULL) {
         if (bytes_avail >= offset + 0x10) {
@@ -816,8 +818,8 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
         }
         return (0);
       }
-      if (bytes_avail > 1024 * 128)
-        bytes_avail = 1024 * 128;
+      if (bytes_avail > SFX_MAX_READAHEAD)
+        bytes_avail = SFX_MAX_READAHEAD;
       while (offset <= bytes_avail - 7) {
         if (memcmp(h + offset, RAR_SIGNATURE, 7) == 0)
           return (30);

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -152,6 +152,8 @@ enum REDIR_TYPE {
 #define	OWNER_GROUP_GID		0x08
 #define	OWNER_MAXNAMELEN	256
 
+#define	SFX_MAX_READAHEAD	(1024 * 512)
+
 enum FILTER_TYPE {
 	FILTER_DELTA = 0,   /* Generic pattern. */
 	FILTER_E8    = 1,   /* Intel x86 code. */
@@ -1130,7 +1132,7 @@ static int bid_sfx(struct archive_read *a)
 
 		rar5_signature(signature);
 
-		while (offset + window <= 1024 * 512) {
+		while (offset + window <= SFX_MAX_READAHEAD) {
 			ssize_t bytes_avail;
 
 			h = __archive_read_ahead(a, offset + window, &bytes_avail);
@@ -1142,8 +1144,8 @@ static int bid_sfx(struct archive_read *a)
 				}
 				return 0;
 			}
-			if (bytes_avail > 1024 * 512)
-				bytes_avail = 1024 * 512;
+			if (bytes_avail > SFX_MAX_READAHEAD)
+				bytes_avail = SFX_MAX_READAHEAD;
 			while (offset <= bytes_avail - 8) {
 				if (memcmp(h + offset, signature,
 				    sizeof(signature)) == 0)

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1130,7 +1130,7 @@ static int bid_sfx(struct archive_read *a)
 
 		rar5_signature(signature);
 
-		while (offset + window <= (1024 * 512)) {
+		while (offset + window <= 1024 * 512) {
 			ssize_t bytes_avail;
 
 			h = __archive_read_ahead(a, offset + window, &bytes_avail);

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1135,11 +1135,12 @@ static int bid_sfx(struct archive_read *a)
 
 			h = __archive_read_ahead(a, offset + window, &bytes_avail);
 			if (h == NULL) {
-				/* Remaining bytes are less than window. */
-				window >>= 1;
-				if (window < 0x40)
-					return 0;
-				continue;
+				if (bytes_avail >= offset + 0x10) {
+					/* Remaining bytes are less than window. */
+					window = bytes_avail - offset;
+					continue;
+				}
+				return 0;
 			}
 			if (bytes_avail > 1024 * 512)
 				bytes_avail = 1024 * 512;

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1141,6 +1141,8 @@ static int bid_sfx(struct archive_read *a)
 					return 0;
 				continue;
 			}
+			if (bytes_avail > 1024 * 512)
+				bytes_avail = 1024 * 512;
 			while (offset <= bytes_avail - 8) {
 				if (memcmp(h + offset, signature,
 				    sizeof(signature)) == 0)

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1101,15 +1101,15 @@ static char read_u64(struct archive_read* a, uint64_t* pvalue) {
 }
 
 static int bid_standard(struct archive_read* a) {
-	const uint8_t* p;
+	const uint8_t* h;
 	char signature[sizeof(rar5_signature_xor)];
 
 	rar5_signature(signature);
 
-	if(!read_ahead(a, sizeof(rar5_signature_xor), &p))
+	if(!read_ahead(a, sizeof(rar5_signature_xor), &h))
 		return -1;
 
-	if(!memcmp(signature, p, sizeof(rar5_signature_xor)))
+	if(!memcmp(h, signature, sizeof(rar5_signature_xor)))
 		return 30;
 
 	return -1;
@@ -1117,36 +1117,38 @@ static int bid_standard(struct archive_read* a) {
 
 static int bid_sfx(struct archive_read *a)
 {
-	const char *p;
+	const char *h;
 
-	if ((p = __archive_read_ahead(a, 7, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, 7, NULL)) == NULL)
 		return -1;
 
-	if ((p[0] == 'M' && p[1] == 'Z') || memcmp(p, "\x7F\x45LF", 4) == 0) {
+	if ((h[0] == 'M' && h[1] == 'Z') || memcmp(h, "\x7F\x45LF", 4) == 0) {
 		/* This is a PE file */
 		char signature[sizeof(rar5_signature_xor)];
 		ssize_t offset = 0x10000;
 		ssize_t window = 4096;
-		ssize_t bytes_avail;
 
 		rar5_signature(signature);
 
 		while (offset + window <= (1024 * 512)) {
-			const char *buff = __archive_read_ahead(a, offset + window, &bytes_avail);
-			if (buff == NULL) {
+			ssize_t bytes_avail;
+			const char *p;
+
+			h = __archive_read_ahead(a, offset + window, &bytes_avail);
+			if (h == NULL) {
 				/* Remaining bytes are less than window. */
 				window >>= 1;
 				if (window < 0x40)
 					return 0;
 				continue;
 			}
-			p = buff + offset;
-			while (p + 8 < buff + bytes_avail) {
+			p = h + offset;
+			while (p + 8 < h + bytes_avail) {
 				if (memcmp(p, signature, sizeof(signature)) == 0)
 					return 30;
 				p += 0x10;
 			}
-			offset = p - buff;
+			offset = p - h;
 		}
 	}
 

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1132,7 +1132,6 @@ static int bid_sfx(struct archive_read *a)
 
 		while (offset + window <= (1024 * 512)) {
 			ssize_t bytes_avail;
-			const char *p;
 
 			h = __archive_read_ahead(a, offset + window, &bytes_avail);
 			if (h == NULL) {
@@ -1142,13 +1141,12 @@ static int bid_sfx(struct archive_read *a)
 					return 0;
 				continue;
 			}
-			p = h + offset;
-			while (p + 8 < h + bytes_avail) {
-				if (memcmp(p, signature, sizeof(signature)) == 0)
+			while (offset <= bytes_avail - 8) {
+				if (memcmp(h + offset, signature,
+				    sizeof(signature)) == 0)
 					return 30;
-				p += 0x10;
+				offset += 0x10;
 			}
-			offset = p - h;
 		}
 	}
 

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -189,20 +189,20 @@ archive_read_format_warc_cleanup(struct archive_read *a)
 static int
 archive_read_format_warc_bid(struct archive_read *a, int best_bid)
 {
-	const char *hdr;
+	const void *h;
 	ssize_t nrd;
 	unsigned int ver;
 
 	(void)best_bid; /* UNUSED */
 
 	/* Check the first line, which should already be a record header. */
-	if ((hdr = __archive_read_ahead(a, 12, &nrd)) == NULL) {
+	if ((h = __archive_read_ahead(a, 12, &nrd)) == NULL) {
 		/* Not enough data to identify this format. */
 		return -1;
 	}
 
 	/* Parse the record version number. */
-	ver = warc_read_version(hdr, nrd);
+	ver = warc_read_version(h, nrd);
 	if (ver < 1200U || ver > 10000U) {
 		/* Only WARC 0.12 through WARC 1.0 are supported. */
 		return -1;

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -499,38 +499,38 @@ archive_read_support_format_xar(struct archive *_a)
 static int
 xar_bid(struct archive_read *a, int best_bid)
 {
-	const unsigned char *b;
+	const char *h;
 	int bid;
 
 	(void)best_bid; /* UNUSED */
 
-	b = __archive_read_ahead(a, HEADER_SIZE, NULL);
-	if (b == NULL)
+	h = __archive_read_ahead(a, HEADER_SIZE, NULL);
+	if (h == NULL)
 		return (-1);
 
 	bid = 0;
 	/*
 	 * Verify magic code
 	 */
-	if (archive_be32dec(b) != HEADER_MAGIC)
+	if (archive_be32dec(h) != HEADER_MAGIC)
 		return (0);
 	bid += 32;
 	/*
 	 * Verify header size
 	 */
-	if (archive_be16dec(b+4) != HEADER_SIZE)
+	if (archive_be16dec(h+4) != HEADER_SIZE)
 		return (0);
 	bid += 16;
 	/*
 	 * Verify header version
 	 */
-	if (archive_be16dec(b+6) != HEADER_VERSION)
+	if (archive_be16dec(h+6) != HEADER_VERSION)
 		return (0);
 	bid += 16;
 	/*
 	 * Verify type of checksum
 	 */
-	switch (archive_be32dec(b+24)) {
+	switch (archive_be32dec(h+24)) {
 	case CKSUM_NONE:
 	case CKSUM_SHA1:
 	case CKSUM_MD5:

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3653,11 +3653,11 @@ archive_read_support_format_zip_capabilities_streamable(struct archive_read * a)
 static int
 archive_read_format_zip_streamable_bid(struct archive_read *a, int best_bid)
 {
-	const char *p;
+	const char *h;
 
 	(void)best_bid; /* UNUSED */
 
-	if ((p = __archive_read_ahead(a, 4, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, 4, NULL)) == NULL)
 		return (-1);
 
 	/*
@@ -3668,13 +3668,13 @@ archive_read_format_zip_streamable_bid(struct archive_read *a, int best_bid)
 	 *
 	 * So we've effectively verified ~29 total bits of check data.
 	 */
-	if (p[0] == 'P' && p[1] == 'K') {
-		if ((p[2] == '\001' && p[3] == '\002')
-		    || (p[2] == '\003' && p[3] == '\004')
-		    || (p[2] == '\005' && p[3] == '\006')
-		    || (p[2] == '\006' && p[3] == '\006')
-		    || (p[2] == '\007' && p[3] == '\010')
-		    || (p[2] == '0' && p[3] == '0'))
+	if (h[0] == 'P' && h[1] == 'K') {
+		if ((h[2] == '\001' && h[3] == '\002')
+		    || (h[2] == '\003' && h[3] == '\004')
+		    || (h[2] == '\005' && h[3] == '\006')
+		    || (h[2] == '\006' && h[3] == '\006')
+		    || (h[2] == '\007' && h[3] == '\010')
+		    || (h[2] == '0' && h[3] == '0'))
 			return (29);
 	}
 
@@ -4026,7 +4026,7 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 {
 	struct zip *zip = a->format->data;
 	int64_t file_size, current_offset;
-	const char *p;
+	const char *h;
 	int i, tail;
 
 	/* If someone has already bid more than 32, then avoid
@@ -4044,22 +4044,22 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 	current_offset = __archive_read_seek(a, -tail, SEEK_END);
 	if (current_offset < 0)
 		return 0;
-	if ((p = __archive_read_ahead(a, (size_t)tail, NULL)) == NULL)
+	if ((h = __archive_read_ahead(a, (size_t)tail, NULL)) == NULL)
 		return 0;
 	/* Boyer-Moore search backwards from the end, since we want
 	 * to match the last EOCD in the file (there can be more than
 	 * one if there is an uncompressed Zip archive as a member
 	 * within this Zip archive). */
 	for (i = tail - 22; i > 0;) {
-		switch (p[i]) {
+		switch (h[i]) {
 		case 'P':
-			if (memcmp(p + i, "PK\005\006", 4) == 0) {
-				int ret = read_eocd(zip, p + i,
+			if (memcmp(h + i, "PK\005\006", 4) == 0) {
+				int ret = read_eocd(zip, h + i,
 				    current_offset + i);
 				/* Zip64 EOCD locator precedes
 				 * regular EOCD if present. */
-				if (i >= 20 && memcmp(p + i - 20, "PK\006\007", 4) == 0) {
-					int ret_zip64 = read_zip64_eocd(a, zip, p + i - 20);
+				if (i >= 20 && memcmp(h + i - 20, "PK\006\007", 4) == 0) {
+					int ret_zip64 = read_zip64_eocd(a, zip, h + i - 20);
 					if (ret_zip64 > ret)
 						ret = ret_zip64;
 				}


### PR DESCRIPTION
The various format parsers with SFX (self extracting executable) support have subtle differences between each other, which makes auditing harder than it has to be. I've found these issues:

- Some SFX parsers use `<` instead of `<=` which could miss a byte
- Maximum amount of SFX data to inspect can be ignored if `bytes_avail` is sufficiently large due to memory mapping an archive
- Inefficient window calculation if less bytes are available than expected
- Theoretically undefined pointer arithmetic when `p + x` is larger than the buffer of read input

It's best again to iterate through the commits instead of looking at the PR diff at once. Some of them fix style, so eventually the SFX code looks almost the same for all parsers. Differences are offset values and expected amount of bytes.