### PR TITLE
archive_match: free the error string in archive_match_free()

### DIFF
--- a/libarchive/archive_match.c
+++ b/libarchive/archive_match.c
@@ -269,6 +269,7 @@ archive_match_free(struct archive *_a)
 	free(a->inclusion_gids.ids);
 	match_list_free(&(a->inclusion_unames));
 	match_list_free(&(a->inclusion_gnames));
+	archive_string_free(&a->archive.error_string);
 	free(a);
 	return (ARCHIVE_OK);
 }


### PR DESCRIPTION
## The leak

`archive_match_free()` frees the match lists and the `archive_match` object, but never releases the base archive's `error_string` buffer:

```c
match_list_free(&(a->inclusion_unames));
match_list_free(&(a->inclusion_gnames));
free(a);            /* a->archive.error_string.s is leaked */
```

As soon as any `archive_match_*()` call reports an error through `archive_set_error()` (for example `archive_match_exclude_pattern()` on an empty pattern) that buffer is heap-allocated, and it is then leaked when the object is freed:

```
Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 realloc
    #1 archive_string_ensure archive_string.c:338
    #2 archive_string_vsprintf archive_string_sprintf.c:99
    #3 archive_set_error archive_util.c:184
    #4 archive_match_exclude_pattern archive_match.c:337
```

## The fix

`archive_read_free()` and `archive_write_free()` already call `archive_string_free(&a->archive.error_string)` before freeing their object. `archive_match_free()` was missing the same cleanup; this adds it, matching the existing idiom.

## Testing

Found with LeakSanitizer while fuzzing the in-tree `contrib/oss-fuzz/libarchive_match_fuzzer` (which the OSS-Fuzz integration does not build). The harness already calls `archive_match_free()`. With this one-line change, a 30-second run (143,000 executions, leak detection enabled) reports no leaks; the reproducer that previously leaked 64 bytes is clean.