### PR TITLE
oss-fuzz: seed filter fuzzer for lzip/rpm/uudecode and program filters

### DIFF
--- a/contrib/oss-fuzz/oss-fuzz-build.sh
+++ b/contrib/oss-fuzz/oss-fuzz-build.sh
@@ -104,7 +104,10 @@ create_corpus "libarchive_ar_fuzzer" "test_read_format_ar*.uu"
 
 # Filter corpus - use compressed test files
 mkdir -p /tmp/filter_corpus
-for f in $TEST_DIR/*.gz.uu $TEST_DIR/*.bz2.uu $TEST_DIR/*.xz.uu $TEST_DIR/*.lz4.uu $TEST_DIR/*.zst.uu $TEST_DIR/*.Z.uu; do
+for f in $TEST_DIR/*.gz.uu $TEST_DIR/*.bz2.uu $TEST_DIR/*.xz.uu $TEST_DIR/*.lz4.uu \
+         $TEST_DIR/*.zst.uu $TEST_DIR/*.Z.uu $TEST_DIR/*.lz.uu $TEST_DIR/*.rpm.uu \
+         $TEST_DIR/test_read_filter_uudecode*.uu \
+         $TEST_DIR/*.lrz.uu $TEST_DIR/*.grz.uu $TEST_DIR/*.lzo.uu; do
     if [ -f "$f" ]; then
         base=$(basename "$f" .uu)
         uudecode -o "/tmp/filter_corpus/$base" "$f" 2>/dev/null || true


### PR DESCRIPTION
`libarchive_filter_fuzzer` registers every read filter via `archive_read_support_filter_all()`, but its seed corpus in `contrib/oss-fuzz/oss-fuzz-build.sh` is built from only gzip, bzip2, xz, lz4, zstd and compress archives.

`lzip`, `rpm` and `uudecode` are decoded by **native in-process parsers**, and the test suite already ships archives for all of them. Without seeds the fuzzer has to synthesise valid container headers before it can reach those decoders.

### Measurements

Built `libarchive_filter_fuzzer` with `-fsanitize=fuzzer,address,undefined` and replayed each corpus with `-runs=0` (clang 22.1.8, arm64 macOS, at `b100df7e`):

| seed corpus | files | edges | features |
|---|---|---|---|
| current globs | 56 | 2232 | 5103 |
| + lzip/rpm/uudecode | 62 | 2546 (+314) | 5804 (+701) |
| + lrzip/grzip/lzop | 69 | 2683 (+451) | 6021 (+918) |

Six extra seed files reach **314 more edges**, all in natively-implemented filter code.

`lrzip`/`grzip`/`lzop` are included in the patch too, but I want to be precise about them: those filters shell out to external binaries via `__archive_read_program`, so their additional ~137 edges are in container detection rather than in-process decoding. They cost nothing to seed, but they are not the reason for this change.

### Caveat

This shows the *seed* corpus omits these filters. OSS-Fuzz also accumulates its own corpus through mutation over time, so I can't claim from outside that these parsers are currently unfuzzed in production — only that they get no seeds.

### Testing

`bash -n contrib/oss-fuzz/oss-fuzz-build.sh` passes. All globs are guarded by the existing `[ -f "$f" ]` check, so patterns matching nothing are skipped as before. Verified the added patterns match real files in `libarchive/test/`: `*.lz.uu` (1), `*.rpm.uu` (3), `test_read_filter_uudecode*.uu` (2), `*.lrz.uu` (1), `*.grz.uu` (1), `*.lzo.uu` (5). I did not add `*.lzma.uu` since nothing matches it.
