### PR TITLE
Windows: Use `ARCHIVE_CRYPTO_WIN` for CNG check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ OPTION(ENABLE_PCREPOSIX "Enable the use of the system PCREPOSIX library if found
 OPTION(ENABLE_PCRE2POSIX "Enable the use of the system PCRE2POSIX library if found" ON)
 OPTION(ENABLE_LIBGCC "Enable the use of the system LibGCC library if found" ON)
 # CNG is used for encrypt/decrypt Zip archives on Windows.
-OPTION(ENABLE_CNG "Enable the use of CNG(Crypto Next Generation)" ON)
+OPTION(ENABLE_CNG "Enable the use of Windows CNG (Crypto Next Generation) if" ON)
 
 OPTION(ENABLE_TAR "Enable tar building" ON)
 OPTION(ENABLE_TAR_SHARED "Enable dynamic build of tar" FALSE)
@@ -823,6 +823,7 @@ LA_CHECK_INCLUDE_FILE("bcrypt.h" HAVE_BCRYPT_H)
 IF(HAVE_BCRYPT_H)
   LIST(APPEND ADDITIONAL_LIBS "bcrypt")
   IF(ENABLE_CNG)
+    SET(ARCHIVE_CRYPTO_WIN        1)
     # bcrypt supports these algorithms on all available versions
     SET(ARCHIVE_CRYPTO_MD5        1)
     SET(ARCHIVE_CRYPTO_MD5_WIN    1)

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -336,6 +336,9 @@ typedef uint64_t uintmax_t;
 /* SHA512 via ARCHIVE_CRYPTO_SHA512_WIN supported. */
 #cmakedefine ARCHIVE_CRYPTO_SHA512_WIN 1
 
+/* Use Windows CNG(Crypto Next Generation) */
+#cmakedefine ARCHIVE_CRYPTO_WIN 1
+
 /* AIX xattr support */
 #cmakedefine ARCHIVE_XATTR_AIX 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -552,7 +552,7 @@ if test "x$with_lzo2" = "xyes"; then
 fi
 
 AC_ARG_WITH([cng],
-  AS_HELP_STRING([--without-cng], [Don't build support of CNG(Crypto Next Generation)]))
+  AS_HELP_STRING([--without-cng], [Don't build with crypto support from Windows CNG (Crypto Next Generation)]))
 
 AC_ARG_WITH([mbedtls],
   AS_HELP_STRING([--with-mbedtls], [Build with crypto support from mbed TLS]))
@@ -1313,6 +1313,8 @@ AC_CHECK_HEADERS([bcrypt.h],[
         found_SHA256=yes
         found_SHA384=yes
         found_SHA512=yes
+        AC_DEFINE(ARCHIVE_CRYPTO_WIN, 1,
+	    [ Use Windows CNG (Crypto Next Generation)])
         AC_DEFINE(ARCHIVE_CRYPTO_MD5_WIN, 1,
 	    [ MD5 via ARCHIVE_CRYPTO_MD5_WIN supported.])
         AC_DEFINE(ARCHIVE_CRYPTO_SHA1_WIN, 1,

--- a/contrib/android/config/windows_host.h
+++ b/contrib/android/config/windows_host.h
@@ -118,6 +118,9 @@
 /* SHA512 via ARCHIVE_CRYPTO_SHA512_WIN supported. */
 #define ARCHIVE_CRYPTO_SHA512_WIN 1
 
+/* Use Windows CNG (Crypto Next Generation) */
+#define ARCHIVE_CRYPTO_WIN 1
+
 /* Define to 1 if you have the `acl_create_entry' function. */
 /* #undef HAVE_ACL_CREATE_ENTRY */
 

--- a/libarchive/archive_cryptor.c
+++ b/libarchive/archive_cryptor.c
@@ -44,7 +44,7 @@ pbkdf2_sha1(const char *pw, size_t pw_len, const uint8_t *salt,
 	return 0;
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(ARCHIVE_CRYPTO_WIN)
 #ifdef _MSC_VER
 #pragma comment(lib, "Bcrypt.lib")
 #endif
@@ -184,7 +184,7 @@ aes_ctr_release(archive_crypto_ctx *ctx)
 	return 0;
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(ARCHIVE_CRYPTO_WIN)
 
 static int
 aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)

--- a/libarchive/archive_cryptor_private.h
+++ b/libarchive/archive_cryptor_private.h
@@ -52,7 +52,7 @@ typedef struct {
 	size_t		encr_pos;
 } archive_crypto_ctx;
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(ARCHIVE_CRYPTO_WIN)
 #include <bcrypt.h>
 #define	ARCHIVE_CRYPTOR_USE_CNG 1
 

--- a/libarchive/archive_digest.c
+++ b/libarchive/archive_digest.c
@@ -44,7 +44,7 @@
 /*
  * Message digest functions for Windows platform.
  */
-#if defined(HAVE_BCRYPT_H)
+#if defined(ARCHIVE_CRYPTO_WIN)
 
 /*
  * Initialize a Message digest.
@@ -97,7 +97,7 @@ win_crypto_Final(unsigned char *buf, size_t bufsize, Digest_CTX *ctx)
 	return (ARCHIVE_OK);
 }
 
-#endif /* defined(HAVE_BCRYPT_H) */
+#endif /* defined(ARCHIVE_CRYPTO_WIN) */
 
 
 /* MD5 implementations */

--- a/libarchive/archive_digest_private.h
+++ b/libarchive/archive_digest_private.h
@@ -179,7 +179,6 @@
   defined(ARCHIVE_CRYPTO_SHA256_WIN) ||\
   defined(ARCHIVE_CRYPTO_SHA384_WIN) ||\
   defined(ARCHIVE_CRYPTO_SHA512_WIN)
-#if defined(HAVE_BCRYPT_H)
 #include <bcrypt.h>
 #define	ARCHIVE_CRYPTO_CNG 1
 typedef struct {
@@ -187,7 +186,6 @@ typedef struct {
   BCRYPT_ALG_HANDLE  hAlg;
   BCRYPT_HASH_HANDLE hHash;
 } Digest_CTX;
-#endif
 #endif
 
 /* typedefs */

--- a/libarchive/archive_hmac.c
+++ b/libarchive/archive_hmac.c
@@ -60,7 +60,7 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ctx *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 }
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(ARCHIVE_CRYPTO_WIN)
 
 #ifndef BCRYPT_HASH_REUSABLE_FLAG
 # define BCRYPT_HASH_REUSABLE_FLAG 0x00000020

--- a/libarchive/archive_hmac_private.h
+++ b/libarchive/archive_hmac_private.h
@@ -42,7 +42,7 @@
 
 typedef	CCHmacContext archive_hmac_sha1_ctx;
 
-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(ARCHIVE_CRYPTO_WIN)
 #include <bcrypt.h>
 
 typedef struct {


### PR DESCRIPTION
We use bcrypt.h for random functions. If the header exists, this does not necessarily mean that we want to use CNG.

Check for CNG request and availability through ARCHIVE_CRYPTO_WIN instead.

Resolves https://github.com/libarchive/libarchive/issues/3498