### PR TITLE
filter_fork_posix: add child stubs

### DIFF
--- a/libarchive/filter_fork_posix.c
+++ b/libarchive/filter_fork_posix.c
@@ -266,4 +266,20 @@ __archive_check_child(int in, int out)
 #endif
 }
 
+#elif !(defined(_WIN32) && !defined(__CYGWIN__))
+
+#include "archive.h"
+
+int
+__archive_create_child(const char *cmd, int *child_stdin, int *child_stdout,
+		pid_t *out_child)
+{
+	return (ARCHIVE_FAILED);
+}
+
+void
+__archive_check_child(int in, int out)
+{
+}
+
 #endif /* defined(HAVE_PIPE) && defined(HAVE_VFORK) && defined(HAVE_FCNTL) */


### PR DESCRIPTION
If the platform doesn't support any of the require APIs, these functions are never defined, and lead to link time errors due to some other helpers calling them.  Add stubs like exist for filter_fork_windows.c already.

In practice, much of the libarchive platform can be used just fine even when these are unavailable since only a few compression algorithms only work with external programs with no library APIs (e.g. lrzip).

This can come up when building for WASI (WebAssembly) where compression libs are provided & used for the algorithms desired.