### PR TITLE
namespace time conversion symbols to avoid collisions

### DIFF
--- a/libarchive/archive_entry_copy_bhfi.c
+++ b/libarchive/archive_entry_copy_bhfi.c
@@ -37,11 +37,11 @@ archive_entry_copy_bhfi(struct archive_entry *entry,
 	int64_t secs;
 	uint32_t nsecs;
 
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
 	archive_entry_set_atime(entry, secs, nsecs);
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastWriteTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftLastWriteTime), &secs, &nsecs);
 	archive_entry_set_mtime(entry, secs, nsecs);
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftCreationTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftCreationTime), &secs, &nsecs);
 	archive_entry_set_birthtime(entry, secs, nsecs);
 	archive_entry_set_ctime(entry, secs, nsecs);
 	archive_entry_set_dev(entry, bhfi->dwVolumeSerialNumber);

--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -1172,8 +1172,8 @@ set_timefilter_find_data(struct archive_match *a, int timetype,
 	time_t ctime_sec, mtime_sec;
 	uint32_t ctime_ns, mtime_ns;
 
-	ntfs_to_unix(FILETIME_to_ntfs(ftLastWriteTime), &mtime_sec, &mtime_ns);
-	ntfs_to_unix(FILETIME_to_ntfs(ftCreationTime), &ctime_sec, &ctime_ns);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(ftLastWriteTime), &mtime_sec, &mtime_ns);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(ftCreationTime), &ctime_sec, &ctime_ns);
 	return set_timefilter(a, timetype,
 			mtime_sec, mtime_ns, ctime_sec, ctime_ns);
 }

--- a/libarchive/archive_read_disk_windows.c
+++ b/libarchive/archive_read_disk_windows.c
@@ -2056,11 +2056,11 @@ entry_copy_bhfi(struct archive_entry *entry, const wchar_t *path,
 	uint32_t nsecs;
 	mode_t mode;
 
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftLastAccessTime), &secs, &nsecs);
 	archive_entry_set_atime(entry, secs, nsecs);
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftLastWriteTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftLastWriteTime), &secs, &nsecs);
 	archive_entry_set_mtime(entry, secs, nsecs);
