### PR TITLE
unzip: Set O_BINARY on Windows systems

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -639,7 +639,7 @@ extract2fd(struct archive *a, char *pathname, int fd)
 static void
 extract_file(struct archive *a, struct archive_entry *e, char **path)
 {
-	int mode;
+	int flags, mode;
 	struct timespec mtime;
 	struct stat sb;
 	int fd, check, text;
@@ -739,7 +739,11 @@ recheck:
 		return;
 	}
 
-	if ((fd = open(*path, O_RDWR|O_CREAT|O_TRUNC, mode)) < 0)
+	flags = O_RDWR|O_CREAT|O_TRUNC;
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	flags |= O_BINARY;
+#endif
+	if ((fd = open(*path, flags, mode)) < 0)
 		error("open('%s')", *path);
 
 	info(" extracting: %s", *path);
@@ -1312,6 +1316,13 @@ main(int argc, char *argv[])
 
 	if (n_opt + o_opt + u_opt > 1)
 		errorx("-n, -o and -u are contradictory");
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	if (c_opt || p_opt) {
+		if (_setmode(STDOUT_FILENO, _O_BINARY) == -1)
+			errorx("unable to set binary output mode");
+	}
+#endif
 
 	unzip(zipfile);
 


### PR DESCRIPTION
Set O_BINARY for input files and standard output if needed to avoid issues with \n to \r\n translations.

Suggested by @oech3 at https://github.com/msys2/MINGW-packages/pull/30696#issuecomment-5308577468