### PR TITLE
man: fix option names that archive_write_set_options rejects

### DIFF
--- a/libarchive/archive_write_set_options.3
+++ b/libarchive/archive_write_set_options.3
@@ -639,7 +639,7 @@ Supported values are
 .Dq lzma
 and
 .Dq xz .
-.It Cm compression_level
+.It Cm compression-level
 The value is a decimal integer from 1 to 9 specifying the compression level.
 .It Cm toc-checksum Ns = Ns Ar type
 Use
@@ -751,7 +751,7 @@ compressor should use the maximum compression level.
 a = archive_write_new();
 archive_write_add_filter_gzip(a);
 archive_write_set_format_iso9660(a);
-archive_write_set_options(a, "boot=kernel.img,compression=9");
+archive_write_set_options(a, "boot=kernel.img,gzip:compression-level=9");
 archive_write_open_filename(a, filename, blocksize);
 .Ed
 .\"


### PR DESCRIPTION
Two option names in archive_write_set_options.3 are not names the code matches, so copying them out of the manual returns ARCHIVE_FAILED with "Undefined option". The xar section documents compression_level, but xar_options() in archive_write_set_format_xar.c only accepts compression-level, and the EXAMPLES block passes compression=9 for the gzip filter when archive_compressor_gzip_options() in archive_write_add_filter_gzip.c only accepts compression-level. This corrects both names and writes the example as gzip:compression-level=9, using the module-scoped form documented earlier on the same page, since the iso9660 writer has a compression-level of its own and the surrounding text says the setting is meant for the gzip compressor. I checked it with a short program that calls archive_write_set_options() exactly as the example does: the two documented spellings return -25, the corrected ones return 0, and mandoc -Tlint reports no warnings that were not already there.
