### PR TITLE
iso9660: fix NULL deref writing directory records for a relocated dir

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -4399,6 +4399,18 @@ _write_directory_descriptors(struct archive_write *a, struct vdd *vdd,
 			p += dr_l;
 			file->cur_content = file->cur_content->next;
 		} while (file->cur_content != NULL);
+		/*
+		 * Rockridge deep-directory relocation can leave one of
+		 * these children marked as a non-directory placeholder
+		 * (see isoent_rr_move_dir()) that the traversal in
+		 * write_directory_descriptors() still visits in its own
+		 * right afterwards, to write its self/parent records.
+		 * That later call reads this same file's cur_content
+		 * through set_directory_record()'s non-directory branch,
+		 * so leave it pointing at the head of the chain rather
+		 * than at the NULL the loop above ends on.
+		 */
+		file->cur_content = &(file->content);
 	}
 	memset(p, 0, WD_REMAINING);
 	return (wb_consume(a, LOGICAL_BLOCK_SIZE));

--- a/libarchive/test/test_write_format_iso9660_bugs.c
+++ b/libarchive/test/test_write_format_iso9660_bugs.c
@@ -307,6 +307,75 @@ DEFINE_TEST(test_write_format_iso9660_boot_image_size_overflow)
 	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
 }
 
+DEFINE_TEST(test_write_format_iso9660_rockridge_deep_relocation)
+{
+	/*
+	 * A deep enough path under Rockridge with depth limiting
+	 * disabled forces isoent_rr_move_dir() to relocate one of the
+	 * ancestor directories under rr_moved and mark the original
+	 * entry as a non-directory placeholder (the RRIP "CL" record).
+	 * That placeholder is still walked by the directory-descriptor
+	 * writer as a node in its own right, which used to crash with
+	 * a NULL pointer dereference; it just needs to survive.
+	 */
+	const char *pathname = "a/a/a/a/a/a/a/a/a";
+	struct archive *a;
+	struct archive_entry *entry;
+	unsigned char *buff;
+	size_t buffsize = 4 * 1024 * 1024;
+	size_t used = 0;
+
+	buff = malloc(buffsize);
+	assert(buff != NULL);
+	if (buff == NULL)
+		return;
+
+	assert((a = archive_write_new()) != NULL);
+	if (a == NULL) {
+		free(buff);
+		return;
+	}
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_iso9660(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_bytes_in_last_block(a, 1));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:joliet"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:rockridge"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:iso-level=4"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_set_options(a, "iso9660:!limit-depth"));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, buffsize, &used));
+
+	entry = archive_entry_new();
+	if (!assert(entry != NULL)) {
+		archive_write_free(a);
+		free(buff);
+		return;
+	}
+	archive_entry_copy_pathname(entry, pathname);
+	archive_entry_set_filetype(entry, AE_IFREG);
+	archive_entry_set_perm(entry, 0644);
+	archive_entry_set_size(entry, 0);
+	archive_entry_set_uid(entry, 1000);
+	archive_entry_set_gid(entry, 1000);
+	archive_entry_set_uname(entry, "user");
+	archive_entry_set_gname(entry, "group");
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, entry));
+	archive_entry_free(entry);
+
+	/* This used to segfault while writing out the directory
+	 * descriptors for the relocated placeholder entry. */
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	free(buff);
+}
+
 DEFINE_TEST(test_write_format_iso9660_symlink)
 {
 	const size_t buffsize = 512 * 1024;


### PR DESCRIPTION
Closes #3235.

The relocated placeholder that Rockridge deep-directory relocation leaves behind gets written twice: once as a NORMAL child record in its parent's listing, and again on its own when the tree walk in `write_directory_descriptors()` reaches it as a node in its own right (to emit its self/parent records). Both uses share the same `file->cur_content` pointer, and the first pass leaves it sitting at NULL once it's walked off the end of the content chain. The second pass never resets it before reading `cur_content->next` in `set_directory_record()`'s non-directory branch, hence the crash.

I reproduced it with the same setup from the issue (Rockridge, ISO level 4, `!limit-depth`, a nine-level-deep zero-length file) under ASan/UBSan, confirmed it segfaults on current master, and added a regression test for it in `test_write_format_iso9660_bugs.c`.

There was an earlier PR for this, #3330, closed as a duplicate of two others that were supposed to cover it individually. One of those, the integer-overflow half, landed as #3320. The other one referenced for this specific NULL deref no longer resolves to anything on GitHub, so as far as I can tell this particular crash was never actually fixed, just marked as handled elsewhere by mistake. Issue #3235 is still open, so I think this is worth another look.

Ran the full ISO9660 test suite (18 tests, ~4.1M assertions) under ASan+UBSan, all green, including the new test.