### PR TITLE
unify helper to read current umask

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,7 @@ noinst_HEADERS= \
 	libarchive/archive_string.h \
 	libarchive/archive_string_composition.h \
 	libarchive/archive_time_private.h \
+	libarchive/archive_umask_private.h \
 	libarchive/archive_write_disk_private.h \
 	libarchive/archive_write_private.h \
 	libarchive/archive_write_set_format_private.h \
@@ -218,6 +219,7 @@ libarchive_la_SOURCES= \
 	libarchive/archive_string.c \
 	libarchive/archive_string_sprintf.c \
 	libarchive/archive_time.c \
+	libarchive/archive_umask.c \
 	libarchive/archive_util.c \
 	libarchive/archive_version_details.c \
 	libarchive/archive_virtual.c \

--- a/contrib/android/Android.mk
+++ b/contrib/android/Android.mk
@@ -98,6 +98,7 @@ libarchive_src_files := libarchive/archive_acl.c \
 						libarchive/archive_string.c \
 						libarchive/archive_string_sprintf.c \
 						libarchive/archive_time.c \
+						libarchive/archive_umask.c \
 						libarchive/archive_util.c \
 						libarchive/archive_version_details.c \
 						libarchive/archive_virtual.c \

--- a/libarchive/CMakeLists.txt
+++ b/libarchive/CMakeLists.txt
@@ -120,6 +120,8 @@ SET(libarchive_SOURCES
   archive_string_sprintf.c
   archive_time.c
   archive_time_private.h
+  archive_umask.c
+  archive_umask_private.h
   archive_util.c
   archive_version_details.c
   archive_virtual.c

--- a/libarchive/archive_umask.c
+++ b/libarchive/archive_umask.c
@@ -1,0 +1,67 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1989, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Dave Borman at Cray Research, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "archive_platform.h"
+#include "archive_umask_private.h"
+
+#include <stddef.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <sys/stat.h>
+
+/* Return the current umask. Attempt to read it without changing. */
+mode_t
+__archive_get_umask(void)
+{
+	mode_t mask;
+
+#ifdef KERN_PROC_UMASK
+	size_t len;
+	u_short smask;
+
+	/*
+	 * First try requesting the umask without temporarily modifying it.
+	 * Note that this does not work if the sysctl
+	 * security.bsd.unprivileged_proc_debug is set to 0.
+	 */
+	len = sizeof(smask);
+	if (sysctl((int[4]){ CTL_KERN, KERN_PROC, KERN_PROC_UMASK, 0 },
+	    4, &smask, &len, NULL, 0) == 0)
+		return (smask);
+#endif
+
+	umask(mask = umask(0));
+	return (mask);
+}

--- a/libarchive/archive_umask_private.h
+++ b/libarchive/archive_umask_private.h
@@ -1,0 +1,49 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1989, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Dave Borman at Cray Research, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef ARCHIVE_UMASK_PRIVATE_H_INCLUDED
+#define ARCHIVE_UMASK_PRIVATE_H_INCLUDED
+
+#ifndef __LIBARCHIVE_BUILD
+#ifndef __LIBARCHIVE_TEST
+#error This header is only to be used internally to libarchive.
+#endif
+#endif
+
+#include <sys/stat.h>
+
+/* Return the current umask. Attempt to read it without changing. */
+extern mode_t __archive_get_umask(void);
+
+#endif

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -29,6 +29,8 @@
 
 #if !defined(_WIN32) || defined(__CYGWIN__)
 
+#include "archive_umask_private.h"
+
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -646,7 +648,7 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	 * user edits their umask during the extraction for some
 	 * reason.
 	 */
-	umask(a->user_umask = umask(0));
+	a->user_umask = __archive_get_umask();
 
 	/* Figure out what we need to do for this entry. */
 	a->todo = TODO_MODE_BASE;
@@ -2014,8 +2016,8 @@ archive_write_disk_new(void)
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	a->archive.vtable = &archive_write_disk_vtable;
 	a->start_time = time(NULL);
-	/* Query and restore the umask. */
-	umask(a->user_umask = umask(0));
+	/* Query the umask. */
+	a->user_umask = __archive_get_umask();
 #ifdef HAVE_GETEUID
 	a->user_uid = geteuid();
 #endif /* HAVE_GETEUID */

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -29,6 +29,8 @@
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 
+#include "archive_umask_private.h"
+
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -863,7 +865,7 @@ _archive_write_disk_header(struct archive *_a, struct archive_entry *entry)
 	 * user edits their umask during the extraction for some
 	 * reason.
 	 */
-	umask(a->user_umask = umask(0));
+	a->user_umask = __archive_get_umask();
 
 	/* Figure out what we need to do for this entry. */
 	a->todo = TODO_MODE_BASE;
@@ -1368,8 +1370,8 @@ archive_write_disk_new(void)
 	a->archive.state = ARCHIVE_STATE_HEADER;
 	a->archive.vtable = &archive_write_disk_vtable;
 	a->start_time = time(NULL);
-	/* Query and restore the umask. */
-	umask(a->user_umask = umask(0));
+	/* Query the umask. */
+	a->user_umask = __archive_get_umask();
 	if (archive_wstring_ensure(&a->path_safe, 512) == NULL) {
 		free(a);
 		return (NULL);

--- a/libarchive_fe/lafe_setmode.c
+++ b/libarchive_fe/lafe_setmode.c
@@ -34,6 +34,7 @@
 
 #include "lafe_platform.h"
 #include "archive_platform.h" /* for S_I* mode macros on windows */
+#include "archive_umask_private.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef HAVE_SYS_SYSCTL_H
@@ -70,7 +71,6 @@ typedef struct bitcmd {
 #define	CMD2_OBITS	0x08
 #define	CMD2_UBITS	0x10
 
-static mode_t	 get_current_umask(void);
 static BITCMD	*addcmd(BITCMD *, mode_t, mode_t, mode_t, mode_t);
 static void	 compress_mode(BITCMD *);
 #ifdef SETMODE_DEBUG
@@ -187,7 +187,7 @@ lafe_setmode(const char *p)
 	 * Get a copy of the mask for the permissions that are mask relative.
 	 * Flip the bits, we want what's not set.
 	 */
-	mask = ~get_current_umask();
+	mask = ~__archive_get_umask();
 
 	setlen = SET_LEN + 2;
 
@@ -341,30 +341,6 @@ out:
 	free(saveset);
 	errno = serrno;
 	return NULL;
-}
-
-static mode_t
-get_current_umask(void)
-{
-	mode_t mask;
-#ifdef KERN_PROC_UMASK
-	size_t len;
-	u_short smask;
-#endif
-
-#ifdef KERN_PROC_UMASK
-	/*
-	 * First try requesting the umask without temporarily modifying it.
-	 * Note that this does not work if the sysctl
-	 * security.bsd.unprivileged_proc_debug is set to 0.
-	 */
-	len = sizeof(smask);
-	if (sysctl((int[4]){ CTL_KERN, KERN_PROC, KERN_PROC_UMASK, 0 },
-	    4, &smask, &len, NULL, 0) == 0)
-		return (smask);
-#endif
-	umask(mask = umask(0));
-	return (mask);
 }
 
 static BITCMD *


### PR DESCRIPTION
The lafe_setmode.c code has a helper to try and read the current umask without modifying it.  The rest of the codebase uses the unsafe idiom umask(var = umask(0)).  Create a dedicated private header to hold the helper and use it everywhere.