### PR TITLE
rar5: report truncation when a multivolume file's next volume is missing

### DIFF
--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -3464,6 +3464,18 @@ static int scan_for_signature(struct archive_read* a) {
 	return ARCHIVE_FATAL;
 }
 
+/* Report that the archive ended while the current file was still expected to
+ * continue in a following volume (its header had the 'split after' flag set),
+ * which typically happens when a multivolume set is opened without supplying
+ * its later volumes.  Returning a clean EOF here would silently hand back a
+ * short, corrupted read, so this is a fatal error. */
+static int truncated_multivolume_error(struct archive_read* a) {
+	archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+	    "Truncated RAR5 archive: file continues in a subsequent volume "
+	    "that is not available");
+	return ARCHIVE_FATAL;
+}
+
 /* This function will switch the multivolume archive file to another file,
  * i.e. from part03 to part 04. */
 static int advance_multivolume(struct archive_read* a) {
@@ -3601,8 +3613,11 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 		}
 
 		if(!read_ahead(a, cur_block_size, &lp)) {
+			/* We are in the middle of merging a block that spans
+			 * volumes, so more data must follow; running out of
+			 * input here means the following volume is missing. */
 			rar5->cstate.switch_multivolume = 0;
-			return ARCHIVE_EOF;
+			return truncated_multivolume_error(a);
 		}
 
 		/* Sanity check; there should never be a situation where this
@@ -3646,7 +3661,13 @@ static int merge_block(struct archive_read* a, ssize_t block_size,
 			rar5->merge_mode++;
 			ret = advance_multivolume(a);
 			rar5->merge_mode--;
-			if(ret != ARCHIVE_OK) {
+			if(ret == ARCHIVE_EOF) {
+				/* The block is only partially merged but the
+				 * input ended, so the volume that holds the rest
+				 * of it is missing. */
+				rar5->cstate.switch_multivolume = 0;
+				return truncated_multivolume_error(a);
+			} else if(ret != ARCHIVE_OK) {
 				rar5->cstate.switch_multivolume = 0;
 				return ret;
 			}
