### PR TITLE
tar: fix master-only regression in sparse error reporting

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -582,8 +582,11 @@ archive_read_format_tar_read_header(struct archive_read *a,
 			}
 		}
 		count = archive_entry_sparse_count(entry);
-		if (count < 0 || (size_t)count != added)
+		if (count < 0 || (size_t)count != added) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "Malformed sparse map data");
 			return (ARCHIVE_FATAL);
+		}
 	}
 
 	if (r == ARCHIVE_OK && archive_entry_filetype(entry) == AE_IFREG) {

--- a/libarchive/test/test_read_format_gtar_sparse_exceeds_length.c
+++ b/libarchive/test/test_read_format_gtar_sparse_exceeds_length.c
@@ -41,6 +41,7 @@ DEFINE_TEST(test_read_format_gtar_sparse_exceeds_length)
 	    archive_read_open_filename(a, refname, 4096));
 
 	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualString("Malformed sparse map data", archive_error_string(a));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));


### PR DESCRIPTION
The sparse entry count check added on master returns `ARCHIVE_FATAL` without setting an error, causing bsdtar to print `"(null)"`.

Set the existing sparse map diagnostic before returning.

This master-only regression was introduced by the PR #3421.