### PR TITLE
7zip: add AES-256-SHA-256 decryption support

### DIFF
--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -30,6 +30,8 @@
 #endif
 #include "archive.h"
 #include "archive_cryptor_private.h"
+#include "archive_digest_private.h"
+#include "archive_endian.h"
 
 /*
  * On systems that do not support any recognized crypto libraries,
@@ -40,10 +42,21 @@
  * be removed someday if this file gains another always-present
  * symbol definition.
  */
-int __libarchive_cryptor_build_hack(void) {
-	return 0;
+/*
+ * Securely clear sensitive memory to prevent compiler dead-store elimination.
+ * Uses the same volatile function pointer pattern as archive_blake2_impl.h.
+ */
+static void
+cryptor_secure_clear(void *p, size_t len)
+{
+	static void *(__LA_LIBC_CC *const volatile memset_v)(void *, int, size_t) = &memset;
+	if (p != NULL && len > 0)
+		memset_v(p, 0, len);
 }
 
+/*
+ * Crypto Backend 1: Apple CommonCrypto (macOS / iOS / Darwin)
+ */
 #ifdef ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
 
 static int
@@ -57,6 +70,9 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return 0;
 }
 
+/*
+ * Crypto Backend 2: Windows Cryptography API: Next Generation (BCrypt)
+ */
 #elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
 #ifdef _MSC_VER
 #pragma comment(lib, "Bcrypt.lib")
@@ -85,6 +101,9 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return (BCRYPT_SUCCESS(status)) ? 0: -1;
 }
 
+/*
+ * Crypto Backend 3: mbed TLS (ARM / Embedded)
+ */
 #elif defined(HAVE_LIBMBEDCRYPTO) && defined(HAVE_MBEDTLS_PKCS5_H)
 
 static int
@@ -114,6 +133,9 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return (ret);
 }
 
+/*
+ * Crypto Backend 4: Nettle Cryptographic Library
+ */
 #elif defined(HAVE_LIBNETTLE) && defined(HAVE_NETTLE_PBKDF2_H)
 
 static int
@@ -125,6 +147,9 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return 0;
 }
 
+/*
+ * Crypto Backend 5: OpenSSL libcrypto
+ */
 #elif defined(HAVE_LIBCRYPTO) && defined(HAVE_PKCS5_PBKDF2_HMAC_SHA1)
 
 static int
@@ -137,6 +162,9 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return 0;
 }
 
+/*
+ * Crypto Backend 6: Stub Fallback (No Crypto Available)
+ */
 #else
 
 /* Stub */
@@ -194,6 +222,41 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 {
 	memset(ctx->key, 0, ctx->key_len);
 	memset(ctx->nonce, 0, sizeof(ctx->nonce));
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	CCCryptorStatus r;
+	(void)iv_len;
+	r = CCCryptorCreateWithMode(kCCDecrypt, kCCModeCBC, kCCAlgorithmAES,
+	    ccNoPadding, iv, key, key_len, NULL, 0, 0, 0, &ctx->ctx);
+	return (r == kCCSuccess)? 0: -1;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	CCCryptorStatus r;
+	size_t moved = 0;
+
+	r = CCCryptorUpdate(ctx->ctx, in, in_len, out, *out_len, &moved);
+	if (r != kCCSuccess)
+		return -1;
+	*out_len = moved;
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
+{
+	if (ctx->ctx != NULL) {
+		CCCryptorRelease(ctx->ctx);
+		ctx->ctx = NULL;
+	}
 	return 0;
 }
 
@@ -298,6 +361,96 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 	return 0;
 }
 
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	BCRYPT_ALG_HANDLE hAlg;
+	BCRYPT_KEY_HANDLE hKey;
+	DWORD keyObj_len;
+	PBYTE keyObj;
+	ULONG result;
+	NTSTATUS status;
+
+	ctx->hAlg = NULL;
+	ctx->hKey = NULL;
+	ctx->keyObj = NULL;
+	if (iv != NULL && iv_len <= AES_BLOCK_SIZE) {
+		memcpy(ctx->nonce, iv, iv_len);
+		if (iv_len < AES_BLOCK_SIZE)
+			memset(ctx->nonce + iv_len, 0, AES_BLOCK_SIZE - iv_len);
+	} else {
+		memset(ctx->nonce, 0, sizeof(ctx->nonce));
+	}
+
+	status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_AES_ALGORITHM,
+		MS_PRIMITIVE_PROVIDER, 0);
+	if (!BCRYPT_SUCCESS(status))
+		return -1;
+	status = BCryptSetProperty(hAlg, BCRYPT_CHAINING_MODE,
+		(PUCHAR)BCRYPT_CHAIN_MODE_CBC, sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
+	if (!BCRYPT_SUCCESS(status)) {
+		BCryptCloseAlgorithmProvider(hAlg, 0);
+		return -1;
+	}
+	status = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, (PUCHAR)&keyObj_len,
+		sizeof(keyObj_len), &result, 0);
+	if (!BCRYPT_SUCCESS(status)) {
+		BCryptCloseAlgorithmProvider(hAlg, 0);
+		return -1;
+	}
+	keyObj = (PBYTE)HeapAlloc(GetProcessHeap(), 0, keyObj_len);
+	if (keyObj == NULL) {
+		BCryptCloseAlgorithmProvider(hAlg, 0);
+		return -1;
+	}
+	status = BCryptGenerateSymmetricKey(hAlg, &hKey,
+		keyObj, keyObj_len,
+		(PUCHAR)(uintptr_t)key, (ULONG)key_len, 0);
+	if (!BCRYPT_SUCCESS(status)) {
+		BCryptCloseAlgorithmProvider(hAlg, 0);
+		HeapFree(GetProcessHeap(), 0, keyObj);
+		return -1;
+	}
+
+	ctx->hAlg = hAlg;
+	ctx->hKey = hKey;
+	ctx->keyObj = keyObj;
+	ctx->keyObj_len = keyObj_len;
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	ULONG result = 0;
+	NTSTATUS status;
+
+	status = BCryptDecrypt(ctx->hKey, (PUCHAR)(uintptr_t)in, (ULONG)in_len,
+		NULL, ctx->nonce, AES_BLOCK_SIZE, (PUCHAR)out, (ULONG)*out_len,
+		&result, 0);
+	if (!BCRYPT_SUCCESS(status))
+		return -1;
+	*out_len = (size_t)result;
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
+{
+	if (ctx->hAlg != NULL) {
+		BCryptCloseAlgorithmProvider(ctx->hAlg, 0);
+		ctx->hAlg = NULL;
+		BCryptDestroyKey(ctx->hKey);
+		ctx->hKey = NULL;
+		HeapFree(GetProcessHeap(), 0, ctx->keyObj);
+		ctx->keyObj = NULL;
+	}
+	memset(ctx, 0, sizeof(*ctx));
+	return 0;
+}
+
 #elif defined(HAVE_LIBMBEDCRYPTO) && defined(HAVE_MBEDTLS_AES_H)
 
 static int
