### PR TITLE
iso9660: reset max_depth on pathtbl allocation failure

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -7015,13 +7015,13 @@ isoent_alloc_path_table(struct archive_write *a, struct vdd *vdd,
 {
 	int i;
 
-	vdd->max_depth = max_depth;
-	vdd->pathtbl = malloc(sizeof(*vdd->pathtbl) * vdd->max_depth);
+	vdd->pathtbl = malloc(sizeof(*vdd->pathtbl) * max_depth);
 	if (vdd->pathtbl == NULL) {
 		archive_set_error(&a->archive, ENOMEM,
 		    "Can't allocate memory");
 		return (ARCHIVE_FATAL);
 	}
+	vdd->max_depth = max_depth;
 	for (i = 0; i < vdd->max_depth; i++) {
 		vdd->pathtbl[i].first = NULL;
 		vdd->pathtbl[i].last = &(vdd->pathtbl[i].first);


### PR DESCRIPTION
## Summary

`iso9660_free()` crashes with a NULL-pointer dereference when the path-table allocation in `isoent_alloc_path_table()` fails.  This was reported in #3417.

## Root cause

`isoent_alloc_path_table()` sets `vdd->max_depth = max_depth` *before* calling `malloc()`:

```c
vdd->max_depth = max_depth;
vdd->pathtbl = malloc(sizeof(*vdd->pathtbl) * vdd->max_depth);
if (vdd->pathtbl == NULL) {
    archive_set_error(&a->archive, ENOMEM, "Can't allocate memory");
    return (ARCHIVE_FATAL);
}
```

If `malloc()` fails, `max_depth` stays positive while `pathtbl == NULL`.  Later, `iso9660_free()` (invoked from `archive_write_free()`) unconditionally iterates over the path table:

```c
for (i = 0; i < iso9660->primary.max_depth; i++)
    free(iso9660->primary.pathtbl[i].sorted);
```

Dereferencing `pathtbl[i]` with `pathtbl == NULL` reads from address `0 + offsetof(struct path_table, sorted)` = `0x10`, causing `SIGSEGV`.

## Fix

Reset `vdd->max_depth = 0` in the `malloc()` failure path so `iso9660_free()` skips the cleanup loop, matching the initialised state (`max_depth = 0` set in `iso9660_new()`).

```diff
 if (vdd->pathtbl == NULL) {
+    vdd->max_depth = 0;
     archive_set_error(&a->archive, ENOMEM,
         "Can't allocate memory");
     return (ARCHIVE_FATAL);
 }
```

## Reproduction

Build libarchive from source, then use an allocation-failure interposer to make the `pathtbl` `malloc()` (size = `sizeof(struct path_table) * MAX_DEPTH` = 256 bytes) return `NULL` during `archive_write_close()`:

```c
struct archive *a = archive_write_new();
archive_write_set_format_iso9660(a);
archive_write_add_filter_none(a);
archive_write_open_filename(a, "/dev/null");
struct archive_entry *e = archive_entry_new();
archive_entry_set_pathname(e, "dir");
archive_entry_set_filetype(e, AE_IFDIR);
archive_write_header(a, e);
archive_entry_free(e);
archive_write_close(a);   /* pathtbl malloc fails here */
archive_write_free(a);     /* NULL deref -> SIGSEGV at 0x10 */
```

**Before fix:** `strace` shows `SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0x10}`.
**After fix:** `exit_group(0)` — no crash.

## Test

Existing iso9660 tests pass with the fix applied:
```
751: test_write_format_iso9660          ok
753: test_write_format_iso9660_empty    ok
760: test_write_format_iso9660_null_deref  ok
761: test_write_format_iso9660_underflow   ok
762: test_write_format_iso9660_joliet_overflow ok
5 tests passed, no failures
```

Fixes #3417.
