### PR TITLE
check HAVE_TZSET

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -2525,7 +2525,9 @@ get_tmfromtime(struct tm *tm, time_t *t)
 #if HAVE_LOCALTIME_S
 	localtime_s(tm, t);
 #elif HAVE_LOCALTIME_R
+# ifdef HAVE_TZSET
 	tzset();
+# endif
 	localtime_r(t, tm);
 #else
 	memcpy(tm, localtime(t), sizeof(*tm));


### PR DESCRIPTION
The build system already checks for tzset dynamically, so respect the test in the code that uses the function.