### PR TITLE
cryptor: batch CTR keystream generation for the OpenSSL provider (~12x faster WinZip AES decryption)

### DIFF
--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -472,6 +472,77 @@ aes_ctr_increase_counter(archive_crypto_ctx *ctx)
 	}
 }
 
+#if defined(ARCHIVE_CRYPTOR_USE_OPENSSL)
+/* Generate the keystream for complete blocks in batches.
+ *
+ * The one-by-one variant below asks the provider for a single
+ * 16-byte keystream block per AES block.  With OpenSSL, every such
+ * request pays an EVP_EncryptInit_ex() plus an EVP_EncryptUpdate()
+ * call, which caps WinZip AES decryption at roughly 60 MB/s on
+ * current hardware even though the EVP cipher itself can deliver
+ * several GB/s when driven with large buffers.
+ *
+ * Here the next counter blocks are collected into ctx->ctr_blk (in
+ * the same increment-then-encrypt order the one-by-one variant
+ * uses), encrypted with a single EVP_EncryptUpdate() call and XORed
+ * in bulk.  The cipher context runs in ECB mode, so encrypting
+ * several blocks at once produces exactly the same keystream as
+ * encrypting them one at a time.  Partial trailing blocks and
+ * leftover keystream bytes still go through the single-block path,
+ * so the visible sequence of keystream bytes is unchanged. */
+static int
+aes_ctr_update(archive_crypto_ctx *ctx, const uint8_t * const in,
+    size_t in_len, uint8_t * const out, size_t *out_len)
+{
+	enum { ks_batch = sizeof(ctx->ctr_blk) };
+	size_t max = (in_len < *out_len) ? in_len : *out_len;
+	size_t i = 0, pos = ctx->encr_pos;
+
+	/* Consume any leftover keystream of the current block. */
+	while (i < max && pos < AES_BLOCK_SIZE)
+		out[i++] = in[i] ^ ctx->encr_buf[pos++];
+
+	/* Complete blocks: one EVP call per ks_batch bytes. */
+	while (max - i >= AES_BLOCK_SIZE) {
+		size_t blocks = (max - i) / AES_BLOCK_SIZE;
+		size_t b, k;
+		int outl = 0;
+
+		if (blocks > ks_batch / AES_BLOCK_SIZE)
+			blocks = ks_batch / AES_BLOCK_SIZE;
+		for (b = 0; b < blocks; b++) {
+			aes_ctr_increase_counter(ctx);
+			memcpy(ctx->ctr_blk + b * AES_BLOCK_SIZE,
+			    ctx->nonce, AES_BLOCK_SIZE);
+		}
+		if (EVP_EncryptInit_ex(ctx->ctx, ctx->type, NULL,
+		    ctx->key, NULL) != 1 ||
+		    EVP_EncryptUpdate(ctx->ctx, ctx->ctr_ks, &outl,
+		    ctx->ctr_blk, (int)(blocks * AES_BLOCK_SIZE)) != 1 ||
+		    (size_t)outl != blocks * AES_BLOCK_SIZE)
+			return -1;
+		for (k = 0; k < blocks * AES_BLOCK_SIZE; k++)
+			out[i + k] = in[i + k] ^ ctx->ctr_ks[k];
+		i += blocks * AES_BLOCK_SIZE;
+		pos = AES_BLOCK_SIZE;
+	}
+
+	/* Partial trailing block: refill keystream one block at a time. */
+	if (i < max) {
+		aes_ctr_increase_counter(ctx);
+		if (aes_ctr_encrypt_counter(ctx) != 0)
+			return -1;
+		pos = 0;
+		while (i < max)
+			out[i++] = in[i] ^ ctx->encr_buf[pos++];
+	}
+
+	ctx->encr_pos = pos;
+	*out_len = i;
+
+	return 0;
+}
+#else
 static int
 aes_ctr_update(archive_crypto_ctx *ctx, const uint8_t * const in,
     size_t in_len, uint8_t * const out, size_t *out_len)
@@ -506,6 +577,7 @@ aes_ctr_update(archive_crypto_ctx *ctx, const uint8_t * const in,
 
 	return 0;
 }
+#endif /* ARCHIVE_CRYPTOR_USE_OPENSSL */
 #endif /* ARCHIVE_CRYPTOR_STUB */
 
 

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -134,6 +134,10 @@ typedef struct {
 	uint8_t		nonce[AES_BLOCK_SIZE];
 	uint8_t		encr_buf[AES_BLOCK_SIZE];
 	unsigned	encr_pos;
+	/* Scratch buffers used to generate multiple keystream blocks
+	 * with a single EVP call. */
+	uint8_t		ctr_blk[64 * 1024];
+	uint8_t		ctr_ks[64 * 1024];
 } archive_crypto_ctx;
 
 #else

