### PR TITLE
rar5: fix varint byte-count accounting in extra-field size tracking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1074,6 +1074,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_owner.rar.uu \
 	libarchive/test/test_read_format_rar5_owner_name_toolong.rar.uu \
 	libarchive/test/test_read_format_rar5_readtables_overflow.rar.uu \
+	libarchive/test/test_read_format_rar5_redir_varint_2byte.rar.uu \
 	libarchive/test/test_read_format_rar5_sfx.exe.uu \
 	libarchive/test/test_read_format_rar5_solid.rar.uu \
 	libarchive/test/test_read_format_rar5_stored.rar.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1448,6 +1448,7 @@ static int parse_file_extra_redir(struct archive_read* a,
     struct archive_entry* e, struct rar5 *rar5, int64_t* extra_data_size)
 {
 	uint64_t value_size = 0;
+	size_t varint_len = 0;
 	size_t target_size = 0;
 	char target_utf8_buf[MAX_NAME_IN_BYTES];
 	const uint8_t* p;
@@ -1464,9 +1465,11 @@ static int parse_file_extra_redir(struct archive_read* a,
 		return ARCHIVE_EOF;
 	*extra_data_size -= value_size;
 
-	if(!read_var_sized(a, &target_size, NULL))
+	if(!read_var_sized(a, &target_size, &varint_len))
 		return ARCHIVE_EOF;
-	*extra_data_size -= target_size + 1;
+	if(ARCHIVE_OK != consume(a, (int64_t)varint_len))
+		return ARCHIVE_EOF;
+	*extra_data_size -= (int64_t)(target_size + varint_len);
 
 	if(target_size > (MAX_NAME_IN_CHARS - 1)) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
@@ -1523,6 +1526,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 	uint64_t id = 0;
 	size_t name_len = 0;
 	size_t name_size = 0;
+	size_t varint_len = 0;
 	char namebuf[OWNER_MAXNAMELEN];
 	const uint8_t* p;
 
@@ -1533,7 +1537,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 	*extra_data_size -= value_size;
 
 	if ((flags & OWNER_USER_NAME) != 0) {
-		if(!read_var_sized(a, &name_size, NULL))
+		if(!read_var_sized(a, &name_size, &varint_len))
 			return ARCHIVE_EOF;
 
 		/* The name cannot be larger than the remaining extra data of
@@ -1545,7 +1549,9 @@ static int parse_file_extra_owner(struct archive_read* a,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Owner name is too long");
 			return ARCHIVE_FATAL;
 		}
-		*extra_data_size -= name_size + 1;
+		if(ARCHIVE_OK != consume(a, (int64_t)varint_len))
+			return ARCHIVE_EOF;
+		*extra_data_size -= (int64_t)(name_size + varint_len);
 
 		if(!read_ahead(a, name_size, &p))
 			return ARCHIVE_EOF;
@@ -1564,7 +1570,7 @@ static int parse_file_extra_owner(struct archive_read* a,
 		archive_entry_set_uname(e, namebuf);
 	}
 	if ((flags & OWNER_GROUP_NAME) != 0) {
-		if(!read_var_sized(a, &name_size, NULL))
+		if(!read_var_sized(a, &name_size, &varint_len))
 			return ARCHIVE_EOF;
 
 		if(*extra_data_size < 0 ||
@@ -1573,7 +1579,9 @@ static int parse_file_extra_owner(struct archive_read* a,
 			    ARCHIVE_ERRNO_FILE_FORMAT, "Group name is too long");
 			return ARCHIVE_FATAL;
 		}
-		*extra_data_size -= name_size + 1;
+		if(ARCHIVE_OK != consume(a, (int64_t)varint_len))
+			return ARCHIVE_EOF;
+		*extra_data_size -= (int64_t)(name_size + varint_len);
 
 		if(!read_ahead(a, name_size, &p))
 			return ARCHIVE_EOF;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -1628,3 +1628,33 @@ DEFINE_TEST(test_read_format_rar5_seek_data_unsupported)
 
 	EPILOGUE();
 }
+
+DEFINE_TEST(test_read_format_rar5_redir_varint_2byte)
+{
+	/*
+	 * A crafted RAR5 whose EX_REDIR symlink target is exactly 128 bytes.
+	 * That makes read_var_sized() encode the length as a 2-byte varint
+	 * (0x80 0x01) instead of the 1-byte form assumed by the old "+1" code.
+	 * With the old code extra_data_size was decremented by only target_size+1
+	 * (129) instead of target_size+2 (130), leaving it 1 too large.
+	 * process_head_file_extra() would then loop back and attempt to parse a
+	 * phantom extra field from the one byte of padding that follows, which
+	 * returns ARCHIVE_EOF.  With the fix, extra_data_size reaches exactly 0
+	 * and the loop exits cleanly.
+	 */
+	char expected_target[129];
+	memset(expected_target, 'a', 128);
+	expected_target[128] = '\0';
+
+	PROLOGUE("test_read_format_rar5_redir_varint_2byte.rar");
+
+	assertA(0 == archive_read_next_header(a, &ae));
+	assertEqualString("link.txt", archive_entry_pathname(ae));
+	assertEqualInt(AE_IFLNK, archive_entry_filetype(ae));
+	assertEqualString(expected_target, archive_entry_symlink(ae));
+	assertEqualInt(128, (int)strlen(archive_entry_symlink(ae)));
+
+	assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
+
+	EPILOGUE();
+}

--- a/libarchive/test/test_read_format_rar5_redir_varint_2byte.rar.uu
+++ b/libarchive/test/test_read_format_rar5_redir_varint_2byte.rar.uu
@@ -1,0 +1,8 @@
+begin 644 test_read_format_rar5_redir_varint_2byte.rar
+M4F%R(1H'`0#%&C,R`P$``%DA0:R:`0(#AP$`````(`$(;&EN:RYT>'2%`04!
+M`(`!86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A
+M86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A
+M86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86%A86$Y^;*!
+#`@4`
+`
+end


### PR DESCRIPTION
## Summary

`read_var_sized()` called with a NULL third argument auto-consumes the varint bytes but returns no byte count. Three call sites in `parse_file_extra_redir()` and `parse_file_extra_owner()` then subtracted `field_size + 1` from `extra_data_size`, hardcoding the assumption that the varint was always one byte. For values >= 128 the varint is two bytes, so `extra_data_size` was left 1 too large, causing the `process_head_file_extra()` loop to re-enter and attempt to parse a phantom extra field beyond the declared boundary.

## Fix

Switch each site to the non-consuming form (non-NULL `pvalue_len`), consume the varint bytes explicitly, then subtract `field_size + varint_len` so the accounting is exact regardless of how many bytes the varint occupies.

## Affected call sites

1. `parse_file_extra_redir` — `target_size` varint
2. `parse_file_extra_owner` — user `name_size` varint  
3. `parse_file_extra_owner` — group `name_size` varint

## Regression test

A crafted RAR5 archive whose EX_REDIR symlink target is exactly 128 bytes long. That encodes the target length as a 2-byte varint (`0x80 0x01`). The test verifies the symlink is parsed correctly and the archive ends cleanly at EOF.

This PR also includes the EX_UOWNER bounds-check improvements (reject oversized owner names + 32-bit truncation fix) cherry-picked onto master.