### PR TITLE
xar: bound XML TOC resource usage

### DIFF
--- a/libarchive/archive_read_set_options.3
+++ b/libarchive/archive_read_set_options.3
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 31, 2020
+.Dd September 1, 2026
 .Dt ARCHIVE_READ_OPTIONS 3
 .Os
 .Sh NAME
@@ -252,6 +252,23 @@ Ignore zeroed blocks in the archive, which occurs when multiple tar archives
 have been concatenated together.
 Without this option, only the contents of
 the first concatenated archive would be read.
+.El
+.It Format xar
+.Bl -tag -compact -width indent
+.It Cm max-pathname-size
+Set the maximum combined size of retained pathnames and resolved hardlink
+pathnames, in bytes.
+The default limit is 67108864 bytes.
+A value of 0 disables the limit.
+.It Cm max-toc-records
+Set the maximum combined number of file and extended-attribute records
+retained while reading the XML table of contents.
+The default limit is 100000 records.
+A value of 0 disables the limit.
+.It Cm max-toc-size
+Set the maximum uncompressed size of the XML table of contents, in bytes.
+The default limit is 67108864 bytes.
+A value of 0 disables the limit.
 .El
 .It Format zip
 .Bl -tag -compact -width indent

--- a/libarchive/archive_read_support_format_xar.c
+++ b/libarchive/archive_read_support_format_xar.c
@@ -61,6 +61,7 @@
 #include "archive_entry_locale.h"
 #include "archive_integer.h"
 #include "archive_private.h"
+#include "archive_rb.h"
 #include "archive_read_private.h"
 
 #if (!defined(HAVE_LIBXML_XMLREADER_H) && \
@@ -119,6 +120,16 @@ archive_read_support_format_xar(struct archive *_a)
 #define SHA256_SIZE	32
 #define SHA512_SIZE	64
 #define MAX_SUM_SIZE	64
