### PR TITLE
read: Introduce `ARCHIVE_STATE_OPEN`

### DIFF
--- a/libarchive/archive_private.h
+++ b/libarchive/archive_private.h
@@ -72,23 +72,25 @@
  * Generally checked via `__archive_check_magic()`.
  */
 
-/* Newly created archive object, not yet opened */
-#define	ARCHIVE_STATE_NEW	1U
+/* Newly created archive object, not yet opened. */
+#define	ARCHIVE_STATE_NEW	0x01U
+/* Archive is opened. */
+#define	ARCHIVE_STATE_OPEN	0x02U
 /* Archive is ready to read a header. */
-#define	ARCHIVE_STATE_HEADER	2U
+#define	ARCHIVE_STATE_HEADER	0x04U
 /* A header has been read: client can ask for data
  * or they can ask for the next header and
  * we'll automatically skip the remaining data. */
-#define	ARCHIVE_STATE_DATA	4U
+#define	ARCHIVE_STATE_DATA	0x08U
 /* Similar to STATE_DATA but after a FAILED header:
  * the client may not read data, but they may ask
  * for the next header and we'll recover. */
-#define	ARCHIVE_STATE_DATA_RECOVERY	8U
+#define	ARCHIVE_STATE_DATA_RECOVERY	0x10U
 /* End-of-archive has been reached.  Client can only
  * close or free the archive. */
-#define	ARCHIVE_STATE_EOF	0x10U
+#define	ARCHIVE_STATE_EOF	0x20U
 /* Archive is closed; client is only allowed to free the archive. */
-#define	ARCHIVE_STATE_CLOSED	0x20U
+#define	ARCHIVE_STATE_CLOSED	0x40U
 /* Archive is in a FATAL error state: a close request
  * is permitted but ignored. */
 #define	ARCHIVE_STATE_FATAL	0x8000U

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -496,6 +496,8 @@ archive_read_open1(struct archive *_a)
 		return (ARCHIVE_FATAL);
 	}
 
+	a->archive.state = ARCHIVE_STATE_OPEN;
+
 	/* Open data source. */
 	if (a->client.opener != NULL) {
 		e = (a->client.opener)(&a->archive, a->client.dataset[0].data);

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -501,16 +501,19 @@ archive_read_open1(struct archive *_a)
 	/* Open data source. */
 	if (a->client.opener != NULL) {
 		e = (a->client.opener)(&a->archive, a->client.dataset[0].data);
-		if (e != 0) {
+		if (e != ARCHIVE_OK) {
 			/* If the open failed, call the closer to clean up. */
 			read_client_close_proxy(a);
+			a->archive.state = ARCHIVE_STATE_FATAL;
 			return (e);
 		}
 	}
 
 	f = calloc(1, sizeof(*f));
-	if (f == NULL)
+	if (f == NULL) {
+		a->archive.state = ARCHIVE_STATE_FATAL;
 		return (ARCHIVE_FATAL);
+	}
 	f->bidder = NULL;
 	f->upstream = NULL;
 	f->archive = a;

--- a/libarchive/test/test_archive_read.c
+++ b/libarchive/test/test_archive_read.c
@@ -61,3 +61,42 @@ DEFINE_TEST(test_archive_read_ahead_eof)
 
 	assert(0 == archive_read_free(a));
 }
+
+static ssize_t
+eof_read_callback(struct archive *a, void *data, const void **buffer)
+{
+	(void)a;
+	(void)data;
+	(void)buffer;
+
+	return (0);
+}
+
+static int
+evil_open_callback(struct archive *a, void *data)
+{
+	(void)data;
+
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_set_read_callback(a, NULL));
+	return (ARCHIVE_OK);
+}
+
+DEFINE_TEST(test_archive_read_state_open)
+{
+	struct archive *a;
+
+	assert((a = archive_read_new()) != NULL);
+
+	/* Prepare callbacks which modify callbacks when used. */
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_open_callback(a, evil_open_callback));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_read_callback(a, eof_read_callback));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_callback_data(a, NULL));
+
+	/* Try to open archive. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_open1(a));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
Protect libarchive's internals against callback function modifications while bidders are running. This would require custom callbacks which call libarchive's callback setters; clearly unintendend behavior.

Since the fix is cheap, this has no negative impact on regular use cases.

This enforces the `Opening freezes the callbacks.` comment in `archive.h`:
https://github.com/libarchive/libarchive/blob/6a714b66f0376a8cee3fca4a013abb7c70f6e6a1/libarchive/archive.h#L526-L555