### PR TITLE
Fix permissions for files with NFS4 ACLs

### DIFF
--- a/libarchive/archive_acl.c
+++ b/libarchive/archive_acl.c
@@ -232,30 +232,84 @@ archive_acl_add_entry_len_l(struct archive_acl *acl,
 }
 
 /*
- * If this ACL entry is part of the standard POSIX permissions set,
- * store the permissions in the stat structure and return zero.
+ * Translate ACL entry into POSIX file permissions and store them, then
+ * return zero if the entry mapped perfectly onto POSIX file permissions
+ * and non-zero if it requires further processing.
  */
 static int
 acl_special(struct archive_acl *acl, int type, int permset, int tag)
 {
-	if (type == ARCHIVE_ENTRY_ACL_TYPE_ACCESS
-	    && ((permset & ~007) == 0)) {
+	int bits;
+
+	switch (type) {
+	case ARCHIVE_ENTRY_ACL_TYPE_ACCESS:
+		/* POSIX ACL */
+		bits = permset & 7;
 		switch (tag) {
 		case ARCHIVE_ENTRY_ACL_USER_OBJ:
 			acl->mode &= ~0700;
-			acl->mode |= (permset & 7) << 6;
-			return (0);
+			acl->mode |= bits << 6;
+			break;
 		case ARCHIVE_ENTRY_ACL_GROUP_OBJ:
 			acl->mode &= ~0070;
-			acl->mode |= (permset & 7) << 3;
-			return (0);
+			acl->mode |= bits << 3;
+			break;
 		case ARCHIVE_ENTRY_ACL_OTHER:
 			acl->mode &= ~0007;
-			acl->mode |= permset & 7;
-			return (0);
+			acl->mode |= bits;
+			break;
+		default:
+			return (1);
 		}
+		return ((permset & ~7) != 0);
+	case ARCHIVE_ENTRY_ACL_TYPE_ALLOW:
+	case ARCHIVE_ENTRY_ACL_TYPE_DENY:
+		/* NFS4 ACL */
+		bits = permset & 7;
+		if (permset & ARCHIVE_ENTRY_ACL_READ_DATA)
+			bits |= 4;
+		if (permset & ARCHIVE_ENTRY_ACL_WRITE_DATA)
+			bits |= 2;
+		switch (tag) {
+		case ARCHIVE_ENTRY_ACL_USER_OBJ:
+			bits = bits << 6;
+			if (type == ARCHIVE_ENTRY_ACL_TYPE_ALLOW)
+				acl->mode |= bits;
+			else
+				acl->mode &= ~bits;
+			break;
+		case ARCHIVE_ENTRY_ACL_GROUP_OBJ:
+			bits = bits << 3;
+			if (type == ARCHIVE_ENTRY_ACL_TYPE_ALLOW)
+				acl->mode |= bits;
+			else
+				acl->mode &= ~bits;
+			break;
+		case ARCHIVE_ENTRY_ACL_OTHER:
+			if (type == ARCHIVE_ENTRY_ACL_TYPE_ALLOW)
+				acl->mode |= bits;
+			else
+				acl->mode &= ~bits;
+			break;
+		case ARCHIVE_ENTRY_ACL_EVERYONE:
+			bits = (bits << 6) | (bits << 3) | bits;
+			if (type == ARCHIVE_ENTRY_ACL_TYPE_ALLOW)
+				acl->mode |= bits;
+			else
+				acl->mode &= ~bits;
+			break;
+		default:
+			return (1);
+		}
+#ifdef NOTYET
+		return ((permset & ~037) != 0);
+#else
+		/* returning zero here breaks test_acl_platform_nfs4 */
+		return (1);
+#endif
+	default:
+		return (1);
 	}
-	return (1);
 }
 
 /*

--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -1350,7 +1350,7 @@ header_common(struct archive_read *a, struct tar *tar,
 	/* Split mode handling: Set filetype always, perm only if not already set */
 	header_mode = (mode_t)tar_atol(header->mode, sizeof(header->mode));
 	archive_entry_set_filetype(entry, header_mode);
-	if (!archive_entry_perm_is_set(entry))
+	if (!archive_entry_perm_is_set(entry) || archive_entry_perm(entry) == 0)
 		archive_entry_set_perm(entry, header_mode);
 
 	/* Set uid, gid, mtime if not already set */


### PR DESCRIPTION
Since 3.7.5, files that have an ACL get extracted with mode 0000. This is because the same bit, `AE_SET_PERM`, gets used to indicate that file permissions have been set and that an ACL has been set. Thus, after reading an ACL from an extension header, the mode field of the actual file header is ignored.

On some POSIXish platforms, this not only results in an incorrect mode on extraction but prevents setting the ACL since `_archive_write_disk_finish_entry()` sets the file mode before applying ACLs, and the latter is not permitted if the file is not writeable.

This PR works around the issue by setting perm for an entry even if `AE_SET_PERM` is already set if the current value is zero. A better solution would be to introduce a separate `AE_SET_ACL` flag.

I haven't written a test case yet as I'm not sure where to put it.