### PR TITLE
read: Handle all 0 read edge cases

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1411,16 +1411,18 @@ __archive_read_ahead(struct archive_read *a, size_t min, ssize_t *avail)
 
 const void *
 __archive_read_filter_ahead(struct archive_read_filter *f,
-    size_t min, ssize_t *avail)
+    size_t request, ssize_t *avail)
 {
 	ssize_t bytes_read;
-	size_t tocopy;
+	size_t min, tocopy;
 
 	if (f->fatal) {
 		if (avail)
 			*avail = ARCHIVE_FATAL;
 		return (NULL);
 	}
+	/* request == 0 is perfectly well-defined.*/
+	min = request == 0 ? 1 : request;
 
 	/*
 	 * Keep pulling more data until we can satisfy the request.
@@ -1429,11 +1431,9 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 
 		/*
 		 * If we can satisfy from the copy buffer (and the
-		 * copy buffer isn't empty), we're done.  In particular,
-		 * note that min == 0 is a perfectly well-defined
-		 * request.
+		 * copy buffer isn't empty), we're done.
 		 */
-		if (f->avail >= min && f->avail > 0) {
+		if (f->avail >= min) {
 			if (avail != NULL)
 				*avail = f->avail;
 			return (f->next);
@@ -1468,10 +1468,18 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 
 		/* If we've used up the client data, get more. */
 		if (f->client_avail <= 0) {
+			static const char *empty = "";
+
 			if (f->end_of_file) {
+				const char *eof;
+
 				if (avail != NULL)
 					*avail = f->avail;
-				return (NULL);
+				if (request == 0)
+					eof = f->avail == 0 ? empty : f->next;
+				else
+				 	eof = NULL;
+				return (eof);
 			}
 			bytes_read = (f->vtable->read)(f,
 			    &f->client_buff);
@@ -1485,6 +1493,8 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 				return (NULL);
 			}
 			if (bytes_read == 0) {
+				const char *eof;
+
 				/* Check for another client object first */
 				if (f->archive->client.cursor !=
 				      f->archive->client.nodes - 1) {
@@ -1501,7 +1511,11 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 				/* Return whatever we do have. */
 				if (avail != NULL)
 					*avail = f->avail;
-				return (NULL);
+				if (request == 0)
+					eof = f->avail == 0 ? empty : f->next;
+				else
+				 	eof = NULL;
+				return (eof);
 			}
 			f->client_total = bytes_read;
 			f->client_avail = f->client_total;

--- a/libarchive/test/test_archive_read.c
+++ b/libarchive/test/test_archive_read.c
@@ -62,6 +62,69 @@ DEFINE_TEST(test_archive_read_ahead_eof)
 	assert(0 == archive_read_free(a));
 }
 
+DEFINE_TEST(test_archive_read_ahead_zero)
+{
+	struct archive *a;
+	struct archive_read *ar;
+	ssize_t avail;
+
+	/* prepare a reader of raw in-memory data */
+	assert((a = archive_read_new()) != NULL);
+	ar = (struct archive_read *)a;
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_raw(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, buf, sizeof(buf)));
+
+	/* perform a zero read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, 0, &avail));
+	assertEqualIntA(ar, sizeof(buf), avail);
+
+	/* perform a read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, 1, &avail));
+	assertEqualIntA(ar, sizeof(buf), avail);
+
+	/* perform the zero read again */
+	assert(NULL != __archive_read_ahead(ar, 0, &avail));
+	assertEqualIntA(ar, sizeof(buf), avail);
+
+	/* consume all available bytes */
+	assertEqualIntA(ar, sizeof(buf),
+	    __archive_read_consume(ar, sizeof(buf)));
+
+	/* perform a read which cannot be fulfilled */
+	assert(NULL == __archive_read_ahead(ar, 1, &avail));
+	assertEqualIntA(ar, 0, avail);
+
+	/* perform another zero read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, 0, &avail));
+	assertEqualIntA(ar, 0, avail);
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* prepare a reader of raw in-memory data */
+	assert((a = archive_read_new()) != NULL);
+	ar = (struct archive_read *)a;
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_empty(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, buf, 0));
+
+	/* perform a zero read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, 0, &avail));
+	assertEqualIntA(ar, 0, avail);
+
+	/* perform a read which cannot be fulfilled */
+	assert(NULL == __archive_read_ahead(ar, 1, &avail));
+	assertEqualIntA(ar, 0, avail);
+
+	/* perform another zero read which can be fulfilled */
+	assert(NULL != __archive_read_ahead(ar, 0, &avail));
+	assertEqualIntA(ar, 0, avail);
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 static ssize_t
 eof_read_callback(struct archive *a, void *data, const void **buffer)
 {


### PR DESCRIPTION
Make sure that read of 0 bytes succeeds as long as the filter itself is not in a fatal state.

This means that the return value must not be NULL, otherwise the code treats it as failure.

See supplied test for examples where accidentally NULL is returned.

In total, the fastest implementation is to treat a 0 read as a 1 read except when EOF occurred. This removes an if-check from the "hot path" and moves it to the beginning of the function, outside of the for-loop.

The other code is triggered on EOF, which is fortunately a rare situation.