--- a/libarchive/test/test_write_format_zip.c
+++ b/libarchive/test/test_write_format_zip.c
@@ -923,3 +923,184 @@ DEFINE_TEST(test_write_format_zip_winzip_aes256_encryption)
 
 	free(buff);
 }
+
+/*
+ * WinZip AES round-trip tests with entry sizes chosen to exercise the
+ * CTR keystream generation across AES block boundaries (16 bytes) and
+ * with entries large enough to require multiple keystream batches in
+ * the crypto provider, including sizes that leave a partial trailing
+ * block.  Reading back through readers with very small blocks (7
+ * bytes) additionally stresses the partial-chunk handling of the
+ * decryption state machine.
+ */
+static const size_t aes_large_sizes[] = {
+	15,			/* One byte short of an AES block */
+	16,			/* Exactly one AES block */
+	17,			/* One AES block plus one byte */
+	64 * 1024 - 1,		/* Around the keystream batch size */
+	64 * 1024,
+	64 * 1024 + 1,
+	3 * 64 * 1024 + 15,	/* Several batches plus a partial block */
+};
+
+static void
+fill_test_pattern(unsigned char *p, size_t size, unsigned seed)
+{
+	size_t i;
+	uint32_t x = (uint32_t)seed;
+
+	for (i = 0; i < size; i++) {
+		x = x * 1103515245u + 12345u;
+		p[i] = (unsigned char)(x >> 16);
+	}
+}
+
+static void
+write_aes_large_contents(struct archive *a)
+{
+	unsigned char *data;
+	size_t k, chunk, n = sizeof(aes_large_sizes) / sizeof(aes_large_sizes[0]);
+
+	data = malloc(3 * 64 * 1024 + 16);
+	for (k = 0; k < n; k++) {
+		struct archive_entry *ae;
+		char name[32];
+
+		fill_test_pattern(data, aes_large_sizes[k], (unsigned)(k + 1));
+		assert((ae = archive_entry_new()) != NULL);
+		sprintf(name, "file%u", (unsigned)k);
+		archive_entry_copy_pathname(ae, name);
+		archive_entry_set_mode(ae, AE_IFREG | 0755);
+		archive_entry_set_size(ae, aes_large_sizes[k]);
+		assertEqualInt(ARCHIVE_OK, archive_write_header(a, ae));
+		archive_entry_free(ae);
+		/* Write in chunks that straddle the AES block size. */
+		chunk = aes_large_sizes[k] > 17 ? 17 : aes_large_sizes[k];
+		assertEqualInt((int)chunk, archive_write_data(a, data, chunk));
+		if (aes_large_sizes[k] > chunk)
+			assertEqualInt((int)(aes_large_sizes[k] - chunk),
+			    archive_write_data(a, data + chunk,
+				aes_large_sizes[k] - chunk));
+	}
+	free(data);
+}
+
+static void
+verify_aes_large_contents(struct archive *a, int check_sizes)
+{
+	struct archive_entry *ae;
+	unsigned char *data, *expected;
+	size_t k, n = sizeof(aes_large_sizes) / sizeof(aes_large_sizes[0]);
+	int r;
+
+	data = malloc(3 * 64 * 1024 + 16);
+	expected = malloc(3 * 64 * 1024 + 16);
+	for (k = 0; k < n; k++) {
+		char name[32];
+
+		sprintf(name, "file%u", (unsigned)k);
+		fill_test_pattern(expected, aes_large_sizes[k], (unsigned)(k + 1));
+		r = archive_read_next_header(a, &ae);
+		if (r != ARCHIVE_OK) {
+			failure("file%u: next header returned %d", (unsigned)k, r);
+			assert(0);
+			break;
+		}
+		assertEqualString(name, archive_entry_pathname(ae));
+		/* The streaming reader cannot see the uncompressed size
+		 * of WinZip AES entries before the Central Directory. */
+		if (check_sizes)
+			assertEqualInt(aes_large_sizes[k],
+			    (size_t)archive_entry_size(ae));
+		memset(data, 0, aes_large_sizes[k]);
+		assertEqualInt((int)aes_large_sizes[k],
+		    archive_read_data(a, data, aes_large_sizes[k]));
+		assertEqualMem(data, expected, aes_large_sizes[k]);
+		/* Nothing more in this entry. */
+		assertEqualInt(0, archive_read_data(a, data, 1));
+	}
+	assertEqualInt(ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	free(data);
+	free(expected);
+}
+
+static void
+test_write_format_zip_winzip_aes_multiblock(const char *encryption)
+{
+	struct archive *a;
+	size_t used;
+	size_t buffsize = 4 * 1024 * 1024;
+	char *buff;
+
+	buff = malloc(buffsize);
+
+	/* Create a new archive in memory. */
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_zip(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	if (ARCHIVE_OK != archive_write_set_options(a, encryption))
+	{
+		skipping("This system does not have cryptographic library");
+		archive_write_free(a);
+		free(buff);
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_passphrase(a, "password1234"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "zip:experimental"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+	write_aes_large_contents(a);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+
+	/* With the standard memory reader. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_add_passphrase(a, "password1234"));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
+	verify_aes_large_contents(a, 1);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* With the test memory reader -- streaming mode with small
+	 * blocks, to stress partial-chunk decryption. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_add_passphrase(a, "password1234"));
+	assertEqualIntA(a, ARCHIVE_OK, read_open_memory(a, buff, used, 7));
+	verify_aes_large_contents(a, 0);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* With the test memory reader -- seeking mode with small
+	 * blocks. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_add_passphrase(a, "password1234"));
+	assertEqualIntA(a, ARCHIVE_OK, read_open_memory_seek(a, buff, used, 7));
+	verify_aes_large_contents(a, 1);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	free(buff);
+}
+
+DEFINE_TEST(test_write_format_zip_winzip_aes128_multiblock)
+{
+
+	test_write_format_zip_winzip_aes_multiblock("zip:encryption=aes128");
+}
+
+DEFINE_TEST(test_write_format_zip_winzip_aes256_multiblock)
+{
+
+	test_write_format_zip_winzip_aes_multiblock("zip:encryption=aes256");
+}


### PR DESCRIPTION
## Problem

WinZip AES decryption is far slower than the underlying hardware allows. Extracting a 2 GiB AES-256 (WinZip AES) zip created by 7-Zip caps at roughly **60 MB/s**, while the same OpenSSL EVP cipher delivers **~10 GB/s** on the same machine when driven with large buffers.

## Root cause

`aes_ctr_update()` in `libarchive/archive_cryptor.c` requests one 16-byte keystream block at a time. With the OpenSSL/libcrypto provider, every such request pays:

- one `EVP_EncryptInit_ex()` call (done per block inside `aes_ctr_encrypt_counter()`), plus
- one `EVP_EncryptUpdate()` call for exactly `AES_BLOCK_SIZE` bytes.

The per-call EVP overhead dominates: ~16 bytes of AES-NI work per full EVP round trip, plus a manual 16-byte XOR loop.

## Fix

For the OpenSSL provider, batch the keystream generation:

- collect the next counter blocks into a scratch buffer (`ctx->ctr_blk`), in the **same increment-then-encrypt order** the one-by-one loop uses;
- encrypt up to 64 KiB of them with a **single** `EVP_EncryptUpdate()` call — the cipher context runs in ECB mode, so multi-block calls encrypt each block independently, which is exactly the CTR keystream;
- XOR the result in bulk;
- partial trailing blocks and leftover keystream bytes still go through the existing single-block path.

The visible sequence of keystream bytes and the `(nonce, encr_buf, encr_pos)` state transitions are unchanged, so this is a pure performance change. Providers other than OpenSSL (CNG, CommonCrypto, mbedTLS, Nettle) and the stub build keep the existing generic implementation.

## Tests

New `test_write_format_zip_winzip_aes128/aes256_multiblock` round-trip tests:

- entry sizes cross AES block boundaries (15/16/17 bytes), sit around the keystream batch size (64 KiB ± 1) and span multiple batches with a partial trailing block (3 × 64 KiB + 15);
- entries are written in chunks that straddle the AES block size;
- read back through the standard memory reader as well as streaming and seeking readers delivering 7-byte blocks, which stresses partial-chunk handling of the decryption state machine;
- content verified byte-for-byte against the generated pattern.

Validation on Windows 11 x64 / MSVC / OpenSSL 3.6:

- New tests pass; injecting a subtle batching bug (regenerating the next keystream block between batches) makes them fail with 21+ assertion failures each while the existing small-payload AES tests still pass — i.e. the new tests cover the multi-batch boundary that was previously untested.
- Full `libarchive_test` suite: **866 tests run, 0 failures attributable to this change** (the single failing test, `test_archive_read_support_twice`, fails identically on pristine master in this environment).

## Benchmark

Extracting a 2 GiB WinZip AES-256 zip (stored, 7-Zip created), best of repeated runs:

| Scenario | Before | After |
|---|---|---|
| Extract 2 GiB WinZip AES-256 zip | 33.6 s (~61 MB/s) | **2.8 s (~740 MB/s)** |
| Same archive without encryption (I/O baseline) | 0.8 s | 0.8 s |

Extracted content is byte-identical before/after (SHA-256 verified, random 2 GiB payload).

The region is textually identical between v3.8.7 and current master, so the change applies cleanly to both.