### PR TITLE
tar: Turn `safe_fprintf` into `safe_fputs`

### DIFF
--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -196,7 +196,7 @@ int	edit_pathname(struct bsdtar *, struct archive_entry *);
 void	edit_mtime(struct bsdtar *, struct archive_entry *);
 int	need_report(void);
 int	pathcmp(const char *a, const char *b);
-void	safe_fprintf(FILE * ARCHIVE_RESTRICT, const char * ARCHIVE_RESTRICT fmt, ...) __LA_PRINTF(2, 3);
+void	safe_fputs(const char * ARCHIVE_RESTRICT s, FILE * ARCHIVE_RESTRICT);
 void	set_chdir(struct bsdtar *, const char *newdir);
 void	tar_mode_c(struct bsdtar *bsdtar);
 void	tar_mode_r(struct bsdtar *bsdtar);

--- a/tar/read.c
+++ b/tar/read.c
@@ -128,8 +128,8 @@ progress_func(void *cookie)
 		    archive_file_count(a), (uintmax_t)uncomp);
 	}
 	if (entry != NULL) {
-		safe_fprintf(stderr, "Current: %s",
-		    archive_entry_pathname(entry));
+		fputs("Current: ", stderr);
+		safe_fputs(archive_entry_pathname(entry), stderr);
 		fprintf(stderr, " (%jd bytes)\n",
 		    (intmax_t)archive_entry_size(entry));
 	}
@@ -314,8 +314,7 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 			 * you cannot easily preview rewrites.
 			 */
 			if (bsdtar->verbose < 2)
-				safe_fprintf(out, "%s",
-				    archive_entry_pathname(entry));
+				safe_fputs(archive_entry_pathname(entry), out);
 			else
 				list_item_verbose(bsdtar, out, entry);
 			fflush(out);
@@ -349,14 +348,15 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 
 			if (bsdtar->verbose > 1) {
 				/* GNU tar uses -tv format with -xvv */
-				safe_fprintf(stderr, "x ");
+				fputs("x ", stderr);
 				list_item_verbose(bsdtar, stderr, entry);
 				fflush(stderr);
 			} else if (bsdtar->verbose > 0) {
 				/* Format follows SUSv2, including the
 				 * deferred '\n'. */
-				safe_fprintf(stderr, "x %s",
-				    archive_entry_pathname(entry));
+				fputs("x ", stderr);
+				safe_fputs(archive_entry_pathname(entry),
+				    stderr);
 				fflush(stderr);
 			}
 
@@ -368,9 +368,12 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
 				r = archive_read_extract2(a, entry, writer);
 			if (r != ARCHIVE_OK) {
 				if (!bsdtar->verbose)
-					safe_fprintf(stderr, "%s", archive_entry_pathname(entry));
-				safe_fprintf(stderr, ": %s: %s",
-				    archive_error_string(a),
+					safe_fputs(
+					    archive_entry_pathname(entry),
+					    stderr);
+				fputs(": ", stderr);
+				safe_fputs(archive_error_string(a), stderr);
+				fprintf(stderr, ": %s",
 				    strerror(archive_errno(a)));
 				if (!bsdtar->verbose)
 					fprintf(stderr, "\n");

--- a/tar/util.c
+++ b/tar/util.c
@@ -79,11 +79,20 @@ safe_fputs(const char * restrict s, FILE * restrict f)
 		return;
 	}
 
-	/* Write data, expanding unprintable characters. */
 	p = s;
-	length = strlen(p);
+
+	/* Directly print as many ASCII characters as possible. */
+	if (mbtowc(NULL, NULL, 0) == 0) {
+		while (*p != '\0' && isprint((unsigned char)*p) &&
+		    (unsigned char)*p < 128 && *p != '\\')
+			p++;
+		fwrite(s, 1, p - s, f);
+	}
+
+	/* Write data, expanding unprintable characters. */
 	i = 0;
 	try_wc = 1;
+	length = strlen(p);
 	while (*p != '\0') {
 
 		/* Convert to wide char, test if the wide
@@ -109,13 +118,11 @@ safe_fputs(const char * restrict s, FILE * restrict f)
 
 		/* If our output buffer is full, dump it and keep going. */
 		if (i > (sizeof(outbuff) - 128)) {
-			outbuff[i] = '\0';
-			fprintf(f, "%s", outbuff);
+			fwrite(outbuff, 1, i, f);
 			i = 0;
 		}
 	}
-	outbuff[i] = '\0';
-	fprintf(f, "%s", outbuff);
+	fwrite(outbuff, 1, i, f);
 }
 
 /*

--- a/tar/util.c
+++ b/tar/util.c
@@ -59,90 +59,29 @@ static const char *strip_components(const char *path, int elements);
  * #endif
  */
 
