### PR TITLE
memory: Adjust seek logic

### DIFF
--- a/libarchive/archive_read_open_memory.c
+++ b/libarchive/archive_read_open_memory.c
@@ -151,29 +151,27 @@ static int64_t
 memory_read_seek(struct archive *a, void *client_data, int64_t offset, int whence)
 {
 	struct read_memory_data *mine = (struct read_memory_data *)client_data;
+	const unsigned char *p;
 
 	(void)a; /* UNUSED */
 	switch (whence) {
 	case SEEK_SET:
-		mine->p = mine->start + offset;
+		p = mine->start + offset;
 		break;
 	case SEEK_CUR:
-		mine->p += offset;
+		p = mine->p + offset;
 		break;
 	case SEEK_END:
-		mine->p = mine->end + offset;
+		p = mine->end + offset;
 		break;
 	default:
 		return ARCHIVE_FATAL;
 	}
-	if (mine->p < mine->start) {
-		mine->p = mine->start;
-		return ARCHIVE_FAILED;
-	}
-	if (mine->p > mine->end) {
-		mine->p = mine->end;
-		return ARCHIVE_FAILED;
-	}
+	if (p < mine->start)
+		return ARCHIVE_FATAL;
+	if (p > mine->end)
+		return ARCHIVE_FATAL;
+	mine->p = p;
 	return (mine->p - mine->start);
 }
 

--- a/libarchive/test/read_open_memory.c
+++ b/libarchive/test/read_open_memory.c
@@ -188,27 +188,27 @@ static int64_t
 memory_read_seek(struct archive *a, void *client_data, int64_t offset, int whence)
 {
 	struct read_memory_data *mine = (struct read_memory_data *)client_data;
+	const unsigned char *p;
 
 	(void)a; /* UNUSED */
 	switch (whence) {
 	case SEEK_SET:
-		mine->p = mine->start + offset;
+		p = mine->start + offset;
 		break;
 	case SEEK_END:
-		mine->p = mine->end + offset;
+		p = mine->end + offset;
 		break;
 	case SEEK_CUR:
-		mine->p += offset;
+		p = mine->p + offset;
 		break;
+	default:
+		return ARCHIVE_FATAL;
 	}
-	if (mine->p < mine->start) {
-		mine->p = mine->start;
-		return ARCHIVE_FAILED;
-	}
-	if (mine->p > mine->end) {
-		mine->p = mine->end;
-		return ARCHIVE_FAILED;
-	}
+	if (p < mine->start)
+		return ARCHIVE_FATAL;
+	if (p > mine->end)
+		return ARCHIVE_FATAL;
+	mine->p = p;
 	return (mine->p - mine->start);
 }
 


### PR DESCRIPTION
The seek implementations for files return `ARCHIVE_FATAL` if seek fails to adjust the position. `ARCHIVE_FAILED` is used in case of pipes etc.

Also, if a file seek fails, the position is not adjusted.

Adjust the memory implementations to do the same.