### PR TITLE
Guard bsdtar substitution allocation sizes

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -38,6 +38,14 @@ struct substitution {
 	struct subst_rule *first_rule, *last_rule;
 };
 
+static size_t
+checked_size_add(size_t old_len, size_t len)
+{
+	if (len > (size_t)-1 - old_len || old_len + len > (size_t)-1 - 1)
+		lafe_errc(1, ENOMEM, "Out of memory");
+	return old_len + len + 1;
+}
+
 static void
 init_substitution(struct bsdtar *bsdtar)
 {
@@ -168,7 +176,7 @@ realloc_strncat(char **str, const char *append, size_t len)
 	else
 		old_len = strlen(*str);
 
-	new_str = malloc(old_len + len + 1);
+	new_str = malloc(checked_size_add(old_len, len));
 	if (new_str == NULL)
 		lafe_errc(1, errno, "Out of memory");
 	if (*str != NULL)
@@ -190,7 +198,7 @@ realloc_strcat(char **str, const char *append)
 	else
 		old_len = strlen(*str);
 
-	new_str = malloc(old_len + strlen(append) + 1);
+	new_str = malloc(checked_size_add(old_len, strlen(append)));
 	if (new_str == NULL)
 		lafe_errc(1, errno, "Out of memory");
 	if (*str != NULL)


### PR DESCRIPTION
## Summary

This PR adds overflow checks for allocation size calculations in `bsdtar` substitution string handling.

The affected code builds replacement strings using expressions such as:

```c
old_len + len + 1
```

and:

```c
old_len + strlen(append) + 1
```

These values are used as allocation sizes before appending string contents. If the addition overflows `size_t`, `malloc()` may receive a smaller size than intended while later copy operations still use the original component lengths.

This change adds a small helper to validate the size calculation before allocation.

## CWE

Primary classification:

```text
CWE-190: Integer Overflow or Wraparound
```

Potential impact if unchecked:

```text
Incorrect allocation size calculation may lead to an undersized heap buffer before string copy operations.
```

## Change

A helper was added to check both parts of the allocation size calculation:

```c
static size_t
checked_size_add(size_t old_len, size_t len)
{
    if (len > (size_t)-1 - old_len || old_len + len > (size_t)-1 - 1)
        lafe_errc(1, ENOMEM, "Out of memory");
    return old_len + len + 1;
}
```

The allocation sites now use the checked helper:

```c
new_str = malloc(checked_size_add(old_len, len));
```

and:

```c
new_str = malloc(checked_size_add(old_len, strlen(append)));
```

## Rationale

This keeps the existing behavior for normal inputs while avoiding unchecked unsigned size calculations before heap allocation. If the requested size cannot be represented safely, the code now follows the existing error handling path instead of allocating with a wrapped size.

## Testing

Built `bsdtar` locally with CMake:

```text
cmake --build /private/tmp/avr-target-libarchive/build --target bsdtar --parallel 4
```

The target built successfully.