### PR TITLE
localize pack_native function

### DIFF
--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -101,8 +101,7 @@ static const char tooManyFields[] = "too many fields for format";
 #define apd_makedev(maj, min) makedev((maj), (min))
 #endif
 
-/* exported */
-dev_t
+static dev_t
 pack_native(int n, unsigned long numbers[], const char **error)
 {
 	dev_t dev = 0;

--- a/libarchive/archive_pack_dev.h
+++ b/libarchive/archive_pack_dev.h
@@ -37,7 +37,6 @@
 typedef	dev_t pack_t(int, unsigned long [], const char **);
 
 pack_t	*pack_find(const char *);
-pack_t	 pack_native;
 
 #define	major_netbsd(x)		((int32_t)((((x) & 0x000fff00) >>  8)))
 #define	minor_netbsd(x)		((int32_t)((((x) & 0xfff00000) >> 12) | \


### PR DESCRIPTION
Nothing calls this function outside this module, and it isn't exported as part of the shared lib, so nothing could use it outside the project.