### PR TITLE
util: Use archive_random in __archive_mktempx

### DIFF
--- a/libarchive/archive_random.c
+++ b/libarchive/archive_random.c
@@ -83,12 +83,16 @@ archive_random(void *buf, size_t nbytes)
 	BCRYPT_ALG_HANDLE hAlg;
 
 	status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RNG_ALGORITHM, NULL, 0);
-	if (!BCRYPT_SUCCESS(status))
+	if (!BCRYPT_SUCCESS(status)) {
+		la_dosmaperr(GetLastError());
 		return ARCHIVE_FAILED;
+	}
 	status = BCryptGenRandom(hAlg, buf, (ULONG)nbytes, 0);
 	BCryptCloseAlgorithmProvider(hAlg, 0);
-	if (!BCRYPT_SUCCESS(status))
+	if (!BCRYPT_SUCCESS(status)) {
+		la_dosmaperr(GetLastError());
 		return ARCHIVE_FAILED;
+	}
 
 	return ARCHIVE_OK;
 #elif !defined(HAVE_ARC4RANDOM_BUF) && (!defined(_WIN32) || defined(__CYGWIN__))

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -41,14 +41,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#include <bcrypt.h>
-
-/* Common in other bcrypt implementations, but missing from VS2008. */
-#ifndef BCRYPT_SUCCESS
-#define BCRYPT_SUCCESS(r) ((NTSTATUS)(r) == STATUS_SUCCESS)
-#endif
-#endif
 #ifdef HAVE_ZLIB_H
 #include <zlib.h>
 #endif
@@ -243,7 +235,6 @@ __archive_mktempx(const char *tmpdir, wchar_t *template)
 	DWORD attr;
 	wchar_t *xp, *ep;
 	int fd;
-	BCRYPT_ALG_HANDLE hAlg = NULL;
 	fd = -1;
 	ws = NULL;
 	archive_string_init(&temp_name);
@@ -331,12 +322,6 @@ __archive_mktempx(const char *tmpdir, wchar_t *template)
 			abort();
 	}
 
-	if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RNG_ALGORITHM,
-		NULL, 0))) {
-		la_dosmaperr(GetLastError());
-		goto exit_tmpfile;
-	}
-
 	for (;;) {
 		wchar_t *p;
 		HANDLE h;
@@ -344,13 +329,10 @@ __archive_mktempx(const char *tmpdir, wchar_t *template)
 		CREATEFILE2_EXTENDED_PARAMETERS createExParams;
 #endif
 
-		/* Generate a random file name through CryptGenRandom(). */
+		/* Generate a random file name. */
 		p = xp;
-		if (!BCRYPT_SUCCESS(BCryptGenRandom(hAlg, (PUCHAR)p,
-		    (DWORD)(ep - p)*sizeof(wchar_t), 0))) {
-			la_dosmaperr(GetLastError());
+		if (archive_random(p, (ep - p)*sizeof(wchar_t)) != ARCHIVE_OK)
 			goto exit_tmpfile;
-		}
 		for (; p < ep; p++)
 			*p = num[((DWORD)*p) % (sizeof(num)/sizeof(num[0]))];
 
@@ -404,8 +386,6 @@ __archive_mktempx(const char *tmpdir, wchar_t *template)
 			break;/* success! */
 	}
 exit_tmpfile:
-	if (hAlg != NULL)
-		BCryptCloseAlgorithmProvider(hAlg, 0);
 	free(ws);
 	if (template == temp_name.s)
 		archive_wstring_free(&temp_name);


### PR DESCRIPTION
We already have random number generation code in archive_random. Do not repeat it here in case of Windows builds. Instead, use the already existing code for easier auditing.