### PR TITLE
read: Simplify `__archive_read_filter_ahead`

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1521,7 +1521,7 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 				}
 				/* Move data into newly-enlarged buffer. */
 				if (f->avail > 0)
-					memmove(p, f->next, f->avail);
+					memcpy(p, f->next, f->avail);
 				free(f->buffer);
 				f->next = f->buffer = p;
 				f->buffer_size = s;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1528,12 +1528,8 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 			}
 
 			/* We can add client data to copy buffer. */
-			/* First estimate: copy to fill rest of buffer. */
-			tocopy = (f->buffer + f->buffer_size)
-			    - (f->next + f->avail);
 			/* Don't waste time buffering more than we need to. */
-			if (tocopy + f->avail > min)
-				tocopy = min - f->avail;
+			tocopy = min - f->avail;
 			/* Don't copy more than is available. */
 			if (tocopy > f->client_avail)
 				tocopy = f->client_avail;

--- a/libarchive/archive_read_support_filter_uu.c
+++ b/libarchive/archive_read_support_filter_uu.c
@@ -428,7 +428,7 @@ ensure_in_buff_size(struct archive_read_filter *f,
 		}
 		/* Move the remaining data in in_buff into the new buffer. */
 		if (uu->in_cnt)
-			memmove(ptr, uu->in_buff, uu->in_cnt);
+			memcpy(ptr, uu->in_buff, uu->in_cnt);
 		/* Replace in_buff with the new buffer. */
 		free(uu->in_buff);
 		uu->in_buff = ptr;


### PR DESCRIPTION
There is no need to calculate a maximum of available free space if we will enforce a limit of only required bytes,
i.e. `min - f->avail`.

The latter will never be larger than the initial upper estimation:
- At line 1431 `f->next` will be set to `f->buffer` if not enough bytes are available to hold the requested min bytes. Thus, the code in question can already be simplified:
  1. Original Code
  `tocopy = (f->buffer + f->buffer_size) - (f->next + f->avail)`
  2. Substitute `f->next` with `f->buffer`
  `tocopy = (f->buffer + f->buffer_size) - (f->buffer + f->avail)`
  3. Simplify
  `tocopy = f->buffer_size - f->avail`

- If `f->buffer_size` itself is not large enough, the buffer will be increased in line 1488. At this point, `min` cannot be larger than `f->buffer_size` anymore:
  `f->buffer_size - f->avail` >= `min - f->avail`

Thus, the initial upper estimation is not needed. Note that `min` is always larger than `f->avail` because otherwise line 1406 would have led to an early return.

While at it, replace `memmove` with `memcpy` if the target is newly allocated.