### PR TITLE
configure: fix ctime_s typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -856,8 +856,8 @@ AC_CHECK_FUNCS(m4_flatten([
 	wcrtomb wcscmp wcscpy wcslen wctomb wmemcmp wmemcpy wmemmove
 	_fseeki64 _get_timezone
 ]))
-AC_CHECK_DECL([cmtime_s],
-		[AC_DEFINE(HAVE_CMTIME_S, 1, [cmtime_s function])],
+AC_CHECK_DECL([ctime_s],
+		[AC_DEFINE(HAVE_CTIME_S, 1, [ctime_s function])],
 		[],
 		[#include <time.h>])
 AC_CHECK_DECL([gmtime_s],


### PR DESCRIPTION
The function is named "ctime_s", not "cmtime_s".  The macro used in the source, and defined by cmake, is "HAVE_CTIME_S", not "HAVE_CMTIME_S". The commit that introduced this code replaced "_ctime64_s".  Searching Google for "cmtime_s" results in 1 hit: libarchive.  So clearly this is a typo.