### PR TITLE
7zip: reject a header that extends beyond the end of the file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -916,6 +916,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_malformed3.7z.uu \
 	libarchive/test/test_read_format_7zip_malformed4.7z.uu \
 	libarchive/test/test_read_format_7zip_malformed_numfiles_oom.7z.uu \
+	libarchive/test/test_read_format_7zip_malformed_header_toobig.7z.uu \
 	libarchive/test/test_read_format_7zip_packinfo_digests.7z.uu \
 	libarchive/test/test_read_format_7zip_ppmd.7z.uu \
 	libarchive/test/test_read_format_7zip_ppmd_small_block.7z.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -3358,6 +3358,38 @@ slurp_central_directory(struct archive_read *a, struct _7zip *zip,
 	}
 	zip->stream_offset = next_header_offset;
 	zip->header_offset = next_header_offset;
+
+	/*
+	 * next_header_size comes straight from the archive and is only
+	 * checked for sign above, so a crafted archive can declare a header
+	 * of nearly any 63-bit size.  read_Header() passes it on to
+	 * header_bytes()/__archive_read_ahead(), which then tries to
+	 * allocate a buffer of that size (a ~30 GB allocation from a
+	 * 400-byte file in the reproducer below).  When the input is
+	 * seekable the real file size is known, so reject a header that
+	 * cannot fit in the bytes remaining after its start offset.
+	 */
+	if (a->filter->can_seek) {
+		int64_t header_start = a->filter->position;
+		int64_t file_size = __archive_read_seek(a, 0, SEEK_END);
+
+		if (file_size >= 0) {
+			if (header_start < 0 ||
+			    next_header_size > file_size - header_start) {
+				archive_set_error(&a->archive,
+				    ARCHIVE_ERRNO_FILE_FORMAT,
+				    "7-Zip header extends beyond end of file");
+				return (ARCHIVE_FATAL);
+			}
+			/* Restore the read position to the header start. */
+			if (__archive_read_seek(a, header_start, SEEK_SET) < 0) {
+				archive_set_error(&a->archive,
+				    ARCHIVE_ERRNO_MISC, "Seek error");
+				return (ARCHIVE_FATAL);
+			}
+		}
+	}
+
 	zip->header_bytes_remaining = next_header_size;
 	zip->header_crc32 = 0;
 	zip->header_is_encoded = 0;

--- a/libarchive/test/test_read_format_7zip_malformed.c
+++ b/libarchive/test/test_read_format_7zip_malformed.c
@@ -110,6 +110,29 @@ test_malformed_numfiles_oom(void)
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
+static void
+test_malformed_header_toobig(void)
+{
+	/*
+	 * The start header declares a next-header (central directory) size
+	 * far larger than the file, which previously drove an unbounded
+	 * allocation in header_bytes()/__archive_read_ahead().  On seekable
+	 * input the reader now rejects a header that extends past EOF.
+	 */
+	const char *refname = "test_read_format_7zip_malformed_header_toobig.7z";
+	struct archive *a;
+	struct archive_entry *ae;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_filename(a, refname, 10240));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
 DEFINE_TEST(test_read_format_7zip_malformed)
 {
 	test_malformed1();
@@ -117,4 +140,5 @@ DEFINE_TEST(test_read_format_7zip_malformed)
 	test_malformed3();
 	test_malformed4();
 	test_malformed_numfiles_oom();
+	test_malformed_header_toobig();
 }

--- a/libarchive/test/test_read_format_7zip_malformed_header_toobig.7z.uu
+++ b/libarchive/test/test_read_format_7zip_malformed_header_toobig.7z.uu
@@ -1,0 +1,12 @@
+begin 644 test_read_format_7zip_malformed_header_toobig.7z
+M-WJ\KR<<]P    $             3%I)   X  &T_T\!!3,S,PH*75U=75UR
+M<E):25P ,S,*"EU=75U=<G)26DE<0#,S,S,S,ST]/3T*75U=75U=75UJ"EU=
+M75U=0"TZ+4!O9S,S,S,S,S,*"EU=75U=75U=75U=75U=75U=75U=8%UJ"F)E
+M9VEN+6)A<V5=77)R75U=75UA<V4W9VH*8F5G:6XM8F%=75U=75U=75U=8%UJ
+M"F)E9VEN+5U=8EUR75U=75UJ"ET*"F)E9VDS"@IB96=I;@8@75U=75TS,PH*
+M8F5G:6X@75U=72!=75U=72TV"@IB96=I;O__________________________
+M_________________TU:-GJ\KR<<]P    @      $D"              "\
+MKR<<*R8Q]P  -WJ\KR<<]P  "   "   2<S,S,S,S,S,S,S,S,S,S,S,S,S,
+HS,S,S,S,S,S,S,S,S,S,S,S,S&=I;F4V(%U 73,S"@IB96=I;B!=70  
+`
+end


### PR DESCRIPTION
## The bug

`archive_read_format_7zip_read_header()` reads `next_header_size` directly from the 7-Zip start-header and validates it only for a negative value:

```c
next_header_size = archive_le64dec(p + 20);
if (next_header_size < 0) {
    archive_set_error(&a->archive, -1, "Malformed 7-Zip archive");
    return (ARCHIVE_FATAL);
}
...
zip->header_bytes_remaining = next_header_size;
```

`read_Header()` then passes that size to `header_bytes()`, which calls `__archive_read_ahead()` and grows the copy buffer to hold it. Because the size is attacker-controlled and unbounded, a tiny archive can drive a multi-gigabyte allocation. From a 400-byte reproducer:

```
==ERROR: AddressSanitizer: out of memory: allocator is trying to allocate 0x708000000 bytes
    #1 __archive_read_filter_ahead archive_read.c:1514
    #2 header_bytes archive_read_support_format_7zip.c:3263
    #3 read_Header archive_read_support_format_7zip.c:3043
    #4 archive_read_format_7zip_read_header
```

That is roughly a 75-million-to-one amplification: 400 input bytes to a ~30 GB allocation, i.e. a denial-of-service for anything that opens an untrusted `.7z`.

## The fix

The declared header cannot be larger than the bytes that actually remain in the file after its start offset. When the input is seekable, look up the real file size, reject a header that runs past EOF, and restore the read position so the normal header read continues unchanged. For non-seekable input the file size is not known here, so the check is skipped and the existing truncation handling in `header_bytes()` still applies.

I deliberately bounded the *total* header size against the file rather than capping any single sub-count (such as the number of pack streams): the number of pack streams is not directly related to the header byte count, so a per-count cap is not the right limit. This bounds exactly the quantity that feeds the allocation.

## Testing

- The reproducer is rejected cleanly on a seekable open (`archive_read_open_filename`) with `7-Zip header extends beyond end of file` instead of the OOM.
- All 530 7-Zip test archives in the tree were replayed through the patched library: no sanitizer errors and identical results to before. The only two inputs that hit the new check are `test_read_format_7zip_malformed.7z` and `test_read_format_7zip_malformed2.7z`, which were already rejected as `Damaged 7-Zip archive` before this change.

Found by fuzzing the in-tree `contrib/oss-fuzz/libarchive_7zip_fuzzer`, which the upstream OSS-Fuzz integration does not build (its `build.sh` compiles only `libarchive_fuzzer`).

This is a corrected, tested version of the problem raised in #2845, which was closed as incorrect.
