### PR TITLE
archive_write_disk: avoid unnecessary user and group lookups

### DIFF
--- a/libarchive/archive_write_disk_posix.c
+++ b/libarchive/archive_write_disk_posix.c
@@ -1819,16 +1819,14 @@ _archive_write_disk_finish_entry(struct archive *_a)
 
 	/*
 	 * Look up the "real" UID only if we're going to need it.
-	 * TODO: the TODO_SGID condition can be dropped here, can't it?
 	 */
-	if (a->todo & (TODO_OWNER | TODO_SUID | TODO_SGID)) {
+	if (a->todo & (TODO_OWNER | TODO_SUID)) {
 		a->uid = archive_write_disk_uid(&a->archive,
 		    archive_entry_uname(a->entry),
 		    archive_entry_uid(a->entry));
 	}
 	/* Look up the "real" GID only if we're going to need it. */
-	/* TODO: the TODO_SUID condition can be dropped here, can't it? */
-	if (a->todo & (TODO_OWNER | TODO_SGID | TODO_SUID)) {
+	if (a->todo & (TODO_OWNER | TODO_SGID)) {
 		a->gid = archive_write_disk_gid(&a->archive,
 		    archive_entry_gname(a->entry),
 		    archive_entry_gid(a->entry));

--- a/libarchive/archive_write_disk_windows.c
+++ b/libarchive/archive_write_disk_windows.c
@@ -1202,16 +1202,14 @@ _archive_write_disk_finish_entry(struct archive *_a)
 
 	/*
 	 * Look up the "real" UID only if we're going to need it.
-	 * TODO: the TODO_SGID condition can be dropped here, can't it?
 	 */
-	if (a->todo & (TODO_OWNER | TODO_SUID | TODO_SGID)) {
+	if (a->todo & (TODO_OWNER | TODO_SUID)) {
 		a->uid = archive_write_disk_uid(&a->archive,
 		    archive_entry_uname(a->entry),
 		    archive_entry_uid(a->entry));
 	}
 	/* Look up the "real" GID only if we're going to need it. */
-	/* TODO: the TODO_SUID condition can be dropped here, can't it? */
-	if (a->todo & (TODO_OWNER | TODO_SGID | TODO_SUID)) {
+	if (a->todo & (TODO_OWNER | TODO_SGID)) {
 		a->gid = archive_write_disk_gid(&a->archive,
 		    archive_entry_gname(a->entry),
 		    archive_entry_gid(a->entry));


### PR DESCRIPTION
Restoring SUID only needs the resolved UID, while restoring SGID only needs the resolved GID. Skip the unrelated lookup unless owner restoration was requested.