### PR TITLE
xar: reject decompressor success without progress

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1135,8 +1135,11 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_xar_base64_oob.xar.uu \
 	libarchive/test/test_read_format_xar_doublelink.xar.uu \
 	libarchive/test/test_read_format_xar_duplicate_filename_node.xar.uu \
+	libarchive/test/test_read_format_xar_empty_xattr.xar.uu \
 	libarchive/test/test_read_format_xar_large_mode.xar.uu \
 	libarchive/test/test_read_format_xar_parse_time_overread.xar.uu \
+	libarchive/test/test_read_format_xar_toc_premature_stream_end.xar.uu \
+	libarchive/test/test_read_format_xar_toc_premature_stream_end_control.xar.uu \
 	libarchive/test/test_read_format_zip.zip.uu \
 	libarchive/test/test_read_format_zip_7075_utf8_paths.zip.uu \
 	libarchive/test/test_read_format_zip_7z_deflate.zip.uu \

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -1066,6 +1066,11 @@ rd_contents(struct archive_read *a, const void **buff, size_t *size,
 	*used = bytes;
 	if (decompress(a, buff, size, b, used) != ARCHIVE_OK)
 		return (ARCHIVE_FATAL);
+	if (remaining > 0 && *used == 0 && *size == 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "XAR decompressor made no progress");
+		return (ARCHIVE_FATAL);
+	}
 
 	/*
 	 * Update checksum of a compressed data and a extracted data.

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -1042,6 +1042,102 @@ DEFINE_TEST(test_read_format_xar_atou64_overread)
 }
 
 /*
+ * A valid uncompressed empty xattr makes no decompression progress when no
+ * declared bytes remain.  It must not be rejected as a stalled stream.
+ */
+DEFINE_TEST(test_read_format_xar_empty_xattr)
+{
+	const char *refname = "test_read_format_xar_empty_xattr.xar";
+	const char *name;
+	const void *value;
+	struct archive_entry *ae;
+	struct archive *a;
+	size_t size;
+	char data;
+	int r;
+
+	extract_reference_file(refname);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("XAR reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, refname, 10240));
+	if (!assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_next_header(a, &ae))) {
+		assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualString("f", archive_entry_pathname(ae));
+	assertEqualInt(1, archive_entry_size(ae));
+	assertEqualInt(1, archive_entry_xattr_reset(ae));
+	assertEqualInt(ARCHIVE_OK,
+	    archive_entry_xattr_next(ae, &name, &value, &size));
+	assertEqualString("user.empty", name);
+	assertEqualInt(0, size);
+	assertEqualIntA(a, 1, archive_read_data(a, &data, 1));
+	assertEqualInt('Z', data);
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+}
+
+DEFINE_TEST(test_read_format_xar_toc_premature_stream_end)
+{
+	const char *control =
+	    "test_read_format_xar_toc_premature_stream_end_control.xar";
+	const char *malformed =
+	    "test_read_format_xar_toc_premature_stream_end.xar";
+	struct archive_entry *ae;
+	struct archive *a;
+	int r;
+
+	extract_reference_file(control);
+	extract_reference_file(malformed);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("XAR reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, control, 10240));
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+#if !defined(HAVE_LIBXML_XMLREADER_H) && !defined(HAVE_BSDXML_H) && \
+    !defined(HAVE_EXPAT_H) && defined(HAVE_XMLLITE_H)
+	skipping("Malformed XAR TOC behavior is not validated with XmlLite");
+#else
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_all(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_filename(a, malformed, 10240));
+	/* The declared TOC length continues past the end of the zlib stream. */
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assert(archive_errno(a) != 0);
+#if !defined(HAVE_LIBXML_XMLREADER_H) && \
+    (defined(HAVE_BSDXML_H) || defined(HAVE_EXPAT_H))
+	assertEqualString("XAR decompressor made no progress",
+	    archive_error_string(a));
+#endif
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
+}
+
+/*
  * parse_time() reads a fixed 20-byte timestamp and handed atou64() a width
  * of 4 for every field.  The trailing seconds field sits at offset 17, so a
  * value whose last three bytes are all digits (here "...00:00:123") made

--- a/libarchive/test/test_read_format_xar_empty_xattr.xar.uu
+++ b/libarchive/test/test_read_format_xar_empty_xattr.xar.uu
@@ -1,0 +1,9 @@
+begin 644 test_read_format_xar_empty_xattr.xar
+M>&%R(0`<``$`````````R`````````%W`````'B<G9#+"L(P$$7W_8J2O4X+
+M(BZF<><7Z`<,[50#>91F%.O7FX3J5G!US^3!'"X>G\[6#YZC";Y3[;91-?L^
+M#,9?.W4YGS8'==05/FG6**%/.!K+M1G28Z71DV,](I1$6:8TI7N$@NC"P+K9
+M[W8(!2MD^OZU[*]RTPW"2AC&,;+DDY4PFA?GN21^S.HHB^5.T319TY,D=PB]
+ML&RBS$Q.P6IVCSQOV4VR?!2!*5D,)/05:'\*M/\(0%E2(>1"<N;Z$'*3U1MU
+$S7Z=6@``
+`
+end

--- a/libarchive/test/test_read_format_xar_toc_premature_stream_end.xar.uu
+++ b/libarchive/test/test_read_format_xar_toc_premature_stream_end.xar.uu
@@ -1,0 +1,7 @@
+begin 644 test_read_format_xar_toc_premature_stream_end.xar
+M>&%R(0`<``$`````````H0`````````\`````'C:L[&OR,U1*$LM*L[,S[-5
+M,M0S4%)(S4O.3\G,2[=5"@UQT[50LK>SJ4@LLK,IR4^VL]&'D"`!`$ND$R1'
+M1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='
+M1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='1T='
+)1T='1T='1T='
+end

--- a/libarchive/test/test_read_format_xar_toc_premature_stream_end_control.xar.uu
+++ b/libarchive/test/test_read_format_xar_toc_premature_stream_end_control.xar.uu
@@ -1,0 +1,4 @@
+begin 644 test_read_format_xar_toc_premature_stream_end_control.xar
+M>&%R(0`<``$`````````/0`````````\`````'C:L[&OR,U1*$LM*L[,S[-5
+L,M0S4%)(S4O.3\G,2[=5"@UQT[50LK>SJ4@LLK,IR4^VL]&'D"`!`$ND$R0`
+end


### PR DESCRIPTION
## Summary

- Reject a successful internal XAR decompression iteration when compressed TOC
  bytes remain but the decompressor consumes and produces zero bytes.
- Add a regression archive containing a complete zlib stream followed by bytes
  still included in the declared compressed TOC length.
- Add a corrected-length control archive.
- Cover a legitimate uncompressed zero-length XAR xattr to ensure the
  no-progress check remains limited to cases where declared input remains.

## Background

With the Expat/bsdxml-backed XAR TOC reader, a malformed archive can reach the
end of the embedded zlib stream before the declared compressed TOC length is
exhausted. Subsequent decompression iterations can report success while
consuming and producing no bytes, causing the reader to loop without progress.

This change treats that state as a malformed archive and returns
`ARCHIVE_FATAL`.

The test coverage complements the XAR decompression work in #3211 by exercising
the TOC path with the reported trigger and corrected-size control.

## Testing

Tested locally with separately configured Expat and libxml2 builds.

- The regression exercises the public archive-read path.
- The malformed archive fails immediately with:
  `XAR decompressor made no progress`
- The corrected-length control succeeds.
- A legitimate zero-length extended attribute succeeds.
- Focused Expat regression tests pass.
- Focused libxml2 regression tests pass.