### PR TITLE
disk: Check file size limits with sparse files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -526,6 +526,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_gtar_lzma.c \
 	libarchive/test/test_read_format_gtar_redundant_L.c \
 	libarchive/test/test_read_format_gtar_sparse.c \
+	libarchive/test/test_read_format_gtar_sparse_exceeds_length.c \
 	libarchive/test/test_read_format_gtar_sparse_length.c \
 	libarchive/test/test_read_format_gtar_sparse_skip_entry.c \
 	libarchive/test/test_read_format_huge_rpm.c \
@@ -961,6 +962,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_gtar_sparse_1_17_posix01.tar.uu \
 	libarchive/test/test_read_format_gtar_sparse_1_17_posix10.tar.uu \
 	libarchive/test/test_read_format_gtar_sparse_1_17_posix10_modified.tar.uu \
+	libarchive/test/test_read_format_gtar_sparse_exceeds_length.tar.Z.uu \
 	libarchive/test/test_read_format_gtar_sparse_reuse.tar.uu \
 	libarchive/test/test_read_format_gtar_sparse_length.tar.Z.uu \
 	libarchive/test/test_read_format_gtar_sparse_skip_entry.tar.Z.uu \

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -569,12 +569,19 @@ archive_read_format_tar_read_header(struct archive_read *a,
 			return (ARCHIVE_FATAL);
 	} else {
 		struct sparse_block *sb;
+		size_t added = 0;
+		int count;
 
 		for (sb = tar->sparse_list; sb != NULL; sb = sb->next) {
-			if (!sb->hole)
+			if (!sb->hole) {
 				archive_entry_sparse_add_entry(entry,
 				    sb->offset, sb->remaining);
+				added++;
+			}
 		}
+		count = archive_entry_sparse_count(entry);
+		if (count < 0 || (size_t)count != added)
+			return (ARCHIVE_FATAL);
 	}
 
 	if (r == ARCHIVE_OK && archive_entry_filetype(entry) == AE_IFREG) {
@@ -3137,6 +3144,8 @@ gnu_add_sparse_entry(struct archive_read *a, struct tar *tar,
 {
 	struct sparse_block *p;
 
+	if (remaining == 0)
+		return (ARCHIVE_OK);
 	p = calloc(1, sizeof(*p));
 	if (p == NULL) {
 		archive_set_error(&a->archive, ENOMEM, "Out of memory");

--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -997,8 +997,11 @@ write_data_block(struct archive_write_disk *a, const char *buff, size_t size)
 	}
 
 	/* If this write would run beyond the file size, truncate it. */
-	if (a->filesize >= 0 && (int64_t)(a->offset + size) > a->filesize)
-		start_size = size = (size_t)(a->filesize - a->offset);
+	if (a->filesize >= 0 && a->filesize - a->offset < (int64_t)size) {
+		int64_t diff = a->filesize - a->offset;
+
+		start_size = size = diff < 0 ? 0 : (size_t)diff;
+	}
 
 	/* Write the data. */
 	while (size > 0) {
@@ -1614,8 +1617,11 @@ hfs_write_data_block(struct archive_write_disk *a, const char *buff,
 	}
 
 	/* If this write would run beyond the file size, truncate it. */
-	if (a->filesize >= 0 && (int64_t)(a->offset + size) > a->filesize)
-		start_size = size = (size_t)(a->filesize - a->offset);
+	if (a->filesize >= 0 && a->filesize - a->offset < (int64_t)size) {
+		int64_t diff = a->filesize - a->offset;
+
+		start_size = size = diff < 0 ? 0 : (size_t)diff;
+	}
 
 	/* Write the data. */
 	while (size > 0) {

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1070,8 +1070,11 @@ write_data_block(struct archive_write_disk *a, const char *buff, size_t size)
 	}
 
 	/* If this write would run beyond the file size, truncate it. */
-	if (a->filesize >= 0 && (int64_t)(a->offset + size) > a->filesize)
-		start_size = size = (size_t)(a->filesize - a->offset);
+	if (a->filesize >= 0 && a->filesize - a->offset < (int64_t)size) {
+		int64_t diff = a->filesize - a->offset;
+
+		start_size = size = diff < 0 ? 0 : (size_t)diff;
+	}
 
 	/* Write the data. */
 	while (size > 0) {

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -152,6 +152,7 @@ IF(ENABLE_TEST)
     test_read_format_gtar_lzma.c
     test_read_format_gtar_redundant_L.c
     test_read_format_gtar_sparse.c
+    test_read_format_gtar_sparse_exceeds_length.c
     test_read_format_gtar_sparse_length.c
     test_read_format_gtar_sparse_skip_entry.c
     test_read_format_huge_rpm.c

--- a/libarchive/test/test_read_format_gtar_sparse_exceeds_length.c
+++ b/libarchive/test/test_read_format_gtar_sparse_exceeds_length.c
@@ -1,0 +1,47 @@
+/*-
+ * Copyright (c) 2026 Tobias Stoeckmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+
+DEFINE_TEST(test_read_format_gtar_sparse_exceeds_length)
+{
+	const char *refname =
+	    "test_read_format_gtar_sparse_exceeds_length.tar.Z";
+	struct archive *a;
+	struct archive_entry *ae;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 4096));
+
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_gtar_sparse_exceeds_length.tar.Z.uu
+++ b/libarchive/test/test_read_format_gtar_sparse_exceeds_length.tar.Z.uu
@@ -1,0 +1,9 @@
+begin 644 test_read_format_gtar_sparse_exceeds_length.tar.Z
+M'YV0+EY`"8,'29DP9,K(F>,"RXLY<,(L+`.@HL6+&#-JW,BQH\>/`&"(A&&#
+M!HV0(T>B3`EC)<L8,6RX9"DR9(P9-&[(```"#\B?0(,*':JQSAPZ$E'*>?.&
+M#E&.2YL^G4JUJM6K6+-6G1$#Q!$G55Q`E#BGC(LV8>#TH"$C!XT<,&+<L!&#
+M10P%,KI^#3MVHM@T>LKTN"O#AE>P8B/Z=1.FC6`[:<;02=-&@=;+F#-KWLRY
+ML^?/H$-KABR9LNC3(%.6/$FS9>N9+V&SM`EC[DX0+5'K_FD4J1RE3)UFC2I\
+2M_'CR+->2<Z\N?/GT*-+GZX;
+`
+end


### PR DESCRIPTION
While verifying that sparse file sizes actually fit into disk file sizes, consider that the offset itself might be outside of file size limits. While at it, make sure that tar properly checks sparse ranges to prevent this on archive level, too.

Resolves ZDI-CAN-32407

Reported by Eldudareeno working with TrendAI Zero Day Initiative who also supplied the example file. Thanks!