### PR TITLE
man: tweak malloc() style with structs

### DIFF
--- a/libarchive/archive_read.3
+++ b/libarchive/archive_read.3
@@ -170,7 +170,7 @@ list_archive(const char *name)
   struct archive *a;
   struct archive_entry *entry;
 
-  mydata = malloc(sizeof(struct mydata));
+  mydata = malloc(sizeof(*mydata));
   a = archive_read_new();
   mydata->name = name;
   archive_read_support_filter_all(a);

--- a/libarchive/archive_write.3
+++ b/libarchive/archive_write.3
@@ -174,7 +174,7 @@ myclose(struct archive *a, void *client_data)
 void
 write_archive(const char *outname, const char **filename)
 {
-  struct mydata *mydata = malloc(sizeof(struct mydata));
+  struct mydata *mydata = malloc(sizeof(*mydata));
   struct archive *a;
   struct archive_entry *entry;
   struct stat st;


### PR DESCRIPTION
Make allocation slightly less error prone by letting the compiler determine the underlying type rather than copying & pasting.