### PR TITLE
check_magic: Add `ARCHIVE_STATE_OPEN` name

### DIFF
--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -83,6 +83,7 @@ state_name(unsigned s)
 {
 	switch (s) {
 	case ARCHIVE_STATE_NEW:		return ("new");
+	case ARCHIVE_STATE_OPEN:	return ("open");
 	case ARCHIVE_STATE_HEADER:	return ("header");
 	case ARCHIVE_STATE_DATA:	return ("data");
 	case ARCHIVE_STATE_DATA_RECOVERY: return ("data_recovery");


### PR DESCRIPTION
Add name in case of errors to avoid `??` entries.

Still fits the static buffer size of 64 in worst case.