### PR TITLE
RAR4: bound delta and audio filter channel counts

### DIFF
--- a/libarchive/archive_read_support_format_rar.c
+++ b/libarchive/archive_read_support_format_rar.c
@@ -3714,7 +3714,9 @@ execute_filter_delta(struct rar_filter *filter, struct rar_virtual_machine *vm)
   uint8_t *src, *dst;
   uint32_t i, idx;
 
-  if (length > PROGRAM_WORK_SIZE / 2)
+  if (length > PROGRAM_WORK_SIZE / 2 ||
+      numchannels == 0 ||
+      numchannels > 128)
     return 0;
 
   src = &vm->memory[0];
@@ -3829,7 +3831,9 @@ execute_filter_audio(struct rar_filter *filter, struct rar_virtual_machine *vm)
   uint8_t *src, *dst;
   uint32_t i, j;
 
-  if (length > PROGRAM_WORK_SIZE / 2)
+  if (length > PROGRAM_WORK_SIZE / 2 ||
+      numchannels == 0 ||
+      numchannels > 128)
     return 0;
 
   src = &vm->memory[0];


### PR DESCRIPTION
This adds validation for the RAR4 VM delta and audio built-in filters so that channel counts of 0 or greater than 128 are rejected before entering the outer processing loop.

The bound is aligned with the reference UnRAR implementation and prevents attacker-controlled initialregisters[0] values from driving excessive iteration counts.

Tested with:

ctest -R rar --output-on-failure

Result:

100% tests passed, 0 tests failed out of 110.