### PR TITLE
archive_read_disk_posix: stop requiring fchdir

### DIFF
--- a/libarchive/archive_read_disk_posix.c
+++ b/libarchive/archive_read_disk_posix.c
@@ -97,9 +97,6 @@
 #include "archive_private.h"
 #include "archive_read_disk_private.h"
 
-#ifndef HAVE_FCHDIR
-#error fchdir function required.
-#endif
 #ifndef O_BINARY
 #define O_BINARY	0
 #endif
@@ -112,6 +109,18 @@
 #if defined(__hpux) && !defined(HAVE_DIRFD)
 #define dirfd(x) ((x)->__dd_fd)
 #define HAVE_DIRFD
+#endif
+
+#ifndef HAVE_FCHDIR
+/*
+ * Stub function for platforms that do not support fchdir.  This is OK on
+ * platforms with newer *at functions as fchdir isn't used there (e.g. WASI).
+ */
+static int fchdir(int fd)
+{
+	errno = ENOSYS;
+	return -1;
+}
 #endif
 
 /*-
@@ -2231,7 +2240,12 @@ tree_enter_initial_dir(struct tree *t)
 	int r = 0;
 
 	if ((t->flags & onInitialDir) == 0) {
+#ifdef HAVE_FCHDIR
 		r = fchdir(t->initial_dir_fd);
+#else
+		r = -1;
+		errno = ENOSYS;
+#endif
 		if (r == 0) {
 			t->flags &= ~onWorkingDir;
 			t->flags |= onInitialDir;
@@ -2254,7 +2268,12 @@ tree_enter_working_dir(struct tree *t)
 	 * descent.
 	 */
 	if (t->depth > 0 && (t->flags & onWorkingDir) == 0) {
+#ifdef HAVE_FCHDIR
 		r = fchdir(t->working_dir_fd);
+#else
+		r = -1;
+		errno = ENOSYS;
+#endif
 		if (r == 0) {
 			t->flags &= ~onInitialDir;
 			t->flags |= onWorkingDir;


### PR DESCRIPTION
The fchdir function is used to implement the tree_enter_working_dir and tree_enter_initial_dir helpers.  But they are basically never called if the system implements the suite of *at functions, and doesn't support extended file attributes.

When struct tree is initialized, it starts with the onInitialDir flag set.  In this case, the tree_enter_initial_dir function never calls fchdir.  The only way that flag is cleared is if tree_enter_working_dir is called.  So let's see if/when it's used.

In archive_read_disk_posix.c, tree_enter_working_dir is never called if fd-based funcs are available (e.g. openat, fstatat, fstatfs, fstatvfs, fdopendir).
NB: NetBSD's setup_current_filesystem always calls tree_enter_working_dir currently, so it requires fchdir.  It probably could/should be improved.

In archive_read_disk_entry_from_file.c, tree_enter_working_dir is used to implement archive_read_disk_entry_setup_path, or if readlinkat is not available.

The archive_read_disk_entry_setup_path private API is used to manage ACLs & xattrs & sparseness.  It's called from archive_disk_acl_*.c and archive_read_disk_entry_from_file.c files, but all usage is guarded by respective OS or other function or library checks.

WASI is such a target.  It supports the suite of fd-based functions, does not support ACLs, nor xattrs, nor file sparseness.  It currently supports chdir, but not fchdir.  Arguably it has enough pieces to add fchdir support, but that would be a separate discussion with them, and considering libarchive doesn't actually require fchdir here, it should be more flexible.

Unfortunately, because of how the APIs are spread across the files, trying to disable the functions entirely would require duplicating a non-trivial amount of ifdefs, and that doesn't seem to justify the maintenance overhead.