### PR TITLE
read: Improve `__archive_read_filter_ahead` performance

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1389,16 +1389,6 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 	for (;;) {
 
 		/*
-		 * If we can satisfy from the copy buffer (and the
-		 * copy buffer isn't empty), we're done.
-		 */
-		if (f->avail >= min) {
-			if (avail != NULL)
-				*avail = f->avail;
-			return (f->next);
-		}
-
-		/*
 		 * We can satisfy directly from client buffer if everything
 		 * currently in the copy buffer is still in the client buffer.
 		 */
@@ -1414,6 +1404,13 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 			if (avail != NULL)
 				*avail = f->client_avail;
 			return (f->client_next);
+		}
+
+		/* If we can satisfy from the copy buffer, we're done. */
+		if (f->avail >= min) {
+			if (avail != NULL)
+				*avail = f->avail;
+			return (f->next);
 		}
 
 		/* Move data forward in copy buffer if necessary. */

--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1413,15 +1413,6 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 			return (f->next);
 		}
 
-		/* Move data forward in copy buffer if necessary. */
-		if (f->next > f->buffer &&
-		    min > f->buffer_size - (f->next - f->buffer)) {
-			if (f->avail > 0)
-				memmove(f->buffer, f->next,
-				    f->avail);
-			f->next = f->buffer;
-		}
-
 		/* If we've used up the client data, get more. */
 		if (f->client_avail <= 0) {
 			static const char *empty = "";
@@ -1525,6 +1516,14 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 				free(f->buffer);
 				f->next = f->buffer = p;
 				f->buffer_size = s;
+			} else if (f->next > f->buffer &&
+			    min > f->buffer_size - (f->next - f->buffer)) {
+				/* Move data forward in copy buffer
+				 * if necessary. */
+				if (f->avail > 0)
+					memmove(f->buffer, f->next,
+					    f->avail);
+				f->next = f->buffer;
 			}
 
 			/* We can add client data to copy buffer. */


### PR DESCRIPTION
Check most likely if-checks first for faster evaluation. This also clarifies the priority (client buffer first, then copy buffer, then reading, then copying data into copy buffer if needed).

Can only be applied after https://github.com/libarchive/libarchive/pull/3447 has been merged.