### PR TITLE
bsdunzip: Support -Z -1 as well

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -1210,7 +1210,8 @@ getopts(int argc, char *argv[])
 		case 'Z':
 			zipinfo_mode = 1;
 			if (bsdunzip->argument != NULL &&
-			    strcmp(bsdunzip->argument, "1") == 0) {
+			    (strcmp(bsdunzip->argument, "1") == 0 ||
+			    strcmp(bsdunzip->argument, "-1") == 0)) {
 				Z1_opt = 1;
 			}
 			break;

--- a/unzip/test/test_Z1.c
+++ b/unzip/test/test_Z1.c
@@ -19,3 +19,17 @@ DEFINE_TEST(test_Z1)
 	assertTextFileContents("test_basic/\ntest_basic/a\ntest_basic/b\ntest_basic/c\ntest_basic/CAPS\n", "test.out");
 	assertEmptyFile("test.err");
 }
+
+/* Test -Z -1 arg - List filenames */
+DEFINE_TEST(test_Z_1)
+{
+	const char *reffile = "test_basic.zip";
+	int r;
+
+	extract_reference_file(reffile);
+	r = systemf("%s -Z -1 %s >test.out 2>test.err", testprog, reffile);
+	assertEqualInt(0, r);
+	assertNonEmptyFile("test.out");
+	assertTextFileContents("test_basic/\ntest_basic/a\ntest_basic/b\ntest_basic/c\ntest_basic/CAPS\n", "test.out");
+	assertEmptyFile("test.err");
+}


### PR DESCRIPTION
Info-ZIP's unzip takes -Z as first argument and all following arguments are treated as zipinfo arguments. Our bsdunzip implementation only supports -Z1 so far.

Since -1 is a valid zipinfo argument, allow -Z -1 for extended compatibility.

Resolves #3406