### PR TITLE
ar: Ignore special file entries

### DIFF
--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -253,22 +253,11 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 	 * Ignore it since it contains linker information.
 	 */
 	if (strcmp(filename, "/") == 0) {
-		size_t entry_size;
-
 		/* This is not a file entry. Ignore. */
 		archive_entry_copy_pathname(entry, NULL);
 
-		/* Get the size of the ranlib index. */
-		number = ar_atol10(h + AR_size_offset, AR_size_size);
-		if (number > SIZE_MAX || number > 1024 * 1024 * 1024) {
-			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "Filename table too large");
-			return (ARCHIVE_FATAL);
-		}
-		entry_size = (size_t)number;
-		*unconsumed += entry_size;
-
-		return (ARCHIVE_OK);
+		/* Skip special file entry. */
+		return (archive_read_format_ar_skip(a));
 	}
 
 	/*
@@ -277,20 +266,21 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 	 */
 	if (strcmp(filename, "//") == 0) {
 		char *st;
-		size_t entry_size;
+		int64_t entry_size;
+		size_t strtab_size;
 
 		/* This is not a file entry. Ignore. */
 		archive_entry_copy_pathname(entry, NULL);
 
 		/* Get the size of the filename table. */
-		number = ar_atol10(h + AR_size_offset, AR_size_size);
-		if (number > SIZE_MAX || number > 1024 * 1024 * 1024) {
+		entry_size = archive_entry_size(entry);
+		if (entry_size > 1024 * 1024 * 1024) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Filename table too large");
 			return (ARCHIVE_FATAL);
 		}
-		entry_size = (size_t)number;
-		if (entry_size == 0) {
+		strtab_size = (size_t)entry_size;
+		if (strtab_size == 0) {
 			archive_set_error(&a->archive, EINVAL,
 			    "Invalid string table");
 			return (ARCHIVE_FATAL);
@@ -302,27 +292,27 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 		}
 
 		/* Read the filename table into memory. */
-		st = malloc(entry_size);
+		st = malloc(strtab_size);
 		if (st == NULL) {
 			archive_set_error(&a->archive, ENOMEM,
 			    "Can't allocate filename table buffer");
 			return (ARCHIVE_FATAL);
 		}
 		ar->strtab = st;
-		ar->strtab_size = entry_size;
+		ar->strtab_size = strtab_size;
 
 		if (*unconsumed) {
 			__archive_read_consume(a, *unconsumed);
 			*unconsumed = 0;
 		}
 
-		if ((b = __archive_read_ahead(a, entry_size, NULL)) == NULL)
+		if ((b = __archive_read_ahead(a, strtab_size, NULL)) == NULL)
 			return (ARCHIVE_FATAL);
-		memcpy(st, b, entry_size);
-		__archive_read_consume(a, entry_size);
-		/* All contents are consumed. */
-		ar->entry_bytes_remaining = 0;
-		archive_entry_set_size(entry, ar->entry_bytes_remaining);
+		memcpy(st, b, strtab_size);
+
+		/* Skip special file entry. */
+		if (archive_read_format_ar_skip(a) != ARCHIVE_OK)
+			return (ARCHIVE_FATAL);
 
 		/* Parse the filename table. */
 		return (ar_parse_gnu_filename_table(a));

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -256,7 +256,9 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 		char *st;
 		size_t entry_size;
 
-		archive_entry_copy_pathname(entry, filename);
+		/* This is not a file entry. Ignore. */
+		archive_entry_copy_pathname(entry, NULL);
+
 		/* Get the size of the filename table. */
 		number = ar_atol10(h + AR_size_offset, AR_size_size);
 		if (number > SIZE_MAX || number > 1024 * 1024 * 1024) {
@@ -412,17 +414,20 @@ archive_read_format_ar_read_header(struct archive_read *a,
 		a->archive.archive_format = ARCHIVE_FORMAT_AR;
 	}
 
-	/* Read the header for the next file entry. */
-	if ((header_data = __archive_read_ahead(a, 60, NULL)) == NULL)
-		/* Broken header. */
-		return (ARCHIVE_EOF);
+	do {
+		/* Read the header for the next file entry. */
+		if ((header_data = __archive_read_ahead(a, 60, NULL)) == NULL)
+			/* Broken header. */
+			return (ARCHIVE_EOF);
 
-	unconsumed = 60;
+		unconsumed = 60;
 
-	ret = _ar_read_header(a, entry, ar, (const char *)header_data, &unconsumed);
+		ret = _ar_read_header(a, entry, ar, (const char *)header_data,
+		    &unconsumed);
 
-	if (unconsumed)
-		__archive_read_consume(a, unconsumed);
+		if (unconsumed)
+			__archive_read_consume(a, unconsumed);
+	} while (ret == ARCHIVE_OK && archive_entry_pathname(entry) == NULL);
 
 	return ret;
 }

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -249,6 +249,29 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 	ar_parse_common_header(ar, entry, h);
 
 	/*
+	 * '/' is the ranlib index.
+	 * Ignore it since it contains linker information.
+	 */
+	if (strcmp(filename, "/") == 0) {
+		size_t entry_size;
+
+		/* This is not a file entry. Ignore. */
+		archive_entry_copy_pathname(entry, NULL);
+
+		/* Get the size of the ranlib index. */
+		number = ar_atol10(h + AR_size_offset, AR_size_size);
+		if (number > SIZE_MAX || number > 1024 * 1024 * 1024) {
+			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+			    "Filename table too large");
+			return (ARCHIVE_FATAL);
+		}
+		entry_size = (size_t)number;
+		*unconsumed += entry_size;
+
+		return (ARCHIVE_OK);
+	}
+
+	/*
 	 * '//' is the GNU filename table.
 	 * Later entries can refer to names in this table.
 	 */

--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -274,20 +274,15 @@ _ar_read_header(struct archive_read *a, struct archive_entry *entry,
 
 		/* Get the size of the filename table. */
 		entry_size = archive_entry_size(entry);
-		if (entry_size > 1024 * 1024 * 1024) {
+		if (entry_size == 0 || entry_size > 1024 * 1024 * 1024) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-			    "Filename table too large");
+			    "Invalid filename table size");
 			return (ARCHIVE_FATAL);
 		}
 		strtab_size = (size_t)entry_size;