-	ntfs_to_unix(FILETIME_to_ntfs(&bhfi->ftCreationTime), &secs, &nsecs);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&bhfi->ftCreationTime), &secs, &nsecs);
 	archive_entry_set_birthtime(entry, secs, nsecs);
 	archive_entry_set_ctime(entry, secs, nsecs);
 	archive_entry_set_dev(entry, bhfi_dev(bhfi));

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3186,19 +3186,19 @@ read_Times(struct archive_read *a, int type)
 			goto failed;
 		switch (type) {
 		case kCTime:
-			ntfs_to_unix(archive_le64dec(p),
+			__archive_ntfs_to_unix(archive_le64dec(p),
 			    &(entries[i].ctime),
 			    &(entries[i].ctime_ns));
 			entries[i].flg |= CTIME_IS_SET;
 			break;
 		case kATime:
-			ntfs_to_unix(archive_le64dec(p),
+			__archive_ntfs_to_unix(archive_le64dec(p),
 			    &(entries[i].atime),
 			    &(entries[i].atime_ns));
 			entries[i].flg |= ATIME_IS_SET;
 			break;
 		case kMTime:
-			ntfs_to_unix(archive_le64dec(p),
+			__archive_ntfs_to_unix(archive_le64dec(p),
 			    &(entries[i].mtime),
 			    &(entries[i].mtime_ns));
 			entries[i].flg |= MTIME_IS_SET;

--- a/libarchive/archive_read_support_format_lha.c
+++ b/libarchive/archive_read_support_format_lha.c
@@ -815,7 +815,7 @@ lha_read_file_header_0(struct archive_read *a, struct lha *lha)
 	headersum = p[H0_HEADER_SUM_OFFSET];
 	lha->compsize = archive_le32dec(p + H0_COMP_SIZE_OFFSET);
 	lha->origsize = archive_le32dec(p + H0_ORIG_SIZE_OFFSET);
-	lha->mtime = dos_to_unix(archive_le32dec(p + H0_DOS_TIME_OFFSET));
+	lha->mtime = __archive_dos_to_unix(archive_le32dec(p + H0_DOS_TIME_OFFSET));
 	namelen = p[H0_NAME_LEN_OFFSET];
 	extdsize = (int)lha->header_size - H0_FIXED_SIZE - namelen;
 	if ((namelen > 221 || extdsize < 0) && extdsize != -2) {
@@ -915,7 +915,7 @@ lha_read_file_header_1(struct archive_read *a, struct lha *lha)
 	/* Note: An extended header size is included in a compsize. */
 	lha->compsize = archive_le32dec(p + H1_COMP_SIZE_OFFSET);
 	lha->origsize = archive_le32dec(p + H1_ORIG_SIZE_OFFSET);
-	lha->mtime = dos_to_unix(archive_le32dec(p + H1_DOS_TIME_OFFSET));
+	lha->mtime = __archive_dos_to_unix(archive_le32dec(p + H1_DOS_TIME_OFFSET));
 	namelen = p[H1_NAME_LEN_OFFSET];
 	/* Calculate a padding size. The result will be normally 0 only(?) */
 	padding = ((int)lha->header_size) - H1_FIXED_SIZE - namelen;
@@ -1328,15 +1328,15 @@ lha_read_file_extended_header(struct archive_read *a, struct lha *lha,
 			break;
 		case EXT_TIMESTAMP:
 			if (datasize == (sizeof(uint64_t) * 3)) {
-				ntfs_to_unix(archive_le64dec(extdheader),
+				__archive_ntfs_to_unix(archive_le64dec(extdheader),
 					&lha->birthtime,
 				    &lha->birthtime_tv_nsec);
 				extdheader += sizeof(uint64_t);
-				ntfs_to_unix(archive_le64dec(extdheader),
+				__archive_ntfs_to_unix(archive_le64dec(extdheader),
 					&lha->mtime,
 				    &lha->mtime_tv_nsec);
 				extdheader += sizeof(uint64_t);
-				ntfs_to_unix(archive_le64dec(extdheader),
+				__archive_ntfs_to_unix(archive_le64dec(extdheader),
 					&lha->atime,
 				    &lha->atime_tv_nsec);
 				lha->setflag |= BIRTHTIME_IS_SET |

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1310,7 +1310,7 @@ static int parse_htime_item(struct archive_read* a, char unix_time,
 		if(!read_u64(a, &windows_time))
 			return ARCHIVE_EOF;
 
-		ntfs_to_unix(windows_time, sec, nsec);
+		__archive_ntfs_to_unix(windows_time, sec, nsec);
 		*extra_data_size -= 8;
 	}
 

--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -1153,7 +1153,7 @@ zip_read_local_file_header(struct archive_read *a, struct archive_entry *entry,
 	}
 	zip->init_decryption = (zip_entry->zip_flags & ZIP_ENCRYPTED);
 	zip_entry->compression = (char)archive_le16dec(p + 8);
-	zip_entry->mtime = dos_to_unix(archive_le32dec(p + 10));
+	zip_entry->mtime = __archive_dos_to_unix(archive_le32dec(p + 10));
 	zip_entry->crc32 = archive_le32dec(p + 14);
 	if (zip_entry->zip_flags & ZIP_LENGTH_AT_END)
 		zip_entry->decdat = p[11];
@@ -4266,7 +4266,7 @@ slurp_central_directory(struct archive_read *a, struct archive_entry* entry,
 			zip->has_encrypted_entries = 1;
 		}
 		zip_entry->compression = (char)archive_le16dec(p + 10);
-		zip_entry->mtime = dos_to_unix(archive_le32dec(p + 12));
+		zip_entry->mtime = __archive_dos_to_unix(archive_le32dec(p + 12));
 		zip_entry->crc32 = archive_le32dec(p + 16);
 		if (zip_entry->zip_flags & ZIP_LENGTH_AT_END)
 			zip_entry->decdat = p[13];

--- a/libarchive/archive_time.c
+++ b/libarchive/archive_time.c
@@ -49,7 +49,7 @@
 #include <winnt.h>
 /* Windows FILETIME to NTFS time. */
 uint64_t
-FILETIME_to_ntfs(const FILETIME* filetime)
+__archive_FILETIME_to_ntfs(const FILETIME* filetime)
 {
 	ULARGE_INTEGER utc;
 	utc.HighPart = filetime->dwHighDateTime;
@@ -60,7 +60,7 @@ FILETIME_to_ntfs(const FILETIME* filetime)
 
 /* Convert an MSDOS-style date/time into Unix-style time. */
 int64_t
-dos_to_unix(uint32_t dos_time)
+__archive_dos_to_unix(uint32_t dos_time)
 {
 	uint16_t msTime, msDate;
 	struct tm ts;
@@ -83,7 +83,7 @@ dos_to_unix(uint32_t dos_time)
 
 /* Convert into MSDOS-style date/time. */
 uint32_t
-unix_to_dos(int64_t unix_time)
+__archive_unix_to_dos(int64_t unix_time)
 {
 	struct tm *t;
 	uint32_t dt;
@@ -132,7 +132,7 @@ unix_to_dos(int64_t unix_time)
 
 /* Convert NTFS time to Unix sec/nsec */
 void
-ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs)
+__archive_ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs)
 {
 	if (ntfs > INT64_MAX) {
 		ntfs -= NTFS_EPOC_TICKS;
@@ -151,7 +151,7 @@ ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs)
 
 /* Convert Unix sec/nsec to NTFS time */
 uint64_t
-unix_to_ntfs(int64_t secs, uint32_t nsecs)
+__archive_unix_to_ntfs(int64_t secs, uint32_t nsecs)
 {
 	uint64_t ntfs;
 

--- a/libarchive/archive_time_private.h
+++ b/libarchive/archive_time_private.h
@@ -31,17 +31,17 @@
 #include <stdint.h>
 
 /* NTFS time to Unix sec/nsec. */
-void ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs);
+void __archive_ntfs_to_unix(uint64_t ntfs, int64_t* secs, uint32_t* nsecs);
 /* DOS time to Unix sec. */
-int64_t dos_to_unix(uint32_t dos);
+int64_t __archive_dos_to_unix(uint32_t dos);
 /* Unix sec/nsec to NTFS time. */
-uint64_t unix_to_ntfs(int64_t secs, uint32_t nsecs);
+uint64_t __archive_unix_to_ntfs(int64_t secs, uint32_t nsecs);
 /* Unix sec to DOS time. */
-uint32_t unix_to_dos(int64_t secs);
+uint32_t __archive_unix_to_dos(int64_t secs);
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <windef.h>
 #include <winbase.h>
 /* Windows FILETIME to NTFS time. */
-uint64_t FILETIME_to_ntfs(const FILETIME* filetime);
+uint64_t __archive_FILETIME_to_ntfs(const FILETIME* filetime);
 #endif
 #endif /* ARCHIVE_TIME_PRIVATE_H_INCLUDED */

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -598,9 +598,9 @@ __hstat(HANDLE handle, struct ustat *st)
 		mode |= S_IFREG;
 	st->st_mode = mode;
 
-	ntfs_to_unix(FILETIME_to_ntfs(&info.ftLastAccessTime), &st->st_atime, &st->st_atime_nsec);
-	ntfs_to_unix(FILETIME_to_ntfs(&info.ftLastWriteTime), &st->st_mtime, &st->st_mtime_nsec);
-	ntfs_to_unix(FILETIME_to_ntfs(&info.ftCreationTime), &st->st_ctime, &st->st_ctime_nsec);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&info.ftLastAccessTime), &st->st_atime, &st->st_atime_nsec);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&info.ftLastWriteTime), &st->st_mtime, &st->st_mtime_nsec);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&info.ftCreationTime), &st->st_ctime, &st->st_ctime_nsec);
 	st->st_size =
 	    ((int64_t)(info.nFileSizeHigh) * ((int64_t)MAXDWORD + 1))
 		+ (int64_t)(info.nFileSizeLow);

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -2694,17 +2694,17 @@ set_times(struct archive_write_disk *a,
 		h = hw;
 	}
 
-	wintm.QuadPart = unix_to_ntfs(atime, atime_nanos);
+	wintm.QuadPart = __archive_unix_to_ntfs(atime, atime_nanos);
 	fatime.dwLowDateTime = wintm.LowPart;
 	fatime.dwHighDateTime = wintm.HighPart;
-	wintm.QuadPart = unix_to_ntfs(mtime, mtime_nanos);
+	wintm.QuadPart = __archive_unix_to_ntfs(mtime, mtime_nanos);
 	fmtime.dwLowDateTime = wintm.LowPart;
 	fmtime.dwHighDateTime = wintm.HighPart;
 	/*
 	 * SetFileTime() supports birthtime.
 	 */
 	if (birthtime > 0 || birthtime_nanos > 0) {
-		wintm.QuadPart = unix_to_ntfs(birthtime, birthtime_nanos);
+		wintm.QuadPart = __archive_unix_to_ntfs(birthtime, birthtime_nanos);
 		fbtime.dwLowDateTime = wintm.LowPart;
 		fbtime.dwHighDateTime = wintm.HighPart;
 		pfbtime = &fbtime;
@@ -2935,7 +2935,7 @@ older(BY_HANDLE_FILE_INFORMATION *st, struct archive_entry *entry)
 	int64_t sec;
 	uint32_t nsec;
 
-	ntfs_to_unix(FILETIME_to_ntfs(&st->ftLastWriteTime), &sec, &nsec);
+	__archive_ntfs_to_unix(__archive_FILETIME_to_ntfs(&st->ftLastWriteTime), &sec, &nsec);
 	/* First, test the seconds and return if we have a definite answer. */
 	/* Definitely older. */
 	if (sec < archive_entry_mtime(entry))

--- a/libarchive/archive_write_set_format_7zip.c
+++ b/libarchive/archive_write_set_format_7zip.c
@@ -1357,7 +1357,7 @@ make_time(struct archive_write *a, uint8_t type, unsigned flg, int ti)
 	for (;file != NULL; file = file->next) {
 		if ((file->flg & flg) == 0)
 			continue;
-		archive_le64enc(filetime, unix_to_ntfs(file->times[ti].time,
+		archive_le64enc(filetime, __archive_unix_to_ntfs(file->times[ti].time,
 			file->times[ti].time_ns));
 		r = (int)compress_out(a, filetime, 8, ARCHIVE_Z_RUN);
 		if (r < 0)

--- a/libarchive/archive_write_set_format_zip.c
+++ b/libarchive/archive_write_set_format_zip.c
@@ -1153,7 +1153,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	else
 		archive_le16enc(local_header + 8, zip->entry_compression);
 	archive_le32enc(local_header + 10,
-		unix_to_dos(archive_entry_mtime(zip->entry)));
+		__archive_unix_to_dos(archive_entry_mtime(zip->entry)));
 	if ((zip->entry_flags & ZIP_ENTRY_FLAG_LENGTH_AT_END) == 0) {
 		archive_le32enc(local_header + 14, zip->entry_crc32);
 		archive_le32enc(local_header + 18, (uint32_t)zip->entry_compressed_size);
@@ -1184,7 +1184,7 @@ archive_write_zip_header(struct archive_write *a, struct archive_entry *entry)
 	else
 		archive_le16enc(zip->file_header + 10, zip->entry_compression);
 	archive_le32enc(zip->file_header + 12,
-		unix_to_dos(archive_entry_mtime(zip->entry)));
+		__archive_unix_to_dos(archive_entry_mtime(zip->entry)));
 	archive_le16enc(zip->file_header + 28, (uint16_t)filename_length);
 	/* Following Info-Zip, store mode in the "external attributes" field. */
 	archive_le32enc(zip->file_header + 38,


### PR DESCRIPTION
While shared libs can use whatever names they want and mark specific ones for export, static libs effectively export every non-local symbol which leads to collisions when linking.  That means these time funcs are all exported without any archive prefix.

I wasn't sure if we wanted to go this route again (defines to rename), or just rename the funcs directly & avoid the define logic.  Happy to switch to the other option if people prefer.