### PR TITLE
shar: reject entries without a pathname

### DIFF
--- a/libarchive/archive_write_set_format_shar.c
+++ b/libarchive/archive_write_set_format_shar.c
@@ -165,6 +165,13 @@ archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 	const char *name;
 	char *p, *pp;
 
+	name = archive_entry_pathname(entry);
+	if (name == NULL || *name == '\0') {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Can't record entry in shar file without pathname");
+		return (ARCHIVE_FAILED);
+	}
+
 	if (!shar->wrote_header) {
 		archive_strcat(&shar->work, "#!/bin/sh\n");
 		archive_strcat(&shar->work, "# This is a shell archive\n");
@@ -178,7 +185,6 @@ archive_write_shar_header(struct archive_write *a, struct archive_entry *entry)
 		archive_set_error(&a->archive, ENOMEM, "Out of memory");
 		return (ARCHIVE_FATAL);
 	}
-	name = archive_entry_pathname(entry);
 
 	/* Handle some preparatory issues. */
 	switch(archive_entry_filetype(entry)) {

--- a/libarchive/test/test_write_format_shar_empty.c
+++ b/libarchive/test/test_write_format_shar_empty.c
@@ -51,3 +51,40 @@ DEFINE_TEST(test_write_format_shar_empty)
 	failure("Empty shar archive should be exactly 0 bytes, was %zu.", used);
 	assert(used == 0);
 }
+
+DEFINE_TEST(test_write_format_shar_invalid_pathname)
+{
+	struct archive *a;
+	struct archive_entry *ae;
+	char buff[2048];
+	size_t used;
+	int dump, empty;
+
+	for (dump = 0; dump <= 1; dump++) {
+		for (empty = 0; empty <= 1; empty++) {
+			assert((a = archive_write_new()) != NULL);
+			if (dump)
+				assertEqualInt(ARCHIVE_OK,
+				    archive_write_set_format_shar_dump(a));
+			else
+				assertEqualInt(ARCHIVE_OK,
+				    archive_write_set_format_shar(a));
+			assertEqualInt(ARCHIVE_OK, archive_write_open_memory(a,
+			    buff, sizeof(buff), &used));
+
+			assert((ae = archive_entry_new()) != NULL);
+			if (empty)
+				archive_entry_set_pathname(ae, "");
+			archive_entry_set_filetype(ae, AE_IFREG);
+			archive_entry_set_perm(ae, 0644);
+			archive_entry_set_size(ae, 0);
+			assertEqualIntA(a, ARCHIVE_FAILED,
+			    archive_write_header(a, ae));
+			archive_entry_free(ae);
+
+			assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+			assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+			assertEqualInt(0, used);
+		}
+	}
+}


### PR DESCRIPTION
`archive_write_header()` currently reaches `shar_quote()` when a shar entry has a null pathname, which triggers a null-pointer load. An empty pathname is likewise not a valid shar entry name.

Reject null and empty pathnames with `ARCHIVE_FAILED` before the writer emits its prologue or changes entry state. The regression test covers both pathname cases for the regular shar and shar-dump writers and verifies that no output is emitted.

Validation on macOS arm64 with AddressSanitizer and UndefinedBehaviorSanitizer:

- The new test crashes on the unmodified source with a null-pointer load in `shar_quote()`.
- The focused shar tests pass (2/2).
- A selected shar, mtree, and 7zip regression set passes (16/16).
