### PR TITLE
archive_write: fix master-only regression in fatal cleanup

### DIFF
--- a/libarchive/archive_write.c
+++ b/libarchive/archive_write.c
@@ -639,26 +639,33 @@ _archive_write_close(struct archive *_a)
 {
 	struct archive_write *a = (struct archive_write *)_a;
 	int r = ARCHIVE_OK, r1 = ARCHIVE_OK;
+	int was_fatal;
 
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
-	    ARCHIVE_STATE_ANY, "archive_write_close");
+	    ARCHIVE_STATE_ANY | ARCHIVE_STATE_FATAL,
+	    "archive_write_close");
 	if (a->archive.state == ARCHIVE_STATE_NEW
 	    || a->archive.state == ARCHIVE_STATE_CLOSED)
 		return (ARCHIVE_OK); /* Okay to close() when not open. */
 
-	archive_clear_error(&a->archive);
+	was_fatal = a->archive.state == ARCHIVE_STATE_FATAL;
+	if (was_fatal)
+		r = ARCHIVE_FATAL;
+	else {
+		archive_clear_error(&a->archive);
 
-	/* Finish the last entry if a finish callback is specified */
-	if (a->archive.state == ARCHIVE_STATE_DATA
-	    && a->format_finish_entry != NULL)
-		r = ((a->format_finish_entry)(a));
+		/* Finish the last entry if a finish callback is specified */
+		if (a->archive.state == ARCHIVE_STATE_DATA
+		    && a->format_finish_entry != NULL)
+			r = ((a->format_finish_entry)(a));
 
-	/* Finish off the archive. */
-	/* TODO: have format closers invoke compression close. */
-	if (a->format_close != NULL) {
-		r1 = (a->format_close)(a);
-		if (r1 < r)
-			r = r1;
+		/* Finish off the archive. */
+		/* TODO: have format closers invoke compression close. */
+		if (a->format_close != NULL) {
+			r1 = (a->format_close)(a);
+			if (r1 < r)
+				r = r1;
+		}
 	}
 
 	/* Finish the compression and close the stream. */
@@ -666,7 +673,7 @@ _archive_write_close(struct archive *_a)
 	if (r1 < r)
 		r = r1;
 
-	if (a->archive.state != ARCHIVE_STATE_FATAL)
+	if (!was_fatal && a->archive.state != ARCHIVE_STATE_FATAL)
 		a->archive.state = ARCHIVE_STATE_CLOSED;
 	return (r);
 }
@@ -745,7 +752,9 @@ _archive_write_free(struct archive *_a)
 	/* It is okay to call free() in state FATAL. */
 	archive_check_magic(&a->archive, ARCHIVE_WRITE_MAGIC,
 	    ARCHIVE_STATE_ANY | ARCHIVE_STATE_FATAL, "archive_write_free");
-	if (a->archive.state != ARCHIVE_STATE_FATAL)
+	if (a->archive.state == ARCHIVE_STATE_FATAL)
+		(void)archive_write_close(&a->archive);
+	else
 		r = archive_write_close(&a->archive);
 
 	/* Release format resources. */

--- a/libarchive/test/test_write_format_raw.c
+++ b/libarchive/test/test_write_format_raw.c
@@ -24,6 +24,57 @@
  */
 #include "test.h"
 
+static la_ssize_t
+write_callback(struct archive *a, void *client_data, const void *buffer,
+    size_t length)
+{
+	(void)a;
+	(void)client_data;
+	(void)buffer;
+	return ((la_ssize_t)length);
+}
+
+static int
+close_callback(struct archive *a, void *client_data)
+{
+	int *close_count = client_data;
+
+	(void)a;
+	(*close_count)++;
+	return (ARCHIVE_OK);
+}
+
+static void
+test_fatal_cleanup(int close_first)
+{
+	struct archive_entry *ae;
+	struct archive *a;
+	int close_count = 0;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_raw(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_open(a, &close_count,
+	    NULL, write_callback, close_callback));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "first");
+	archive_entry_set_filetype(ae, AE_IFREG);
+	archive_entry_set_size(ae, 0);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_set_pathname(ae, "second");
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	if (close_first) {
+		assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
+		assertEqualInt(1, close_count);
+		assertEqualIntA(a, ARCHIVE_FATAL, archive_write_close(a));
+	}
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	assertEqualInt(1, close_count);
+}
+
 static void
 test_format(int	(*set_format)(struct archive *))
 {
@@ -120,4 +171,6 @@ test_format(int	(*set_format)(struct archive *))
 DEFINE_TEST(test_write_format_raw)
 {
 	test_format(archive_write_set_format_raw);
+	test_fatal_cleanup(0);
+	test_fatal_cleanup(1);
 }


### PR DESCRIPTION
`archive_write_close()` returns early for fatal writers, so initialized filters and client close callbacks never run. This can leave output file descriptors open.

Skip unsafe format finalization, but still close the filter chain. `archive_write_close()` keeps returning `ARCHIVE_FATAL`, while `archive_write_free()` cleans up without returning that status.

This master-only regression was introduced by the PR #3354.