### PR TITLE
tests: Fix failing tests with minimal setup

### DIFF
--- a/libarchive/test/test_archive_read_support.c
+++ b/libarchive/test/test_archive_read_support.c
@@ -148,6 +148,7 @@ DEFINE_TEST(test_archive_read_support)
 DEFINE_TEST(test_archive_read_support_twice)
 {
 	struct archive *a;
+	int r;
 
 	a = archive_read_new();
 	assert(a != NULL);
@@ -162,7 +163,12 @@ DEFINE_TEST(test_archive_read_support_twice)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_lha(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_mtree(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_xar(a));
+	r = archive_read_support_format_xar(a);
+	if (r == ARCHIVE_WARN)
+		assertEqualStringA(a, "Xar not supported on this platform",
+		    archive_error_string(a));
+	else
+		assertEqualIntA(a, ARCHIVE_OK, r);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_zip(a));
 
 	/* Adding format bidders twice should lead to warnings. */

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -831,6 +831,7 @@ test_ppmd(void)
 static void
 test_ppmd_small_block(void)
 {
+#ifdef HAVE_LZMA_H
 	const char *refname = "test_read_format_7zip_ppmd_small_block.7z";
 	const void *block;
 	struct archive_entry *ae;
@@ -865,6 +866,9 @@ test_ppmd_small_block(void)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 	free(archive_data);
+#else
+	skipping("lzma tests require liblzma");
+#endif
 }
 
 static void

--- a/libarchive/test/test_read_format_zip_winzip_aes_large.c
+++ b/libarchive/test/test_read_format_zip_winzip_aes_large.c
@@ -159,7 +159,6 @@ test_winzip_aes_large(const char *refname, const char *compression_name)
 
 DEFINE_TEST(test_read_format_zip_winzip_aes256_large)
 {
-	// Deflate is always supported, no need to test for it
 	test_winzip_aes_large("test_read_format_zip_winzip_aes256_large.zip", NULL);
 }
 
@@ -176,7 +175,11 @@ DEFINE_TEST(test_read_format_zip_winzip_aes256_large_lzma)
 
 DEFINE_TEST(test_read_format_zip_winzip_aes256_large_ppmd)
 {
+#ifdef HAVE_LIBZ
 	test_winzip_aes_large("test_read_format_zip_winzip_aes256_large_ppmd.zip", NULL);
+#else
+	skipping("zlib not available");
+#endif
 }
 
 DEFINE_TEST(test_read_format_zip_winzip_aes256_large_xz)

--- a/libarchive/test/test_read_set_format.c
+++ b/libarchive/test/test_read_set_format.c
@@ -150,19 +150,15 @@ DEFINE_TEST(test_read_append_filter)
 DEFINE_TEST(test_read_append_wrong_filter)
 {
   struct archive *a;
-  int r;
 
   assert((a = archive_read_new()) != NULL);
-  assertA(0 == archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
-  r = archive_read_append_filter(a, ARCHIVE_FILTER_XZ);
-  if (r == ARCHIVE_WARN && !canXz()) {
-    skipping("xz reading not fully supported on this platform");
-    assertEqualInt(ARCHIVE_OK, archive_read_free(a));
-    return;
-  }
-  assertEqualInt(ARCHIVE_FATAL,
+  assertEqualIntA(a, ARCHIVE_OK,
+      archive_read_set_format(a, ARCHIVE_FORMAT_RAW));
+  assertEqualIntA(a, ARCHIVE_OK,
+      archive_read_append_filter(a, ARCHIVE_FILTER_UU));
+  assertEqualIntA(a, ARCHIVE_FATAL,
       archive_read_open_memory(a, archive, sizeof(archive)));
-  assertEqualInt(ARCHIVE_OK,archive_read_free(a));
+  assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 DEFINE_TEST(test_read_append_lzop_filter)

--- a/libarchive/test/test_write_format_pax_align.c
+++ b/libarchive/test/test_write_format_pax_align.c
@@ -129,10 +129,15 @@ write_archive(char *buff, size_t buffsize, size_t *used, int gzip)
 
 	assert((a = archive_write_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_pax_restricted(a));
-	if (gzip)
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_gzip(a));
-	else
-		assertEqualIntA(a, ARCHIVE_OK, archive_write_add_filter_none(a));
+	if (gzip) {
+		int r;
+
+		r = archive_write_add_filter_gzip(a);
+		if (r != ARCHIVE_WARN)
+			assertEqualIntA(a, ARCHIVE_OK, r);
+	} else
+		assertEqualIntA(a, ARCHIVE_OK,
+		    archive_write_add_filter_none(a));
 	/* Small blocks so the writer doesn't tail-pad past our offsets. */
 	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_bytes_per_block(a, 512));
 	assertEqualIntA(a, ARCHIVE_OK,
@@ -178,10 +183,15 @@ verify_archive(const char *buff, size_t used, int gzip)
 
 	assert((a = archive_read_new()) != NULL);
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_support_format_tar(a));
-	if (gzip)
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_gzip(a));
-	else
-		assertEqualIntA(a, ARCHIVE_OK, archive_read_support_filter_none(a));
+	if (gzip) {
+		int r;
+
+		r = archive_read_support_filter_gzip(a);
+		if (r != ARCHIVE_WARN)
+			assertEqualIntA(a, ARCHIVE_OK, r);
+	} else
+		assertEqualIntA(a, ARCHIVE_OK,
+		    archive_read_support_filter_none(a));
 	assertEqualIntA(a, ARCHIVE_OK,
 	    archive_read_open_memory(a, buff, used));
 


### PR DESCRIPTION
Building libarchive with minimalistic setup revealed some failing tests due to incomplete feature tests.

Skip tests which are known to fail due to missing requirements.

Spotted on:
- Plain Windows 11 installation + Visual Studio Community 2026
- Arch Linux with `configure --without-zlib --without-bz2lib --without-libb2 --without-iconv --without-lz4 --without-zstd --without-lzma --without-lzo2 --without-openssl --without-xml2 --without-expat