### PR TITLE
tar: report skipped hardlink entries and set non-zero exit status

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1316,6 +1316,7 @@ bsdtar_test_SOURCES= \
 	tar/test/test_extract_tar_lzo.c \
 	tar/test/test_extract_tar_xz.c \
 	tar/test/test_extract_tar_zstd.c \
+	tar/test/test_edit_pathname_hardlink.c \
 	tar/test/test_format_newc.c \
 	tar/test/test_help.c \
 	tar/test/test_leading_slash.c \
@@ -1407,6 +1408,7 @@ bsdtar_test_EXTRA_DIST= \
 	tar/test/test_extract.tar.lzo.uu \
 	tar/test/test_extract.tar.xz.uu \
 	tar/test/test_leading_slash.tar.uu \
+	tar/test/test_edit_pathname_hardlink.tar.Z.uu \
 	tar/test/test_list_item.tar.uu \
 	tar/test/test_option_keep_newer_files.tar.Z.uu \
 	tar/test/test_option_passphrase.zip.uu \

--- a/tar/test/CMakeLists.txt
+++ b/tar/test/CMakeLists.txt
@@ -27,6 +27,7 @@ IF(ENABLE_TAR AND ENABLE_TEST)
     test_extract_tar_lzo.c
     test_extract_tar_xz.c
     test_extract_tar_zstd.c
+    test_edit_pathname_hardlink.c
     test_format_newc.c
     test_help.c
     test_leading_slash.c

--- a/tar/test/test_edit_pathname_hardlink.c
+++ b/tar/test/test_edit_pathname_hardlink.c
@@ -1,0 +1,46 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 lilu
+ * All rights reserved.
+ */
+#include "test.h"
+
+/*
+ * An entry whose hardlink target reduces to the empty string after
+ * stripping the leading '/' is skipped by edit_pathname().  This used to
+ * happen silently: the entry vanished from the output and bsdtar exited 0,
+ * so a caller could not detect the incomplete result.  The entry must now be
+ * named in a diagnostic and must cause a non-zero exit status.
+ */
+DEFINE_TEST(test_edit_pathname_hardlink)
+{
+	const char *reffile = "test_edit_pathname_hardlink.tar.Z";
+	char *p;
+	size_t s;
+	const char *expected_errmsg =
+	    "Skipping ./hardlink: hardlink target becomes empty "
+	    "after removing leading '/'";
+
+	extract_reference_file(reffile);
+
+	/* Transforming the archive must report the dropped entry and fail. */
+	assert(0 != systemf("%s -cf out.tar @%s >test.out 2>test.err",
+	    testprog, reffile));
+
+	/* out.tar must list ./a.txt and must not list the dropped ./hardlink. */
+	assertEqualInt(0, systemf("%s -tf out.tar >list.out 2>list.err",
+	    testprog));
+	p = slurpfile(&s, "list.out");
+	assert(p != NULL);
+	assert(strstr(p, "a.txt") != NULL);
+	assert(strstr(p, "hardlink") == NULL);
+	free(p);
+
+	/* The diagnostic must name the entry and the reason. */
+	if (assertFileExists("test.err")) {
+		p = slurpfile(&s, "test.err");
+		assert(strstr(p, expected_errmsg) != NULL);
+		free(p);
+	}
+}

--- a/tar/test/test_edit_pathname_hardlink.tar.Z.uu
+++ b/tar/test/test_edit_pathname_hardlink.tar.Z.uu
@@ -1,0 +1,8 @@
+begin 644 test_edit_pathname_hardlink.tar.Z
+M'YV0+EZ$<4$'#QT "!,J7,BPH<.'$"-*G(@0AD4;-&B  &"Q(XR-'BV"#.E1
+M(\F0(&#$@"'C1@T *2G*G$FSIDT =>;0"2.'(XR;0(/Z]#B2J-"C2),J72HS
+MC%,%3*-*G4JUJM6K6+-JW<JU:\2 :'B289/&S1JO:!-VQ*AQ:,>B;]V>3'GR
+MK<H8*V_ C/$BK5^'.7?VM/B7)DFX(@LK7LRXL>/'D"-+GDRYLN7+F#-KWLRY
+!*P  
+ 
+end

--- a/tar/util.c
+++ b/tar/util.c
@@ -551,8 +551,13 @@ edit_pathname(struct bsdtar *bsdtar, struct archive_entry *entry)
 
 		if (hardlinkname != NULL) {
 			hardlinkname = strip_absolute_path(bsdtar, hardlinkname);
-			if (*hardlinkname == '\0')
+			if (*hardlinkname == '\0') {
+				lafe_warnc(0, "Skipping %s: hardlink target "
+				    "becomes empty after removing leading '/'",
+				    original_name);
+				bsdtar->return_value = 1;
 				return (1);
+			}
 		}
 	} else {
 		/* Strip redundant leading '/' characters. */


### PR DESCRIPTION
## Problem

`edit_pathname()` in `tar/util.c` silently discarded entries whose hardlink target reduced to the empty string after `strip_absolute_path()`. It returned `1` without emitting a per-entry diagnostic and without setting `bsdtar->return_value`, so:

- The entry vanished from the output archive.
- bsdtar exited `0`.
- The only message was the generic `Removing leading '/' from member names`.

This made the data loss undetectable by callers relying on stderr or the exit status. Closes #3378.

## Fix

Add a `lafe_warnc()` diagnostic naming the skipped entry and the reason, and set `bsdtar->return_value = 1` before returning, matching the existing `"Skipping %s: ..."` convention used elsewhere in the same function.

```diff
 if (*hardlinkname == '\0') {
+    lafe_warnc(0, "Skipping %s: hardlink target "
+        "becomes empty after removing leading '/'",
+        original_name);
+    bsdtar->return_value = 1;
     return (1);
 }
```

## Test

New test `test_edit_pathname_hardlink` verifies that:
1. Transforming an archive with a hardlink target of `/` fails (non-zero exit).
2. The dropped entry is named in the diagnostic on stderr.
3. The output archive still contains the non-affected entry (`./a.txt`).

```
$ ctest -R test_edit_pathname_hardlink --output-on-failure
1/1 Test #890: bsdtar_test_edit_pathname_hardlink ...   Passed    0.02 sec
```

### Before (unpatched)
```
$ bsdtar -cf out.tar @test.tar; echo rc=$?
rc=0
$ bsdtar -tf out.tar
./a.txt          # ./hardlink silently dropped
```

### After (patched)
```
$ bsdtar -cf out.tar @test.tar; echo rc=$?
bsdtar: Skipping ./hardlink: hardlink target becomes empty after removing leading '/'
rc=1
$ bsdtar -tf out.tar
./a.txt
```
