### PR TITLE
build: Turn libmd opt-out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 OPTION(ENABLE_MBEDTLS "Enable use of mbed TLS" OFF)
 OPTION(ENABLE_NETTLE "Enable use of Nettle" OFF)
 OPTION(ENABLE_OPENSSL "Enable use of OpenSSL" ON)
+OPTION(ENABLE_MD "Enable use of md" ON)
 OPTION(ENABLE_LIBB2 "Enable the use of the system LIBB2 library if found" ON)
 OPTION(ENABLE_LZ4 "Enable the use of the system LZ4 library if found" ON)
 OPTION(ENABLE_LZO "Enable the use of the system LZO library if found" OFF)
@@ -929,7 +930,7 @@ ELSE()
 ENDIF()
 
 # FreeBSD libmd
-IF(NOT OPENSSL_FOUND)
+IF(ENABLE_MD AND NOT OPENSSL_FOUND)
   CHECK_LIBRARY_EXISTS(md "MD5Init" "" LIBMD_FOUND)
   IF(LIBMD_FOUND)
     CMAKE_PUSH_CHECK_STATE()	# Save the state of the variables
@@ -938,7 +939,7 @@ IF(NOT OPENSSL_FOUND)
     LIST(APPEND ADDITIONAL_LIBS ${LIBMD_LIBRARY})
     CMAKE_POP_CHECK_STATE()	# Restore the state of the variables
   ENDIF(LIBMD_FOUND)
-ENDIF(NOT OPENSSL_FOUND)
+ENDIF(ENABLE_MD AND NOT OPENSSL_FOUND)
 
 # libbsd for readpassphrase on Haiku
 IF("${CMAKE_SYSTEM_NAME}" MATCHES "Haiku")

--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,8 @@ AC_ARG_WITH([nettle],
   AS_HELP_STRING([--with-nettle], [Build with crypto support from Nettle]))
 AC_ARG_WITH([openssl],
   AS_HELP_STRING([--without-openssl], [Don't build support for mtree and xar hashes through openssl]))
+AC_ARG_WITH([md],
+  AS_HELP_STRING([--without-md], [Don't build with crypto support from md]))
 case "$host_os" in
   *darwin* ) with_openssl=no ;;
 esac
@@ -1376,17 +1378,19 @@ fi
 
 AC_SUBST(LIBSREQUIRED)
 
-dnl Probe libmd AFTER OpenSSL/libcrypto.
-dnl The two are incompatible and OpenSSL is more complete.
-saved_LIBS=$LIBS
-AC_CHECK_LIB(md, MD5Init)
-CRYPTO_CHECK(MD5, LIBMD, md5)
-CRYPTO_CHECK(RMD160, LIBMD, rmd160)
-CRYPTO_CHECK(SHA1, LIBMD, sha1)
-CRYPTO_CHECK(SHA256, LIBMD, sha256)
-CRYPTO_CHECK(SHA512, LIBMD, sha512)
-if test "x$found_LIBMD" != "xyes"; then
-  LIBS=$saved_LIBS
+if test "x$with_md" != "xno"; then
+    dnl Probe libmd AFTER OpenSSL/libcrypto.
+    dnl The two are incompatible and OpenSSL is more complete.
+    saved_LIBS=$LIBS
+    AC_CHECK_LIB(md, MD5Init)
+    CRYPTO_CHECK(MD5, LIBMD, md5)
+    CRYPTO_CHECK(RMD160, LIBMD, rmd160)
+    CRYPTO_CHECK(SHA1, LIBMD, sha1)
+    CRYPTO_CHECK(SHA256, LIBMD, sha256)
+    CRYPTO_CHECK(SHA512, LIBMD, sha512)
+    if test "x$found_LIBMD" != "xyes"; then
+      LIBS=$saved_LIBS
+    fi
 fi
 
 dnl Visibility annotations...


### PR DESCRIPTION
Allow libarchive build to ignore libmd on the system. Keep the default, i.e. check for availability if OpenSSL is not available.

Spotted while analyzing https://github.com/libarchive/libarchive/issues/3154. Arch Linux has a libmd package as well and it would be impossible to disable all external (shared) libraries without this option.