### PR TITLE
tar: Write correct message on data read error

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -830,7 +830,8 @@ copy_file_data_block(struct bsdtar *bsdtar, struct archive *a,
 		progress += bytes_written;
 	}
 	if (r < ARCHIVE_WARN) {
-		lafe_warnc(archive_errno(a), "%s", archive_error_string(a));
+		lafe_warnc(archive_errno(in_a), "%s",
+		    archive_error_string(in_a));
 		return (-1);
 	}
 	return (0);


### PR DESCRIPTION
Use the correct archive as source for errno and error message.

Reported in #3434

Before (as regular user on Linux system):
```
$ bsdtar --no-read-sparse -cf shadow.tar /etc/shadow
bsdtar: Removing leading '/' from member names
bsdtar: (null)
```
After:
```
$ bsdtar --no-read-sparse -cf shadow.tar /etc/shadow
bsdtar: Removing leading '/' from member names
bsdtar: Couldn't open /etc/shadow: Permission denied
```