### PR TITLE
read: Handle skipper failures

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -195,9 +195,9 @@ client_skip_proxy(struct archive_read_filter *f, int64_t request)
 	if (f->archive->client.skipper != NULL) {
 		int64_t total = 0;
 		for (;;) {
-			int64_t get, ask = request;
+			int64_t get;
 			get = (f->archive->client.skipper)
-				(&f->archive->archive, f->data, ask);
+			    (&f->archive->archive, f->data, request);
 			if (get < 0 || get > request)
 				return (ARCHIVE_FATAL);
 			total += get;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -198,11 +198,11 @@ client_skip_proxy(struct archive_read_filter *f, int64_t request)
 			int64_t get, ask = request;
 			get = (f->archive->client.skipper)
 				(&f->archive->archive, f->data, ask);
+			if (get < 0 || get > request)
+				return (ARCHIVE_FATAL);
 			total += get;
 			if (get == 0 || get == request)
 				return (total);
-			if (get > request)
-				return ARCHIVE_FATAL;
 			request -= get;
 		}
 	} else if (f->archive->client.seeker != NULL


### PR DESCRIPTION
If the skipper callback fails, treat it properly as fatal error instead of calculating the negative return value into total bytes read.

While at it, clean up the surrounding code a bit (remove unneeded variable, intendation).