@@ -3669,7 +3690,15 @@ static int process_block(struct archive_read* a) {
 	/* If we don't have any data to be processed, this most probably means
 	 * we need to switch to the next volume. */
 	if(rar5->main.volume && rar5->file.bytes_remaining == 0) {
+		/* Capture 'split after' before advancing: advance_multivolume()
+		 * parses following headers and overwrites this flag. */
+		int split_after = rar5->generic.split_after > 0;
 		ret = advance_multivolume(a);
+		if(ret == ARCHIVE_EOF && split_after) {
+			/* The file is promised to continue in a following
+			 * volume, but the input ended first. */
+			return truncated_multivolume_error(a);
+		}
 		if(ret != ARCHIVE_OK)
 			return ret;
 	}
@@ -4082,7 +4111,16 @@ static int do_unstore_file(struct archive_read* a,
 		ret = advance_multivolume(a);
 		rar5->cstate.switch_multivolume = 0;
 
-		if(ret != ARCHIVE_OK) {
+		if(ret == ARCHIVE_EOF) {
+			/* We only reach this advance because 'split after' was
+			 * set, i.e. the file is promised to continue in a
+			 * following volume, but the input ended before we could
+			 * reach it (for example, only the first volume of the
+			 * set was supplied).  The data decoded so far is
+			 * incomplete, so report truncation rather than silently
+			 * returning a short read as a clean end of file. */
+			return truncated_multivolume_error(a);
+		} else if(ret != ARCHIVE_OK) {
 			/* Failed to advance to next multivolume archive
 			 * file. */
 			return ret;

--- a/libarchive/test/test_read_format_rar5.c
+++ b/libarchive/test/test_read_format_rar5.c
@@ -253,6 +253,35 @@ DEFINE_TEST(test_read_format_rar5_multiple_files_solid)
 	EPILOGUE();
 }
 
+DEFINE_TEST(test_read_format_rar5_multiarchive_first_volume_only)
+{
+	/* Regression test: opening only the first volume of a multivolume
+	 * RAR5 set must not silently return a truncated file.  The first
+	 * entry's data is flagged 'split after', i.e. it continues in the
+	 * following volumes; when those are not supplied, reading the data
+	 * has to fail rather than report a clean end of file after a short
+	 * read, which used to silently hand back corrupted data. */
+	char buf[16384];
+	la_ssize_t r;
+
+	PROLOGUE("test_read_format_rar5_multiarchive.part01.rar");
+
+	assertA(0 == archive_read_next_header(a, &ae));
+	assertEqualString(
+	    "home/antek/temp/build/unrar5/libarchive/bin/bsdcat_test",
+	    archive_entry_pathname(ae));
+
+	/* Drain the entry's data.  It must terminate with a fatal error,
+	 * not a clean 0-length end of file. */
+	do {
+		r = archive_read_data(a, buf, sizeof(buf));
+	} while(r > 0);
+
+	assertEqualInt(ARCHIVE_FATAL, r);
+
+	EPILOGUE();
+}
+
 DEFINE_TEST(test_read_format_rar5_multiarchive_skip_all)
 {
 	const char* reffiles[] = {


### PR DESCRIPTION
## Problem

Opening a multivolume RAR5 set by its first volume(s) only — e.g. `bsdtar -xf archive.part1.rar`, or `archive_read_open_filename()` on the first part — silently returns truncated, corrupted data for any file that continues into a volume that wasn't supplied. There is no error: `archive_read_data()` hands back the bytes present in the volumes given and then reports a clean end of file, and `archive_read_next_header()` returns `ARCHIVE_EOF`.

I found this by differential testing against `unrar`/WinRAR. With a 3-volume stored (`-m0`) set opened at part 1:

```
unrar x archive.part1.rar   -> extracts data.bin (1400000 bytes, correct) + readme.txt
bsdtar -xf archive.part1.rar -> data.bin truncated to 524124 bytes, readme.txt missing, exit 0
```

It affects compressed entries too, and can be worse there: with the in-tree `test_read_format_rar5_multiarchive` fixture opened at `part01` only, the first entry (declared 144608 bytes) reads back **zero** bytes and still reports success, because its very first compressed block already spans into `part02`.

For contrast, an ordinary *truncated single-volume* RAR5 is already handled correctly — it fails with "I/O error when unstoring file". Only the multivolume-continuation case slips through as a clean EOF.

## Cause

`advance_multivolume()` returns `ARCHIVE_EOF` when it runs out of input while trying to reach the continuation of a file, and the data-reading paths forwarded that as a normal end of data. The `HFL_SPLIT_AFTER` flag on the file header promises the file continues in the next volume, so reaching EOF while it is set means the set is incomplete, not finished.

## Fix

Detect the condition at the three points that try to continue into the next volume — `do_unstore_file()` (stored), and `process_block()` / `merge_block()` (compressed) — and return a fatal "Truncated RAR5 archive" error (via a small shared helper) instead of a clean EOF.

The `merge_block()` sites are always mid-block, so running out of input there is unconditionally a missing continuation. `process_block()` captures the `split_after` flag *before* calling `advance_multivolume()`, because that function parses following headers and overwrites the flag; the stored path is already guarded by `split_after` in its surrounding condition.

When every volume is supplied nothing changes: the last volume's header does not set `split_after`, so extraction still ends with a clean EOF. All existing multivolume tests (`multiarchive`, `multiarchive_solid`, the RAR4 multivolume set, `bad_window_size_in_multiarchive_file`) continue to pass.

## Testing

- New test `test_read_format_rar5_multiarchive_first_volume_only` opens only `part01` of the existing multivolume fixture (no new fixture data) and asserts that draining the entry ends in `ARCHIVE_FATAL` rather than a clean short read. It fails on master and passes with this change.
- Full `libarchive_test` run before/after on the same machine (MinGW/Windows, external codec libs disabled): identical results, no new failures; every RAR multivolume test passes.
- Verified end to end with `bsdtar` and a small `archive_read_open_filenames()` harness across stored, compressed and solid sets: first-volume-only now errors; supplying all volumes still extracts every file with matching CRC.