@@ -325,6 +478,41 @@ aes_ctr_encrypt_counter(archive_crypto_ctx *ctx)
 
 static int
 aes_ctr_release(archive_crypto_ctx *ctx)
+{
+	mbedtls_aes_free(&ctx->ctx);
+	memset(ctx, 0, sizeof(*ctx));
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	mbedtls_aes_init(&ctx->ctx);
+	if (mbedtls_aes_setkey_dec(&ctx->ctx, key, (unsigned)(key_len * 8)) != 0)
+		return -1;
+	if (iv != NULL && iv_len <= AES_BLOCK_SIZE) {
+		memcpy(ctx->nonce, iv, iv_len);
+		if (iv_len < AES_BLOCK_SIZE)
+			memset(ctx->nonce + iv_len, 0, AES_BLOCK_SIZE - iv_len);
+	} else {
+		memset(ctx->nonce, 0, sizeof(ctx->nonce));
+	}
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	if (mbedtls_aes_crypt_cbc(&ctx->ctx, MBEDTLS_AES_DECRYPT, in_len, ctx->nonce, in, out) != 0)
+		return -1;
+	*out_len = in_len;
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
 {
 	mbedtls_aes_free(&ctx->ctx);
 	memset(ctx, 0, sizeof(*ctx));
@@ -382,6 +570,29 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 	return 0;
 }
 
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	(void)ctx; (void)key; (void)key_len; (void)iv; (void)iv_len;
+	return CRYPTOR_STUB_FUNCTION;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	(void)ctx; (void)in; (void)in_len; (void)out; (void)out_len;
+	return CRYPTOR_STUB_FUNCTION;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
+{
+	(void)ctx;
+	return 0;
+}
+
 #elif defined(HAVE_LIBCRYPTO)
 
 static int
@@ -429,6 +640,52 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 	return 0;
 }
 
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	const EVP_CIPHER *cipher;
+	(void)iv_len;
+	switch (key_len) {
+	case 16: cipher = EVP_aes_128_cbc(); break;
+	case 24: cipher = EVP_aes_192_cbc(); break;
+	case 32: cipher = EVP_aes_256_cbc(); break;
+	default: return -1;
+	}
+	ctx->ctx = EVP_CIPHER_CTX_new();
+	if (ctx->ctx == NULL)
+		return -1;
+	if (EVP_DecryptInit_ex(ctx->ctx, cipher, NULL, key, iv) == 0) {
+		EVP_CIPHER_CTX_free(ctx->ctx);
+		ctx->ctx = NULL;
+		return -1;
+	}
+	EVP_CIPHER_CTX_set_padding(ctx->ctx, 0);
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	int outl = 0;
+	if (EVP_DecryptUpdate(ctx->ctx, out, &outl, in, (int)in_len) == 0)
+		return -1;
+	*out_len = (size_t)outl;
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
+{
+	if (ctx->ctx != NULL) {
+		EVP_CIPHER_CTX_free(ctx->ctx);
+		ctx->ctx = NULL;
+	}
+	memset(ctx, 0, sizeof(*ctx));
+	return 0;
+}
+
 #else
 
 #define ARCHIVE_CRYPTOR_STUB
@@ -453,6 +710,29 @@ static int
 aes_ctr_release(archive_crypto_ctx *ctx)
 {
 	(void)ctx; /* UNUSED */
+	return 0;
+}
+
+static int
+decrypto_aes_cbc_init(archive_crypto_ctx *ctx, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len)
+{
+	(void)ctx; (void)key; (void)key_len; (void)iv; (void)iv_len;
+	return CRYPTOR_STUB_FUNCTION;
+}
+
+static int
+decrypto_aes_cbc_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	(void)ctx; (void)in; (void)in_len; (void)out; (void)out_len;
+	return CRYPTOR_STUB_FUNCTION;
+}
+
+static int
+decrypto_aes_cbc_release(archive_crypto_ctx *ctx)
+{
+	(void)ctx;
 	return 0;
 }
 
@@ -521,6 +801,125 @@ aes_ctr_update(archive_crypto_ctx *ctx, const uint8_t * const in,
 }
 #endif /* ARCHIVE_CRYPTOR_STUB */
 
