### PR TITLE
rar5: raise the signature bid above the seekable Zip bidder's

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1091,6 +1091,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_rar5_bad_tables.rar.uu \
 	libarchive/test/test_read_format_rar5_bad_window_sz_in_mltarc_file.rar.uu \
 	libarchive/test/test_read_format_rar5_data_ready_pointer_leak.rar.uu \
+	libarchive/test/test_read_format_rar5_zip_in_rar.rar.uu \
 	libarchive/test/test_read_format_raw.bufr.uu \
 	libarchive/test/test_read_format_raw.data.gz.uu \
 	libarchive/test/test_read_format_raw.data.Z.uu \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -85,6 +85,16 @@ static const unsigned char rar5_signature_xor[] = {
 };
 static const size_t g_unpack_window_size = 0x20000;
 
+/* Bid returned when the RAR5 signature is found at offset 0.  Bidders
+ * conventionally return the number of bits they verified, so an exact
+ * match of the 8-byte signature bids 64 (like the ar and warc readers
+ * do for their 8-byte magics).  This must stay above the seekable Zip
+ * bidder's 32 so that a RAR archive which merely stores an uncompressed
+ * Zip is still recognized as RAR (see issue #2249).  The weaker SFX
+ * heuristic, which only scans for the signature somewhere inside an
+ * executable, deliberately keeps its lower bid of 30. */
+#define RAR5_SIGNATURE_BID ((int)(8 * sizeof(rar5_signature_xor)))
+
 /* These could have been static const's, but they aren't, because of
  * Visual Studio. */
 #define MAX_NAME_IN_CHARS 2048
@@ -1110,7 +1120,7 @@ static int bid_standard(struct archive_read* a) {
 		return -1;
 
 	if(!memcmp(h, signature, sizeof(rar5_signature_xor)))
-		return 30;
+		return RAR5_SIGNATURE_BID;
 
 	return -1;
 }
@@ -1159,7 +1169,7 @@ static int bid_sfx(struct archive_read *a)
 static int rar5_bid(struct archive_read* a, int best_bid) {
 	int my_bid;
 
-	if(best_bid > 30)
+	if(best_bid >= RAR5_SIGNATURE_BID)
 		return -1;
 
 	my_bid = bid_standard(a);

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -154,6 +154,37 @@ DEFINE_TEST(test_read_format_rar5_stored)
 	EPILOGUE();
 }
 
