### PR TITLE
read: Fix possible use after free when seek fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -409,6 +409,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_archive_read_multiple_data_objects.c \
 	libarchive/test/test_archive_read_next_header_empty.c \
 	libarchive/test/test_archive_read_next_header_raw.c \
+	libarchive/test/test_archive_read_open_filenames.c \
 	libarchive/test/test_archive_read_open2.c \
 	libarchive/test/test_archive_read_set_options.c \
 	libarchive/test/test_archive_read_support.c \

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -187,45 +187,8 @@ client_read_proxy(struct archive_read_filter *f, const void **buff)
 static int64_t
 client_skip_proxy(struct archive_read_filter *f, int64_t request)
 {
-	if (request < 0)
-		__archive_errx(1, "Negative skip requested");
-	if (request == 0)
-		return 0;
-
-	if (f->archive->client.skipper != NULL) {
-		int64_t total = 0;
-		for (;;) {
-			int64_t get;
-			get = (f->archive->client.skipper)
-			    (&f->archive->archive, f->data, request);
-			if (get < 0 || get > request)
-				return (ARCHIVE_FATAL);
-			total += get;
-			if (get == 0 || get == request)
-				return (total);
-			request -= get;
-		}
-	} else if (f->archive->client.seeker != NULL
-		&& request > 64 * 1024) {
-		/* If the client provided a seeker but not a skipper,
-		 * we can use the seeker to skip forward.
-		 *
-		 * Note: This isn't always a good idea.  The client
-		 * skipper is allowed to skip by less than requested
-		 * if it needs to maintain block alignment.  The
-		 * seeker is not allowed to play such games, so using
-		 * the seeker here may be a performance loss compared
-		 * to just reading and discarding.  That's why we
-		 * only do this for skips of over 64k.
-		 */
-		int64_t before = f->position;
-		int64_t after = (f->archive->client.seeker)
-		    (&f->archive->archive, f->data, request, SEEK_CUR);
-		if (after != before + request)
-			return ARCHIVE_FATAL;
-		return after - before;
-	}
-	return 0;
+	return (f->archive->client.skipper)(&f->archive->archive,
+	    f->data, request);
 }
 
 static int64_t
@@ -236,11 +199,6 @@ client_seek_proxy(struct archive_read_filter *f, int64_t offset, int whence)
 	 * other libarchive code that assumes a successful forward
 	 * seek means it can also seek backwards.
 	 */
-	if (f->archive->client.seeker == NULL) {
-		archive_set_error(&f->archive->archive, ARCHIVE_ERRNO_MISC,
-		    "Current client reader does not support seeking a device");
-		return (ARCHIVE_FAILED);
-	}
 	return (f->archive->client.seeker)(&f->archive->archive,
 	    f->data, offset, whence);
 }
@@ -521,8 +479,8 @@ archive_read_open1(struct archive *_a)
 	f->vtable = &none_reader_vtable;
 	f->name = "none";
 	f->code = ARCHIVE_FILTER_NONE;
-	f->can_skip = 1;
-	f->can_seek = 1;
+	f->can_skip = a->client.skipper != NULL;
+	f->can_seek = a->client.seeker != NULL;
 
 	a->client.dataset[0].begin_position = 0;
 	if (!a->filter || !a->bypass_filter_bidding)
