### PR TITLE
cpio: fail if extra arguments are supplied

### DIFF
--- a/cpio/cpio.c
+++ b/cpio/cpio.c
@@ -409,6 +409,10 @@ main(int argc, char *argv[])
 			else
 				cpio->format = "cpio";
 		}
+		if (cpio->argc > 0)
+			lafe_errc(1, 0,
+			    "Too many arguments for -o mode (got %d, expected 0)",
+			    cpio->argc);
 		mode_out(cpio);
 		break;
 	case 'i':
@@ -429,6 +433,10 @@ main(int argc, char *argv[])
 		if (*cpio->argv == NULL || **cpio->argv == '\0')
 			lafe_errc(1, 0,
 			    "-p mode requires a target directory");
+		if (cpio->argc > 1)
+			lafe_errc(1, 0,
+			    "Too many arguments for -p mode (got %d, expected 1)",
+			    cpio->argc);
 		mode_pass(cpio, *cpio->argv);
 		break;
 	default:

--- a/cpio/test/test_cmdline.c
+++ b/cpio/test/test_cmdline.c
@@ -82,7 +82,15 @@ DEFINE_TEST(test_cmdline)
 	assert(0 != systemf("%s -p -o <empty >16.out 2>16.err", testprog));
 	assertEmptyFile("16.out");
 
-	failure("-p with empty input should fail");
+	failure("-p with missing directory should fail");
 	assert(0 != systemf("%s -p <empty >17.out 2>17.err", testprog));
 	assertEmptyFile("17.out");
+
+	failure("-p with more than one argument should fail");
+	assert(0 != systemf("%s -p out abc <empty >18.out 2>18.err", testprog));
+	assertEmptyFile("18.out");
+
+	failure("-o with arguments should fail");
+	assert(0 != systemf("%s -o abc <empty >19.out 2>19.err", testprog));
+	assertEmptyFile("19.out");
 }


### PR DESCRIPTION
Both gnu and schilytools cpio complain about extra args, and an error is useful for people not familiar with cpio's syntax.

When testing cpio changes, I kept trying to put filenames on the commandline like tar, and wondered why cpio wasn't doing what I asked.