-		if (strtab_size == 0) {
-			archive_set_error(&a->archive, EINVAL,
-			    "Invalid string table");
-			return (ARCHIVE_FATAL);
-		}
 		if (ar->strtab != NULL) {
 			archive_set_error(&a->archive, EINVAL,
-			    "More than one string table exists");
+			    "More than one filename table exists");
 			return (ARCHIVE_FATAL);
 		}
 

--- a/libarchive/test/test_read_format_ar.c
+++ b/libarchive/test/test_read_format_ar.c
@@ -40,16 +40,6 @@ DEFINE_TEST(test_read_format_ar)
 	assertA(0 == archive_read_support_format_all(a));
 	assertA(0 == archive_read_open_filename(a, reffile, 7));
 
-	/* Filename table.  */
-	assertA(0 == archive_read_next_header(a, &ae));
-	assertEqualString("//", archive_entry_pathname(ae));
-	assertEqualInt(0, archive_entry_mtime(ae));
-	assertEqualInt(0, archive_entry_uid(ae));
-	assertEqualInt(0, archive_entry_gid(ae));
-	assertEqualInt(0, archive_entry_size(ae));
-	assertEqualInt(archive_entry_is_encrypted(ae), 0);
-	assertEqualIntA(a, archive_read_has_encrypted_entries(a), ARCHIVE_READ_FORMAT_ENCRYPTION_UNSUPPORTED);
-
 	/* First Entry */
 	assertA(0 == archive_read_next_header(a, &ae));
 	assertEqualString("yyytttsssaaafff.o", archive_entry_pathname(ae));
@@ -86,7 +76,7 @@ DEFINE_TEST(test_read_format_ar)
 
 	/* Test EOF */
 	assertA(1 == archive_read_next_header(a, &ae));
-	assertEqualInt(4, archive_file_count(a));
+	assertEqualInt(3, archive_file_count(a));
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_close(a));
 	assertEqualInt(ARCHIVE_OK, archive_read_free(a));
 }

--- a/libarchive/test/test_write_format_ar.c
+++ b/libarchive/test/test_write_format_ar.c
@@ -111,11 +111,6 @@ DEFINE_TEST(test_write_format_ar)
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_open_memory(a, buff, used));
 
 	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
-	assertEqualInt(0, archive_entry_mtime(ae));
-	assertEqualString("//", archive_entry_pathname(ae));
-	assertEqualInt(0, archive_entry_size(ae));
-
-	assertEqualIntA(a, ARCHIVE_OK, archive_read_next_header(a, &ae));
 	assertEqualInt(1, archive_entry_mtime(ae));
 	assertEqualString("abcdefghijklmn.o", archive_entry_pathname(ae));
 	assertEqualInt(8, archive_entry_size(ae));


### PR DESCRIPTION
`/` is the ranlib index, `//` the GNU filename table. Both are ignored by GNU ar and even bsdtar lists 0 size entries.

Since it just leads to confusion without real gain, let's ignore them.

Resolves https://github.com/libarchive/libarchive/issues/2291
Resolves https://github.com/libarchive/libarchive/issues/2524