### PR TITLE
archive_string: treat POSIX iconv positive return as lossy conversion (#3413)

### DIFF
--- a/libarchive/archive_string.c
+++ b/libarchive/archive_string.c
@@ -2130,8 +2130,21 @@ iconv_strncat_in_locale(struct archive_string *as, const void *_p,
 	while (remaining >= from_size) {
 		size_t result = iconv(cd, &itp, &remaining, &outp, &avail);
 
-		if (result != (size_t)-1)
+		if (result != (size_t)-1) {
+			if (result > 0) {
+				/* POSIX-conformant iconv() (NetBSD, macOS) returns
+				 * the count of characters converted with a non-
+				 * identical (lossy) substitution when the input is
+				 * valid but has no exact representation in the
+				 * target codeset.  Report this as a conversion
+				 * failure at the mstring level, mirroring the
+				 * EILSEQ branch below (glibc's iconv() returns -1
+				 * / EILSEQ in the same situation, so the two paths
+				 * agree post-fix). */
+				return_value = -1;
+			}
 			break; /* Conversion completed. */
+		}
 
 		if (errno == EILSEQ || errno == EINVAL) {
 			/*


### PR DESCRIPTION
Closes #3413.

POSIX-conformant iconv() has three return conventions:

0 — conversion complete, no substitutions
positive N — conversion complete, but N input characters were converted with a non-identical (lossy) substitution
(size_t)-1 — invalid input; errno set to EILSEQ or EINVAL

iconv_strncat_in_locale was checking only against (size_t)-1 and treating every other outcome as clean success, so the positive-lossy case wasn't recorded as a conversion failure. On NetBSD, macOS, and other POSIX-conformant platforms test_archive_string_conversion_fail_c therefore hits its -1 != r assertion and the bug @riastradh filed under NetBSD gnats 60560 reproduces. glibc happens to report the same input as -1 / EILSEQ, so the existing substitute-and-flag path catches it there — that's why the bug shows only on POSIX-iconv platforms.

What changes

libarchive/archive_string.c — after the iconv() call in iconv_strncat_in_locale, when the result is not (size_t)-1 and is greater than zero, set return_value = -1 before breaking out of the loop. iconv has already performed the substitution itself and advanced itp / outp / remaining / avail, so no additional output work is needed.

+14 / -1 in one file. No behavior change on glibc (positive return never happens); the two branches now agree on POSIX-iconv platforms.

Verify

Applied to master e8852e788031. libarchive_test test_archive_string_conversion_fail_c: 1 test passed, 18 assertions checked, 0 failures on Debian/glibc. NetBSD verification is per @riastradh's NetBSD gnats 60560 diagnosis; happy to add a POSIX-iconv runner if you'd like independent confirmation.

Drafted with AI assistance; I read every hunk and stand behind it.