+DEFINE_TEST(test_read_format_rar5_zip_in_rar)
+{
+	/* Regression test for issue #2249.  This archive begins with the
+	 * RAR5 signature but stores an uncompressed (method "store") Zip
+	 * file as one of its members.  The Zip bidder used to outscore the
+	 * RAR5 bidder on such archives (its seekable end-of-central-directory
+	 * bid of 32 beat the RAR5 signature bid of 30), so auto-detection
+	 * misread the whole thing as a Zip and reported the embedded Zip's
+	 * entries instead of the RAR members.  With the RAR5 signature bid
+	 * raised to 64 the reader must pick RAR5 and list the real members. */
+
+	const char *expected[] = {
+		"payload/inner.zip",
+		"payload/real_after.txt",
+		"payload",
+	};
+	size_t i;
+
+	PROLOGUE("test_read_format_rar5_zip_in_rar.rar");
+
+	for(i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+		assertA(0 == archive_read_next_header(a, &ae));
+		assertEqualInt(ARCHIVE_FORMAT_RAR_V5, archive_format(a));
+		assertEqualString(expected[i], archive_entry_pathname(ae));
+	}
+
+	assertA(ARCHIVE_EOF == archive_read_next_header(a, &ae));
+
+	EPILOGUE();
+}
+
 DEFINE_TEST(test_read_format_rar5_compressed)
 {
 	const int DATA_SIZE = 1200;

--- a/libarchive/test/test_read_format_rar5_zip_in_rar.rar.uu
+++ b/libarchive/test/test_read_format_rar5_zip_in_rar.rar.uu
@@ -1,0 +1,11 @@
+begin 644 test_read_format_rar5_zip_in_rar.rar
+M4F%R(1H' 0 SDK7E"@$%!@ % 0& @ "(/\@F+0(#"Z4!!*4!("[A<86    1
+M<&%Y;&]A9"]I;FYE<BYZ:7 * P*O8J^S2S'= 5!+ P04    "  XB!5=^CV7
+M-@\    -    &@   %1(25-?25-?24Y3241%7U1(15]:25 N='ATR\S+2RU2
+M2,[/*TG-*P$ 4$L! A0 %     @ .(@57?H]ES8/    #0   !H         
+M             %1(25-?25-?24Y3241%7U1(15]:25 N='AT4$L%!@     !
+M  $ 2    $<       /8X5DR @,+E0 $E0 @+J9-]H   !9P87EL;V%D+W)E
+M86Q?869T97(N='AT"@,"O-BOLTLQW0%I(&%M(&$@<F5A;"!R87(@96YT<GGM
+II2BC'0(#"P ! !"    '<&%Y;&]A9 H# OO$K[-+,=T!'7=640,%!   
+`
+end


### PR DESCRIPTION
Fixes #2249.

## Problem

A RAR5 archive that stores an uncompressed Zip file gets read as that Zip file. `bid_standard()` returns 30 for an exact 8-byte signature match at offset 0, but the seekable Zip bidder returns 32 whenever it finds a valid EOCD record — which the stored Zip conveniently provides at the tail of the file. Zip wins the auction and libarchive silently lists the embedded Zip's entries instead of the RAR members. No error, no warning:

```
$ rar l test.rar        # payload, payload/inner.zip, payload/real.txt
$ bsdtar tf test.rar    # INSIDE_THE_ZIP.txt   <- the embedded zip's entry
```

Since the `tar.exe` bundled with Windows 11 is bsdtar, this reproduces on a stock Windows machine with nothing but `rar a -m0` and the OS's own tar, and the resulting listing disagrees with WinRAR/7-Zip/unrar.

## Change

This takes the approach suggested in the issue discussion: bump the RAR5 signature bid to 64 (8 bytes = 64 bits of verified magic, the same bits-examined convention the `ar` and `warc` readers already use for their 8-byte magics), and raise the early-out in `rar5_bid()` to match. The constant is derived from `sizeof(rar5_signature_xor)` rather than hardcoded.

I deliberately did **not** raise the SFX bid. Finding the signature somewhere in the first 512 KB of an executable is much weaker evidence than finding it at offset 0: a Zip SFX that merely *stores* a RAR5 file inside also matches that scan. I built exactly such an executable (MZ stub, raw RAR5 archive at an aligned offset past 0x10000, valid Zip appended) and confirmed that raising the SFX bid to 64 would have flipped it from Zip to RAR — i.e. it would have traded one misdetection for another. With the SFX bid left at 30, that file still reads as Zip, and a regular RAR5 SFX executable still reads as RAR, both unchanged from current behavior.

One small side effect worth mentioning: the early-out is now `best_bid >= 64` instead of `> 30`, so when the Zip reader has already bid 32 on an MZ/ELF file, the SFX scan (bounded at 512 KB) now runs and then loses, where previously it was skipped. Behavior is identical; it's just a little wasted read-ahead in that narrow case. I kept it this way for simplicity, but happy to gate `bid_sfx()` on `best_bid < 30` if you'd prefer.

## Testing

* New test `test_read_format_rar5_zip_in_rar` with a small fixture (a RAR5 archive created by `rar a -m0`, storing a Zip plus a regular file). It fails on master — the reader comes back as Zip and returns the embedded Zip's entry — and passes with this change, verifying all three members and `ARCHIVE_FORMAT_RAR_V5`.
* Full `libarchive_test` run before/after on the same machine (MinGW/Windows, codec libs disabled): identical results, no new failures.
* Manual matrix with the patched bsdtar: RAR-storing-a-Zip now lists RAR members; a plain Zip, a Zip storing a RAR5 file, a RAR5 SFX executable, and the adversarial Zip-SFX-containing-a-RAR5 described above all detect the same as before.
