### PR TITLE
archive_read_disk.3: clarify symlink following modes

### DIFF
--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -191,15 +191,17 @@ By default, sparse file information is read from disk.
 This sets the mode used for handling symbolic links.
 The
 .Dq logical
-mode follows all symbolic links.
+mode follows all symbolic links, except that a symbolic link whose
+target is an ancestor directory of the link is archived as a symbolic
+link rather than being followed, to avoid loops.
 The
 .Dq physical
 mode does not follow any symbolic links.
 The
 .Dq hybrid
-mode currently behaves identically to the
-.Dq logical
-mode.
+mode follows a symbolic link that is named as a starting point of the
+traversal but does not follow any symbolic links encountered below such
+a starting point.
 .It Xo
 .Fn archive_read_disk_gname ,
 .Fn archive_read_disk_uname

--- a/libarchive/archive_read_disk.3
+++ b/libarchive/archive_read_disk.3
@@ -199,9 +199,11 @@ The
 mode does not follow any symbolic links.
 The
 .Dq hybrid
-mode follows a symbolic link that is named as a starting point of the
-traversal but does not follow any symbolic links encountered below such
-a starting point.
+mode follows symbolic links specified as the target of
+.Fn archive_read_disk_open
+or
+.Fn archive_read_disk_open_w
+but does not follow symbolic links anywhere else.
 .It Xo
 .Fn archive_read_disk_gname ,
 .Fn archive_read_disk_uname


### PR DESCRIPTION
The manual page said the hybrid mode behaves identically to the logical mode, but the traversal only follows the symlink named as the starting point and then stops following, and the logical mode leaves a link that would form a loop as a symlink rather than following it. This updates the descriptions of the three modes to match what the code does. Closes #571.