### PR TITLE
blake2: namespace symbols to avoid collisions

### DIFF
--- a/libarchive/archive_blake2.h
+++ b/libarchive/archive_blake2.h
@@ -19,6 +19,19 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Rename functions for libarchive namespacing.
+#define blake2s __archive_blake2s
+#define blake2s_final __archive_blake2s_final
+#define blake2s_init __archive_blake2s_init
+#define blake2s_init_key __archive_blake2s_init_key
+#define blake2s_init_param __archive_blake2s_init_param
+#define blake2sp __archive_blake2sp
+#define blake2sp_final __archive_blake2sp_final
+#define blake2sp_init __archive_blake2sp_init
+#define blake2sp_init_key __archive_blake2sp_init_key
+#define blake2sp_update __archive_blake2sp_update
+#define blake2s_update __archive_blake2s_update
+
 #if defined(_MSC_VER)
 #define BLAKE2_PACKED(x) __pragma(pack(push, 1)) x __pragma(pack(pop))
 #elif defined(__GNUC__)


### PR DESCRIPTION
While shared libs can use whatever names they want and mark specific ones for export, static libs effectively export every non-local symbol which leads to collisions when linking.  That means these blake2 funcs are all exported without any archive prefix.

Add some defines to the header to easily rename everything since the blake2 files themselves are basically imported from other codebases.