+
+/*
+ * The XAR reader retains file and extended-attribute records until the
+ * complete XML TOC has been parsed.  Bound both the retained records and
+ * their XML representation and derived pathnames.  Trusted callers can
+ * adjust these limits with xar reader options.
+ */
+#define XAR_DEFAULT_MAX_TOC_RECORDS	UINT64_C(100000)
+#define XAR_DEFAULT_MAX_TOC_SIZE	(UINT64_C(64) * 1024 * 1024)
+#define XAR_DEFAULT_MAX_PATHNAME_SIZE	(UINT64_C(64) * 1024 * 1024)
 
 enum enctype {
 	NONE,
@@ -215,12 +226,13 @@ struct xar_file {
 	unsigned int		 nlink;
 	struct archive_string	 hardlink;
 	struct xattr		*xattr_list;
+	struct xattr		*xattr_last;
 };
 
 struct hdlink {
-	struct hdlink		 *next;
+	struct archive_rb_node	 rbnode;
 
-	unsigned int		 id;
+	uint64_t		 id;
 	int			 cnt;
 	struct xar_file		 *files;
 };
@@ -337,8 +349,14 @@ struct xar {
 	 */
 	uint64_t		 toc_remaining;
 	uint64_t		 toc_total;
+	uint64_t		 toc_expected;
 	uint64_t		 toc_chksum_offset;
 	uint64_t		 toc_chksum_size;
+	uint64_t		 max_toc_size;
+	uint64_t		 toc_record_count;
+	uint64_t		 max_toc_records;
+	uint64_t		 pathname_total;
+	uint64_t		 max_pathname_size;
 
 	/*
 	 * For Decoding data.
@@ -364,7 +382,7 @@ struct xar {
 	struct xattr		*xattr; /* current reading extended attribute. */
 	struct heap_queue	 file_queue;
 	struct xar_file		*hdlink_orgs;
-	struct hdlink		*hdlink_list;
+	struct archive_rb_tree	 hdlink_tree;
 
 	int	 		 entry_init;
 	uint64_t		 entry_total;
@@ -390,6 +408,7 @@ struct xmlattr_list {
 };
 
 static int	xar_bid(struct archive_read *, int);
+static int	xar_options(struct archive_read *, const char *, const char *);
 static int	xar_read_header(struct archive_read *,
 		    struct archive_entry *);
 static int	xar_read_data(struct archive_read *,
@@ -426,6 +445,12 @@ static void	file_free(struct xar_file *);
 static int	xattr_new(struct archive_read *,
     struct xar *, struct xmlattr_list *);
 static void	xattr_free(struct xattr *);
+static struct xattr *xattr_list_sort(struct xattr *);
+static int	hdlink_cmp_node(const struct archive_rb_node *,
+    const struct archive_rb_node *);
+static int	hdlink_cmp_key(const struct archive_rb_node *, const void *);
+static int	xar_toc_record_allowed(struct archive_read *, struct xar *);
+static int	xar_pathname_add_bytes(struct archive_read *, uint64_t);
 static int	getencoding(struct xmlattr_list *);
 static int	getsumalgorithm(struct xmlattr_list *);
 static int	unknowntag_start(struct archive_read *,
@@ -435,6 +460,7 @@ static int	xml_start(struct archive_read *,
     const char *, struct xmlattr_list *);
 static void	xml_end(void *, const char *);
 static int	xml_data(void *, const char *, size_t);
+static int	xar_toc_add_bytes(struct archive_read *, size_t);
 static int	xml_parse_file_flags(struct xar *, const char *);
 static int	xml_parse_file_ext2(struct xar *, const char *);
 #if defined(HAVE_LIBXML_XMLREADER_H)
@@ -463,6 +489,9 @@ static int	xmllite_read_toc(struct archive_read *);
 int
 archive_read_support_format_xar(struct archive *_a)
 {
+	static const struct archive_rb_tree_ops rb_ops = {
+		hdlink_cmp_node, hdlink_cmp_key,
+	};
 	struct archive_read *a = (struct archive_read *)_a;
 	struct xar *xar;
 	int r;
@@ -480,12 +509,16 @@ archive_read_support_format_xar(struct archive *_a)
 	xar->file_queue.allocated = 0;
 	xar->file_queue.used = 0;
 	xar->file_queue.files = NULL;
+	__archive_rb_tree_init(&xar->hdlink_tree, &rb_ops);
+	xar->max_toc_records = XAR_DEFAULT_MAX_TOC_RECORDS;
+	xar->max_toc_size = XAR_DEFAULT_MAX_TOC_SIZE;
+	xar->max_pathname_size = XAR_DEFAULT_MAX_PATHNAME_SIZE;
 
 	r = __archive_read_register_format(a,
 	    xar,
 	    "xar",
 	    xar_bid,
-	    NULL,
+	    xar_options,
 	    xar_read_header,
 	    xar_read_data,
 	    xar_read_data_skip,
@@ -497,6 +530,42 @@ archive_read_support_format_xar(struct archive *_a)
 	if (r != ARCHIVE_OK)
 		free(xar);
 	return (r);
+}
+
+static int
+xar_options(struct archive_read *a, const char *key, const char *val)
+{
+	struct xar *xar = a->format->data;
+	uint64_t value;
+	uint64_t *limit;
+	const char *p;
+
+	if (strcmp(key, "max-toc-records") == 0)
+		limit = &xar->max_toc_records;
+	else if (strcmp(key, "max-toc-size") == 0)
+		limit = &xar->max_toc_size;
+	else if (strcmp(key, "max-pathname-size") == 0)
+		limit = &xar->max_pathname_size;
+	else
+		return (ARCHIVE_WARN);
+
+	if (val == NULL || val[0] == '\0') {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "xar: %s option requires a non-negative integer", key);
+		return (ARCHIVE_FAILED);
+	}
+	value = 0;
+	for (p = val; *p != '\0'; ++p) {
+		if (*p < '0' || *p > '9' ||
+		    archive_ckd_mul_u64(&value, value, 10) ||
+		    archive_ckd_add_u64(&value, value, *p - '0')) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "xar: invalid %s option value", key);
+			return (ARCHIVE_FAILED);
+		}
+	}
+	*limit = value;
+	return (ARCHIVE_OK);
 }
 
 static int
@@ -590,9 +659,17 @@ read_toc(struct archive_read *a)
 	xar->toc_remaining = toc_compressed_size;
 	toc_uncompressed_size = archive_be64dec(b+16);
 	toc_chksum_alg = archive_be32dec(b+24);
+	if (xar->max_toc_size != 0 &&
+	    toc_uncompressed_size > xar->max_toc_size) {
+		archive_set_error(&a->archive, ENOMEM,
+		    "XAR TOC is larger than configured limit (%" PRIu64
+		    " bytes)", xar->max_toc_size);
+		return (ARCHIVE_FATAL);
+	}
 	__archive_read_consume(a, HEADER_SIZE);
 	xar->offset += HEADER_SIZE;
 	xar->toc_total = 0;
+	xar->toc_expected = toc_uncompressed_size;
 
 	/*
 	 * Read TOC(Table of Contents).
@@ -654,29 +731,26 @@ read_toc(struct archive_read *a)
 	 * Connect hardlinked files.
 	 */
 	for (file = xar->hdlink_orgs; file != NULL; file = file->hdnext) {
-		struct hdlink **hdlink;
+		struct hdlink *hdlink;
+		struct xar_file *f2;
+		int nlink;
 
-		for (hdlink = &(xar->hdlink_list); *hdlink != NULL;
-		    hdlink = &((*hdlink)->next)) {
-			if ((*hdlink)->id == file->id) {
-				struct hdlink *hltmp;
-				struct xar_file *f2;
-				int nlink = (*hdlink)->cnt + 1;
-
-				file->nlink = nlink;
-				for (f2 = (*hdlink)->files; f2 != NULL;
-				    f2 = f2->hdnext) {
-					f2->nlink = nlink;
-					archive_string_copy(
-					    &(f2->hardlink), &(file->pathname));
-				}
-				/* Remove resolved files from hdlist_list. */
-				hltmp = *hdlink;
-				*hdlink = hltmp->next;
-				free(hltmp);
-				break;
-			}
+		hdlink = (struct hdlink *)__archive_rb_tree_find_node(
+		    &xar->hdlink_tree, &file->id);
+		if (hdlink == NULL)
+			continue;
+		nlink = hdlink->cnt + 1;
+		file->nlink = nlink;
+		for (f2 = hdlink->files; f2 != NULL; f2 = f2->hdnext) {
+			f2->nlink = nlink;
+			if (xar_pathname_add_bytes(a,
+			    archive_strlen(&(file->pathname))) != ARCHIVE_OK)
+				return (ARCHIVE_FATAL);
+			archive_string_copy(&(f2->hardlink), &(file->pathname));
 		}
+		/* Remove resolved files from the hardlink tree. */
+		__archive_rb_tree_remove_node(&xar->hdlink_tree, &hdlink->rbnode);
+		free(hdlink);
 	}
 	a->archive.archive_format = ARCHIVE_FORMAT_XAR;
 	a->archive.archive_format_name = "xar";
@@ -826,7 +900,7 @@ xar_read_header(struct archive_read *a, struct archive_entry *entry)
 	/*
 	 * Read extended attributes.
 	 */
-	xattr = file->xattr_list;
+	xattr = file->xattr_list = xattr_list_sort(file->xattr_list);
 	while (xattr != NULL) {
 		const void *d;
 		size_t outbytes = 0;
@@ -969,18 +1043,15 @@ static int
 xar_cleanup(struct archive_read *a)
 {
 	struct xar *xar = a->format->data;
-	struct hdlink *hdlink;
+	struct archive_rb_node *node, *next;
 	size_t i;
 	int r;
 
 	checksum_cleanup(a);
 	r = decompression_cleanup(a);
-	hdlink = xar->hdlink_list;
-	while (hdlink != NULL) {
-		struct hdlink *next = hdlink->next;
-
-		free(hdlink);
-		hdlink = next;
+	ARCHIVE_RB_TREE_FOREACH_SAFE(node, &xar->hdlink_tree, next) {
+		__archive_rb_tree_remove_node(&xar->hdlink_tree, node);
+		free(node);
 	}
 	for (i = 0; i < xar->file_queue.used; i++)
 		file_free(xar->file_queue.files[i]);
@@ -1318,17 +1389,45 @@ heap_get_entry(struct heap_queue *heap)
 }
 
 static int
+hdlink_cmp_node(const struct archive_rb_node *n1,
+    const struct archive_rb_node *n2)
+{
+	const struct hdlink *h1 = (const struct hdlink *)n1;
+	const struct hdlink *h2 = (const struct hdlink *)n2;
+
+	if (h1->id < h2->id)
+		return (1);
+	if (h1->id > h2->id)
+		return (-1);
+	return (0);
+}
+
+static int
+hdlink_cmp_key(const struct archive_rb_node *n, const void *key)
+{
+	const struct hdlink *hdlink = (const struct hdlink *)n;
+	const uint64_t id = *(const uint64_t *)key;
+
+	if (hdlink->id < id)
+		return (1);
+	if (hdlink->id > id)
+		return (-1);
+	return (0);
+}
+
+static int
 add_link(struct archive_read *a, struct xar *xar, struct xar_file *file)
 {
 	struct hdlink *hdlink;
+	uint64_t id = file->link;
 
-	for (hdlink = xar->hdlink_list; hdlink != NULL; hdlink = hdlink->next) {
-		if (hdlink->id == file->link) {
-			file->hdnext = hdlink->files;
-			hdlink->cnt++;
-			hdlink->files = file;
-			return (ARCHIVE_OK);
-		}
+	hdlink = (struct hdlink *)__archive_rb_tree_find_node(
+	    &xar->hdlink_tree, &id);
+	if (hdlink != NULL) {
+		file->hdnext = hdlink->files;
+		hdlink->cnt++;
+		hdlink->files = file;
+		return (ARCHIVE_OK);
 	}
 	hdlink = malloc(sizeof(*hdlink));
 	if (hdlink == NULL) {
@@ -1336,11 +1435,16 @@ add_link(struct archive_read *a, struct xar *xar, struct xar_file *file)
 		return (ARCHIVE_FATAL);
 	}
 	file->hdnext = NULL;
-	hdlink->id = file->link;
+	hdlink->id = id;
 	hdlink->cnt = 1;
 	hdlink->files = file;
-	hdlink->next = xar->hdlink_list;
-	xar->hdlink_list = hdlink;
+	if (!__archive_rb_tree_insert_node(&xar->hdlink_tree,
+	    &hdlink->rbnode)) {
+		free(hdlink);
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Duplicate hardlink group");
+		return (ARCHIVE_FATAL);
+	}
 	return (ARCHIVE_OK);
 }
 
@@ -1815,11 +1919,48 @@ xmlattr_cleanup(struct xmlattr_list *list)
 }
 
 static int
+xar_toc_record_allowed(struct archive_read *a, struct xar *xar)
+{
+	if (xar->max_toc_records != 0 &&
+	    xar->toc_record_count >= xar->max_toc_records) {
+		archive_set_error(&a->archive, ENOMEM,
+		    "XAR TOC record count exceeds configured limit (%" PRIu64 ")",
+		    xar->max_toc_records);
+		return (ARCHIVE_FATAL);
+	}
+	return (ARCHIVE_OK);
+}
+
+static int
+xar_pathname_add_bytes(struct archive_read *a, uint64_t bytes)
+{
+	struct xar *xar = a->format->data;
+	uint64_t total;
+
+	if (archive_ckd_add_u64(&total, xar->pathname_total, bytes)) {
+		archive_set_error(&a->archive, ENOMEM,
+		    "XAR pathname data size overflow");
+		return (ARCHIVE_FATAL);
+	}
+	if (xar->max_pathname_size != 0 &&
+	    total > xar->max_pathname_size) {
+		archive_set_error(&a->archive, ENOMEM,
+		    "XAR pathname data exceeds configured limit (%" PRIu64
+		    " bytes)", xar->max_pathname_size);
+		return (ARCHIVE_FATAL);
+	}
+	xar->pathname_total = total;
+	return (ARCHIVE_OK);
+}
+
+static int
 file_new(struct archive_read *a, struct xar *xar, struct xmlattr_list *list)
 {
 	struct xar_file *file;
 	struct xmlattr *attr;
 
+	if (xar_toc_record_allowed(a, xar) != ARCHIVE_OK)
+		return (ARCHIVE_FATAL);
 	file = calloc(1, sizeof(*file));
 	if (file == NULL) {
 		archive_set_error(&a->archive, ENOMEM, "Out of memory");
@@ -1849,6 +1990,7 @@ file_new(struct archive_read *a, struct xar *xar, struct xmlattr_list *list)
 		file_free(file);
 		return (ARCHIVE_FATAL);
 	}
+	xar->toc_record_count++;
 	return (ARCHIVE_OK);
 }
 
@@ -1878,9 +2020,11 @@ file_free(struct xar_file *file)
 static int
 xattr_new(struct archive_read *a, struct xar *xar, struct xmlattr_list *list)
 {
-	struct xattr *xattr, **nx;
+	struct xattr *xattr;
 	struct xmlattr *attr;
 
+	if (xar_toc_record_allowed(a, xar) != ARCHIVE_OK)
+		return (ARCHIVE_FATAL);
 	xattr = calloc(1, sizeof(*xattr));
 	if (xattr == NULL) {
 		archive_set_error(&a->archive, ENOMEM, "Out of memory");
@@ -1899,14 +2043,13 @@ xattr_new(struct archive_read *a, struct xar *xar, struct xmlattr_list *list)
 		}
 	}
 	xar->xattr = xattr;
-	/* Chain to xattr list. */
-	for (nx = &(xar->file->xattr_list);
-	    *nx != NULL; nx = &((*nx)->next)) {
-		if (xattr->id < (*nx)->id)
-			break;
-	}
-	xattr->next = *nx;
-	*nx = xattr;
+	/* Append in constant time; sort once before exposing the entry. */
+	if (xar->file->xattr_last == NULL)
+		xar->file->xattr_list = xattr;
+	else
+		xar->file->xattr_last->next = xattr;
+	xar->file->xattr_last = xattr;
+	xar->toc_record_count++;
 
 	return (ARCHIVE_OK);
 }
@@ -1917,6 +2060,46 @@ xattr_free(struct xattr *xattr)
 	archive_string_free(&(xattr->name));
 	archive_string_free(&(xattr->fstype));
 	free(xattr);
+}
+
+static struct xattr *
+xattr_list_merge(struct xattr *left, struct xattr *right)
+{
+	struct xattr *result = NULL;
+	struct xattr **tail = &result;
+
+	while (left != NULL && right != NULL) {
+		if (left->id <= right->id) {
+			*tail = left;
+			left = left->next;
+		} else {
+			*tail = right;
+			right = right->next;
+		}
+		tail = &((*tail)->next);
+	}
+	*tail = left != NULL ? left : right;
+	return (result);
+}
+
+static struct xattr *
+xattr_list_sort(struct xattr *list)
+{
+	struct xattr *fast, *left, *right, *slow;
+
+	if (list == NULL || list->next == NULL)
+		return (list);
+	left = list;
+	slow = list;
+	fast = list->next;
+	while (fast != NULL && fast->next != NULL) {
+		slow = slow->next;
+		fast = fast->next->next;
+	}
+	right = slow->next;
+	slow->next = NULL;
+	return (xattr_list_merge(xattr_list_sort(left),
+	    xattr_list_sort(right)));
 }
 
 static int
@@ -2771,9 +2954,24 @@ xml_data(void *userData, const char *s, size_t len)
 		return (ARCHIVE_OK);
 
 	switch (xar->xmlsts) {
-	case FILE_NAME:
+	case FILE_NAME: {
+		uint64_t pathname_size = (uint64_t)len;
+
 		if (xar->file->has & HAS_PATHNAME)
 			break;
+
+		if (xar->file->parent != NULL) {
+			if (archive_ckd_add_u64(&pathname_size, pathname_size,
+			    archive_strlen(&(xar->file->parent->pathname))) ||
+			    archive_ckd_add_u64(&pathname_size,
+			    pathname_size, 1)) {
+				archive_set_error(&a->archive, ENOMEM,
+				    "XAR pathname data size overflow");
+				return (ARCHIVE_FATAL);
+			}
+		}
+		if (xar_pathname_add_bytes(a, pathname_size) != ARCHIVE_OK)
+			return (ARCHIVE_FATAL);
 
 		if (xar->file->parent != NULL) {
 			archive_string_concat(&(xar->file->pathname),
@@ -2787,6 +2985,7 @@ xml_data(void *userData, const char *s, size_t len)
 		} else
 			archive_strncat(&(xar->file->pathname), s, len);
 		break;
+	}
 	case FILE_LINK:
 		xar->file->has |= HAS_SYMLINK;
 		archive_strncpy(&(xar->file->symlink), s, len);
@@ -3177,6 +3376,27 @@ xml_parse_file_ext2(struct xar *xar, const char *name)
 	return (1);
 }
 
+static int
+xar_toc_add_bytes(struct archive_read *a, size_t bytes)
+{
+	struct xar *xar = a->format->data;
+
+	if ((uint64_t)bytes > xar->toc_expected - xar->toc_total) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "TOC uncompressed size error");
+		return (ARCHIVE_FATAL);
+	}
+	if (xar->max_toc_size != 0 &&
+	    (uint64_t)bytes > xar->max_toc_size - xar->toc_total) {
+		archive_set_error(&a->archive, ENOMEM,
+		    "XAR TOC is larger than configured limit (%" PRIu64
+		    " bytes)", xar->max_toc_size);
+		return (ARCHIVE_FATAL);
+	}
+	xar->toc_total += (uint64_t)bytes;
+	return (ARCHIVE_OK);
+}
+
 #ifdef HAVE_LIBXML_XMLREADER_H
 
 static int
@@ -3235,10 +3455,12 @@ xml2_read_cb(void *context, char *buffer, int len)
 	r = rd_contents(a, &d, &outbytes, &used, xar->toc_remaining);
 	if (r != ARCHIVE_OK)
 		return (r);
+	r = xar_toc_add_bytes(a, outbytes);
+	if (r != ARCHIVE_OK)
+		return (r);
 	__archive_read_consume(a, used);
 	xar->toc_remaining -= used;
 	xar->offset += used;
-	xar->toc_total += outbytes;
 	PRINT_TOC(buffer, len);
 
 	return ((int)outbytes);
@@ -3440,9 +3662,13 @@ expat_read_toc(struct archive_read *a)
 			XML_ParserFree(parser);
 			return (r);
 		}
+		r = xar_toc_add_bytes(a, outbytes);
+		if (r != ARCHIVE_OK) {
+			XML_ParserFree(parser);
+			return (r);
+		}
 		xar->toc_remaining -= used;
 		xar->offset += used;
-		xar->toc_total += outbytes;
 		PRINT_TOC(d, outbytes);
 
 		xr = XML_Parse(parser, d, (int)outbytes, xar->toc_remaining == 0);
@@ -3513,10 +3739,12 @@ asaRead(ISequentialStream *this, void *pv, ULONG cb, ULONG *pcbRead)
 	r = rd_contents(a, &d, &outbytes, &used, xar->toc_remaining);
 	if (r != ARCHIVE_OK)
 		return E_FAIL;
+	r = xar_toc_add_bytes(a, outbytes);
+	if (r != ARCHIVE_OK)
+		return E_FAIL;
 	__archive_read_consume(a, used);
 	xar->toc_remaining -= used;
 	xar->offset += used;
-	xar->toc_total += outbytes;
 	PRINT_TOC(pv, outbytes);
 
 	*pcbRead = (ULONG)outbytes;

--- a/libarchive/test/test_read_format_xar.c
+++ b/libarchive/test/test_read_format_xar.c
@@ -25,6 +25,10 @@
  */
 #include "test.h"
 
+#ifdef HAVE_ZLIB_H
+#include <zlib.h>
+#endif
+
 #define UID	1001
 #define UNAME	"cue"
 #define GID	1001
@@ -901,6 +905,359 @@ DEFINE_TEST(test_read_format_xar)
 	verify(archive11, sizeof(archive11), verify0, NULL, GZIP);
         verify(archive12, sizeof(archive12), verify12, NULL, GZIP);
 	verifyB(archive13, sizeof(archive13));
+}
+
+#ifdef HAVE_ZLIB_H
+static void
+xar_be16enc(unsigned char *p, unsigned int v)
+{
+	p[0] = (unsigned char)(v >> 8);
+	p[1] = (unsigned char)v;
+}
+
+static void
+xar_be32enc(unsigned char *p, uint32_t v)
+{
+	p[0] = (unsigned char)(v >> 24);
+	p[1] = (unsigned char)(v >> 16);
+	p[2] = (unsigned char)(v >> 8);
+	p[3] = (unsigned char)v;
+}
+
+static void
+xar_be64enc(unsigned char *p, uint64_t v)
+{
+	xar_be32enc(p, (uint32_t)(v >> 32));
+	xar_be32enc(p + 4, (uint32_t)v);
+}
+
+static unsigned char *
+make_xar_from_toc(const unsigned char *toc, size_t toc_size,
+    size_t *archive_size)
+{
+	unsigned char *archive;
+	uLongf compressed_size;
+
+	compressed_size = compressBound((uLong)toc_size);
+	archive = malloc(28 + (size_t)compressed_size);
+	assert(archive != NULL);
+	assertEqualInt(Z_OK, compress2(archive + 28, &compressed_size, toc,
+	    (uLong)toc_size, Z_BEST_COMPRESSION));
+
+	memcpy(archive, "xar!", 4);
+	xar_be16enc(archive + 4, 28);
+	xar_be16enc(archive + 6, 1);
+	xar_be64enc(archive + 8, compressed_size);
+	xar_be64enc(archive + 16, toc_size);
+	xar_be32enc(archive + 24, 0);
+	*archive_size = 28 + (size_t)compressed_size;
+	return (archive);
+}
+
+static unsigned char *
+make_xar_with_files(size_t count, size_t *archive_size)
+{
+	static const char prefix[] = "<xar><toc>";
+	static const char file[] = "<file><name>a</name></file>";
+	static const char suffix[] = "</toc></xar>";
+	unsigned char *archive;
+	unsigned char *toc;
+	unsigned char *p;
+	size_t i, toc_size;
+
+	toc_size = sizeof(prefix) - 1 + count * (sizeof(file) - 1) +
+	    sizeof(suffix) - 1;
+	toc = malloc(toc_size);
+	assert(toc != NULL);
+	p = toc;
+	memcpy(p, prefix, sizeof(prefix) - 1);
+	p += sizeof(prefix) - 1;
+	for (i = 0; i < count; ++i) {
+		memcpy(p, file, sizeof(file) - 1);
+		p += sizeof(file) - 1;
+	}
+	memcpy(p, suffix, sizeof(suffix) - 1);
+
+	archive = make_xar_from_toc(toc, toc_size, archive_size);
+	free(toc);
+	return (archive);
+}
+
+static unsigned char *
+make_xar_with_xattrs(size_t count, size_t *archive_size)
+{
+	static const char prefix[] = "<xar><toc><file><name>a</name>";
+	static const char xattr[] = "<ea/>";
+	static const char suffix[] = "</file></toc></xar>";
+	unsigned char *archive;
+	unsigned char *toc;
+	unsigned char *p;
+	size_t i, toc_size;
+
+	toc_size = sizeof(prefix) - 1 + count * (sizeof(xattr) - 1) +
+	    sizeof(suffix) - 1;
+	toc = malloc(toc_size);
+	assert(toc != NULL);
+	p = toc;
+	memcpy(p, prefix, sizeof(prefix) - 1);
+	p += sizeof(prefix) - 1;
+	for (i = 0; i < count; ++i) {
+		memcpy(p, xattr, sizeof(xattr) - 1);
+		p += sizeof(xattr) - 1;
+	}
+	memcpy(p, suffix, sizeof(suffix) - 1);
+
+	archive = make_xar_from_toc(toc, toc_size, archive_size);
+	free(toc);
+	return (archive);
+}
+
+static unsigned char *
+make_xar_with_hardlinks(size_t count, size_t *archive_size)
+{
+	static const char prefix[] = "<xar><toc>";
+	static const char suffix[] = "</toc></xar>";
+	unsigned char *archive;
+	unsigned char *toc;
+	unsigned char *p;
+	size_t i, toc_capacity, toc_size;
+	int written;
+
+	assert(count <= (SIZE_MAX - sizeof(prefix) - sizeof(suffix)) / 80);
+	toc_capacity = sizeof(prefix) - 1 + count * 80 + sizeof(suffix) - 1;
+	toc = malloc(toc_capacity);
+	assert(toc != NULL);
+	p = toc;
+	memcpy(p, prefix, sizeof(prefix) - 1);
+	p += sizeof(prefix) - 1;
+	for (i = 0; i < count; ++i) {
+		written = snprintf((char *)p, 80,
+		    "<file><name>a</name><type link=\"%zu\">"
+		    "hardlink</type></file>", i + 1);
+		assert(written > 0 && written < 80);
+		p += written;
+	}
+	memcpy(p, suffix, sizeof(suffix) - 1);
+	p += sizeof(suffix) - 1;
+	toc_size = (size_t)(p - toc);
+
+	archive = make_xar_from_toc(toc, toc_size, archive_size);
+	free(toc);
+	return (archive);
+}
+
+static unsigned char *
+make_xar_with_nested_files(size_t count, size_t *archive_size)
+{
+	static const char prefix[] = "<xar><toc>";
+	static const char file[] = "<file><name>a</name>";
+	static const char file_end[] = "</file>";
+	static const char suffix[] = "</toc></xar>";
+	unsigned char *archive;
+	unsigned char *toc;
+	unsigned char *p;
+	size_t i, toc_size;
+
+	toc_size = sizeof(prefix) - 1 + count * (sizeof(file) - 1) +
+	    count * (sizeof(file_end) - 1) + sizeof(suffix) - 1;
+	toc = malloc(toc_size);
+	assert(toc != NULL);
+	p = toc;
+	memcpy(p, prefix, sizeof(prefix) - 1);
+	p += sizeof(prefix) - 1;
+	for (i = 0; i < count; ++i) {
+		memcpy(p, file, sizeof(file) - 1);
+		p += sizeof(file) - 1;
+	}
+	for (i = 0; i < count; ++i) {
+		memcpy(p, file_end, sizeof(file_end) - 1);
+		p += sizeof(file_end) - 1;
+	}
+	memcpy(p, suffix, sizeof(suffix) - 1);
+
+	archive = make_xar_from_toc(toc, toc_size, archive_size);
+	free(toc);
+	return (archive);
+}
+#endif
+
+DEFINE_TEST(test_read_format_xar_resource_limits)
+{
+#ifndef HAVE_ZLIB_H
+	skipping("xar reading requires zlib");
+#else
+	struct archive_entry *ae;
+	struct archive *a;
+	unsigned char *large_xar;
+	unsigned char *nested_xar;
+	unsigned char *small_xar;
+	unsigned char *xattr_xar;
+	size_t large_xar_size;
+	size_t nested_xar_size;
+	size_t small_xar_size;
+	size_t xattr_xar_size;
+	int r;
+
+	/* Also exercises many distinct hardlink groups without a binary fixture. */
+	large_xar = make_xar_with_hardlinks(100001, &large_xar_size);
+	assert((a = archive_read_new()) != NULL);
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN) {
+		skipping("xar reading not fully supported on this platform");
+		assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+		free(large_xar);
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, large_xar, large_xar_size));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR TOC record count exceeds configured limit (100000)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(large_xar);
+
+	/* A false small declaration must not bypass the actual-output check. */
+	small_xar = make_xar_with_files(2, &small_xar_size);
+	xar_be64enc(small_xar + 16, 1);
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "1"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, small_xar, small_xar_size));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assert(strcmp("XAR TOC record count exceeds configured limit (1)",
+	    archive_error_string(a)) != 0);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(small_xar);
+
+	/* A value of zero disables the corresponding configured limit. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "0"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-size", "0"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-pathname-size", "0"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive1, sizeof(archive1)));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("f1", archive_entry_pathname(ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("hardlink", archive_entry_pathname(ae));
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "1"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive1, sizeof(archive1)));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR TOC record count exceeds configured limit (1)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* The documented boundary still accepts the same valid archive. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "2"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-size", "1136"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-pathname-size", "12"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive1, sizeof(archive1)));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("f1", archive_entry_pathname(ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
+	assertEqualString("hardlink", archive_entry_pathname(ae));
+	assertEqualIntA(a, ARCHIVE_EOF, archive_read_next_header(a, &ae));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Resolved hardlink pathnames are charged before being copied. */
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-pathname-size", "11"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive1, sizeof(archive1)));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR pathname data exceeds configured limit (11 bytes)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	/* Extended attributes consume the same retained-record budget. */
+	xattr_xar = make_xar_with_xattrs(2, &xattr_xar_size);
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "2"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, xattr_xar, xattr_xar_size));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR TOC record count exceeds configured limit (2)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(xattr_xar);
+
+	/* Nested names must not amplify a small TOC into unbounded path data. */
+	nested_xar = make_xar_with_nested_files(40, &nested_xar_size);
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-pathname-size",
+	    "512"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, nested_xar, nested_xar_size));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR pathname data exceeds configured limit (512 bytes)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+	free(nested_xar);
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_set_format_option(a, "xar", "max-toc-size", "1135"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_read_open_memory(a, archive1, sizeof(archive1)));
+	assertEqualIntA(a, ARCHIVE_FATAL, archive_read_next_header(a, &ae));
+	assertEqualInt(ENOMEM, archive_errno(a));
+	assertEqualString("XAR TOC is larger than configured limit (1135 bytes)",
+	    archive_error_string(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+
+	assert((a = archive_read_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "-1"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", " 1"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_read_set_format_option(a, "xar", "max-toc-records", "1x"));
+	assertEqualIntA(a, ARCHIVE_FAILED,
+	    archive_read_set_format_option(a, "xar", "max-toc-records",
+	    "18446744073709551616"));
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
+#endif
 }
 
 DEFINE_TEST(test_read_format_xar_xattr_fstype_cleanup)


### PR DESCRIPTION
## Summary

Bound resource usage while parsing XAR XML tables of contents.

The XAR reader retains the complete TOC before returning the first entry. A small, highly compressed XAR can therefore create large numbers of retained records and consume excessive memory or CPU.

This change:

- limits retained file and extended-attribute records;
- limits decompressed TOC and derived pathname data;
- replaces quadratic xattr ordering and hardlink lookup;
- provides options to adjust or disable the limits; and
- generates the regression archives in memory, without adding a binary fixture.

The default limits are:

- 100,000 file and extended-attribute records;
- 64 MiB decompressed TOC data; and
- 64 MiB retained pathname and resolved-hardlink data.

A value of `0` disables the corresponding limit for trusted inputs.

## Testing

The regression test covers record, TOC, pathname and hardlink limits, including exact boundaries, disabled limits and false size declarations.

Focused XAR tests pass with libxml2, Expat and AddressSanitizer. The original reproducer is rejected at the configured record limit, while ordinary control archives continue to succeed.