@@ -1596,16 +1554,14 @@ __archive_read_filter_consume(struct archive_read_filter *f,
 static int64_t
 advance_file_pointer(struct archive_read_filter *f, int64_t request)
 {
-	int64_t bytes_skipped, total_bytes_skipped = 0;
-	ssize_t bytes_read;
-	size_t min;
+	int64_t total_bytes_skipped = 0;
 
 	if (f->fatal)
 		return (-1);
 
 	/* Use up the copy buffer first. */
 	if (f->avail > 0) {
-		min = (size_t)minimum(request, (int64_t)f->avail);
+		size_t min = (size_t)minimum(request, (int64_t)f->avail);
 		f->next += min;
 		f->avail -= min;
 		request -= min;
@@ -1615,7 +1571,7 @@ advance_file_pointer(struct archive_read_filter *f, int64_t request)
 
 	/* Then use up the client buffer. */
 	if (f->client_avail > 0) {
-		min = (size_t)minimum(request, (int64_t)f->client_avail);
+		size_t min = (size_t)minimum(request, (int64_t)f->client_avail);
 		f->client_next += min;
 		f->client_avail -= min;
 		request -= min;
@@ -1627,11 +1583,40 @@ advance_file_pointer(struct archive_read_filter *f, int64_t request)
 
 	/* If there's an optimized skip function, use it. */
 	if (f->can_skip != 0) {
-		bytes_skipped = client_skip_proxy(f, request);
-		if (bytes_skipped < 0) {	/* error */
-			f->fatal = 1;
-			return (bytes_skipped);
+		while (request > 0) {
+			int64_t get = client_skip_proxy(f, request);
+			if (get < 0 || get > request) {
+				f->fatal = 1;
+				return (ARCHIVE_FATAL);
+			}
+			if (get == 0)
+				break;
+			f->position += get;
+			total_bytes_skipped += get;
+			request -= get;
 		}
+		if (request == 0)
+			return (total_bytes_skipped);
+	} else if (f->can_seek != 0 && request > 64 * 1024) {
+		/* If the client provided a seeker but not a skipper,
+		 * we can use the seeker to skip forward.
+		 *
+		 * Note: This isn't always a good idea.  The client
+		 * skipper is allowed to skip by less than requested
+		 * if it needs to maintain block alignment.  The
+		 * seeker is not allowed to play such games, so using
+		 * the seeker here may be a performance loss compared
+		 * to just reading and discarding.  That's why we
+		 * only do this for skips of over 64k.
+		 */
+		int64_t bytes_skipped;
+		int64_t before = f->position;
+		int64_t after = client_seek_proxy(f, request, SEEK_CUR);
+		if (after != before + request) {
+			f->fatal = 1;
+			return (ARCHIVE_FATAL);
+		}
+		bytes_skipped = after - before;
 		f->position += bytes_skipped;
 		total_bytes_skipped += bytes_skipped;
 		request -= bytes_skipped;
@@ -1641,7 +1626,7 @@ advance_file_pointer(struct archive_read_filter *f, int64_t request)
 
 	/* Use ordinary reads as necessary to complete the request. */
 	for (;;) {
-		bytes_read = (f->vtable->read)(f, &f->client_buff);
+		ssize_t bytes_read = (f->vtable->read)(f, &f->client_buff);
 		if (bytes_read < 0) {
 			f->client_buff = NULL;
 			f->fatal = 1;

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1707,9 +1707,9 @@ __archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
 		while (1) {
 			r = client_switch_proxy(f, cursor);
 			if (r != ARCHIVE_OK)
-				return r;
+				goto clear_buffer;
 			if ((r = client_seek_proxy(f, 0, SEEK_END)) < 0)
-				return r;
+				goto clear_buffer;
 			client->dataset[cursor].total_size = r;
 			if (client->dataset[cursor].begin_position +
 			    client->dataset[cursor].total_size - 1 > offset ||
@@ -1721,10 +1721,12 @@ __archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
 		}
 		offset -= client->dataset[cursor].begin_position;
 		if (offset < 0
-		    || offset > client->dataset[cursor].total_size)
-			return ARCHIVE_FATAL;
+		    || offset > client->dataset[cursor].total_size) {
+			r = ARCHIVE_FATAL;
+			goto clear_buffer;
+		}
 		if ((r = client_seek_proxy(f, offset, SEEK_SET)) < 0)
-			return r;
+			goto clear_buffer;
 		break;
 
 	case SEEK_END:
@@ -1741,9 +1743,9 @@ __archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
 		while (1) {
 			r = client_switch_proxy(f, cursor);
 			if (r != ARCHIVE_OK)
-				return r;
+				goto clear_buffer;
 			if ((r = client_seek_proxy(f, 0, SEEK_END)) < 0)
-				return r;
+				goto clear_buffer;
 			client->dataset[cursor].total_size = r;
 			r = client->dataset[cursor].begin_position +
 				client->dataset[cursor].total_size;
@@ -1764,10 +1766,10 @@ __archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
 		}
 		offset = (r + offset) - client->dataset[cursor].begin_position;
 		if ((r = client_switch_proxy(f, cursor)) != ARCHIVE_OK)
-			return r;
+			goto clear_buffer;
 		r = client_seek_proxy(f, offset, SEEK_SET);
 		if (r < ARCHIVE_OK)
-			return r;
+			goto clear_buffer;
 		break;
 
 	default:
@@ -1775,28 +1777,31 @@ __archive_read_filter_seek(struct archive_read_filter *f, int64_t offset,
 	}
 	r += client->dataset[cursor].begin_position;
 
+clear_buffer:
+	/*
+	 * Ouch.  Clearing the buffer like this hurts, especially
+	 * at bid time.  A lot of our efficiency at bid time comes
+	 * from having bidders reuse the data we've already read.
+	 *
+	 * TODO: If the seek request is in data we already
+	 * have, then don't call the seek callback.
+	 *
+	 * TODO: Zip seeks to end-of-file at bid time.  If
+	 * other formats also start doing this, we may need to
+	 * find a way for clients to fudge the seek offset to
+	 * a block boundary.
+	 *
+	 * Hmmm... If whence was SEEK_END, we know the file
+	 * size is (r - offset).  Can we use that to simplify
+	 * the TODO items above?
+	*/
+	f->avail = f->client_avail = 0;
+	f->next = f->buffer;
 	if (r >= 0) {
-		/*
-		 * Ouch.  Clearing the buffer like this hurts, especially
-		 * at bid time.  A lot of our efficiency at bid time comes
-		 * from having bidders reuse the data we've already read.
-		 *
-		 * TODO: If the seek request is in data we already
-		 * have, then don't call the seek callback.
-		 *
-		 * TODO: Zip seeks to end-of-file at bid time.  If
-		 * other formats also start doing this, we may need to
-		 * find a way for clients to fudge the seek offset to
-		 * a block boundary.
-		 *
-		 * Hmmm... If whence was SEEK_END, we know the file
-		 * size is (r - offset).  Can we use that to simplify
-		 * the TODO items above?
-		 */
-		f->avail = f->client_avail = 0;
-		f->next = f->buffer;
 		f->position = r;
 		f->end_of_file = 0;
-	}
+	} else
+		f->fatal = 1;
+
 	return r;
 }

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -38,6 +38,7 @@ IF(ENABLE_TEST)
     test_archive_read_multiple_data_objects.c
     test_archive_read_next_header_empty.c
     test_archive_read_next_header_raw.c
+    test_archive_read_open_filenames.c
     test_archive_read_open2.c
     test_archive_read_set_options.c
     test_archive_read_support.c

--- a/libarchive/test/test_archive_read_open_filenames.c
+++ b/libarchive/test/test_archive_read_open_filenames.c
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+DEFINE_TEST(test_archive_read_open_filenames)
+{
+	const char *filenames[] = {
+		"zero",
+		"nonexisting",
+		NULL
+	};
+	char *buf;
+	struct archive *a;
+	struct archive_entry *ae;
+
+	/* Create a file sufficiently large for bidders to not reach EOF. */
+	buf = calloc(512, 1024);
+	assert(buf != NULL);
+	dumpfile("zero", buf, 512 * 1024);
+	free(buf);
+
+	/* Open file and a non-existing one as well. */
+	a = archive_read_new();
+	assert(a != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+
+	/* Verify that archive can be opened. */
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filenames(a, filenames, 4096));
+
+	/* Verify that no entry is found. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
It's possible to trigger a use after free bug if `__archive_read_filter_seek` fails while switching a client proxy, which implies that it requires the use of `archive_read_open_filenames` with multiple files or any setup like that. See added test.

If the client proxies are switched, the client buffer will be released. The logic in `__archive_read_filter_seek` only resets buffer information if seek was successful. The fix is to reset buffer information in case of errors as well.

But it's not as simple as that. Right now, `__archive_read_filter_seek` performs various actions even if seeking is not supported. This happens because `can_seek` is unconditionally set to `1` for the client filter, i.e. the one which performs actual I/O. Only if the seeker is actually called, `ARCHIVE_FAILED` is returned. In such a situation, the buffer must stay in tact, because it wasn't modified and is still valid. Tests and actual operations depend on this.

So, in order to fix this use after free bug, I had to modify the `ARCHIVE_FAILED` handling here: Set `can_seek` only if seeker actually exists. While this sounds trivial and obvious, doing the same for `can_skip` is not as straight-forward, because the proxy function internally falls back to seeker if skipper does not exist.

This in turn required a bit of refactoring of `advance_file_pointer` function to independently handle `can_seek` and `can_skip`. This in turn made the proxy functions more straightforward, leading to 200 less bytes in resulting library.