### PR TITLE
mtree: omit unknown nlink values

### DIFF
--- a/libarchive/archive_write_set_format_mtree.c
+++ b/libarchive/archive_write_set_format_mtree.c
@@ -997,7 +997,7 @@ write_mtree_entry(struct archive_write *a, struct mtree_entry *me)
 
 	keys = get_global_set_keys(mtree, me);
 	if ((keys & F_NLINK) != 0 &&
-	    me->nlink != 1 && me->filetype != AE_IFDIR)
+	    me->nlink != 0 && me->nlink != 1 && me->filetype != AE_IFDIR)
 		archive_string_sprintf(str, " nlink=%u", me->nlink);
 
 	if ((keys & F_GNAME) != 0 && archive_strlen(&me->gname) > 0) {

--- a/libarchive/test/test_write_format_mtree.c
+++ b/libarchive/test/test_write_format_mtree.c
@@ -269,3 +269,34 @@ DEFINE_TEST(test_write_format_mtree_no_leading_dotslash)
   /* Use /set keyword with directory only */
   test_write_format_mtree_sub2(1, 1);
 }
+
+DEFINE_TEST(test_write_format_mtree_nlink)
+{
+	struct archive_entry *ae;
+	struct archive *a;
+	size_t used;
+
+	assert((a = archive_write_new()) != NULL);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_set_format_mtree(a));
+	assertEqualIntA(a, ARCHIVE_OK,
+	    archive_write_open_memory(a, buff, sizeof(buff) - 1, &used));
+
+	assert((ae = archive_entry_new()) != NULL);
+	archive_entry_set_pathname(ae, "nlink-unset");
+	archive_entry_set_mode(ae, AE_IFREG | 0644);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_set_pathname(ae, "nlink-one");
+	archive_entry_set_nlink(ae, 1);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_set_pathname(ae, "nlink-two");
+	archive_entry_set_nlink(ae, 2);
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_header(a, ae));
+	archive_entry_free(ae);
+
+	assertEqualIntA(a, ARCHIVE_OK, archive_write_close(a));
+	assertEqualInt(ARCHIVE_OK, archive_write_free(a));
+	buff[used] = '\0';
+	assert(strstr(buff, "nlink=0") == NULL);
+	assert(strstr(buff, "nlink=1") == NULL);
+	assert(strstr(buff, "nlink=2") != NULL);
+}


### PR DESCRIPTION
### Problem

The mtree writer currently emits `nlink=0` when the link count is not
available.

`archive_entry_nlink()` returns zero for an unset link count, and the
mtree writer only excluded the default value `1`, causing unknown
metadata to be serialized as an explicit `nlink=0`.

### Fix

Do not emit the `nlink` keyword when the value is `0` or `1`.

Values greater than `1` continue to be written normally.

### Testing

Added a focused regression test covering:

- unset nlink → no `nlink=0`
- `nlink=1` → omitted
- `nlink=2` → emitted

Focused test result:

```text
783: test_write_format_mtree_nlink    ok

Tests run:                1
Tests failed:             0
Assertions checked:      20
Assertions failed:        0