### PR TITLE
rar5: three robustness fixes found by inspection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -565,6 +565,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_rar5_bad_filter.c \
 	libarchive/test/test_read_format_rar5_bad_tables.c \
 	libarchive/test/test_read_format_rar5_block_hdr_fail_loop.c \
+	libarchive/test/test_read_format_rar5_header_size_wraparound.c \
 	libarchive/test/test_read_format_rar5_loop_bug.c \
 	libarchive/test/test_read_format_raw.c \
 	libarchive/test/test_read_format_tar.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -567,6 +567,7 @@ libarchive_test_SOURCES= \
 	libarchive/test/test_read_format_rar5_block_hdr_fail_loop.c \
 	libarchive/test/test_read_format_rar5_header_size_wraparound.c \
 	libarchive/test/test_read_format_rar5_loop_bug.c \
+	libarchive/test/test_read_format_rar5_truncated_htime.c \
 	libarchive/test/test_read_format_raw.c \
 	libarchive/test/test_read_format_tar.c \
 	libarchive/test/test_read_format_tar_acl_oob_read.c \

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -2343,15 +2343,17 @@ static int process_base_block(struct archive_read* a,
 		return ARCHIVE_EOF;
 	}
 
-	hdr_size = raw_hdr_size + hdr_size_len;
-
-	/* Sanity check, maximum header size for RAR5 is 2MB. */
-	if(hdr_size > (2 * 1024 * 1024)) {
+	/* Sanity check, maximum header size for RAR5 is 2MB.  Bounding
+	 * raw_hdr_size (instead of the sum) also ensures that adding
+	 * hdr_size_len below cannot wrap hdr_size around SIZE_MAX. */
+	if(raw_hdr_size > (2 * 1024 * 1024) - hdr_size_len) {
 		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
 		    "Base block header is too large");
 
 		return ARCHIVE_FATAL;
 	}