-/*
- * Print a string, taking care with any non-printable characters.
- *
- * Note that we use a stack-allocated buffer to receive the formatted
- * string if we can.  This is partly performance (avoiding a call to
- * malloc()), partly out of expedience (we have to call vsnprintf()
- * before malloc() anyway to find out how big a buffer we need; we may
- * as well point that first call at a small local buffer in case it
- * works).
- */
+/* Print a string, taking care of any non-printable characters. */
 
 void
-safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
+safe_fputs(const char * restrict s, FILE * restrict f)
 {
-	char fmtbuff_stack[256]; /* Place to format the printf() string. */
 	char outbuff[256]; /* Buffer for outgoing characters. */
-	char *fmtbuff_heap; /* If fmtbuff_stack is too small, we use malloc */
-	char *fmtbuff;  /* Pointer to fmtbuff_stack or fmtbuff_heap. */
-	size_t fmtbuff_length;
-	int length, n;
-	va_list ap;
+	int n;
 	const char *p;
-	size_t i;
+	size_t i, length;
 	wchar_t wc;
 	char try_wc;
-
-	/* Use a stack-allocated buffer if we can, for speed and safety. */
-	memset(fmtbuff_stack, '\0', sizeof(fmtbuff_stack));
-	fmtbuff_heap = NULL;
-	fmtbuff_length = sizeof(fmtbuff_stack);
-	fmtbuff = fmtbuff_stack;
-
-	/* Try formatting into the stack buffer. */
-	va_start(ap, fmt);
-	length = vsnprintf(fmtbuff, fmtbuff_length, fmt, ap);
-	va_end(ap);
-
-	/* If vsnprintf will always fail, stop early. */
-	if (length < 0 && errno == EOVERFLOW)
-		return;
-
-	/* If the result was too large, allocate a buffer on the heap. */
-	while (length < 0 || (size_t)length >= fmtbuff_length) {
-		if (length >= 0 && (size_t)length >= fmtbuff_length)
-			fmtbuff_length = (size_t)length + 1;
-		else if (fmtbuff_length < 8192)
-			fmtbuff_length *= 2;
-		else if (fmtbuff_length < 1000000)
-			fmtbuff_length += fmtbuff_length / 4;
-		else {
-			fmtbuff[fmtbuff_length - 1] = '\0';
-			length = (int)strlen(fmtbuff);
-			break;
-		}
-		free(fmtbuff_heap);
-		fmtbuff_heap = malloc(fmtbuff_length);
-
-		/* Reformat the result into the heap buffer if we can. */
-		if (fmtbuff_heap != NULL) {
-			fmtbuff = fmtbuff_heap;
-			va_start(ap, fmt);
-			length = vsnprintf(fmtbuff, fmtbuff_length, fmt, ap);
-			va_end(ap);
-		} else {
-			/* Leave fmtbuff pointing to the truncated
-			 * string in fmtbuff_stack. */
-			fmtbuff_stack[sizeof(fmtbuff_stack) - 1] = '\0';
-			fmtbuff = fmtbuff_stack;
-			length = (int)strlen(fmtbuff);
-			break;
-		}
-	}
 
 	/* Note: mbrtowc() has a cleaner API, but mbtowc() seems a bit
 	 * more portable, so we use that here instead. */
 	if (mbtowc(NULL, NULL, 1) == -1) { /* Reset the shift state. */
 		/* mbtowc() should never fail in practice, but
 		 * handle the theoretical error anyway. */
-		free(fmtbuff_heap);
 		return;
 	}
 
 	/* Write data, expanding unprintable characters. */
-	p = fmtbuff;
+	p = s;
+	length = strlen(p);
 	i = 0;
 	try_wc = 1;
 	while (*p != '\0') {
@@ -177,9 +116,6 @@ safe_fprintf(FILE * restrict f, const char * restrict fmt, ...)
 	}
 	outbuff[i] = '\0';
 	fprintf(f, "%s", outbuff);
-
-	/* If we allocated a heap-based formatting buffer, free it now. */
-	free(fmtbuff_heap);
 }
 
 /*
@@ -768,12 +704,16 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	if (!ltime || !sw)
 		p = "-- -- ----";
 	fprintf(out, " %s ", p);
-	safe_fprintf(out, "%s", archive_entry_pathname(entry));
+	safe_fputs(archive_entry_pathname(entry), out);
 
 	/* Extra information for links. */
