### PR TITLE
Treat non-identical conversions in iconv as failure.

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -2130,8 +2130,16 @@ iconv_strncat_in_locale(struct archive_string *as, const void *_p,
 	while (remaining >= from_size) {
 		size_t result = iconv(cd, &itp, &remaining, &outp, &avail);
 
-		if (result != (size_t)-1)
+		if (result == 0)
 			break; /* Conversion completed. */
+		if (result != (size_t)-1) {
+			/*
+			 * Conversion did not fail, but it performed
+			 * some non-identical character substitutions.
+			 */
+			return_value = -1;
+			break;
+		}
 
 		if (errno == EILSEQ || errno == EINVAL) {
 			/*


### PR DESCRIPTION
I.e., if the input data can't be represented in the output form and requires replacement character substitutions, treat that as failure. This appears to be what the code intends to do anyway, just under the assumption of nonstandard GNU iconv semantics.

Fixes the tests test_archive_string_conversion_fail_c and test_archive_string_conversion_fail_latin1 under POSIX-compliant iconv.

fix https://github.com/libarchive/libarchive/issues/3413