### PR TITLE
rar5: reject truncated BLAKE2sp hash extra fields

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1055,6 +1055,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_solid_encrypted_filenames.rar.uu \
 	libarchive/test/test_read_format_rar5_arm.rar.uu \
 	libarchive/test/test_read_format_rar5_blake2.rar.uu \
+	libarchive/test/test_read_format_rar5_blake2sp_hash_too_short.rar.uu \
 	libarchive/test/test_read_format_rar5_bytes_remaining_underflow.rar.uu \
 	libarchive/test/test_read_format_rar5_compressed.rar.uu \
 	libarchive/test/test_read_format_rar5_different_window_size.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1272,6 +1272,12 @@ static int parse_file_extra_hash(struct archive_read* a, struct rar5 *rar5,
 		const uint8_t* p;
 		const int hash_size = sizeof(rar5->file.blake2sp);
 
+		if(*extra_data_size < hash_size) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+			    "RAR5 BLAKE2sp hash field is too short");
+			return ARCHIVE_FATAL;
+		}
+
 		if(!read_ahead(a, hash_size, &p))
 			return ARCHIVE_EOF;
 

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1718,3 +1718,19 @@ DEFINE_TEST(test_read_format_rar5_redir_varint_2byte)
 
 	EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_blake2sp_hash_too_short)
+{
+	/* A crafted HEAD_FILE declares an EX_HASH extra field with
+	 * hash_type=BLAKE2sp (0x00) but the extra field is only 3 bytes
+	 * (field_size + field_id + hash_type), leaving no room for the
+	 * 32-byte BLAKE2sp digest.  Without the bounds check the reader
+	 * would call read_ahead(a, 32) past the extra-field boundary and
+	 * then decrement *extra_data_size by 32, causing a signed underflow.
+	 * With the fix the reader returns ARCHIVE_FATAL instead. */
+	PROLOGUE("test_read_format_rar5_blake2sp_hash_too_short.rar");
+
+	assertA(archive_read_next_header(a, &ae) < 0);
+
+	EPILOGUE();
+}

--- a/libarchive/test/test_read_format_rar5_blake2sp_hash_too_short.rar.uu
+++ b/libarchive/test/test_read_format_rar5_blake2sp_hash_too_short.rar.uu
@@ -1,0 +1,5 @@
+begin 644 -
+M4F%R(1H' 0 ]/-[E @$ UPJA2PX" P,4      $!80("                
+)            
+`
+end


### PR DESCRIPTION
## Summary

- Validate that a RAR5 BLAKE2sp extra field contains the full 32-byte digest before reading it.
- Return `ARCHIVE_FATAL` with a format error when the declared extra field is too short.
- Add a minimal UU-encoded regression fixture and include it in release archives.

Without this check, `read_ahead(a, 32)` could cross the declared extra-field boundary and `extra_data_size` would then underflow.

## Test

- Focused BLAKE2sp regression test passes.
- Full source-tree `libarchive_test`: 873 tests passed, 0 failures.
- Exact Ubuntu 24.04 `distcheck` passes, including the packaged 1,048-test CMake run, autotools tests, install/uninstall checks, and release archive regeneration.

## Rebase note

The earlier owner-name commits from this branch already landed through #3332 and #3368. The htime error propagation was independently merged in #3414 (`1460d722a`), so the rebased branch intentionally retains only the still-needed BLAKE2sp fix.
