### PR TITLE
7zip reader: add RISCV filter support in non-lzma archives

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -890,6 +890,7 @@ libarchive_test_EXTRA_DIST=\
 	libarchive/test/test_read_format_7zip_deflate_arm64.7z.uu \
 	libarchive/test/test_read_format_7zip_deflate_arm_arm64.7z.uu \
 	libarchive/test/test_read_format_7zip_deflate_powerpc.7z.uu \
+	libarchive/test/test_read_format_7zip_deflate_riscv.7z.uu \
 	libarchive/test/test_read_format_7zip_delta_lzma1.7z.uu \
 	libarchive/test/test_read_format_7zip_delta4_lzma1.7z.uu \
 	libarchive/test/test_read_format_7zip_delta_lzma2.7z.uu \

--- a/libarchive/archive_read_support_format_7zip.c
+++ b/libarchive/archive_read_support_format_7zip.c
@@ -352,7 +352,7 @@ struct _7zip {
 	/* Decoding BCJ and BCJ2 data. */
 	uint32_t		 bcj_state;
 	size_t			 odd_bcj_size;
-	unsigned char		 odd_bcj[4];
+	unsigned char		 odd_bcj[8]; /* Big enough for RISCV's lookahead. */
 	/* Decoding BCJ data. */
 	size_t			 bcj_prevPosT;
 	uint32_t		 bcj_prevMask;
@@ -461,6 +461,7 @@ static size_t	arm64_Convert(struct _7zip *, uint8_t *, size_t);
 static ssize_t	Bcj2_Decode(struct _7zip *, uint8_t *, size_t);
 static size_t	sparc_Convert(struct _7zip *, uint8_t *, size_t);
 static size_t	powerpc_Convert(struct _7zip *, uint8_t *, size_t);
+static size_t	riscv_Convert(struct _7zip *, uint8_t *, size_t);
 static int64_t	seek_compat(struct archive_read *, int64_t, int, int);
 
 
@@ -1348,6 +1349,7 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 			    coder2->codec != _7Z_ARM &&
 			    coder2->codec != _7Z_ARM64 &&
 			    coder2->codec != _7Z_POWERPC &&
+			    coder2->codec != _7Z_RISCV &&
 			    coder2->codec != _7Z_SPARC) {
 				archive_set_error(&a->archive,
 				    ARCHIVE_ERRNO_MISC,
@@ -1364,6 +1366,7 @@ init_decompression(struct archive_read *a, struct _7zip *zip,
 				arm_Init(zip);
 			else if (coder2->codec == _7Z_ARM64 ||
 			    coder2->codec == _7Z_POWERPC ||
+			    coder2->codec == _7Z_RISCV ||
 			    coder2->codec == _7Z_SPARC)
 				zip->bcj_ip = 0;
 		}
@@ -1690,12 +1693,16 @@ decompress(struct archive_read *a, struct _7zip *zip,
 	t_next_in = b;
 	t_next_out = buff;
 
-	if (zip->codec != _7Z_LZMA2 && zip->codec2 == _7Z_X86) {
+	if (zip->codec != _7Z_LZMA2 &&
+	    (zip->codec2 == _7Z_X86 || zip->codec2 == _7Z_RISCV)) {
 		int i;
+		/* X86 needs a lookahead of five bytes, RISCV needs eight. */
+		size_t min_out = (zip->codec2 == _7Z_RISCV) ? 8 : 5;
 
 		/* Do not copy out the BCJ remaining bytes when the output
-		 * buffer size is less than five bytes. */
-		if (o_avail_in != 0 && t_avail_out < 5 && zip->odd_bcj_size) {
+		 * buffer size is less than the filter's lookahead size. */
+		if (o_avail_in != 0 && t_avail_out < min_out &&
+		    zip->odd_bcj_size) {
 			*used = 0;
 			*outbytes = 0;
 			return (ret);
@@ -1980,6 +1987,19 @@ decompress(struct archive_read *a, struct _7zip *zip,
 			*outbytes = sparc_Convert(zip, buff, *outbytes);
 		} else if (zip->codec2 == _7Z_POWERPC) {
 			*outbytes = powerpc_Convert(zip, buff, *outbytes);
+		} else if (zip->codec2 == _7Z_RISCV) {
+			size_t l = riscv_Convert(zip, buff, *outbytes);
+
+			zip->odd_bcj_size = *outbytes - l;
+			if (zip->odd_bcj_size > 0 &&
+			    zip->odd_bcj_size <= sizeof(zip->odd_bcj) &&
+			    o_avail_in && ret != ARCHIVE_EOF) {
+				memcpy(zip->odd_bcj,
+				    ((unsigned char *)buff) + l,
+				    zip->odd_bcj_size);
+				*outbytes = l;
+			} else
+				zip->odd_bcj_size = 0;
 		}
 	}
 
@@ -3668,6 +3688,10 @@ extract_pack_stream(struct archive_read *a, size_t minimum)
 		    zip->uncompressed_buffer_bytes_remaining + 5 >
 		    zip->uncompressed_buffer_size)
 			break;
+		if (zip->codec2 == _7Z_RISCV && zip->odd_bcj_size &&
+		    zip->uncompressed_buffer_bytes_remaining + 8 >
+		    zip->uncompressed_buffer_size)
+			break;
 		if (zip->pack_stream_inbytes_remaining == 0 &&
 		    zip->folder_outbytes_remaining == 0)
 			break;
@@ -4449,6 +4473,106 @@ powerpc_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
 			buf[i + 2] = (dest >> 8);
 			buf[i + 3] &= 0x03;
 			buf[i + 3] |= dest;
+		}
+	}
+
+	zip->bcj_ip += (uint32_t)i;
+
+	return i;
+}
+
+static size_t
+riscv_Convert(struct _7zip *zip, uint8_t *buf, size_t size)
+{
+	// This function was adapted from
+	// static size_t bcj_riscv(struct xz_dec_bcj *s, uint8_t *buf, size_t size)
+	// in https://git.tukaani.org/xz-embedded.git
+
+	/*
+	 * Branch/Call/Jump (BCJ) filter decoders
+	 *
+	 * Authors: Lasse Collin <lasse.collin@tukaani.org>
+	 *          Igor Pavlov <https://7-zip.org/>
+	 *
+	 * SPDX-License-Identifier: 0BSD
+	 */
+
+	if (size < 8)
+		return 0;
+	size -= 8;
+
+	size_t i;
+	for (i = 0; i <= size; i += 2) {
+		uint32_t inst = buf[i];
+
+		if (inst == 0xEF) {
+			// JAL. Only filter rd=x1(ra) and rd=x5(t0).
+			const uint32_t b1 = buf[i + 1];
+
+			if ((b1 & 0x0D) != 0)
+				continue;
+
+			const uint32_t b2 = buf[i + 2];
+			const uint32_t b3 = buf[i + 3];
+
+			uint32_t addr = ((b1 & 0xF0) << 13)
+					| (b2 << 9) | (b3 << 1);
+			addr -= zip->bcj_ip + (uint32_t)i;
+
+			buf[i + 1] = (uint8_t)((b1 & 0x0F)
+					| ((addr >> 8) & 0xF0));
+			buf[i + 2] = (uint8_t)(((addr >> 16) & 0x0F)
+					| ((addr >> 7) & 0x10)
+					| ((addr << 4) & 0xE0));
+			buf[i + 3] = (uint8_t)(((addr >> 4) & 0x7F)
+					| ((addr >> 13) & 0x80));
+
+			i += 4 - 2;
+		} else if ((inst & 0x7F) == 0x17) {
+			// AUIPC, paired with a second instruction (inst2)
+			// that is within the next four bytes.
+			uint32_t inst2;
+
+			inst |= (uint32_t)buf[i + 1] << 8;
+			inst |= (uint32_t)buf[i + 2] << 16;
+			inst |= (uint32_t)buf[i + 3] << 24;
+
+			if (inst & 0xE80) {
+				// AUIPC's rd doesn't equal x0 or x2.
+				inst2 = archive_le32dec(buf + i + 4);
+
+				if (((inst << 8) ^ (inst2 - 3)) & 0xF8003) {
+					i += 6 - 2;
+					continue;
+				}
+
+				uint32_t addr = (inst & 0xFFFFF000)
+						+ (inst2 >> 20);
+
+				inst = 0x17 | (2 << 7) | (inst2 << 12);
+				inst2 = addr;
+			} else {
+				// AUIPC's rd equals x0 or x2.
+				const uint32_t inst2_rs1 = inst >> 27;
+
+				if ((uint32_t)((inst - 0x3117) << 18)
+						>= (inst2_rs1 & 0x1D)) {
+					i += 4 - 2;
+					continue;
+				}
+
+				uint32_t addr = archive_be32dec(buf + i + 4);
+				addr -= zip->bcj_ip + (uint32_t)i;
+
+				inst2 = (inst >> 12) | (addr << 20);
+				inst = 0x17 | (inst2_rs1 << 7)
+					| ((addr + 0x800) & 0xFFFFF000);
+			}
+
+			archive_le32enc(buf + i, inst);
+			archive_le32enc(buf + i + 4, inst2);
+
+			i += 8 - 2;
 		}
 	}
 

--- a/libarchive/test/test_read_format_7zip.c
+++ b/libarchive/test/test_read_format_7zip.c
@@ -1635,7 +1635,6 @@ DEFINE_TEST(test_read_format_7zip_extract_second)
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
-#ifdef LZMA_FILTER_RISCV
 static void
 test_riscv_filter(const char *refname)
 {
@@ -1673,7 +1672,6 @@ test_riscv_filter(const char *refname)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
-#endif
 
 DEFINE_TEST(test_read_format_7zip_lzma2_riscv)
 {
@@ -1693,6 +1691,22 @@ DEFINE_TEST(test_read_format_7zip_lzma2_riscv)
 #else
 	skipping("This version of liblzma does not support LZMA_FILTER_RISCV");
 #endif
+}
+
+DEFINE_TEST(test_read_format_7zip_deflate_riscv)
+{
+	struct archive *a;
+
+	assert((a = archive_read_new()) != NULL);
+
+	if (ARCHIVE_OK != archive_read_support_filter_gzip(a)) {
+		skipping(
+		    "7zip:deflate decoding is not supported on this platform");
+	} else {
+		test_riscv_filter("test_read_format_7zip_deflate_riscv.7z");
+	}
+
+	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }
 
 static void

--- a/libarchive/test/test_read_format_7zip_deflate_riscv.7z.uu
+++ b/libarchive/test/test_read_format_7zip_deflate_riscv.7z.uu
@@ -1,0 +1,62 @@
+This archive was created by extracting hw-riscv64 from test_read_format_7zip_lzma2_riscv.7z.uu,
+chmodding it to 0775 and then creating the archive with 7zip 26.02:
+
+rm -f libarchive/test/test_read_format_7zip_deflate_riscv.7z
+7z a -m0=RISCV -m1=Deflate -mhc=off libarchive/test/test_read_format_7zip_deflate_riscv.7z hw-riscv64 -y
+
+And then uuencoding the resulting archive.
+
+begin 644 test_read_format_7zip_deflate_riscv.7z
+M-WJ\KR<<``1HOFDY<P@```````!B`````````(DMO1'M65?HTT`8OZ3]U[WW
+MKGN@L76CHK:.*NZ)@GK&)MIHEVGJ%C?J@Z*X17`@".*#B`^"N'`^J8BB((JX
+M4!!4'"BB]>YR27J7U($*/OB5Y)?[W??=?7?W77IW63YXQ!!1$(`E/O`6X-2Q
+M,C,]@/+M&II81KA>H"*Z-P:-0`"E_;:>&T,BB^6M>JA=EO!N;`Y8%!R[++:3
+MJ@-/&<^E!0N)[Z6E53D6077;CK3Q6!4S?:P)BY.IOS-$UDZD=E>IW=4F++X6
+M+&3[Q4^O;:0\-PX"+/HICGEJ*/CY&*[4C6BL*')V8Y%=`/R\6-T^#M?WG7X9
+M(UK(CD/GI#:S<U+IE-32^86=="T7G]^C6Z=DMD<W1<IEI+#E6VT:([%1$\&L
+MW@<&/CMQ2+VV;&QD>.N7<S[+_>_[J2\"U;'LJ@&G_\L5C1]5"%K#.W?YGJ7?
+M;2BIOS*>!X[0LFIZZ,;0%?3@A1+Z]='5PH./ERBG%BX'^9.@C>E@963S1@Y`
+MB+HU#G.&K!LP)6MIQ,07RG"6EI:3VF(5X&S<OSU`;,2PZ$#81>K2TW[LV@W`
+M81-&0D75U=E:SE#U"2,')C-I=8(\,ZF:>5XYM*=1&WWH)Y"V"BC=MBA.UFW9
+M$<`]&:;<"93&-GT!&R\^FKY)^_LDQ\^B[3['\1TI_[P9RR>L00]:/)M^2/5%
+M.X_.QR*^>.@_%O'%\^4JY<M(GB,WBGA_$;^S)0!=?1<BOC.K#]7R#?RR=17"
+M\;7`ZN.KP&Q0%=0+/WP,0+.KLWU5\9A;Z1M6^A407QQ95R\\9CQBGZ]20Z#6
+M/*&P<H@0J[@>Y5T5-]<+-T#!U0ZL6H&MQXY!32Y?+[QH(<;X^L.(6[@$V3[<
+M<F'5NE4K'(TIDS%NV+CU3O<!7[:<V;YV[>Y+5/>CJ1NIT>)AO7!D`-9;'?.#
+MP).UCZG&ZRU73)^"8-5.Y,>KM;&6X!TX.$-4(L*J%=I9H4;@98OGH/J1=2U#
+M)[ZV;//NJUES8#_2OK$RUF_MHQE1I4S&7@,SCLQQ5)/)3,?@@HR>5`C?R->G
+ML=77A4*A&XX5A$.Y]Y-O\3@@+!6$1E5$Q)GS[>+70H',N7(":(5C!Y>/;,E<
+MBE8-#EHIKO='*Y<'4\]'KU86@]&JX+_\E__R7_[+?_FG1:#8EF*06U\U!^P^
+MHP%@UUF-N/R&@%UO->;RWW\M9##>%>DZQ]+WV>MD9N%5D2:74:Q$L3[%.OS:
+MV_+/7G>9$J)8FV(YBO4H#BAC^15^UN_7%"MP]3?EVO>Y8+9/H-17FAY#RRM8
+M^5:Y--V/YG^BZ3+P=Z1`Q=X&E%EH[S-_26(#!_8.MILX,Y\V\L%P5ZF+%.K4
+MI6N>I+NUIPR(C$.J9-,&A*%X95N]3$?[-ZU+-@Q37;(A*..G65VR7:"";W',
+M+=;B.=U\F*6FXZI&GE.I?#*<#8&?$+RWR(I>O`BV>?'H=]*3]X.[GGP9NGGQ
+M`7#.DR]'QMG-EP=C//D*8(4G7Y'$JYNOA,;QY_:C)E\%[`IX\57!,4^^&KCA
+MR5<G[PLW7P.<].1K@G.>?"UPU9.OC>>SF\>S/^C%UP7EO7@ZV]U\?1<GD/W7
+MFP+/5\!Y=IPXU=<B=W<_3Z3\38Z?5J+\!+I$I/_`T7?*]^#G4'W`C<LRRG?D
+M^*W8?[M_G/?0/O+L'I?+M)Q97#DWB;Y[?-_8[?+V/Q'XN7[X0,JO9AV\.%)"
+MWR\@?<3S\=^4\GQ<M24-=\=Y;ZI_EXNW,8+W>4Q*\#YW.4UX=WQN0'QUU/_5
+M.7X[X>NXXG9O"?XHX=WEGRK!7T5\#='-W\9\T7O`>MT\*>'G>=P/=IP[9U$O
+ML#X>EW:L_N<2_59)).6[VE5/]#ZO:BQZGWOU$$F[7.5$1=)4MXR/ZT98RJ"#
+M+GFF!@UY-FBU\'?_BY(968&SLP`5G3/RLV9)<>"<B4$C!>/X[`L?MRD9.#N9
+MF2DGH6)D]!R4\PM!/)/*)E5#5:20MP8^CM.@K.OR(JBF#7T1F*7+*14J^51J
+M$3(I2D&D:3"JB052'.D,&1<9.1@.'C4(0@#'C!L]</"@B>,&PQ'#1@V/Q`;#
+M"9'HB,$H9]"449&1PP8B`W0X"@</I79#!XT#,#9B=#0R`HX>,F3\X`G4PGV"
+M..!G3P=A=/QXRR%5D0T94>,'129$8'1P;-@H3$,NB;7,JG`BEX$).:V0D\;1
+MB%:T-,SG5`45ET8WJQNS&2V-*F]%3CP'.,>82&-F+D>+\SC[9%61[Z:SWSO6
+ME'*+4H8\$Z&AFYBPGH@/62"E,X8JS4[GI9EY#1UG:PJE(M%AG7`PDKR$G$L`
+M25F41N411*68.?-5/:=ETDP"HCQ=3<I8D3YEDP:0#'4ANNL9TK>2FJ!QDE!T
+M)P6DK*XZ,8/]=)Z=L"-.R"DMCBK.H$+-(E'W`0E%;TI-(XXL[R39,'1M9MY`
+MT?Y'I!']CQ+!][_W./_;K+1$5SG;WOU=I)7KOX65'IS]29'%X`_L!Z'K`UK3
+M6_9W18I<_67V/H*5473/(]J+%1;/T62`ZI3G]B>3J*IH[[-87/:#_IM.]RR6
+M?3\_B]4Y_T4.Y](]D)4>XV<Q5.2_X-'^Q;1/17M?QN(YIGYW^]=0^ZB]SV,Q
+M5&1?V\-^`_4K4&*_-(#SMSJ'FSC[8V4L/OI!_&SCXG]7P$'W_M?=?WMM^Q+?
+M]WY0_Q'._D:`Q0D_J/\$[0L?X+[W5?'6%[AR+I!56M&^O@G%$O;E.;Q.O^WY
+MN'.)<S]I?P^/G6/O?(^MPGZ'#5AVW/@_(6URGTN<K&;BT!_4_\*Q9U\XU;_G
+MOR.O0+5;Y8OLRP<I6O8_F/_O*.=LN%G[-KP]AU_,NK.LEO,=?OSWZK=CSRWK
+MJ7THX)P[=?:8OQ5(_6XY6=?$J>+WZZ]1PKYV`Q.K"=^W_P8!!`8``0F(<P`'
+M"P$``@,$`0@!"P$`#*$HH2@`"`H!YR3M]P``!0$9!``````1%P!H`'<`+0!R
+K`&D`<P!C`'8`-@`T````&00`````%`H!`'#ZO##"*-L!%08!`""`_8$`````
+`
+end


### PR DESCRIPTION
test_read_format_7zip_deflate_riscv.7z.uu was created by extracting hw-riscv64 from test_read_format_7zip_lzma2_riscv.7z.uu, chmodding it to 0775 and then creating the archive with 7zip 26.02:
```
7z a -m0=RISCV -m1=Deflate -mhc=off libarchive/test/test_read_format_7zip_deflate_riscv.7z hw-riscv64 -y
```
And then uuencoding the resulting archive.

This test fails on the first commit, and passes on the second.