### PR TITLE
libarchive_fe: Fix dynamic build

### DIFF
--- a/libarchive_fe/lafe_setmode.c
+++ b/libarchive_fe/lafe_setmode.c
@@ -33,8 +33,14 @@
  */
 
 #include "lafe_platform.h"
-#include "archive_platform.h" /* for S_I* mode macros on windows */
-#include "archive_umask_private.h"
+/*
+ * Include archive_platform.h only for S_I* mode macros.
+ * Undefine __LIBARCHIVE_BUILD again: libarchive.so can be
+ * linked dynamically, which turns private functions inaccessible.
+ */
+#include "archive_platform.h"
+#undef	__LIBARCHIVE_BUILD
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef HAVE_SYS_SYSCTL_H
@@ -187,7 +193,8 @@ lafe_setmode(const char *p)
 	 * Get a copy of the mask for the permissions that are mask relative.
 	 * Flip the bits, we want what's not set.
 	 */
-	mask = ~__archive_get_umask();
+	umask(mask = umask(0));
+	mask = ~mask;
 
 	setlen = SET_LEN + 2;
 


### PR DESCRIPTION
Building frontend tools in shared mode (e.g. `--disable-static`) leads to a failure with libarchive's private `__archive_get_umask` function.

Our frontends are not multi-threaded, so we can just call `umask` here.

Add a comment and undefine `__LIBARCHIVE_BUILD` after header inclusion to avoid such easily overlooked issue in the future.

Fixes https://github.com/libarchive/libarchive/commit/065488cd453a60c64e9300de83c9ef95ea47e3fa (thus CC @vapier)

How to trigger the issue on a Linux system:
```
./configure --disable-static
make
```
```
/usr/bin/ld: ./.libs/libarchive_fe.a(la-lafe_setmode.o): in function `lafe_setmode':
.../libarchive/libarchive_fe/lafe_setmode.c:190:(.text.lafe_setmode+0x30): undefined reference to `__archive_get_umask'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:5367: bsdtar] Error 1
```