### PR TITLE
disable account/id lookups on WASI

### DIFF
--- a/libarchive/archive_read_disk_set_standard_lookup.c
+++ b/libarchive/archive_read_disk_set_standard_lookup.c
@@ -47,11 +47,11 @@
 #include "archive.h"
 #include "archive_integer.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__) || defined(__wasi__)
 int
 archive_read_disk_set_standard_lookup(struct archive *a)
 {
-	archive_set_error(a, -1, "Standard lookups not available on Windows");
+	archive_set_error(a, -1, "Standard lookups not available on this platform");
 	return (ARCHIVE_FATAL);
 }
 #else /* ! (_WIN32 && !__CYGWIN__) */
@@ -312,4 +312,4 @@ lookup_gname_helper(struct name_cache *cache, id_t id)
 }
 #endif
 
-#endif /* ! (_WIN32 && !__CYGWIN__) */
+#endif /* ! (_WIN32 && !__CYGWIN__ || __wasi__) */

--- a/libarchive/archive_write_disk_set_standard_lookup.c
+++ b/libarchive/archive_write_disk_set_standard_lookup.c
@@ -158,6 +158,8 @@ lookup_gid(void *private_data, const char *gname, int64_t gid)
 #  endif /* HAVE_GETGRNAM_R */
 #elif defined(_WIN32) && !defined(__CYGWIN__)
 	/* TODO: do a gname->gid lookup for Windows. */
+#elif defined(__wasi__)
+	/* WASI has no way to perform GID lookups, so just pass through */
 #else
 	#error No way to perform gid lookups on this platform
 #endif
@@ -228,6 +230,8 @@ lookup_uid(void *private_data, const char *uname, int64_t uid)
 #endif	/* HAVE_GETPWNAM_R */
 #elif defined(_WIN32) && !defined(__CYGWIN__)
 	/* TODO: do a uname->uid lookup for Windows. */
+#elif defined(__wasi__)
+	/* WASI has no way to perform GID lookups, so just pass through */
 #else
 	#error No way to look up uids on this platform
 #endif

--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -58,7 +58,7 @@
 #include "archive_rb.h"
 #include "archive_write_private.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__) || defined(__wasi__)
 #define getuid()			0
 #define getgid()			0
 #endif


### PR DESCRIPTION
The WebAssembly System Interface (WASI) platform does not support the notion of accounts or identities.  Disable the logic for WASI like it's disabled for Windows.