### PR TITLE
lrzip: Return matching bits in bidding

### DIFF
--- a/libarchive/archive_read_support_filter_lrzip.c
+++ b/libarchive/archive_read_support_filter_lrzip.c
@@ -79,14 +79,12 @@ lrzip_bidder_bid(struct archive_read_filter_bidder *b,
     struct archive_read_filter *f)
 {
 	const unsigned char *p;
-	ssize_t len;
 	int i;
 
 	(void)b; /* UNUSED */
 	/* Start by looking at the first six bytes of the header, which
 	 * is all fixed layout. */
-	len = 6;
-	p = __archive_read_filter_ahead(f, len, NULL);
+	p = __archive_read_filter_ahead(f, 6, NULL);
 	if (p == NULL)
 		return (0);
 
@@ -101,7 +99,7 @@ lrzip_bidder_bid(struct archive_read_filter_bidder *b,
 	if ((i < 6) || (i > 10))
 		return 0;
 
-	return (int)len;
+	return (48);
 }
 
 static int


### PR DESCRIPTION
Actually follow the bidder comment and return amount of bits. Has the nice advantage of removing the `int`/`ssize_t` handling, even though it was safe anyway.