### PR TITLE
bsdtar: reject appending to empty filtered archives

### DIFF
--- a/tar/test/test_option_r.c
+++ b/tar/test/test_option_r.c
@@ -14,7 +14,7 @@ DEFINE_TEST(test_option_r)
 	char *buff;
 	char *p0, *p1;
 	size_t buff_size = 35000;
-	size_t s, buff_size_rounded;
+	size_t s, buff_size_rounded, filtered_size;
 	int r, i;
 
 	buff = NULL;
@@ -108,6 +108,30 @@ DEFINE_TEST(test_option_r)
 
 	/* Verify that the second copy of f1 overwrote the first. */
 	assertFileContents(buff, (int)strlen(buff), "f1");
+
+	/* Appending to an empty filtered archive must fail. */
+	free(p0);
+	p0 = NULL;
+	assertMakeFile("empty", 0644, "");
+	r = systemf("%s cf empty.tar.uu --format=ustar --uuencode -T empty "
+	    ">empty-create.out 2>empty-create.err", testprog);
+	assertEqualInt(r, 0);
+	assertEmptyFile("empty-create.out");
+	assertEmptyFile("empty-create.err");
+	p0 = slurpfile(&filtered_size, "empty.tar.uu");
+	if (!assert(p0 != NULL))
+		goto done;
+	r = systemf("%s rf empty.tar.uu f2 "
+	    ">empty-append.out 2>empty-append.err", testprog);
+	assert(r != 0);
+	assertEmptyFile("empty-append.out");
+	assertNonEmptyFile("empty-append.err");
+	p1 = slurpfile(&s, "empty.tar.uu");
+	if (!assert(p1 != NULL))
+		goto done;
+	assertEqualInt(filtered_size, s);
+	assertEqualMem(p0, p1, s);
+	free(p1);
 done:
 	free(buff);
 	free(p0);

--- a/tar/write.c
+++ b/tar/write.c
@@ -297,13 +297,12 @@ tar_mode_r(struct bsdtar *bsdtar)
 		lafe_errc(1, archive_errno(a),
 		    "Can't read archive %s: %s", bsdtar->filename,
 		    archive_error_string(a));
+	if (archive_filter_code(a, 0) != ARCHIVE_FILTER_NONE) {
+		archive_read_free(a);
+		close(bsdtar->fd);
+		lafe_errc(1, 0, "Cannot append to compressed archive");
+	}
 	while (0 == archive_read_next_header(a, &entry)) {
-		if (archive_filter_code(a, 0) != ARCHIVE_FILTER_NONE) {
-			archive_read_free(a);
-			close(bsdtar->fd);
-			lafe_errc(1, 0,
-			    "Cannot append to compressed archive");
-		}
 		/* Keep going until we hit end-of-archive */
 		format = archive_format(a);
 	}


### PR DESCRIPTION
`bsdtar -r` currently allows appending to an empty filtered archive because the filter check only runs inside the entry loop. Empty archives bypass it and get overwritten as unfiltered archives.

Move the check before the loop and add a test.

I think this is justified because bsdtar already rejects non-empty filtered archives. Empty archives only behave differently because the check is in the wrong place, and the current command silently changes the archive format while reporting success. GNU tar also rejects the same operation and leaves the archive unchanged.