+
+	hdr_size = raw_hdr_size + hdr_size_len;
 
 	/* Additional sanity checks to weed out invalid files. */
 	if(raw_hdr_size == 0 || hdr_size_len == 0 ||

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -914,13 +914,10 @@ static int read_ahead(struct archive_read* a, size_t how_many,
 }
 
 static int consume(struct archive_read* a, int64_t how_many) {
-	int ret;
+	if(__archive_read_consume(a, how_many) < 0)
+		return (ARCHIVE_FATAL);
 
-	ret = how_many == __archive_read_consume(a, how_many)
-		? ARCHIVE_OK
-		: ARCHIVE_FATAL;
-
-	return ret;
+	return (ARCHIVE_OK);
 }
 
 /**

--- a/libarchive/archive_read_support_format_rar5.c
+++ b/libarchive/archive_read_support_format_rar5.c
@@ -1374,6 +1374,7 @@ static int parse_file_extra_htime(struct archive_read* a,
 	char unix_time, has_unix_ns, has_mtime, has_ctime, has_atime;
 	size_t flags = 0;
 	size_t value_len;
+	int ret;
 
 	enum HTIME_FLAGS {
 		IS_UNIX       = 0x01,
@@ -1399,18 +1400,24 @@ static int parse_file_extra_htime(struct archive_read* a,
 	rar5->file.e_atime_ns = rar5->file.e_ctime_ns = rar5->file.e_mtime_ns = 0;
 
 	if(has_mtime) {
-		parse_htime_item(a, unix_time, &rar5->file.e_mtime,
+		ret = parse_htime_item(a, unix_time, &rar5->file.e_mtime,
 		    &rar5->file.e_mtime_ns, extra_data_size);
+		if(ret != ARCHIVE_OK)
+			return ret;
 	}
 
 	if(has_ctime) {
-		parse_htime_item(a, unix_time, &rar5->file.e_ctime,
+		ret = parse_htime_item(a, unix_time, &rar5->file.e_ctime,
 		    &rar5->file.e_ctime_ns, extra_data_size);
+		if(ret != ARCHIVE_OK)
+			return ret;
 	}
 
 	if(has_atime) {
-		parse_htime_item(a, unix_time, &rar5->file.e_atime,
+		ret = parse_htime_item(a, unix_time, &rar5->file.e_atime,
 		    &rar5->file.e_atime_ns, extra_data_size);
+		if(ret != ARCHIVE_OK)
+			return ret;
 	}
 
 	if(has_mtime && has_unix_ns) {

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -192,6 +192,7 @@ IF(ENABLE_TEST)
     test_read_format_rar5_bad_filter.c
     test_read_format_rar5_bad_tables.c
     test_read_format_rar5_block_hdr_fail_loop.c
+    test_read_format_rar5_header_size_wraparound.c
     test_read_format_rar5_loop_bug.c
     test_read_format_raw.c
     test_read_format_tar.c

--- a/libarchive/test/CMakeLists.txt
+++ b/libarchive/test/CMakeLists.txt
@@ -194,6 +194,7 @@ IF(ENABLE_TEST)
     test_read_format_rar5_block_hdr_fail_loop.c
     test_read_format_rar5_header_size_wraparound.c
     test_read_format_rar5_loop_bug.c
+    test_read_format_rar5_truncated_htime.c
     test_read_format_raw.c
     test_read_format_tar.c
     test_read_format_tar_acl_oob_read.c

--- a/libarchive/test/test_read_format_rar5_header_size_wraparound.c
+++ b/libarchive/test/test_read_format_rar5_header_size_wraparound.c
@@ -1,0 +1,63 @@
+/*-
+ * Copyright (c) 2026 krishna28238-arch
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * Regression test for a size_t wraparound in process_base_block().
+ *
+ * The size vint of a base block can decode to values close to SIZE_MAX,
+ * because read_var_sized() does not bound the decoded value.  Computing
+ * hdr_size = raw_hdr_size + hdr_size_len then wraps around to a small
+ * number, which passes the 2 MB sanity check.  The reader accepted the
+ * block and desynced; on the 22-byte archive below, the unpatched reader
+ * consumed the size vint as a whole block and reported ARCHIVE_EOF.
+ *
+ * The patched reader bounds raw_hdr_size before the addition and rejects
+ * the block up front.
+ */
+DEFINE_TEST(test_read_format_rar5_header_size_wraparound)
+{
+	/* RAR5 signature, CRC32 of the first nine 0xFF bytes, and a size
+	 * vint that decodes to SIZE_MAX (0xFF * 9, 0x01). */
+	static const uint8_t data[] = {
+		0x52,0x61,0x72,0x21,0x1a,0x07,0x01,0x00,
+		0x90,0x18,0x20,0xeb,0xff,0xff,0xff,0xff,
+		0xff,0xff,0xff,0xff,0xff,0x01
+	};
+
+	struct archive *a = archive_read_new();
+	assert(a != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_rar5(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a,
+	    data, sizeof(data)));
+
+	struct archive_entry *ae;
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertA(archive_error_string(a) != NULL &&
+	    strstr(archive_error_string(a),
+	        "Base block header is too large") != NULL);
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}

--- a/libarchive/test/test_read_format_rar5_truncated_htime.c
+++ b/libarchive/test/test_read_format_rar5_truncated_htime.c
@@ -1,0 +1,61 @@
+/*-
+ * Copyright (c) 2026 krishna28238-arch
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+/*
+ * Regression test for ignored parse_htime_item() failures in
+ * parse_file_extra_htime().
+ *
+ * The HTIME extra record of the FILE header below declares a unix mtime,
+ * ctime and atime, but the archive ends right after the mtime and ctime
+ * values, so reading the atime fails with ARCHIVE_EOF.  The unpatched
+ * code ignored that failure: the extra area accounting then went
+ * negative and the reader reported a misleading ARCHIVE_FATAL
+ * "unsupported structure of file header extra data".  The patched code
+ * propagates the EOF instead.
+ */
+DEFINE_TEST(test_read_format_rar5_truncated_htime)
+{
+	/* RAR5 archive with a FILE header ("a") whose HTIME extra record is
+	 * truncated inside the atime field. */
+	static const uint8_t data[] = {
+		0x52,0x61,0x72,0x21,0x1a,0x07,0x01,0x00,
+		0x01,0xa1,0xc1,0x64,0x17,0x02,0x03,0x03,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x61,
+		0x00,0x03,0x0f,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00
+	};
+
+	struct archive *a = archive_read_new();
+	assert(a != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_rar5(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a,
+	    data, sizeof(data)));
+
+	struct archive_entry *ae;
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}


### PR DESCRIPTION
rar5: three robustness fixes for malformed archives
While auditing the RAR5 reader I found three robustness issues in header parsing. None are memory-safety bugs (all reads are read_ahead-bounded), but each lets a crafted archive desync the parser or produce a misleading error. Each fix comes with the reasoning below; fixes 2 and 3 add regression tests that fail on unpatched master.

1. rar5: Fix error propagation in consume()
__archive_read_consume() returns ARCHIVE_FATAL (-30) when given a negative request. The wrapper compared its return value to how_many and reported success on equality — so a negative how_many that happened to equal -30 was reported as ARCHIVE_OK, silently swallowing the error. Propagate negative return values directly instead.

2. rar5: Bound header size before adding size vint length
read_var_sized() does not bound the value it decodes, so the size vint of a base block can carry values close to SIZE_MAX (e.g. FF FF FF FF FF FF FF FF FF 01 decodes to SIZE_MAX). Computing hdr_size = raw_hdr_size + hdr_size_len then wraps around to a small number which passes both the 2 MB limit and the minimum-size check. On a 22-byte reproducer the unpatched reader consumed the size vint as a whole block, treated the nine 0xFF bytes as the header body and reported ARCHIVE_EOF after desyncing.

The fix bounds raw_hdr_size before the addition; the sum can then no longer wrap. test_read_format_rar5_header_size_wraparound asserts the up-front rejection.

3. rar5: Don't ignore parse_htime_item() failures
If the value bytes of a HTIME extra record are truncated (e.g. unix mtime/ctime present, atime missing), parse_htime_item() returns ARCHIVE_EOF, which parse_file_extra_htime() discarded. The extra-area accounting then went negative and the caller reported ARCHIVE_FATAL "unsupported structure of file header extra data" — a programmer-error message for what is a plain truncated archive. Propagate the error instead; test_read_format_rar5_truncated_htime asserts the clean EOF.

Testing
Full libarchive_test suite: 865/865 pass (146 skips, environment-related).
Both new tests fail on unpatched master (3 assertion failures total) and pass with the patches.
Found by inspection during a sequential audit of the RAR5 reader.