### PR TITLE
drop __libarchive_*_build_hack

### DIFF
--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -31,19 +31,6 @@
 #include "archive.h"
 #include "archive_cryptor_private.h"
 
-/*
- * On systems that do not support any recognized crypto libraries,
- * this file will normally define no usable symbols.
- *
- * But some compilers and linkers choke on empty object files, so
- * define a public symbol that will always exist.  This could
- * be removed someday if this file gains another always-present
- * symbol definition.
- */
-int __libarchive_cryptor_build_hack(void) {
-	return 0;
-}
-
 #ifdef ARCHIVE_CRYPTOR_USE_Apple_CommonCrypto
 
 static int

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -29,16 +29,6 @@
 #ifndef __LIBARCHIVE_BUILD
 #error This header is only to be used internally to libarchive.
 #endif
-/*
- * On systems that do not support any recognized crypto libraries,
- * the archive_cryptor.c file will normally define no usable symbols.
- *
- * But some compilers and linkers choke on empty object files, so
- * define a public symbol that will always exist.  This could
- * be removed someday if this file gains another always-present
- * symbol definition.
- */
-int __libarchive_cryptor_build_hack(void);
 
 #ifdef __APPLE__
 # include <AvailabilityMacros.h>

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -31,20 +31,6 @@
 #include "archive.h"
 #include "archive_hmac_private.h"
 
-/*
- * On systems that do not support any recognized crypto libraries,
- * the archive_hmac.c file is expected to define no usable symbols.
- *
- * But some compilers and linkers choke on empty object files, so
- * define a public symbol that will always exist.  This could
- * be removed someday if this file gains another always-present
- * symbol definition.
- */
-int __libarchive_hmac_build_hack(void) {
-	return 0;
-}
-
-
 #ifdef ARCHIVE_HMAC_USE_Apple_CommonCrypto
 
 static int

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -29,16 +29,6 @@
 #ifndef __LIBARCHIVE_BUILD
 #error This header is only to be used internally to libarchive.
 #endif
-/*
- * On systems that do not support any recognized crypto libraries,
- * the archive_hmac.c file is expected to define no usable symbols.
- *
- * But some compilers and linkers choke on empty object files, so
- * define a public symbol that will always exist.  This could
- * be removed someday if this file gains another always-present
- * symbol definition.
- */
-int __libarchive_hmac_build_hack(void);
 
 #ifdef __APPLE__
 # include <AvailabilityMacros.h>


### PR DESCRIPTION
These files always define a struct which means this hack shouldn't be necessary as there is always an exported symbol in them.