### PR TITLE
test_utils: respect PLATFORM_CONFIG_H

### DIFF
--- a/test_utils/test_common.h
+++ b/test_utils/test_common.h
@@ -30,7 +30,10 @@
  * The goal of this file (and the matching test.c) is to
  * simplify the very repetitive test-*.c test programs.
  */
-#if defined(HAVE_CONFIG_H)
+#if defined(PLATFORM_CONFIG_H)
+/* Use hand-built config.h in environments that need it. */
+#include PLATFORM_CONFIG_H
+#elif defined(HAVE_CONFIG_H)
 /* Most POSIX platforms use the 'configure' script to build config.h */
 #include "config.h"
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
Every other place in libarchive that includes config.h checks this define first.  Harmonize the test code to allow further cleanups.