### PR TITLE
archive_entry_*_l: use double underscore

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -469,7 +469,7 @@ archive_entry_gname_w(struct archive_entry *entry)
 }
 
 int
-_archive_entry_gname_l(struct archive_entry *entry,
+archive_entry_gname_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_get_mbs_l(entry->archive, &entry->ae_gname, p, len, sc));
@@ -533,7 +533,7 @@ archive_entry_hardlink_is_set(struct archive_entry *entry)
 }
 
 int
-_archive_entry_hardlink_l(struct archive_entry *entry,
+archive_entry_hardlink_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	if ((entry->ae_set & AE_SET_HARDLINK) == 0) {
@@ -643,7 +643,7 @@ archive_entry_pathname_w(struct archive_entry *entry)
 }
 
 int
-_archive_entry_pathname_l(struct archive_entry *entry,
+archive_entry_pathname_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_get_mbs_l(entry->archive, &entry->ae_pathname, p, len, sc));
@@ -799,7 +799,7 @@ archive_entry_symlink_w(struct archive_entry *entry)
 }
 
 int
-_archive_entry_symlink_l(struct archive_entry *entry,
+archive_entry_symlink_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	if ((entry->ae_set & AE_SET_SYMLINK) == 0) {
@@ -856,7 +856,7 @@ archive_entry_uname_w(struct archive_entry *entry)
 }
 
 int
-_archive_entry_uname_l(struct archive_entry *entry,
+archive_entry_uname_l(struct archive_entry *entry,
     const char **p, size_t *len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_get_mbs_l(entry->archive, &entry->ae_uname, p, len, sc));
@@ -974,7 +974,7 @@ archive_entry_update_gname_utf8(struct archive_entry *entry, const char *name)
 }
 
 int
-_archive_entry_copy_gname_l(struct archive_entry *entry,
+archive_entry_copy_gname_l(struct archive_entry *entry,
     const char *name, size_t len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_copy_mbs_len_l(&entry->ae_gname, name, len, sc));
@@ -1075,7 +1075,7 @@ archive_entry_update_hardlink_utf8(struct archive_entry *entry, const char *targ
 }
 
 int
-_archive_entry_copy_hardlink_l(struct archive_entry *entry,
+archive_entry_copy_hardlink_l(struct archive_entry *entry,
     const char *target, size_t len, struct archive_string_conv *sc)
 {
 	int r;
@@ -1225,7 +1225,7 @@ archive_entry_update_link_utf8(struct archive_entry *entry, const char *target)
 }
 
 int
-_archive_entry_copy_link_l(struct archive_entry *entry,
+archive_entry_copy_link_l(struct archive_entry *entry,
     const char *target, size_t len, struct archive_string_conv *sc)
 {
 	int r;
@@ -1306,7 +1306,7 @@ archive_entry_update_pathname_utf8(struct archive_entry *entry, const char *name
 }
 
 int
-_archive_entry_copy_pathname_l(struct archive_entry *entry,
+archive_entry_copy_pathname_l(struct archive_entry *entry,
     const char *name, size_t len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_copy_mbs_len_l(&entry->ae_pathname,
@@ -1460,7 +1460,7 @@ archive_entry_update_symlink_utf8(struct archive_entry *entry, const char *linkn
 }
 
 int
-_archive_entry_copy_symlink_l(struct archive_entry *entry,
+archive_entry_copy_symlink_l(struct archive_entry *entry,
     const char *linkname, size_t len, struct archive_string_conv *sc)
 {
 	int r;
@@ -1544,7 +1544,7 @@ archive_entry_set_is_metadata_encrypted(struct archive_entry *entry, char is_enc
 }
 
 int
-_archive_entry_copy_uname_l(struct archive_entry *entry,
+archive_entry_copy_uname_l(struct archive_entry *entry,
     const char *name, size_t len, struct archive_string_conv *sc)
 {
 	return (archive_mstring_copy_mbs_len_l(&entry->ae_uname,
@@ -1748,7 +1748,7 @@ archive_entry_acl_to_text(struct archive_entry *entry, la_ssize_t *len,
 }
 
 char *
-_archive_entry_acl_to_text_l(struct archive_entry *entry, ssize_t *len,
+archive_entry_acl_to_text_l(struct archive_entry *entry, ssize_t *len,
    int flags, struct archive_string_conv *sc)
 {
 	return (archive_acl_to_text_l(&entry->acl, len, flags, sc));
@@ -1772,7 +1772,7 @@ archive_entry_acl_from_text(struct archive_entry *entry,
 }
 
 int
-_archive_entry_acl_from_text_l(struct archive_entry *entry, const char *text,
+archive_entry_acl_from_text_l(struct archive_entry *entry, const char *text,
     int type, struct archive_string_conv *sc)
 {
 	return (archive_acl_from_text_l(&entry->acl, text, type, sc));
@@ -1825,7 +1825,7 @@ archive_entry_acl_text(struct archive_entry *entry, int flags)
 
 /* Deprecated */
 int
-_archive_entry_acl_text_l(struct archive_entry *entry, int flags,
+archive_entry_acl_text_l(struct archive_entry *entry, int flags,
     const char **acl_text, size_t *len, struct archive_string_conv *sc)
 {
 	free(entry->acl.acl_text);

--- a/libarchive/archive_entry_locale.h
+++ b/libarchive/archive_entry_locale.h
@@ -44,47 +44,47 @@ struct archive_string_conv;
  *   Return -1 if the string conversion failed.
  */
 
-#define archive_entry_gname_l	_archive_entry_gname_l
-int _archive_entry_gname_l(struct archive_entry *,
+#define archive_entry_gname_l	__archive_entry_gname_l
+int archive_entry_gname_l(struct archive_entry *,
     const char **, size_t *, struct archive_string_conv *);
-#define archive_entry_hardlink_l	_archive_entry_hardlink_l
-int _archive_entry_hardlink_l(struct archive_entry *,
+#define archive_entry_hardlink_l	__archive_entry_hardlink_l
+int archive_entry_hardlink_l(struct archive_entry *,
     const char **, size_t *, struct archive_string_conv *);
-#define archive_entry_pathname_l	_archive_entry_pathname_l
-int _archive_entry_pathname_l(struct archive_entry *,
+#define archive_entry_pathname_l	__archive_entry_pathname_l
+int archive_entry_pathname_l(struct archive_entry *,
     const char **, size_t *, struct archive_string_conv *);
-#define archive_entry_symlink_l	_archive_entry_symlink_l
-int _archive_entry_symlink_l(struct archive_entry *,
+#define archive_entry_symlink_l	__archive_entry_symlink_l
+int archive_entry_symlink_l(struct archive_entry *,
     const char **, size_t *, struct archive_string_conv *);
-#define archive_entry_uname_l	_archive_entry_uname_l
-int _archive_entry_uname_l(struct archive_entry *,
+#define archive_entry_uname_l	__archive_entry_uname_l
+int archive_entry_uname_l(struct archive_entry *,
     const char **, size_t *, struct archive_string_conv *);
-#define archive_entry_acl_text_l _archive_entry_acl_text_l
-int _archive_entry_acl_text_l(struct archive_entry *, int,
-const char **, size_t *, struct archive_string_conv *) __LA_DEPRECATED;
-#define archive_entry_acl_to_text_l _archive_entry_acl_to_text_l
-char *_archive_entry_acl_to_text_l(struct archive_entry *, ssize_t *, int,
+#define archive_entry_acl_text_l __archive_entry_acl_text_l
+int archive_entry_acl_text_l(struct archive_entry *, int,
+    const char **, size_t *, struct archive_string_conv *) __LA_DEPRECATED;
+#define archive_entry_acl_to_text_l __archive_entry_acl_to_text_l
+char *archive_entry_acl_to_text_l(struct archive_entry *, ssize_t *, int,
     struct archive_string_conv *);
-#define archive_entry_acl_from_text_l _archive_entry_acl_from_text_l
-int _archive_entry_acl_from_text_l(struct archive_entry *, const char* text,
+#define archive_entry_acl_from_text_l __archive_entry_acl_from_text_l
+int archive_entry_acl_from_text_l(struct archive_entry *, const char* text,
     int type, struct archive_string_conv *);
-#define archive_entry_copy_gname_l	_archive_entry_copy_gname_l
-int _archive_entry_copy_gname_l(struct archive_entry *,
+#define archive_entry_copy_gname_l	__archive_entry_copy_gname_l
+int archive_entry_copy_gname_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
-#define archive_entry_copy_hardlink_l	_archive_entry_copy_hardlink_l
-int _archive_entry_copy_hardlink_l(struct archive_entry *,
+#define archive_entry_copy_hardlink_l	__archive_entry_copy_hardlink_l
+int archive_entry_copy_hardlink_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
-#define archive_entry_copy_link_l	_archive_entry_copy_link_l
-int _archive_entry_copy_link_l(struct archive_entry *,
+#define archive_entry_copy_link_l	__archive_entry_copy_link_l
+int archive_entry_copy_link_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
-#define archive_entry_copy_pathname_l	_archive_entry_copy_pathname_l
-int _archive_entry_copy_pathname_l(struct archive_entry *,
+#define archive_entry_copy_pathname_l	__archive_entry_copy_pathname_l
+int archive_entry_copy_pathname_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
-#define archive_entry_copy_symlink_l	_archive_entry_copy_symlink_l
-int _archive_entry_copy_symlink_l(struct archive_entry *,
+#define archive_entry_copy_symlink_l	__archive_entry_copy_symlink_l
+int archive_entry_copy_symlink_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
-#define archive_entry_copy_uname_l	_archive_entry_copy_uname_l
-int _archive_entry_copy_uname_l(struct archive_entry *,
+#define archive_entry_copy_uname_l	__archive_entry_copy_uname_l
+int archive_entry_copy_uname_l(struct archive_entry *,
     const char *, size_t, struct archive_string_conv *);
 
 #endif /* !ARCHIVE_ENTRY_LOCALE_H_INCLUDED */


### PR DESCRIPTION
All other internal libarchive symbols use 2 underscores, so switch these over too.  No functional changes of course.