### PR TITLE
lint: throw a failure when a source file doesn't have a newline on the last line

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Configure
       run: ./build/ci/build.sh -a configure
       env:
-        CMAKE_ARGS: -GNinja -DENABLE_CLANG_TIDY=YES -DCLANG_TIDY_PATH=la-lint
+        CMAKE_ARGS: -GNinja -DENABLE_CLANG_TIDY=YES -DCLANG_TIDY_PATH=la-lint;--extra-arg=-Werror=newline-eof
     - name: Build
       run: ./build/ci/build.sh -a build
       env:


### PR DESCRIPTION
Clang natively supports `-Wnewline-eof`! By surfacing it out of la-lint, we turn it into a lint failure.