### PR TITLE
unzip: Define `O_BINARY`/`O_CLOEXEC` at later stage

### DIFF
--- a/unzip/bsdunzip.c
+++ b/unzip/bsdunzip.c
@@ -63,6 +63,13 @@
 #include "passphrase.h"
 #include "lafe_err.h"
 
+#ifndef O_BINARY
+#define O_BINARY	0
+#endif
+#ifndef O_CLOEXEC
+#define O_CLOEXEC	0
+#endif
+
 /* command-line options */
 static int		 a_opt;		/* convert EOL */
 static int		 C_opt;		/* match case-insensitively */

--- a/unzip/bsdunzip_platform.h
+++ b/unzip/bsdunzip_platform.h
@@ -48,11 +48,4 @@
 #define __LA_NORETURN
 #endif
 
-#ifndef O_BINARY
-#define O_BINARY	0
-#endif
-#ifndef O_CLOEXEC
-#define O_CLOEXEC	0
-#endif
-
 #endif /* !BSDUNZIP_PLATFORM_H_INCLUDED */


### PR DESCRIPTION
Some external headers define `O_BINARY` on their own. If we define them in `bsdunzip_platform.h` already, a warning is emitted.

Define them on C file level if they haven't been defined behavior. This is in sync with other `O_BINARY` handling within libarchive.