### PR TITLE
read: Call bidder for set format as well

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -58,6 +58,7 @@
 
 #define minimum(a, b) (a < b ? a : b)
 
+static int	bid_format(struct archive_read *, int);
 static int	choose_filters(struct archive_read *);
 static int	choose_format(struct archive_read *);
 static int	close_filters(struct archive_read *);
@@ -554,6 +555,17 @@ archive_read_open1(struct archive *_a)
 		}
 		a->format = &(a->formats[slot]);
 	}
+	else if (a->format->bid != NULL)
+	{
+		if (bid_format(a, -1) < 0) {
+			archive_set_error(&a->archive,
+			    ARCHIVE_ERRNO_FILE_FORMAT,
+			    "Registered format does not match");
+			close_filters(a);
+			a->archive.state = ARCHIVE_STATE_FATAL;
+			return (ARCHIVE_FATAL);
+		}
+	}
 
 	a->archive.state = ARCHIVE_STATE_HEADER;
 
@@ -735,6 +747,21 @@ _archive_read_next_header(struct archive *_a, struct archive_entry **entryp)
 	return ret;
 }
 
+static int
+bid_format(struct archive_read *a, int best_bid)
+{
+	int bid;
+
+	bid = (a->format->bid)(a, best_bid);
+	if (bid == ARCHIVE_FATAL)
+		return (ARCHIVE_FATAL);
+	if (a->filter->position != 0 &&
+	    __archive_read_seek(a, 0, SEEK_SET) < 0)
+		return (ARCHIVE_FATAL);
+
+	return (bid);
+}
+
 /*
  * Allow each registered format to bid on whether it wants to handle
  * the next entry.  Return index of winning bidder.
@@ -755,11 +782,8 @@ choose_format(struct archive_read *a)
 	a->format = &(a->formats[0]);
 	for (i = 0; i < slots; i++, a->format++) {
 		if (a->format->bid) {
-			bid = (a->format->bid)(a, best_bid);
+			bid = bid_format(a, best_bid);
 			if (bid == ARCHIVE_FATAL)
-				return (ARCHIVE_FATAL);
-			if (a->filter->position != 0 &&
-			    __archive_read_seek(a, 0, SEEK_SET) < 0)
 				return (ARCHIVE_FATAL);
 			if ((bid > best_bid) || (best_bid_slot < 0)) {
 				best_bid = bid;

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -102,17 +102,13 @@ DEFINE_TEST(test_read_set_format)
 DEFINE_TEST(test_read_set_wrong_format)
 {
   const char reffile[] = "test_read_format_zip.zip";
-  struct archive_entry *ae;
   struct archive *a;
 
   extract_reference_file(reffile);
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_CPIO));
-  assertA(0 == archive_read_append_filter(a, ARCHIVE_FILTER_NONE));
-  assertA(0 == archive_read_open_filename(a, reffile, 10240));
-  /* Check that this actually fails, then close the archive. */
-  assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
-  assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_set_format(a, ARCHIVE_FORMAT_CPIO));
+  assertEqualIntA(a, ARCHIVE_OK, archive_read_append_filter(a, ARCHIVE_FILTER_NONE));
+  assertEqualIntA(a, ARCHIVE_FATAL, archive_read_open_filename(a, reffile, 10240));
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
@@ -153,26 +149,19 @@ DEFINE_TEST(test_read_append_filter)
 
 DEFINE_TEST(test_read_append_wrong_filter)
 {
-  struct archive_entry *ae;
   struct archive *a;
   int r;
 
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_XZ);
   if (r == ARCHIVE_WARN && !canXz()) {
     skipping("xz reading not fully supported on this platform");
     assertEqualInt(ARCHIVE_OK, archive_read_free(a));
     return;
   }
-  assertEqualInt(ARCHIVE_OK,
+  assertEqualInt(ARCHIVE_FATAL,
       archive_read_open_memory(a, archive, sizeof(archive)));
-  assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
-  if (r == ARCHIVE_WARN && canXz()) {
-    assertEqualIntA(a, ARCHIVE_WARN, archive_read_close(a));
-  } else {
-    assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
-  }
   assertEqualInt(ARCHIVE_OK,archive_read_free(a));
 }
 
@@ -403,7 +392,6 @@ DEFINE_TEST(test_read_append_filter_program)
 
 DEFINE_TEST(test_read_append_filter_wrong_program)
 {
-  struct archive_entry *ae;
   struct archive *a;
 #if !defined(_WIN32) || defined(__CYGWIN__)
   FILE * fp;
@@ -428,13 +416,11 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
 #endif
 
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_TAR));
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
   assertEqualIntA(a, ARCHIVE_OK,
       archive_read_append_filter_program(a, "bunzip2 -q"));
-  assertEqualIntA(a, ARCHIVE_OK,
+  assertEqualIntA(a, ARCHIVE_FATAL,
       archive_read_open_memory(a, archive, sizeof(archive)));
-  assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
-  assertEqualIntA(a, ARCHIVE_WARN, archive_read_close(a));
   assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 
 #if !defined(_WIN32) || defined(__CYGWIN__)

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -107,10 +107,9 @@ DEFINE_TEST(test_read_set_wrong_format)
 
   extract_reference_file(reffile);
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAR));
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_CPIO));
   assertA(0 == archive_read_append_filter(a, ARCHIVE_FILTER_NONE));
   assertA(0 == archive_read_open_filename(a, reffile, 10240));
-
   /* Check that this actually fails, then close the archive. */
   assertA(archive_read_next_header(a, &ae) < (ARCHIVE_WARN));
   assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));


### PR DESCRIPTION
Some bidder functions actually initialize fields in format data, thus the call itself must not be skipped even though we "know" the format.

Affected formats are CPIO, ISO9660, and seekable ZIP (which actually is not used when setting format because non-seekable one wins). The easiest PoC is to set CPIO as format and try to read an archive, which is added as unit test. Since function pointers are initialized in bidder, which is never called, it reliably triggers a NULL pointer dereference.

Always call format bidder. Adjust tests since opening an archive will already fail if the format doesn't fit.