-	if (archive_entry_hardlink(entry)) /* Hard link */
-		safe_fprintf(out, " link to %s",
-		    archive_entry_hardlink(entry));
-	else if (archive_entry_symlink(entry)) /* Symbolic link */
-		safe_fprintf(out, " -> %s", archive_entry_symlink(entry));
+	if (archive_entry_hardlink(entry)) {
+		/* Hard link */
+		fputs(" link to ", out);
+		safe_fputs(archive_entry_hardlink(entry), out);
+	} else if (archive_entry_symlink(entry)) {
+		/* Symbolic link */
+		fputs(" -> ", out);
+		safe_fputs(archive_entry_symlink(entry), out);
+	}
 }

--- a/tar/write.c
+++ b/tar/write.c
@@ -725,11 +725,12 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina)
 			continue;
 		edit_mtime(bsdtar, in_entry);
 		if (bsdtar->verbose > 1) {
-			safe_fprintf(stderr, "a ");
+			fputs("a ", stderr);
 			list_item_verbose(bsdtar, stderr, in_entry);
-		} else if (bsdtar->verbose > 0)
-			safe_fprintf(stderr, "a %s",
-			    archive_entry_pathname(in_entry));
+		} else if (bsdtar->verbose > 0) {
+			fputs("a ", stderr);
+			safe_fputs(archive_entry_pathname(in_entry), stderr);
+		}
 		if (need_report())
 			report_write(bsdtar, a, in_entry, 0);
 
@@ -962,12 +963,12 @@ write_hierarchy(struct bsdtar *bsdtar, struct archive *a, const char *path)
 
 		/* Display entry as we process it. */
 		if (bsdtar->verbose > 1) {
-			safe_fprintf(stderr, "a ");
+			fputs("a ", stderr);
 			list_item_verbose(bsdtar, stderr, entry);
 		} else if (bsdtar->verbose > 0) {
-		/* This format is required by SUSv2. */
-			safe_fprintf(stderr, "a %s",
-			    archive_entry_pathname(entry));
+			/* This format is required by SUSv2. */
+			fputs("a ", stderr);
+			safe_fputs(archive_entry_pathname(entry), stderr);
 		}
 
 		/* Non-regular files get archived with zero size. */
@@ -1015,7 +1016,7 @@ write_entry(struct bsdtar *bsdtar, struct archive *a,
 	e = archive_write_header(a, entry);
 	if (e != ARCHIVE_OK) {
 		if (bsdtar->verbose > 1) {
-			safe_fprintf(stderr, "a ");
+			fputs("a ", stderr);
 			list_item_verbose(bsdtar, stderr, entry);
 			lafe_warnc(0, ": %s", archive_error_string(a));
 		} else {
@@ -1058,12 +1059,11 @@ report_write(struct bsdtar *bsdtar, struct archive *a,
 	else
 		compression = (int)((uncomp - comp) * 100 / uncomp);
 	fprintf(stderr,
-	    " Out: %ju bytes, compression %d%%\n",
+	    " Out: %ju bytes, compression %d%%\nCurrent: ",
 	    (uintmax_t)comp, compression);
-	safe_fprintf(stderr, "Current: %s (%jd",
-	    archive_entry_pathname(entry),
-	    (intmax_t)progress);
-	fprintf(stderr, "/%jd bytes)\n",
+	safe_fputs(archive_entry_pathname(entry), stderr);
+	fprintf(stderr, " (%jd/%jd bytes)\n",
+	    (intmax_t)progress,
 	    (intmax_t)archive_entry_size(entry));
 }
 


### PR DESCRIPTION
By adjusting the `fprintf`/`safe_fprintf` combined call sites in a way that `safe_fprintf` always takes `%s` as a formatter, it was possible to turn the entire function into `safe_fputs`.

This has the huge advantage that the entire internal memory handling can be removed, since it's possible to directly iterate over the input string.

Also, "while at it" I have added a quick ASCII check at the beginning of the string. In most cases, we can skip the whole character conversion, as long as input files have no fancy characters. This is true for a lot of regular archive files. As soon as we find a character which takes special processing, we fall back to the regular safe processing.

In combination with the `umask` performance improvement, bsdtar comes very close to GNU tar performance with `xv` or `tv` arguments again. With this PR, a rough measurement gave around 7 % performance increasement with an Arch Linux kernel package.

Regardless of performance, there is less code to audit in the future.