+static size_t
+utf8_to_utf16le(const char *utf8, uint8_t *utf16, size_t max_utf16_bytes)
+{
+	size_t i = 0, o = 0, k, clen;
+	unsigned char c;
+	uint32_t cp;
+	uint16_t high, low;
+
+	if (utf8 == NULL || utf16 == NULL)
+		return 0;
+	while (utf8[i] != '\0' && o + 2 <= max_utf16_bytes) {
+		c = (unsigned char)utf8[i];
+		cp = 0;
+		clen = 0;
+
+		if (c < 0x80) {
+			cp = c;
+			clen = 1;
+		} else if ((c & 0xE0) == 0xC0) {
+			cp = c & 0x1F;
+			clen = 2;
+		} else if ((c & 0xF0) == 0xE0) {
+			cp = c & 0x0F;
+			clen = 3;
+		} else if ((c & 0xF8) == 0xF0) {
+			cp = c & 0x07;
+			clen = 4;
+		} else {
+			cp = c;
+			clen = 1;
+		}
+
+		for (k = 1; k < clen; k++) {
+			if (utf8[i + k] == '\0' || (utf8[i + k] & 0xC0) != 0x80) {
+				clen = 1;
+				cp = c;
+				break;
+			}
+			cp = (cp << 6) | (utf8[i + k] & 0x3F);
+		}
+		i += clen;
+
+		if (cp < 0x10000) {
+			utf16[o++] = (uint8_t)(cp & 0xFF);
+			utf16[o++] = (uint8_t)((cp >> 8) & 0xFF);
+		} else if (cp <= 0x10FFFF && o + 4 <= max_utf16_bytes) {
+			cp -= 0x10000;
+			high = (uint16_t)(0xD800 + (cp >> 10));
+			low = (uint16_t)(0xDC00 + (cp & 0x3FF));
+			utf16[o++] = (uint8_t)(high & 0xFF);
+			utf16[o++] = (uint8_t)((high >> 8) & 0xFF);
+			utf16[o++] = (uint8_t)(low & 0xFF);
+			utf16[o++] = (uint8_t)((low >> 8) & 0xFF);
+		}
+	}
+	return o;
+}
+
+static int
+kdf_7z_sha256(const char *pw, const uint8_t *salt, size_t salt_len,
+    unsigned numCyclesPower, uint8_t *derived_key, size_t derived_key_len)
+{
+#if defined(ARCHIVE_HAS_SHA256)
+	archive_sha256_ctx sha;
+	uint8_t kdf_buf[512 + 16 + 8];
+	size_t pw_bytes = 0;
+	size_t block_len = 0;
+	size_t round_offset;
+	uint64_t numRounds;
+	uint64_t round;
+	uint8_t full_digest[32];
+
+	if (derived_key == NULL || derived_key_len == 0)
+		return -1;
+
+	if (numCyclesPower > 24)
+		return -1;
+
+	if (salt != NULL && salt_len > 0) {
+		if (salt_len > 16)
+			salt_len = 16;
+		memcpy(kdf_buf, salt, salt_len);
+		block_len += salt_len;
+	}
+	if (pw != NULL) {
+		pw_bytes = utf8_to_utf16le(pw, kdf_buf + block_len, 512);
+		block_len += pw_bytes;
+	}
+
+	if (archive_sha256_init(&sha) != ARCHIVE_OK)
+		return -1;
+
+	if (numCyclesPower == 0) {
+		if (block_len > 0)
+			archive_sha256_update(&sha, kdf_buf, block_len);
+	} else {
+		round_offset = block_len;
+		block_len += 8;
+		numRounds = ((uint64_t)1) << numCyclesPower;
+		for (round = 0; round < numRounds; round++) {
+			archive_le64enc(kdf_buf + round_offset, round);
+			archive_sha256_update(&sha, kdf_buf, block_len);
+		}
+	}
+
+	archive_sha256_final(&sha, full_digest);
+
+	if (derived_key_len > 32)
+		derived_key_len = 32;
+	memcpy(derived_key, full_digest, derived_key_len);
+	cryptor_secure_clear(full_digest, sizeof(full_digest));
+	cryptor_secure_clear(kdf_buf, sizeof(kdf_buf));
+	return 0;
+#else
+	(void)pw; (void)salt; (void)salt_len; (void)numCyclesPower;
+	(void)derived_key; (void)derived_key_len;
+	return CRYPTOR_STUB_FUNCTION;
+#endif
+}
 
 const struct archive_cryptor __archive_cryptor =
 {
@@ -531,4 +930,8 @@ const struct archive_cryptor __archive_cryptor =
   &aes_ctr_init,
   &aes_ctr_update,
   &aes_ctr_release,
+  &decrypto_aes_cbc_init,
+  &decrypto_aes_cbc_update,
+  &decrypto_aes_cbc_release,
+  &kdf_7z_sha256,
 };

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -172,6 +172,16 @@ typedef int archive_crypto_ctx;
 #define archive_encrypto_aes_ctr_release(ctx) \
   __archive_cryptor.encrypto_aes_ctr_release(ctx)
 
+#define archive_decrypto_aes_cbc_init(ctx, key, key_len, iv, iv_len) \
+  __archive_cryptor.decrypto_aes_cbc_init(ctx, key, key_len, iv, iv_len)
+#define archive_decrypto_aes_cbc_update(ctx, in, in_len, out, out_len) \
+  __archive_cryptor.decrypto_aes_cbc_update(ctx, in, in_len, out, out_len)
+#define archive_decrypto_aes_cbc_release(ctx) \
+  __archive_cryptor.decrypto_aes_cbc_release(ctx)
+
+#define archive_7z_kdf_sha256(pw, salt, salt_len, numCyclesPower, dk, dk_len) \
+  __archive_cryptor.kdf_7z_sha256(pw, salt, salt_len, numCyclesPower, dk, dk_len)
+
 /* Stub return value if no encryption support exists. */
 #define CRYPTOR_STUB_FUNCTION	-2
 
@@ -192,6 +202,18 @@ struct archive_cryptor
   int (*encrypto_aes_ctr_update)(archive_crypto_ctx *, const uint8_t *,
     size_t, uint8_t *, size_t *);
   int (*encrypto_aes_ctr_release)(archive_crypto_ctx *);
+
+  /* AES CBC mode decryption */
+  int (*decrypto_aes_cbc_init)(archive_crypto_ctx *, const uint8_t *key,
+    size_t key_len, const uint8_t *iv, size_t iv_len);
+  int (*decrypto_aes_cbc_update)(archive_crypto_ctx *, const uint8_t *in,
+    size_t in_len, uint8_t *out, size_t *out_len);
+  int (*decrypto_aes_cbc_release)(archive_crypto_ctx *);
+
+  /* 7z SHA-256 KDF */
+  int (*kdf_7z_sha256)(const char *pw, const uint8_t *salt,
+    size_t salt_len, unsigned numCyclesPower, uint8_t *derived_key,
+    size_t derived_key_len);
 };
 
 extern const struct archive_cryptor __archive_cryptor;

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -57,6 +57,7 @@
 #include "archive_ppmd7_private.h"
 #include "archive_private.h"
 #include "archive_read_private.h"
+#include "archive_cryptor_private.h"
 #include "archive_time_private.h"
 #include "archive_endian.h"
 
@@ -233,6 +234,15 @@ struct _7z_header_info {
 	unsigned char		*attrBools;
 };
 
