### PR TITLE
read: Distinguish more cases during bidding

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -557,7 +557,7 @@ archive_read_open1(struct archive *_a)
 	}
 	else if (a->format->bid != NULL)
 	{
-		if (bid_format(a, -1) < 0) {
+		if (bid_format(a, 0) < 0) {
 			archive_set_error(&a->archive,
 			    ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Registered format does not match");
@@ -775,7 +775,7 @@ choose_format(struct archive_read *a)
 	int best_bid_slot;
 
 	slots = sizeof(a->formats) / sizeof(a->formats[0]);
-	best_bid = -1;
+	best_bid = 0;
 	best_bid_slot = -1;
 
 	/* Set up a->format for convenience of bidders. */

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -601,7 +601,7 @@ archive_read_format_7zip_bid(struct archive_read *a, int best_bid)
 	/* If someone has already bid more than 48, then avoid
 	   trashing the look-ahead buffers with a seek. */
 	if (best_bid > 48)
-		return (-1);
+		return (0);
 
 	if (get_data_offset(a, &data_offset, 0) < 0)
 		return (0);

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -153,11 +153,11 @@ archive_read_format_ar_bid(struct archive_read *a, int best_bid)
 	 * TODO: Do we need to check more than this?
 	 */
 	if ((h = __archive_read_ahead(a, 8, NULL)) == NULL)
-		return (-1);
+		return (0);
 	if (memcmp(h, "!<arch>\n", 8) == 0) {
 		return (64);
 	}
-	return (-1);
+	return (0);
 }
 
 static int
@@ -406,7 +406,8 @@ archive_read_format_ar_read_header(struct archive_read *a,
 		 * We are at the beginning of the archive now,
 		 * so we have to consume the ar global header first.
 		 */
-		__archive_read_consume(a, 8);
+		if (__archive_read_consume(a, 8) < 0)
+			return (ARCHIVE_FATAL);
 		ar->read_global_header = 1;
 		/* Set a default format code for now. */
 		a->archive.archive_format = ARCHIVE_FORMAT_AR;

--- a/libarchive/archive_read_support_format_cab.c
+++ b/libarchive/archive_read_support_format_cab.c
@@ -524,10 +524,10 @@ archive_read_format_cab_bid(struct archive_read *a, int best_bid)
 	/* If there's already a better bid than we can ever
 	   make, don't bother testing. */
 	if (best_bid > 64)
-		return (-1);
+		return (0);
 
 	if ((h = __archive_read_ahead(a, 8, NULL)) == NULL)
-		return (-1);
+		return (0);
 
 	if (memcmp(h, "MSCF\0\0\0\0", 8) == 0)
 		return (64);

--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -268,7 +268,7 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 	(void)best_bid; /* UNUSED */
 
 	if ((h = __archive_read_ahead(a, 6, NULL)) == NULL)
-		return (-1);
+		return (ARCHIVE_FAILED);
 
 	bid = 0;
 	if (memcmp(h, "070707", 6) == 0) {
@@ -315,7 +315,7 @@ archive_read_format_cpio_bid(struct archive_read *a, int best_bid)
 		bid += 16;
 		/* Is more verification possible here? */
 	} else
-		return (ARCHIVE_WARN);
+		return (ARCHIVE_FAILED);
 
 	return (bid);
 }

--- a/libarchive/archive_read_support_format_empty.c
+++ b/libarchive/archive_read_support_format_empty.c
@@ -66,7 +66,7 @@ archive_read_format_empty_bid(struct archive_read *a, int best_bid)
 {
 	if (best_bid < 1 && __archive_read_ahead(a, 1, NULL) == NULL)
 		return (1);
-	return (-1);
+	return (0);
 }
 
 static int

--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -507,7 +507,7 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	/* If there's already a better bid than we can ever
 	   make, don't bother testing. */
 	if (best_bid > 48)
-		return (-1);
+		return (ARCHIVE_FAILED);
 
 	/*
 	 * Skip the first 32k (reserved area) and get the first
@@ -519,7 +519,7 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	    RESERVED_AREA + 8 * LOGICAL_BLOCK_SIZE,
 	    &bytes_read);
 	if (h == NULL)
-	    return (-1);
+	    return (ARCHIVE_FAILED);
 
 	/* Skip the reserved area. */
 	bytes_read -= RESERVED_AREA;
@@ -531,10 +531,10 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	    bytes_read -= LOGICAL_BLOCK_SIZE, h += LOGICAL_BLOCK_SIZE) {
 		/* Do not handle undefined Volume Descriptor Type. */
 		if (h[0] >= 4 && h[0] <= 254)
-			return (0);
+			return (ARCHIVE_FAILED);
 		/* Standard Identifier must be "CD001" */
 		if (memcmp(h + 1, "CD001", 5) != 0)
-			return (0);
+			return (ARCHIVE_FAILED);
 		if (isPVD(iso9660, h))
 			continue;
 		if (!iso9660->joliet.location) {
@@ -553,7 +553,7 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 			seenTerminator = 1;
 			break;
 		}
-		return (0);
+		return (ARCHIVE_FAILED);
 	}
 	/*
 	 * ISO 9660 format must have Primary Volume Descriptor and
@@ -562,8 +562,8 @@ archive_read_format_iso9660_bid(struct archive_read *a, int best_bid)
 	if (seenTerminator && iso9660->primary.location > 16)
 		return (48);
 
-	/* We didn't find a valid PVD; return a bid of zero. */
-	return (0);
+	/* We didn't find a valid PVD; return a failure. */
+	return (ARCHIVE_FAILED);
 }
 
 static int

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -349,10 +349,10 @@ archive_read_format_lha_bid(struct archive_read *a, int best_bid)
 	/* If there's already a better bid than we can ever
 	   make, don't bother testing. */
 	if (best_bid > 30)
-		return (-1);
+		return (0);
 
 	if ((h = __archive_read_ahead(a, H_SIZE, NULL)) == NULL)
-		return (-1);
+		return (0);
 
 	if (lha_check_header_format(h) == 0)
 		return (30);

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -636,7 +636,7 @@ mtree_bid(struct archive_read *a, int best_bid)
 	/* Now let's look at the actual header and see if it matches. */
 	h = __archive_read_ahead(a, strlen(signature), NULL);
 	if (h == NULL)
-		return (-1);
+		return (0);
 
 	if (memcmp(h, signature, strlen(signature)) == 0)
 		return (8 * (int)strlen(signature));
@@ -661,7 +661,7 @@ detect_form(struct archive_read *a, int *is_form_d)
 		*is_form_d = 0;
 	p = __archive_read_ahead(a, 1, &avail);
 	if (p == NULL)
-		return (-1);
+		return (0);
 	ravail = avail;
 	for (;;) {
 		len = next_line(a, &p, &avail, &ravail, &nl);

--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -792,10 +792,10 @@ archive_read_format_rar_bid(struct archive_read *a, int best_bid)
 
   /* If there's already a bid > 30, we'll never win. */
   if (best_bid > 30)
-    return (-1);
+    return (0);
 
   if ((h = __archive_read_ahead(a, 7, NULL)) == NULL)
-    return (-1);
+    return (0);
 
   if (memcmp(h, RAR_SIGNATURE, 7) == 0)
     return (30);

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1107,12 +1107,12 @@ static int bid_standard(struct archive_read* a) {
 	rar5_signature(signature);
 
 	if(!read_ahead(a, sizeof(rar5_signature_xor), &h))
-		return -1;
+		return 0;
 
 	if(!memcmp(h, signature, sizeof(rar5_signature_xor)))
 		return 30;
 
-	return -1;
+	return 0;
 }
 
 static int bid_sfx(struct archive_read *a)
@@ -1120,7 +1120,7 @@ static int bid_sfx(struct archive_read *a)
 	const char *h;
 
 	if ((h = __archive_read_ahead(a, 7, NULL)) == NULL)
-		return -1;
+		return 0;
 
 	if ((h[0] == 'M' && h[1] == 'Z') || memcmp(h, "\x7F\x45LF", 4) == 0) {
 		/* This is a PE file */
@@ -1160,18 +1160,18 @@ static int rar5_bid(struct archive_read* a, int best_bid) {
 	int my_bid;
 
 	if(best_bid > 30)
-		return -1;
+		return 0;
 
 	my_bid = bid_standard(a);
-	if(my_bid > -1) {
+	if(my_bid > 0) {
 		return my_bid;
 	}
 	my_bid = bid_sfx(a);
-	if (my_bid > -1) {
+	if (my_bid > 0) {
 		return my_bid;
 	}
 
-	return -1;
+	return 0;
 }
 
 static int rar5_options(struct archive_read *a, const char *key,

--- a/libarchive/archive_read_support_format_raw.c
+++ b/libarchive/archive_read_support_format_raw.c
@@ -98,7 +98,7 @@ archive_read_format_raw_bid(struct archive_read *a, int best_bid)
 {
 	if (best_bid < 1 && __archive_read_ahead(a, 1, NULL) != NULL)
 		return (1);
-	return (-1);
+	return (0);
 }
 
 /*

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -382,7 +382,7 @@ archive_read_format_tar_bid(struct archive_read *a, int best_bid)
 	/* Now let's look at the actual header and see if it matches. */
 	h = __archive_read_ahead(a, 512, NULL);
 	if (h == NULL)
-		return (-1);
+		return (0);
 
 	/* If it's an end-of-archive mark, we can handle it. */
 	if (h[0] == 0 && archive_block_is_null(h)) {

--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -198,14 +198,14 @@ archive_read_format_warc_bid(struct archive_read *a, int best_bid)
 	/* Check the first line, which should already be a record header. */
 	if ((h = __archive_read_ahead(a, 12, &nrd)) == NULL) {
 		/* Not enough data to identify this format. */
-		return -1;
+		return 0;
 	}
 
 	/* Parse the record version number. */
 	ver = warc_read_version(h, nrd);
 	if (ver < 1200U || ver > 10000U) {
 		/* Only WARC 0.12 through WARC 1.0 are supported. */
-		return -1;
+		return 0;
 	}
 
 	/* WARC magic and version checks passed. */

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -506,7 +506,7 @@ xar_bid(struct archive_read *a, int best_bid)
 
 	h = __archive_read_ahead(a, HEADER_SIZE, NULL);
 	if (h == NULL)
-		return (-1);
+		return (0);
 
 	bid = 0;
 	/*

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -3948,16 +3948,16 @@ read_eocd(struct zip *zip, const char *p, int64_t current_offset)
 
 	/* This must be the first volume. */
 	if (disk_num != 0)
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* Central directory must be on this volume. */
 	if (disk_num != archive_le16dec(p + 6))
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* All central directory entries must be on this volume. */
 	if (archive_le16dec(p + 10) != archive_le16dec(p + 8))
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* Central directory can't extend beyond start of EOCD record. */
 	if ((int64_t)cd_offset + cd_size > current_offset)
-		return 0;
+		return (ARCHIVE_FAILED);
 
 	/* Save the central directory location for later use. */
 	zip->central_directory_offset = cd_offset;
@@ -3984,32 +3984,32 @@ read_zip64_eocd(struct archive_read *a, struct zip *zip, const char *p)
 
 	/* Central dir must be on first volume. */
 	if (archive_le32dec(p + 4) != 0)
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* Must be only a single volume. */
 	if (archive_le32dec(p + 16) != 1)
-		return 0;
+		return (ARCHIVE_FAILED);
 
 	/* Find the Zip64 EOCD record. */
 	eocd64_offset = archive_le64dec(p + 8);
 	if (__archive_read_seek(a, eocd64_offset, SEEK_SET) < 0)
-		return 0;
+		return (ARCHIVE_FAILED);
 	if ((p = __archive_read_ahead(a, 56, NULL)) == NULL)
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* Make sure we can read all of it. */
 	eocd64_size = archive_le64dec(p + 4) + 12;
 	if (eocd64_size < 56 || eocd64_size > 16384)
-		return 0;
+		return (ARCHIVE_FAILED);
 	if ((p = __archive_read_ahead(a, (size_t)eocd64_size, NULL)) == NULL)
-		return 0;
+		return (ARCHIVE_FAILED);
 
 	/* Sanity-check the EOCD64 */
 	if (archive_le32dec(p + 16) != 0) /* Must be disk #0 */
-		return 0;
+		return (ARCHIVE_FAILED);
 	if (archive_le32dec(p + 20) != 0) /* CD must be on disk #0 */
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* CD can't be split. */
 	if (archive_le64dec(p + 24) != archive_le64dec(p + 32))
-		return 0;
+		return (ARCHIVE_FAILED);
 
 	/* Save the central directory offset for later use. */
 	zip->central_directory_offset = archive_le64dec(p + 48);
@@ -4030,20 +4030,20 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 	/* If someone has already bid more than 32, then avoid
 	   trashing the look-ahead buffers with a seek. */
 	if (best_bid > 32)
-		return (-1);
+		return (ARCHIVE_FAILED);
 
 	file_size = __archive_read_seek(a, 0, SEEK_END);
 	if (file_size <= 0)
-		return 0;
+		return (ARCHIVE_FAILED);
 
 	/* Search last 16k of file for end-of-central-directory
 	 * record (which starts with PK\005\006) */
 	tail = (int)zipmin(1024 * 16, file_size);
 	current_offset = __archive_read_seek(a, -tail, SEEK_END);
 	if (current_offset < 0)
-		return 0;
+		return (ARCHIVE_FAILED);
 	if ((h = __archive_read_ahead(a, (size_t)tail, NULL)) == NULL)
-		return 0;
+		return (ARCHIVE_FAILED);
 	/* Boyer-Moore search backwards from the end, since we want
 	 * to match the last EOCD in the file (there can be more than
 	 * one if there is an uncompressed Zip archive as a member
@@ -4071,7 +4071,7 @@ archive_read_format_zip_seekable_bid(struct archive_read *a, int best_bid)
 		default: i -= 4; break;
 		}
 	}
-	return 0;
+	return (ARCHIVE_FAILED);
 }
 
 /* The red-black trees are only used in seeking mode to manage

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -153,7 +153,7 @@ DEFINE_TEST(test_read_append_wrong_filter)
   int r;
 
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_ISO9660));
   r = archive_read_append_filter(a, ARCHIVE_FILTER_XZ);
   if (r == ARCHIVE_WARN && !canXz()) {
     skipping("xz reading not fully supported on this platform");
@@ -416,7 +416,7 @@ DEFINE_TEST(test_read_append_filter_wrong_program)
 #endif
 
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
+  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_ISO9660));
   assertEqualIntA(a, ARCHIVE_OK,
       archive_read_append_filter_program(a, "bunzip2 -q"));
   assertEqualIntA(a, ARCHIVE_FATAL,


### PR DESCRIPTION
Allow to set formats and run their biddings successfully even if the bidding process itself is unable to detect the format. This should allow more edge cases when processing broken files.

To distinguish between a real error, truely unparseable formats and non-matching bidding cases, use proper return values:

- 0 if stream does not match format (instead of -1 in some cases)
- ARCHIVE_FAILED if stream does not match and must not be further parsed
- ARCHIVE_FATAL if a critical issue occurred, to stop bidding process

Also, make sure that header parsers properly work even if bidding returned 0.

Follow-up of PR https://github.com/libarchive/libarchive/pull/3383#issuecomment-5311654399