### PR TITLE
namespace pack_find to avoid collisions

### DIFF
--- a/libarchive/archive_pack_dev.c
+++ b/libarchive/archive_pack_dev.c
@@ -316,7 +316,7 @@ compare_format(const void *key, const void *element)
 
 
 pack_t *
-pack_find(const char *name)
+__archive_pack_find(const char *name)
 {
 	const struct format	*format;
 

--- a/libarchive/archive_pack_dev.h
+++ b/libarchive/archive_pack_dev.h
@@ -36,7 +36,7 @@
 
 typedef	dev_t pack_t(int, unsigned long [], const char **);
 
-pack_t	*pack_find(const char *);
+pack_t	*__archive_pack_find(const char *);
 
 #define	major_netbsd(x)		((int32_t)((((x) & 0x000fff00) >>  8)))
 #define	minor_netbsd(x)		((int32_t)((((x) & 0xfff00000) >> 12) | \

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -1432,7 +1432,7 @@ parse_device(dev_t *pdev, struct archive *a, char *val)
 		 * Decode and pack it accordingly.
 		 */
 		*dev++ = '\0';
-		if ((pack = pack_find(val)) == NULL) {
+		if ((pack = __archive_pack_find(val)) == NULL) {
 			archive_set_error(a, ARCHIVE_ERRNO_FILE_FORMAT,
 			    "Unknown format `%s'", val);
 			return ARCHIVE_WARN;


### PR DESCRIPTION
While shared libs can use whatever names they want and mark specific ones for export, static libs effectively export every non-local symbol which leads to collisions when linking.