### PR TITLE
libarchive: grow the read-ahead buffer incrementally

### DIFF
--- a/libarchive/archive_read.c
+++ b/libarchive/archive_read.c
@@ -1487,16 +1487,23 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 			 * copy buffer.
 			 */
 
+			/* Don't waste time buffering more than we need to. */
+			tocopy = min - f->avail;
+			/* Don't copy more than is available. */
+			if (tocopy > f->client_avail)
+				tocopy = f->client_avail;
+
 			/* Ensure the buffer is big enough. */
-			if (min > f->buffer_size) {
-				size_t s;
+			if (f->avail + tocopy > f->buffer_size) {
+				size_t s, needed;
 				char *p;
 
+				needed = f->avail + tocopy;
 				/* Double the buffer; watch for overflow. */
 				s = f->buffer_size;
 				if (s == 0)
-					s = min;
-				while (s < min) {
+					s = needed;
+				while (s < needed) {
 					if (archive_ckd_mul_size(&s, s, 2)) {
 						/* Integer overflow! */
 						archive_set_error(
@@ -1510,7 +1517,7 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 						return (NULL);
 					}
 				}
-				/* Now s >= min, so allocate a new buffer. */
+				/* Now s >= needed, so allocate a new buffer. */
 				p = malloc(s);
 				if (p == NULL) {
 					archive_set_error(
@@ -1529,13 +1536,6 @@ __archive_read_filter_ahead(struct archive_read_filter *f,
 				f->next = f->buffer = p;
 				f->buffer_size = s;
 			}
-
-			/* We can add client data to copy buffer. */
-			/* Don't waste time buffering more than we need to. */
-			tocopy = min - f->avail;
-			/* Don't copy more than is available. */
-			if (tocopy > f->client_avail)
-				tocopy = f->client_avail;
 
 			memcpy(f->next + f->avail,
 			    f->client_next, tocopy);


### PR DESCRIPTION
Follow-up to #3449, implementing the third option you suggested there: grow the read-ahead buffer incrementally instead of allocating the full requested size up front.

## The problem

`__archive_read_filter_ahead()` grows its copy buffer to satisfy the whole requested read-ahead before pulling any data:

```c
if (min > f->buffer_size) {
    ...
    while (s < min) { archive_ckd_mul_size(&s, s, 2); ... }
    p = malloc(s);   /* the whole request, up front */
}
```

`min` is caller-supplied and frequently derived from the archive itself, so a corrupt archive that claims a huge size (the 7-Zip oversized-header case from #3449 is one example, but it is not 7z-specific) makes libarchive allocate that whole amount before the loop discovers the premature EOF. A few hundred bytes of input can drive a multi-gigabyte allocation.

## The change

Grow the buffer only to hold the data actually in hand: the bytes already buffered plus the chunk about to be copied from the client this pass. A well-formed stream still grows the buffer (by doubling) to the full request over successive iterations; a stream that ends early never grows the buffer past the data that is really there, so the oversized request fails cleanly rather than allocating memory that will never be filled.

Unlike the format-specific guard in #3449, this does not depend on knowing the file size, so it also covers the **non-seekable / streaming** case.

## Why it is safe

The copy destination is `f->next + f->avail`, writing `tocopy` bytes. The compaction step earlier in the loop guarantees that when we reach the copy, either `f->next == f->buffer`, or the buffer already has room for `min` bytes after `f->next`. Since `min >= f->avail + tocopy`, the copy never runs past the end of the buffer in either case. The doubling/overflow guard is unchanged.

## Testing

- The non-seekable 7z reproducer from #3449 (400-byte input, ~30GB request) is now handled cleanly with no large allocation, verified under ASan via `contrib/oss-fuzz/libarchive_7zip_fuzzer` (which reads through a non-seekable memory source). Reverting the change makes the same input OOM.
- Full `libarchive_test` suite: identical pass/fail set to unmodified master (31,578,675 assertions checked; the only failures are pre-existing and due to my local build having xz/lzma/zstd/bz2/lz4 disabled, and they fail the same way on master). So no regression.

This could complement or supersede #3449; happy to reshape either way depending on what you prefer to carry.
