### PR TITLE
read: Fail if bidding position reset fails

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -753,8 +753,9 @@ choose_format(struct archive_read *a)
 			bid = (a->format->bid)(a, best_bid);
 			if (bid == ARCHIVE_FATAL)
 				return (ARCHIVE_FATAL);
-			if (a->filter->position != 0)
-				__archive_read_seek(a, 0, SEEK_SET);
+			if (a->filter->position != 0 &&
+			    __archive_read_seek(a, 0, SEEK_SET) < 0)
+				return (ARCHIVE_FATAL);
 			if ((bid > best_bid) || (best_bid_slot < 0)) {
 				best_bid = bid;
 				best_bid_slot = i;


### PR DESCRIPTION
Check if a position reset during bidding actually works. If it does not work, treat it as fatal error and stop bidding altogether.