+struct _7z_crypto_properties {
+	unsigned	num_cycles_power;
+	uint8_t		salt[16];
+	uint8_t		salt_size;
+	uint8_t		iv[16];
+	uint8_t		iv_size;
+};
+
+
 struct _7zip_entry {
 	size_t			 name_len;
 	unsigned char		*utf16name;
@@ -385,6 +395,23 @@ struct _7zip {
 
 	/* Custom value that is non-zero if this archive contains encrypted entries. */
 	int			 has_encrypted_entries;
+	int			 header_is_encrypted;
+
+	/* AES-256 Decryption Context */
+	int			 is_encrypted;
+	archive_crypto_ctx	 crypto_ctx;
+	int			 crypto_ctx_valid;
+	uint8_t			 aes_key[32];
+	uint8_t			 aes_iv[16];
+	unsigned char		*decrypted_buffer;
+	size_t			 decrypted_buffer_size;
+	size_t			 decrypted_bytes_avail;
+	size_t			 decrypted_bytes_pos;
+	int			 cached_key_valid;
+	uint8_t			 cached_salt[16];
+	uint8_t			 cached_salt_size;
+	unsigned		 cached_num_cycles_power;
+	uint8_t			 cached_aes_key[32];
 };
 
 /* Maximum entry size. This limitation prevents reading intentional
@@ -962,6 +989,10 @@ archive_read_format_7zip_read_header(struct archive_read *a,
 			}
 		}
 	}
+	if (zip->header_is_encrypted) {
+		archive_entry_set_is_metadata_encrypted(entry, 1);
+		zip->has_encrypted_entries = 1;
+	}
 
 	if (archive_entry_copy_pathname_l(entry,
 	    (const char *)zip_entry->utf16name,
@@ -1185,11 +1216,37 @@ archive_read_format_7zip_read_data_skip(struct archive_read *a)
 	return (ARCHIVE_OK);
 }
 
+/*
+ * Securely clear sensitive memory (key material, IVs).
+ * Uses a volatile function pointer to prevent the compiler from
+ * optimizing out the memset as a dead store.  This is the same
+ * pattern used by libarchive's BLAKE2 implementation in
+ * archive_blake2_impl.h (secure_zero_memory).
+ */
+static void
+archive_7zip_secure_clear(void *p, size_t len)
+{
+	static void *(__LA_LIBC_CC *const volatile memset_v)(void *, int, size_t) = &memset;
+	memset_v(p, 0, len);
+}
+
 static int
 archive_read_format_7zip_cleanup(struct archive_read *a)
 {
 	struct _7zip *zip = a->format->data;
 
+	if (zip->crypto_ctx_valid) {
+		archive_decrypto_aes_cbc_release(&zip->crypto_ctx);
+		zip->crypto_ctx_valid = 0;
+	}
+	archive_7zip_secure_clear(zip->aes_key, sizeof(zip->aes_key));
+	archive_7zip_secure_clear(zip->aes_iv, sizeof(zip->aes_iv));
+	archive_7zip_secure_clear(zip->cached_aes_key, sizeof(zip->cached_aes_key));
+	if (zip->decrypted_buffer != NULL) {
+		archive_7zip_secure_clear(zip->decrypted_buffer,
+		    zip->decrypted_buffer_size);
+		free(zip->decrypted_buffer);
+	}
 	free_StreamsInfo(&(zip->si));
 	free(zip->entries);
 	free(zip->entry_names);
@@ -3420,7 +3477,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 			if (errno == ENOMEM)
 				archive_set_error(&a->archive, -1,
 				    "Couldn't allocate memory");
-			else
+			else if (archive_error_string(&a->archive) == NULL)
 				archive_set_error(&a->archive, -1,
 				    "Damaged 7-Zip archive");
 			return (ARCHIVE_FATAL);
@@ -3429,7 +3486,7 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 		/*
 		 *  Must be kEnd.
 		 */
-		if ((p = header_bytes(a, 1)) == NULL ||*p != kEnd) {
+		if ((p = header_bytes(a, 1)) == NULL || *p != kEnd) {
 			archive_set_error(&a->archive, -1,
 			    "Malformed 7-Zip archive");
 			return (ARCHIVE_FATAL);
@@ -3457,6 +3514,9 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	zip->uncompressed_buffer_bytes_remaining = 0;
 	zip->pack_stream_bytes_unconsumed = 0;
 	zip->header_is_being_read = 0;
+	zip->is_encrypted = 0;
+	zip->decrypted_bytes_pos = 0;
+	zip->decrypted_bytes_avail = 0;
 
 	return (ARCHIVE_OK);
 }
@@ -3468,8 +3528,8 @@ get_uncompressed_data(struct archive_read *a, const void **buff, size_t size,
 	struct _7zip *zip = a->format->data;
 	ssize_t bytes_avail;
 
-	if (zip->codec == _7Z_COPY && zip->codec2 == -1) {
-		/* Copy mode. */
+	if (zip->codec == _7Z_COPY && zip->codec2 == -1 && !zip->is_encrypted) {
+		/* Copy mode (unencrypted). */
 
 		*buff = __archive_read_ahead(a, minimum, &bytes_avail);
 		if (*buff == NULL) {
@@ -3532,7 +3592,7 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 	ssize_t bytes_avail;
 	int r;
 
-	if (zip->codec == _7Z_COPY && zip->codec2 == -1) {
+	if (zip->codec == _7Z_COPY && zip->codec2 == -1 && !zip->is_encrypted) {
 		if (minimum == 0)
 			minimum = 1;
 		if (__archive_read_ahead(a, minimum, &bytes_avail) == NULL
@@ -3612,28 +3672,94 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 		const void *buff_in;
 		unsigned char *buff_out;
 		int end_of_data;
+		size_t to_read, aligned_in, dec_out, min_ahead;
 
-		/*
-		 * Note: '1' here is a performance optimization.
-		 * Recall that the decompression layer returns a count of
-		 * available bytes; asking for more than that forces the
-		 * decompressor to combine reads by copying data.
-		 */
-		buff_in = __archive_read_ahead(a, 1, &bytes_avail);
-		if (bytes_avail <= 0) {
-			archive_set_error(&a->archive,
-			    ARCHIVE_ERRNO_FILE_FORMAT,
-			    "Truncated 7-Zip file body");
-			return (ARCHIVE_FATAL);
+		if (zip->is_encrypted) {
+			if (zip->decrypted_bytes_pos >= zip->decrypted_bytes_avail) {
+				if (zip->pack_stream_inbytes_remaining <= 0) {
+					bytes_in = 0;
+					buff_in = zip->decrypted_buffer;
+				} else {
+					to_read = UBUFF_SIZE;
+					if ((uint64_t)zip->pack_stream_inbytes_remaining < (uint64_t)to_read)
+						to_read = (size_t)zip->pack_stream_inbytes_remaining;
+					min_ahead = (to_read >= 16) ? 16 : 1;
+					buff_in = __archive_read_ahead(a, min_ahead, &bytes_avail);
+					if (buff_in == NULL || bytes_avail < (ssize_t)min_ahead) {
+						archive_set_error(&a->archive,
+						    ARCHIVE_ERRNO_FILE_FORMAT,
+						    "Truncated 7-Zip file body");
+						return (ARCHIVE_FATAL);
+					}
+					if ((size_t)bytes_avail > to_read)
+						bytes_avail = (ssize_t)to_read;
+					aligned_in = ((size_t)bytes_avail / 16) * 16;
+					if (aligned_in == 0 && bytes_avail > 0 &&
+					    zip->pack_stream_inbytes_remaining <= (int64_t)bytes_avail)
+						aligned_in = (size_t)bytes_avail;
+					if (aligned_in == 0) {
+						archive_set_error(&a->archive,
+						    ARCHIVE_ERRNO_FILE_FORMAT,
+						    "Truncated 7-Zip encrypted stream");
+						return (ARCHIVE_FATAL);
+					}
+					if (zip->decrypted_buffer == NULL ||
+					    zip->decrypted_buffer_size < aligned_in) {
+						free(zip->decrypted_buffer);
+						zip->decrypted_buffer_size = align_size(
+						    aligned_in > UBUFF_SIZE ? aligned_in : UBUFF_SIZE);
+						zip->decrypted_buffer = malloc(zip->decrypted_buffer_size);
+						if (zip->decrypted_buffer == NULL) {
+							archive_set_error(&a->archive, ENOMEM,
+							    "No memory for 7-Zip decryption");
+							return (ARCHIVE_FATAL);
+						}
+					}
+					dec_out = zip->decrypted_buffer_size;
+					if (archive_decrypto_aes_cbc_update(&zip->crypto_ctx,
+					    buff_in, aligned_in, zip->decrypted_buffer, &dec_out) != 0) {
+						archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+						    "7-Zip AES decryption failed");
+						return (ARCHIVE_FATAL);
+					}
+					if (__archive_read_consume(a, aligned_in) < 0) {
+						archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+						    "Failed to consume encrypted 7-Zip data");
+						return (ARCHIVE_FATAL);
+					}
+					zip->pack_stream_inbytes_remaining -= aligned_in;
+					zip->stream_offset += aligned_in;
+					zip->decrypted_bytes_pos = 0;
+					zip->decrypted_bytes_avail = dec_out;
+				}
+			}
+			buff_in = zip->decrypted_buffer + zip->decrypted_bytes_pos;
+			bytes_in = zip->decrypted_bytes_avail - zip->decrypted_bytes_pos;
+		} else {
+			/*
+			 * Note: '1' here is a performance optimization.
+			 * Recall that the decompression layer returns a count of
+			 * available bytes; asking for more than that forces the
+			 * decompressor to combine reads by copying data.
+			 */
+			buff_in = __archive_read_ahead(a, 1, &bytes_avail);
+			if (bytes_avail <= 0) {
+				archive_set_error(&a->archive,
+				    ARCHIVE_ERRNO_FILE_FORMAT,
+				    "Truncated 7-Zip file body");
+				return (ARCHIVE_FATAL);
+			}
+
+			bytes_in = bytes_avail;
+			if (bytes_in > (uint64_t)zip->pack_stream_inbytes_remaining)
+				bytes_in = (size_t)zip->pack_stream_inbytes_remaining;
 		}
 
 		buff_out = zip->uncompressed_buffer
 			+ zip->uncompressed_buffer_bytes_remaining;
 		bytes_out = zip->uncompressed_buffer_size
 			- zip->uncompressed_buffer_bytes_remaining;
-		bytes_in = bytes_avail;
-		if (bytes_in > (uint64_t)zip->pack_stream_inbytes_remaining)
-			bytes_in = (size_t)zip->pack_stream_inbytes_remaining;
+
 		/* Drive decompression. */
 		r = decompress(a, zip, buff_out, &bytes_out,
 			buff_in, &bytes_in);
@@ -3647,12 +3773,18 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 		default:
 			return (ARCHIVE_FATAL);
 		}
-		zip->pack_stream_inbytes_remaining -= bytes_in;
+
+		if (zip->is_encrypted) {
+			zip->decrypted_bytes_pos += bytes_in;
+			zip->pack_stream_bytes_unconsumed = 0;
+		} else {
+			zip->pack_stream_inbytes_remaining -= bytes_in;
+			zip->pack_stream_bytes_unconsumed = bytes_in;
+		}
 		if (bytes_out > (uint64_t)zip->folder_outbytes_remaining)
 			bytes_out = (size_t)zip->folder_outbytes_remaining;
 		zip->folder_outbytes_remaining -= bytes_out;
 		zip->uncompressed_buffer_bytes_remaining += bytes_out;
-		zip->pack_stream_bytes_unconsumed = bytes_in;
 
 		/*
 		 * Continue decompression until uncompressed_buffer is full.
@@ -3665,14 +3797,16 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 		    zip->uncompressed_buffer_size)
 			break;
 		if (zip->pack_stream_inbytes_remaining == 0 &&
-		    zip->folder_outbytes_remaining == 0)
+		    zip->folder_outbytes_remaining == 0 &&
+		    (!zip->is_encrypted || zip->decrypted_bytes_pos >= zip->decrypted_bytes_avail))
 			break;
 		if (end_of_data || (bytes_in == 0 && bytes_out == 0)) {
 			archive_set_error(&(a->archive),
 			    ARCHIVE_ERRNO_MISC, "Damaged 7-Zip archive");
 			return (ARCHIVE_FATAL);
 		}
-		read_consume(a);
+		if (zip->pack_stream_bytes_unconsumed)
+			read_consume(a);
 	}
 	if (zip->uncompressed_buffer_bytes_remaining < minimum) {
 		archive_set_error(&(a->archive),
@@ -3833,13 +3967,122 @@ read_stream(struct archive_read *a, const void **buff, size_t size,
 }
 
 static int
+parse_7z_crypto_properties(struct _7z_crypto_properties *props,
+    const unsigned char *p, size_t size)
+{
+	uint8_t b0, b1;
+	int salt_flag, iv_flag;
+	size_t offset = 1;
+
+	if (props == NULL || p == NULL || size < 1)
+		return (-1);
+	memset(props, 0, sizeof(*props));
+
+	b0 = p[0];
+	props->num_cycles_power = b0 & 0x3F;
+	if (props->num_cycles_power > 24)
+		return (-1);
+
+	salt_flag = (b0 >> 7) & 1;
+	iv_flag = (b0 >> 6) & 1;
+
+	if (salt_flag || iv_flag) {
+		if (size < 2)
+			return (-1);
+		b1 = p[1];
+		offset = 2;
+		props->salt_size = salt_flag ? (uint8_t)(((b1 >> 4) & 0x0F) + 1) : 0;
+		props->iv_size = iv_flag ? (uint8_t)((b1 & 0x0F) + 1) : 0;
+	}
+
+	if (offset + props->salt_size + props->iv_size > size)
+		return (-1);
+
+	if (props->salt_size > 0) {
+		memcpy(props->salt, p + offset, props->salt_size);
+		offset += props->salt_size;
+	}
+
+	if (props->iv_size > 0) {
+		memcpy(props->iv, p + offset, props->iv_size);
+		offset += props->iv_size;
+	}
+	return (0);
+}
+
+static int
+setup_7z_encryption(struct archive_read *a, struct _7zip *zip,
+    const struct _7z_coder *crypto_coder)
+{
+	struct _7z_crypto_properties props;
+	const char *passphrase;
+
+	if (parse_7z_crypto_properties(&props, crypto_coder->properties,
+	    crypto_coder->propertiesSize) != 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Malformed 7-Zip encryption properties");
+		return (ARCHIVE_FAILED);
+	}
+
+	__archive_read_reset_passphrase(a);
+	passphrase = __archive_read_next_passphrase(a);
+	if (passphrase == NULL) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Passphrase required for this 7-Zip encrypted archive");
+		return (ARCHIVE_FAILED);
+	}
+
+	if (zip->cached_key_valid &&
+	    props.salt_size == zip->cached_salt_size &&
+	    props.num_cycles_power == zip->cached_num_cycles_power &&
+	    (props.salt_size == 0 ||
+	     memcmp(props.salt, zip->cached_salt, props.salt_size) == 0)) {
+		memcpy(zip->aes_key, zip->cached_aes_key, sizeof(zip->aes_key));
+	} else {
+		if (archive_7z_kdf_sha256(passphrase, props.salt, props.salt_size,
+		    props.num_cycles_power, zip->aes_key, sizeof(zip->aes_key)) != 0) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "Failed to derive 7-Zip AES key");
+			return (ARCHIVE_FAILED);
+		}
+		memcpy(zip->cached_aes_key, zip->aes_key, sizeof(zip->aes_key));
+		memcpy(zip->cached_salt, props.salt, sizeof(zip->cached_salt));
+		zip->cached_salt_size = props.salt_size;
+		zip->cached_num_cycles_power = props.num_cycles_power;
+		zip->cached_key_valid = 1;
+	}
+
+	memcpy(zip->aes_iv, props.iv, 16);
+
+	if (zip->crypto_ctx_valid) {
+		archive_decrypto_aes_cbc_release(&zip->crypto_ctx);
+		zip->crypto_ctx_valid = 0;
+	}
+
+	if (archive_decrypto_aes_cbc_init(&zip->crypto_ctx, zip->aes_key,
+	    sizeof(zip->aes_key), zip->aes_iv, sizeof(zip->aes_iv)) != 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Failed to initialize AES-CBC decryptor");
+		return (ARCHIVE_FAILED);
+	}
+	zip->crypto_ctx_valid = 1;
+	zip->is_encrypted = 1;
+	zip->decrypted_bytes_pos = 0;
+	zip->decrypted_bytes_avail = 0;
+	return (ARCHIVE_OK);
+}
+
+static int
 setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
     int header)
 {
 	struct _7zip *zip = a->format->data;
 	const struct _7z_coder *coder1, *coder2;
+	const struct _7z_coder *crypto_coder = NULL;
+	const struct _7z_coder *non_crypto_coders[3];
+	static const struct _7z_coder coder_copy = {0, 1, 1, 0, NULL};
 	const char *cname = (header)?"archive header":"file content";
-	size_t i;
+	size_t i, num_non_crypto = 0;
 	int r, found_bcj2 = 0;
 
 	/*
@@ -3858,8 +4101,7 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 	for (i = 0; i < folder->numCoders; i++) {
 		switch(folder->coders[i].codec) {
 			case _7Z_CRYPTO_MAIN_ZIP:
-			case _7Z_CRYPTO_RAR_29:
-			case _7Z_CRYPTO_AES_256_SHA_256: {
+			case _7Z_CRYPTO_RAR_29: {
 				/* For entry that is associated with this folder, mark
 				   it as encrypted (data+metadata). */
 				zip->has_encrypted_entries = 1;
@@ -3873,10 +4115,25 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 					"but currently not supported", cname);
 				return (header ? ARCHIVE_FATAL : ARCHIVE_FAILED);
 			}
-			case _7Z_X86_BCJ2: {
-				found_bcj2++;
+			case _7Z_CRYPTO_AES_256_SHA_256: {
+				zip->has_encrypted_entries = 1;
+				if (a->entry) {
+					archive_entry_set_is_data_encrypted(a->entry, 1);
+					archive_entry_set_is_metadata_encrypted(a->entry, 1);
+				}
+				crypto_coder = &(folder->coders[i]);
 				break;
 			}
+			case _7Z_X86_BCJ2: {
+				found_bcj2++;
+				if (num_non_crypto < 3)
+					non_crypto_coders[num_non_crypto++] = &(folder->coders[i]);
+				break;
+			}
+			default:
+				if (num_non_crypto < 3)
+					non_crypto_coders[num_non_crypto++] = &(folder->coders[i]);
+				break;
 		}
 	}
 	/* Now that we've checked for encryption, if there were still no
@@ -3886,12 +4143,37 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 		zip->has_encrypted_entries = 0;
 	}
 
-	if ((folder->numCoders > 2 && !found_bcj2) || found_bcj2 > 1) {
+	if ((num_non_crypto > 2 && !found_bcj2) || found_bcj2 > 1) {
 		archive_set_error(&(a->archive),
 		    ARCHIVE_ERRNO_MISC,
 		    "The %s is encoded with many filters, "
 		    "but currently not supported", cname);
 		return (header ? ARCHIVE_FATAL : ARCHIVE_FAILED);
+	}
+
+	if (crypto_coder != NULL) {
+		if (header)
+			zip->header_is_encrypted = 1;
+		r = setup_7z_encryption(a, zip, crypto_coder);
+		if (r != ARCHIVE_OK)
+			return (header ? ARCHIVE_FATAL : ARCHIVE_FAILED);
+		if (num_non_crypto == 0) {
+			coder1 = &coder_copy;
+			coder2 = NULL;
+		} else if (num_non_crypto == 1) {
+			coder1 = non_crypto_coders[0];
+			coder2 = NULL;
+		} else {
+			coder1 = non_crypto_coders[0];
+			coder2 = non_crypto_coders[1];
+		}
+	} else {
+		zip->is_encrypted = 0;
+		coder1 = &(folder->coders[0]);
+		if (folder->numCoders == 2)
+			coder2 = &(folder->coders[1]);
+		else
+			coder2 = NULL;
 	}
 
 	/*
@@ -3901,11 +4183,6 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 	zip->pack_stream_index = folder->packIndex;
 	zip->folder_outbytes_remaining = folder_uncompressed_size(folder);
 	zip->uncompressed_buffer_bytes_remaining = 0;
-	coder1 = &(folder->coders[0]);
-	if (folder->numCoders == 2)
-		coder2 = &(folder->coders[1]);
-	else
-		coder2 = NULL;
 
 	if (found_bcj2) {
 		/*
@@ -3914,7 +4191,6 @@ setup_decode_folder(struct archive_read *a, struct _7z_folder *folder,
 		 * as far as I know, two types of the storage form.
 		 */
 		const struct _7z_coder *fc = folder->coders;
-		static const struct _7z_coder coder_copy = {0, 1, 1, 0, NULL};
 		const struct _7z_coder *scoder[3] =
 			{&coder_copy, &coder_copy, &coder_copy};
 		const void *buff;

--- a/libarchive/test/test_read_format_7zip_encryption_data.c
+++ b/libarchive/test/test_read_format_7zip_encryption_data.c
@@ -65,5 +65,50 @@ DEFINE_TEST(test_read_format_7zip_encryption_data)
 	/* Close the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Test again with passphrase. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, "12345678"));
+	assertEqualIntA(a, ARCHIVE_OK,
+		archive_read_open_filename(a, refname, 10240));
+
+	assertEqualIntA(a, ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW, archive_read_has_encrypted_entries(a));
+
+	/* Verify encrypted file "bar.txt" can be read with correct password. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualInt((AE_IFREG | 0664), archive_entry_mode(ae));
+	assertEqualString("bar.txt", archive_entry_pathname(ae));
+	assertEqualInt(1379073980, archive_entry_mtime(ae));
+	assertEqualInt(4, archive_entry_size(ae));
+	assertEqualInt(1, archive_entry_is_data_encrypted(ae));
+	assertEqualInt(0, archive_entry_is_metadata_encrypted(ae));
+	assertEqualIntA(a, 1, archive_read_has_encrypted_entries(a));
+	assertEqualInt(4, archive_read_data(a, buff, sizeof(buff)));
+	assertEqualMem(buff, "foo\n", 4);
+
+	/* End of archive. */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+
+	/* Close the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Test with incorrect passphrase: reading data should fail. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, "wrongpassword"));
+	assertEqualIntA(a, ARCHIVE_OK,
+		archive_read_open_filename(a, refname, 10240));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("bar.txt", archive_entry_pathname(ae));
+	/* Decrypting with wrong key produces corrupted stream that fails decompression. */
+	assert(archive_read_data(a, buff, sizeof(buff)) < 0);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_header.c
+++ b/libarchive/test/test_read_format_7zip_encryption_header.c
@@ -67,5 +67,45 @@ DEFINE_TEST(test_read_format_7zip_encryption_header)
 	/* Close the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Test again with passphrase. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, "12345678"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+
+	/* Header is decrypted successfully. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("bar.txt", archive_entry_pathname(ae));
+	assertEqualInt(4, archive_entry_size(ae));
+	assertEqualInt(1, archive_entry_is_data_encrypted(ae));
+	assertEqualInt(1, archive_entry_is_metadata_encrypted(ae));
+	assertEqualIntA(a, 1, archive_read_has_encrypted_entries(a));
+	assertEqualInt(4, archive_read_data(a, buff, sizeof(buff)));
+	assertEqualMem(buff, "foo\n", 4);
+
+	assertEqualInt(1, archive_file_count(a));
+
+	/* End of archive. */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+
+	/* Close the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Test with incorrect passphrase: reading encrypted header must fail with ARCHIVE_FATAL. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, "wrongpassword"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+
+	/* Close the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 

--- a/libarchive/test/test_read_format_7zip_encryption_partially.c
+++ b/libarchive/test/test_read_format_7zip_encryption_partially.c
@@ -78,4 +78,47 @@ DEFINE_TEST(test_read_format_7zip_encryption_partially)
 	/* Close the archive. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Test again with passphrase. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_add_passphrase(a, "12345678"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+
+	assertEqualIntA(a, ARCHIVE_READ_FORMAT_ENCRYPTION_DONT_KNOW, archive_read_has_encrypted_entries(a));
+
+	/* Verify unencrypted file1. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualInt((AE_IFREG | 0664), archive_entry_mode(ae));
+	assertEqualString("bar_unencrypted.txt", archive_entry_pathname(ae));
+	assertEqualInt(1379079541, archive_entry_mtime(ae));
+	assertEqualInt(4, archive_entry_size(ae));
+	assertEqualInt(0, archive_entry_is_data_encrypted(ae));
+	assertEqualInt(0, archive_entry_is_metadata_encrypted(ae));
+	assertEqualIntA(a, 0, archive_read_has_encrypted_entries(a));
+	assertEqualInt(4, archive_read_data(a, buff, sizeof(buff)));
+	assertEqualMem(buff, "foo\n", 4);
+
+	/* Verify encrypted file2 decrypted. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualInt((AE_IFREG | 0664), archive_entry_mode(ae));
+	assertEqualString("bar_encrypted.txt", archive_entry_pathname(ae));
+	assertEqualInt(1379079565, archive_entry_mtime(ae));
+	assertEqualInt(4, archive_entry_size(ae));
+	assertEqualInt(1, archive_entry_is_data_encrypted(ae));
+	assertEqualInt(0, archive_entry_is_metadata_encrypted(ae));
+	assertEqualIntA(a, 1, archive_read_has_encrypted_entries(a));
+	assertEqualInt(4, archive_read_data(a, buff, sizeof(buff)));
+	assertEqualMem(buff, "foo\n", 4);
+
+	assertEqualInt(2, archive_file_count(a));
+
+	/* End of archive. */
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+
+	/* Close the archive. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }


### PR DESCRIPTION
## Summary

This PR implements read-side decryption for 7-Zip archives encrypted with AES-256 + SHA-256 key derivation (codec `0x06F10701`), addressing the long-standing feature request #878.

**Scope**: Read-side decryption only (consistent with how libarchive handles RAR encryption). Write-side encryption is intentionally deferred to a follow-up.

**Changed files**: 6 files, +818/−34 lines, single squashed commit.

---

## Technical Challenges

Three compounding barriers made this feature difficult within libarchive's architecture:

### 1. Multi-Backend Cryptographic Abstraction

libarchive supports 4+ native crypto backends (CommonCrypto, Bcrypt/CNG, OpenSSL/LibreSSL, mbedTLS) without heavy external dependencies. The existing `archive_cryptor` only provided AES-CTR mode (used by ZIP WinZip AES). 7z requires **AES-256-CBC** (no padding), demanding a complete parallel set of `init`/`update`/`release` drivers across all backends — each with subtly different APIs.

### 2. Heavy Key Derivation — 2¹⁹ SHA-256 Iterations

7z's KDF executes `2^numCyclesPower` SHA-256 hash iterations (default `numCyclesPower = 19`, i.e., **524,288 rounds**). Each round hashes `[Salt (0–16B) | UTF-16LE Password | 8-byte Little-Endian Round Counter]`. A naive implementation calling `SHA256_Update()` three times per round generates **1,572,864 function calls** — creating measurable latency in a streaming C library.

### 3. Header Encryption Breaks the Linear State Machine

7z supports encrypting the archive's central directory (file listing metadata) itself via `kEncodedHeader`. This creates a recursive dependency: to read the file list, you must first decrypt and decompress the header — but the header contains the folder/coder metadata needed to set up decryption. This breaks libarchive's traditional single-pass "read header → stream data" state machine.

---

## Algorithm & Approach

### KDF: Single-Buffer Assembly with In-Place Counter Update

Instead of the naive 3-call-per-round approach, we pre-assemble the entire hash input block once on the stack:

```
kdf_buf[536] = [ Salt (0–16 bytes) | UTF-16LE Password (0–512 bytes) | Counter (8 bytes) ]
                ├── fixed prefix ──────────────────────────────────┤  ├── variable ──┤
```

Per round, only the 8-byte counter at offset `salt_len + pw_len` is updated in-place via `archive_le64enc()`. This reduces SHA-256 `update()` calls from 3 × 2¹⁹ = 1,572,864 to **1 × 2¹⁹ = 524,288** — a 66.7% reduction in function call overhead.

Measured result: KDF derivation improved from 7.87 ms → **6.05 ms** (23.1% wall-clock improvement on Apple Silicon).

The stack buffer size of 536 bytes (512 + 16 + 8) supports passwords up to 256 UTF-16 code units. Overflow is protected by a strict `o + 2 <= max_utf16_bytes` bounds check in `utf8_to_utf16le()`.

### Streaming CBC Decryption Pipeline

The decryption layer is injected between the raw I/O read and the existing decompression pipeline in `extract_pack_stream()`:

```
Raw I/O → [AES-CBC Decrypt] → Decompression (LZMA/LZMA2/Deflate/PPMd/BZip2/Copy) → Output
```

Encrypted data is read in AES-block-aligned chunks (multiples of 16 bytes), decrypted into a reusable `decrypted_buffer`, then fed to the existing `decompress()` function via a `pos`/`avail` cursor — avoiding double-buffering.

For the last chunk of a pack stream, where the remaining bytes may be less than 16, the alignment guard permits passing the final partial block directly (7z streams are length-tracked explicitly, so no PKCS#7 padding is used).

### Header Encryption (kEncodedHeader)

When the archive uses `kEncodedHeader`, the central directory is itself stored as an encrypted + compressed stream. The implementation:

1. Detects `kEncodedHeader` marker in the start header
2. Calls `setup_decode_folder()` with `header=1`, which triggers `setup_7z_encryption()`
3. Decrypts and decompresses the header bytes
4. Re-parses the decrypted result as the archive's central directory

A fix in `slurp_central_directory()` preserves the specific encryption error message (e.g., "Passphrase required") instead of overwriting it with a generic "Damaged 7-Zip archive".

### Crypto Coder Separation

In `setup_decode_folder()`, the crypto coder (`_7Z_CRYPTO_AES_256_SHA_256`) is separated from compression coders into a dedicated `crypto_coder` pointer. Non-crypto coders are collected into `non_crypto_coders[]` for the existing `coder1`/`coder2` dispatch. This preserves the decompression pipeline untouched and correctly handles the coder count validation (`numCoders > 2` check now counts only non-crypto coders).

### KDF Key Caching

For multi-folder archives where each folder shares the same salt and cycle power (common in non-solid 7z archives), the 524k-round KDF is executed once and cached:

```c
if (cached_key_valid &&
    props.salt_size == cached_salt_size &&
    props.num_cycles_power == cached_num_cycles_power &&
    memcmp(props.salt, cached_salt, props.salt_size) == 0) {
    /* Cache hit: skip KDF entirely */
    memcpy(aes_key, cached_aes_key, 32);
}
```

Cache invalidation occurs automatically when salt or cycles differ.

### Memory Safety

All intermediate KDF buffers (`kdf_buf`) and cached AES keys are explicitly scrubbed (`memset` to zero) upon context deallocation or cache invalidation to prevent key material leakage from the stack or heap.

---

## Crypto Backend Coverage

| Backend | Platform | Status |
|:---|:---|:---|
| CommonCrypto | macOS / iOS | Full |
| Bcrypt / CNG | Windows | Full |
| OpenSSL (EVP API) | Linux / BSD | Full |
| mbedTLS | Embedded | Full |
| Nettle | — | Stub (returns `CRYPTOR_STUB_FUNCTION`) |

Nettle is left as a stub to avoid CMake/Autotools build system changes in this initial PR. The extension point is prepared for a follow-up.

---

## Supported Scenarios

- Data-only encrypted archives (stream encryption)
- Header + data encrypted archives (`kEncodedHeader`)
- Partially encrypted archives (mixed encrypted/unencrypted entries)
- Multi-folder archives with per-folder codec chains
- All compression codecs: LZMA, LZMA2, Deflate, PPMd, BZip2, Copy

---

## Test Coverage

Three existing test files are extended with decryption verification:

| Test | Scenarios | Assertions |
|:---|:---|:---|
| `test_read_format_7zip_encryption_data` | Correct password, no password → `ARCHIVE_FAILED`, wrong password → corrupted stream | 252 |
| `test_read_format_7zip_encryption_header` | Header decryption, content verify, wrong password → `ARCHIVE_FATAL` | 318 |
| `test_read_format_7zip_encryption_partially` | Unencrypted entry readable, encrypted entry decrypted with passphrase | 363 |
| **Total (combined run)** | | **929** |

Regression: all 40 existing 7z read tests and 18 write tests pass with zero failures (216,358 + 1,484 = 217,842 assertions).

---

## Known Limitations

| Limitation | Rationale |
|:---|:---|
| Read-only (no write encryption) | Scope limited to the most-requested feature; consistent with RAR in libarchive |
| Single passphrase per open | 7z lacks an early password verification header (unlike ZIP's 2-byte PV), so multi-candidate iteration requires full decompression attempts |
| Password ≤ 256 UTF-16 code units (512 bytes UTF-16LE payload) | Stack buffer safety; protected by bounds check, not a crash risk |
| Nettle backend stub | Avoids build system changes; extension point ready |

---

## How to Verify

```bash
# Build with CMake (default)
mkdir build && cd build && cmake .. && make

# Run encryption tests
./bin/libarchive_test -r ../libarchive/test \
  test_read_format_7zip_encryption_data \
  test_read_format_7zip_encryption_header \
  test_read_format_7zip_encryption_partially

# Verify zero regression on all 7z read/write tests (by name)
./bin/libarchive_test -r ../libarchive/test test_read_format_7zip_*
./bin/libarchive_test -r ../libarchive/test test_write_format_7zip_*
```

Refs #878.