### PR TITLE
warc: Drop deconst function

### DIFF
--- a/libarchive/archive_read_support_format_warc.c
+++ b/libarchive/archive_read_support_format_warc.c
@@ -456,13 +456,7 @@ archive_read_format_warc_skip(struct archive_read *a)
 
 
 /* Private routines */
-static void*
-deconst(const void *c)
-{
-	return (void *)(uintptr_t)c;
-}
-
-static char*
+static const char*
 xmemmem(const char *hay, const size_t haysize,
 	const char *needle, const size_t needlesize)
 {
@@ -479,7 +473,7 @@ xmemmem(const char *hay, const size_t haysize,
 	 * found anywhere in the haystack; otherwise find the first candidate
 	 * that begins with *NEEDLE. */
 	if (needlesize == 0UL) {
-		return deconst(hay);
+		return hay;
 	} else if ((hay = memchr(hay, *needle, haysize)) == NULL) {
 		/* No candidate match remains. */
 		return NULL;
@@ -498,7 +492,7 @@ xmemmem(const char *hay, const size_t haysize,
 		return NULL;
 	} else if (eqp) {
 		/* Found a match. */
-		return deconst(hay);
+		return hay;
 	}
 
 	/* Loop through the rest of the haystack and update the rolling XOR
@@ -511,7 +505,7 @@ xmemmem(const char *hay, const size_t haysize,
 		 * NEEDLESIZE - 1 characters for equality.  CAND is always before
 		 * HP by design, so no range check is needed. */
 		if (hsum == nsum && memcmp(cand, needle, needlesize - 1U) == 0) {
-			return deconst(cand);
+			return cand;
 		}
 	}
 	return NULL;
@@ -576,7 +570,7 @@ time_from_tm(struct tm *t)
 }
 
 static time_t
-xstrpisotime(const char *s, char **endptr)
+xstrpisotime(const char *s, const char **endptr)
 {
 /* Like strptime(), but only for ISO 8601 Zulu strings. */
 	struct tm tm;
@@ -624,7 +618,7 @@ xstrpisotime(const char *s, char **endptr)
 
 out:
 	if (endptr != NULL) {
-		*endptr = deconst(s);
+		*endptr = s;
 	}
 	return res;
 }
@@ -810,8 +804,7 @@ static time_t
 warc_read_date(const char *buf, size_t bsz)
 {
 	static const char _key[] = "\r\nWARC-Date:";
-	const char *val, *eol;
-	char *on = NULL;
+	const char *val, *eol, *on = NULL;
 	time_t res;
 
 	if ((val = xmemmem(buf, bsz, _key, sizeof(_key) - 1U)) == NULL) {
@@ -837,8 +830,7 @@ static time_t
 warc_read_last_modified(const char *buf, size_t bsz)
 {
 	static const char _key[] = "\r\nLast-Modified:";
-	const char *val, *eol;
-	char *on = NULL;
+	const char *val, *eol, *on = NULL;
 	time_t res;
 
 	if ((val = xmemmem(buf, bsz, _key, sizeof(_key) - 1U)) == NULL) {


### PR DESCRIPTION
Declare variables properly, which turns deconst obsolete.